### PR TITLE
[Simplify Product Editing] Remove SPE experiment from product details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -67,8 +67,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .domainSettings:
             return true
-        case .simplifyProductEditing:
-            return false
         case .jetpackSetupWithApplicationPassword:
             return true
         case .dashboardOnboarding:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -148,10 +148,6 @@ public enum FeatureFlag: Int {
     ///
     case supportRequests
 
-    /// Whether to enable the simplified product editing experience.
-    ///
-    case simplifyProductEditing
-
     /// Whether to enable Jetpack setup for users authenticated with application passwords.
     ///
     case jetpackSetupWithApplicationPassword

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 13.5
 -----
-
+[Internal] Products: Simplify Product Editing experiment is removed; there should be no changes to the existing product creation/editing behavior. [https://github.com/woocommerce/woocommerce-ios/pull/9602]
 
 13.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactoryProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactoryProtocol.swift
@@ -6,9 +6,6 @@ protocol ProductFormActionsFactoryProtocol {
     /// Returns an array of actions that are visible in the product form settings section.
     func settingsSectionActions() -> [ProductFormEditAction]
 
-    /// Returns an array of actions that are visible in the product form options CTA section.
-    func optionsCTASectionActions() -> [ProductFormEditAction]
-
     /// Returns an array of actions that are visible in the product form bottom sheet.
     func bottomSheetActions() -> [ProductFormBottomSheetAction]
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
@@ -12,7 +12,6 @@ enum ProductFormBottomSheetAction {
     case editLinkedProducts
     case editReviews
     case editDownloadableFiles
-    case convertToVariable
 
     init?(productFormAction: ProductFormEditAction) {
         switch productFormAction {
@@ -34,8 +33,6 @@ enum ProductFormBottomSheetAction {
             self = .editReviews
         case .downloadableFiles:
             self = .editDownloadableFiles
-        case .convertToVariable:
-            self = .convertToVariable
         default:
             return nil
         }
@@ -72,9 +69,6 @@ extension ProductFormBottomSheetAction {
         case .editDownloadableFiles:
             return NSLocalizedString("Downloadable files",
                                      comment: "Title of the product form bottom sheet action for editing downloadable files.")
-        case .convertToVariable:
-            return NSLocalizedString("Add product variations",
-                                     comment: "Title of the product form bottom sheet action for switching to variable product type.")
         }
     }
 
@@ -107,9 +101,6 @@ extension ProductFormBottomSheetAction {
         case .editDownloadableFiles:
             return NSLocalizedString("Include downloadable files with purchases",
                                      comment: "Subtitle of the product form bottom sheet action for editing downloadable files.")
-        case .convertToVariable:
-            return NSLocalizedString("Add sizes, colors, or other options",
-                                     comment: "Subtitle of the product form bottom sheet action for switching to variable product type.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -42,16 +42,9 @@ public enum BottomSheetProductType: Hashable {
     /// Title shown on the action sheet.
     ///
     var actionSheetTitle: String {
-        let simplifyProductEditingEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
         switch self {
         case .simple(let isVirtual):
-            if isVirtual, simplifyProductEditingEnabled {
-                return NSLocalizedString("Virtual product",
-                                         comment: "Action sheet option when the user wants to change the Product type to simple virtual product")
-            } else if !isVirtual, simplifyProductEditingEnabled {
-                return NSLocalizedString("Physical product",
-                                         comment: "Action sheet option when the user wants to change the Product type to simple physical product")
-            } else if isVirtual {
+            if isVirtual {
                 return NSLocalizedString("Simple virtual product",
                                          comment: "Action sheet option when the user wants to change the Product type to simple virtual product")
             } else {
@@ -78,16 +71,9 @@ public enum BottomSheetProductType: Hashable {
     /// Description shown on the action sheet.
     ///
     var actionSheetDescription: String {
-        let simplifyProductEditingEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
         switch self {
         case .simple(let isVirtual):
-            if isVirtual, simplifyProductEditingEnabled {
-                return NSLocalizedString("A digital product like services, downloadable books, music or videos",
-                                         comment: "Description of the Action sheet option when the user wants to change the Product type to virtual product")
-            } else if !isVirtual, simplifyProductEditingEnabled {
-                return NSLocalizedString("A tangible item that gets delivered to customers",
-                                         comment: "Description of the Action sheet option when the user wants to change the Product type to physical product")
-            } else if isVirtual {
+            if isVirtual {
                 return NSLocalizedString("A unique digital product like services, downloadable books, music or videos",
                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple virtual product")
             } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
@@ -32,11 +32,6 @@ struct ProductVariationFormActionsFactory: ProductFormActionsFactoryProtocol {
         return visibleSettingsSectionActions()
     }
 
-    /// Returns an array of actions that are visible in the product form options CTA section.
-    func optionsCTASectionActions() -> [ProductFormEditAction] {
-        []
-    }
-
     /// Returns an array of actions that are visible in the product form bottom sheet.
     func bottomSheetActions() -> [ProductFormBottomSheetAction] {
         guard editable else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -40,8 +40,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
 private extension DefaultProductFormTableViewModel {
     mutating func configureSections(product: ProductFormDataModel, actionsFactory: ProductFormActionsFactoryProtocol) {
         sections = [.primaryFields(rows: primaryFieldRows(product: product, actions: actionsFactory.primarySectionActions())),
-                    .settings(rows: settingsRows(productModel: product, actions: actionsFactory.settingsSectionActions())),
-                    .optionsCTA(rows: optionsCTARows(product: product, actions: actionsFactory.optionsCTASectionActions()))]
+                    .settings(rows: settingsRows(productModel: product, actions: actionsFactory.settingsSectionActions()))]
             .filter { $0.isNotEmpty }
     }
 
@@ -155,17 +154,6 @@ private extension DefaultProductFormTableViewModel {
             }
         }
     }
-
-    func optionsCTARows(product: ProductFormDataModel, actions: [ProductFormEditAction]) -> [ProductFormSection.OptionsCTARow] {
-        return actions.map { action in
-            switch action {
-            case .addOptions:
-                return .addOptions
-            default:
-                fatalError("Unexpected action in the options CTA section: \(action)")
-            }
-        }
-    }
 }
 
 private extension DefaultProductFormTableViewModel {
@@ -275,15 +263,14 @@ private extension DefaultProductFormTableViewModel {
         let title = Localization.productTypeTitle
 
         let details: String
-        let hideDownloadableProductType = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
         switch product.productType {
         case .simple:
-            switch (product.downloadable, product.virtual, hideDownloadableProductType) {
-            case (true, _, false):
+            switch (product.downloadable, product.virtual) {
+            case (true, _):
                 details = Localization.downloadableProductType
-            case (_, true, _):
+            case (_, true):
                 details = Localization.virtualProductType
-            case (_, false, _):
+            case (_, false):
                 details = Localization.physicalProductType
             }
         case .custom(let customProductType):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -9,9 +9,6 @@ extension ProductFormSection {
         case .settings(let rows):
             let row = rows[rowIndex]
             return row.reuseIdentifier
-        case .optionsCTA(let rows):
-            let row = rows[rowIndex]
-            return row.reuseIdentifier
         }
     }
 }
@@ -122,26 +119,6 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
             return ImageAndTitleAndTextTableViewCell.self
         case .reviews:
             return ProductReviewsTableViewCell.self
-        }
-    }
-}
-
-extension ProductFormSection.OptionsCTARow: ReusableTableRow {
-    var cellTypes: [UITableViewCell.Type] {
-        switch self {
-        case .addOptions:
-            return [cellType]
-        }
-    }
-
-    var reuseIdentifier: String {
-        return cellType.reuseIdentifier
-    }
-
-    private var cellType: UITableViewCell.Type {
-        switch self {
-        case .addOptions:
-            return BasicTableViewCell.self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -57,8 +57,6 @@ extension ProductFormTableViewDataSource: UITableViewDataSource {
             return rows.count
         case .settings(let rows):
             return rows.count
-        case .optionsCTA(let rows):
-            return rows.count
         }
     }
 
@@ -76,22 +74,8 @@ private extension ProductFormTableViewDataSource {
         switch section {
         case .primaryFields(let rows):
             configureCellInPrimaryFieldsSection(cell, row: rows[indexPath.row])
-            // show full-width separator for last cell in section
-            if indexPath.row == rows.count - 1 {
-                cell.showSeparator(inset: .zero)
-            }
         case .settings(let rows):
             configureCellInSettingsFieldsSection(cell, row: rows[indexPath.row])
-            // show full-width separator for last cell in section
-            if indexPath.row == rows.count - 1 {
-                cell.showSeparator(inset: .zero)
-            }
-        case .optionsCTA(let rows):
-            configureCellInOptionsCTASection(cell, row: rows[indexPath.row])
-            // show full-width separator for last cell in section
-            if indexPath.row == rows.count - 1 {
-                cell.showSeparator(inset: .zero)
-            }
         }
     }
 }
@@ -319,29 +303,5 @@ private extension ProductFormTableViewDataSource {
                                 numberOfLinesForTitle: 0,
                                 isActionable: false,
                                 showsSeparator: false))
-    }
-}
-
-
-// MARK: Configure rows in Options CTA Section
-//
-private extension ProductFormTableViewDataSource {
-    func configureCellInOptionsCTASection(_ cell: UITableViewCell, row: ProductFormSection.OptionsCTARow) {
-        switch row {
-        case .addOptions:
-            configureAddOptions(cell: cell)
-        }
-    }
-
-    func configureAddOptions(cell: UITableViewCell) {
-        guard let cell = cell as? BasicTableViewCell else {
-            fatalError("Unexpected cell type \(cell) for Add Options row")
-        }
-
-        cell.accessoryType = .none
-        cell.textLabel?.text = NSLocalizedString("Add Options",
-                                                 comment: "Title of the CTA button at the bottom of the product form to add more product details.")
-
-        cell.textLabel?.applyActionableStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -4,15 +4,12 @@ import Yosemite
 enum ProductFormSection: Equatable {
     case primaryFields(rows: [PrimaryFieldRow])
     case settings(rows: [SettingsRow])
-    case optionsCTA(rows: [OptionsCTARow])
 
     var isNotEmpty: Bool {
         switch self {
         case .primaryFields(let rows):
             return rows.isNotEmpty
         case .settings(let rows):
-            return rows.isNotEmpty
-        case .optionsCTA(let rows):
             return rows.isNotEmpty
         }
     }
@@ -98,10 +95,6 @@ enum ProductFormSection: Equatable {
             let title: String?
             let isActionable: Bool
         }
-    }
-
-    enum OptionsCTARow: Equatable {
-        case addOptions
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
@@ -56,18 +56,6 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         XCTAssert(factory.settingsSectionActions().contains(.inventorySettings(editable: false)))
     }
 
-    func test_read_only_simple_product_does_not_contain_add_options_row() {
-        // Given
-        let product = Fixtures.simpleProduct
-        let model = EditableProductModel(product: product)
-
-        // When
-        let factory = ProductFormActionsFactory(product: model, formType: .readonly, isAddOptionsButtonEnabled: true)
-
-        // Then
-        XCTAssertFalse(factory.optionsCTASectionActions().contains(.addOptions))
-    }
-
     // MARK: - Affiliate products
 
     func test_readonly_affiliate_product_form_actions_are_all_not_editable() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -164,59 +164,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func test_view_model_for_simple_product_with_downloadable_files_action_not_setting_based_and_has_no_files() {
-        // Arrange
-        let product = Fixtures.virtualSimpleProduct
-        let model = EditableProductModel(product: product)
-
-        // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isDownloadableFilesSettingBased: false)
-
-        // Assert
-        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
-        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
-
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
-                                                                       .reviews,
-                                                                       .inventorySettings(editable: true),
-                                                                       .categories(editable: true),
-                                                                       .tags(editable: true),
-                                                                       .shortDescription(editable: true),
-                                                                       .linkedProducts(editable: true),
-                                                                       .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
-
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
-        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
-    }
-
-    func test_view_model_for_simple_product_with_downloadable_files_action_not_setting_based_and_has_files() {
-        // Arrange
-        let product = Fixtures.virtualSimpleProduct.copy(downloadable: true, downloads: [.fake()])
-        let model = EditableProductModel(product: product)
-
-        // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isDownloadableFilesSettingBased: false)
-
-        // Assert
-        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
-        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
-
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
-                                                                       .reviews,
-                                                                       .inventorySettings(editable: true),
-                                                                       .categories(editable: true),
-                                                                       .tags(editable: true),
-                                                                       .downloadableFiles(editable: true),
-                                                                       .shortDescription(editable: true),
-                                                                       .linkedProducts(editable: true),
-                                                                       .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
-
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
-        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
-    }
-
     func testViewModelForVirtualSimpleProduct() {
         // Arrange
         let product = Fixtures.virtualSimpleProduct
@@ -519,89 +466,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Then
         let containsAttributeAction = factory.settingsSectionActions().contains(ProductFormEditAction.attributes(editable: true))
         XCTAssertTrue(containsAttributeAction)
-    }
-
-    func test_settings_actions_hides_empty_reviews_when_feature_is_enabled() {
-        // Given
-        let product = Fixtures.physicalSimpleProductWithoutImages
-        let model = EditableProductModel(product: product)
-
-        // When
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isEmptyReviewsOptionHidden: true)
-
-        // Then
-        XCTAssertFalse(factory.settingsSectionActions().contains(.reviews))
-        XCTAssertTrue(factory.bottomSheetActions().contains(.editReviews))
-    }
-
-    func test_bottom_sheet_actions_shows_variation_option_when_feature_is_enabled() {
-        // Given
-        let product = Fixtures.physicalSimpleProductWithoutImages
-        let model = EditableProductModel(product: product)
-
-        // When
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: true)
-
-        // Then
-        XCTAssertFalse(factory.settingsSectionActions().contains(.convertToVariable))
-        XCTAssertTrue(factory.bottomSheetActions().contains(.convertToVariable))
-    }
-
-    func test_settings_actions_does_not_contain_product_type_when_it_is_disabled() {
-        // Given
-        let product = Fixtures.physicalSimpleProductWithoutImages
-        let model = EditableProductModel(product: product)
-
-        // When
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isProductTypeActionEnabled: false)
-
-        // Then
-        XCTAssertFalse(factory.settingsSectionActions().contains(.productType(editable: true)))
-    }
-
-    func test_settings_actions_contain_even_empty_categories_when_it_is_enabled() {
-        // Given
-        let product = Product.fake()
-        let model = EditableProductModel(product: product)
-
-        // When
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isCategoriesActionAlwaysEnabled: true)
-
-        // Then
-        XCTAssertFalse(product.categories.isNotEmpty)
-        XCTAssertTrue(factory.settingsSectionActions().contains(.categories(editable: true)))
-    }
-
-    func test_options_CTA_actions_for_simple_product_contain_add_options_when_it_is_enabled() {
-        // Given
-        let product = Fixtures.physicalSimpleProductWithoutImages
-        let model = EditableProductModel(product: product)
-
-        // When
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isAddOptionsButtonEnabled: true)
-
-        // Then
-        XCTAssertTrue(factory.optionsCTASectionActions().contains(.addOptions))
-    }
-
-    func test_options_CTA_actions_for_non_simple_products_do_not_contain_add_options_when_it_is_enabled() {
-        // Given
-        let products = [
-            Fixtures.affiliateProduct,
-            Fixtures.groupedProduct,
-            Fixtures.variableProductWithoutVariations,
-            Fixtures.nonCoreProductWithPrice
-        ]
-
-        products.forEach { product in
-            let model = EditableProductModel(product: product)
-
-            // When
-            let factory = ProductFormActionsFactory(product: model, formType: .edit, isAddOptionsButtonEnabled: true)
-
-            // Then
-            XCTAssertFalse(factory.optionsCTASectionActions().contains(.addOptions))
-        }
     }
 
     func test_view_model_for_bundle_product_with_feature_flag_disabled() {
@@ -934,12 +798,6 @@ private extension ProductFormActionsFactoryTests {
                                    formType: ProductFormType,
                                    addOnsFeatureEnabled: Bool = false,
                                    isLinkedProductsPromoEnabled: Bool = false,
-                                   isAddOptionsButtonEnabled: Bool = false,
-                                   isConvertToVariableOptionEnabled: Bool = false,
-                                   isEmptyReviewsOptionHidden: Bool = false,
-                                   isProductTypeActionEnabled: Bool = true,
-                                   isCategoriesActionAlwaysEnabled: Bool = false,
-                                   isDownloadableFilesSettingBased: Bool = true,
                                    isBundledProductsEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
                                    isSubscriptionProductsEnabled: Bool = false,
@@ -949,12 +807,6 @@ private extension ProductFormActionsFactoryTests {
                                       formType: formType,
                                       addOnsFeatureEnabled: addOnsFeatureEnabled,
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
-                                      isAddOptionsButtonEnabled: isAddOptionsButtonEnabled,
-                                      isConvertToVariableOptionEnabled: isConvertToVariableOptionEnabled,
-                                      isEmptyReviewsOptionHidden: isEmptyReviewsOptionHidden,
-                                      isProductTypeActionEnabled: isProductTypeActionEnabled,
-                                      isCategoriesActionAlwaysEnabled: isCategoriesActionAlwaysEnabled,
-                                      isDownloadableFilesSettingBased: isDownloadableFilesSettingBased,
                                       isBundledProductsEnabled: isBundledProductsEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       isSubscriptionProductsEnabled: isSubscriptionProductsEnabled,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -333,32 +333,6 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertEqual(actionButtons, [.save, .more])
     }
 
-    func test_action_buttons_for_new_product_with_simplified_editing_enabled() throws {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
-        let viewModel = createViewModel(product: product, formType: .add, stores: stores, simplifiedProductEditingEnabled: true)
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.save])
-    }
-
-    func test_action_buttons_for_existing_draft_product_and_no_pending_changes_with_simplified_editing_enabled() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product, formType: .edit, stores: stores, simplifiedProductEditingEnabled: true)
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
-    }
-
     func test_action_buttons_for_existing_published_product_and_pending_changes() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
@@ -632,37 +606,13 @@ final class ProductFormViewModelTests: XCTestCase {
     func test_updateDownloadableFiles_does_not_change_downloadable_when_not_simplifiedProductEditingEnabled() {
         // Given
         let product = Product.fake().copy(downloadable: true, downloads: [.fake()])
-        let viewModel = createViewModel(product: product, formType: .edit, simplifiedProductEditingEnabled: false)
+        let viewModel = createViewModel(product: product, formType: .edit)
 
         // When
         viewModel.updateDownloadableFiles(downloadableFiles: [], downloadLimit: 0, downloadExpiry: 0)
 
         // Then
         XCTAssertTrue(viewModel.productModel.downloadable)
-    }
-
-    func test_updateDownloadableFiles_sets_downloadable_to_true_when_downloadable_files_added_and_simplifiedProductEditingEnabled() {
-        // Given
-        let product = Product.fake().copy(downloadable: false, downloads: [])
-        let viewModel = createViewModel(product: product, formType: .edit, simplifiedProductEditingEnabled: true)
-
-        // When
-        viewModel.updateDownloadableFiles(downloadableFiles: [.fake()], downloadLimit: 0, downloadExpiry: 0)
-
-        // Then
-        XCTAssertTrue(viewModel.productModel.downloadable)
-    }
-
-    func test_updateDownloadableFiles_sets_downloadable_to_false_when_downloadable_files_removed_and_simplifiedProductEditingEnabled() {
-        // Given
-        let product = Product.fake().copy(downloadable: false, downloads: [.fake()])
-        let viewModel = createViewModel(product: product, formType: .edit, simplifiedProductEditingEnabled: true)
-
-        // When
-        viewModel.updateDownloadableFiles(downloadableFiles: [], downloadLimit: 0, downloadExpiry: 0)
-
-        // Then
-        XCTAssertFalse(viewModel.productModel.downloadable)
     }
 }
 
@@ -670,15 +620,13 @@ private extension ProductFormViewModelTests {
     func createViewModel(product: Product,
                          formType: ProductFormType,
                          stores: StoresManager = ServiceLocator.stores,
-                         analytics: Analytics = ServiceLocator.analytics,
-                         simplifiedProductEditingEnabled: Bool = false) -> ProductFormViewModel {
+                         analytics: Analytics = ServiceLocator.analytics) -> ProductFormViewModel {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
                                     formType: formType,
                                     productImageActionHandler: productImageActionHandler,
                                     stores: stores,
-                                    analytics: analytics,
-                                    simplifiedProductEditingEnabled: simplifiedProductEditingEnabled)
+                                    analytics: analytics)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9519
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We're removing the unsuccessful Simplify Product Editing (SPE) experiment from the app. To make it more reasonable for code review, this is divided into three PRs:

* #9600
* #9601
* #9602 (this PR)

The experiment has been remotely disabled already, so there should be no visible change in behavior from `trunk`.

### Changes

* Removes the SPE feature flag completely.
* Removes the visual changes to the product details screen (in `ProductFormViewController`).
* Removes the changes to product type labels (e.g. `Virtual product`, `Physical product`).
* Removes the "Add Options" row/section in `DefaultProductFormTableViewModel`.
* Reverts the changes to the actions available in product details:
   * Removes the bottom sheet action to convert a simple product to a variable product.
   * Shows the Downloadable Files action only if a product is downloadable.
   * Always shows the Reviews row (even if the product has no reviews).
   * Categories row is visible only if a product has categories; otherwise it is in the "Add more details" bottom sheet.
   * Always shows the product type row.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Products tab.
3. Select or add a product to open the product details.
4. Confirm the expected rows are visible, as outlined above, and other expected rows appear in the "Add more details" bottom sheet.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
New product details|Existing product details|Add more details
-|-|-
![Simulator Screenshot - iPhone 14 Pro - 2023-05-02 at 16 08 53](https://user-images.githubusercontent.com/8658164/235709015-78dc9b1b-2d01-41a0-92d2-1e01322a72fd.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-02 at 16 10 00](https://user-images.githubusercontent.com/8658164/235708620-cff0f629-0d5c-436a-9c98-aee05d58cad9.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-02 at 16 10 03](https://user-images.githubusercontent.com/8658164/235708608-f76be4ec-a78b-4b69-af83-55d9fd32b7b9.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
