### PR TITLE
[Gift Cards] Improve formatting for order item attributes in order details

### DIFF
--- a/Networking/Networking/Model/OrderFeeLine.swift
+++ b/Networking/Networking/Model/OrderFeeLine.swift
@@ -38,6 +38,29 @@ public struct OrderFeeLine: Equatable, Codable, GeneratedFakeable, GeneratedCopi
         self.taxes = taxes
         self.attributes = attributes
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let feeID = try container.decode(Int64.self, forKey: .feeID)
+        let name = try container.decode(String.self, forKey: .name)
+        let taxClass = try container.decode(String.self, forKey: .taxClass)
+        let taxStatus = try container.decode(OrderFeeTaxStatus.self, forKey: .taxStatus)
+        let total = try container.decode(String.self, forKey: .total)
+        let totalTax = try container.decode(String.self, forKey: .totalTax)
+        let taxes = try container.decode([OrderItemTax].self, forKey: .taxes)
+
+        // Use failsafe decoding to discard any attributes with non-string values (currently not supported).
+        let attributes = container.failsafeDecodeIfPresent(lossyList: [OrderItemAttribute].self, forKey: .attributes)
+
+        self.init(feeID: feeID,
+                  name: name,
+                  taxClass: taxClass,
+                  taxStatus: taxStatus,
+                  total: total,
+                  totalTax: totalTax,
+                  taxes: taxes,
+                  attributes: attributes)
+    }
 }
 
 // MARK: Codable

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -88,8 +88,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         let total = try container.decode(String.self, forKey: .total)
         let totalTax = try container.decode(String.self, forKey: .totalTax)
 
-        // Do not throw errors in case new metadata is introduced with a different format
-        let allAttributes = (try? container.decodeIfPresent([OrderItemAttribute].self, forKey: .attributes)) ?? []
+        // Use failsafe decoding to discard any attributes with non-string values (currently not supported).
+        let allAttributes = container.failsafeDecodeIfPresent(lossyList: [OrderItemAttribute].self, forKey: .attributes)
         attributes = allAttributes.filter { !$0.name.hasPrefix("_") } // Exclude private items (marked with an underscore)
 
         // initialize the struct

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -24,7 +24,7 @@ public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakea
 
         /// Some extensions send the `value` field with non-string format.
         /// We don't support those, but we also don't want the whole decoding to fail.
-        let value = container.failsafeDecodeIfPresent(String.self, forKey: .value) ?? ""
+        let value = container.failsafeDecodeIfPresent(String.self, forKey: .value)?.strippedHTML ?? ""
 
         // initialize the struct
         self.init(metaID: metaID, name: name, value: value)

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -1,9 +1,13 @@
 import Codegen
 
 /// Represents an attribute of an `OrderItem` in its `attributes` property.
-/// Currently, the use case is
+///
+/// Currently, the use case is:
 /// 1. When an order item is a variation and the attributes are its variation attributes.
 /// 2. Product Add-Ons are stored as attributes.
+///
+/// Only attributes with `String` values are supported.
+///
 public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakeable, GeneratedCopiable {
     public let metaID: Int64
     public let name: String
@@ -21,10 +25,7 @@ public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakea
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let metaID = try container.decode(Int64.self, forKey: .metaID)
         let name = try container.decode(String.self, forKey: .name)
-
-        /// Some extensions send the `value` field with non-string format.
-        /// We don't support those, but we also don't want the whole decoding to fail.
-        let value = container.failsafeDecodeIfPresent(String.self, forKey: .value)?.strippedHTML ?? ""
+        let value = try container.decodeIfPresent(String.self, forKey: .value)?.strippedHTML ?? ""
 
         // initialize the struct
         self.init(metaID: metaID, name: name, value: value)

--- a/Networking/Networking/Model/OrderTaxLine.swift
+++ b/Networking/Networking/Model/OrderTaxLine.swift
@@ -35,6 +35,31 @@ public struct OrderTaxLine: Decodable, Equatable, GeneratedFakeable, GeneratedCo
         self.ratePercent = ratePercent
         self.attributes = attributes
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let taxID = try container.decode(Int64.self, forKey: .taxID)
+        let rateCode = try container.decode(String.self, forKey: .rateCode)
+        let rateID = try container.decode(Int64.self, forKey: .rateID)
+        let label = try container.decode(String.self, forKey: .label)
+        let isCompoundTaxRate = try container.decode(Bool.self, forKey: .isCompoundTaxRate)
+        let totalTax = try container.decode(String.self, forKey: .totalTax)
+        let totalShippingTax = try container.decode(String.self, forKey: .totalShippingTax)
+        let ratePercent = try container.decode(Double.self, forKey: .ratePercent)
+
+        // Use failsafe decoding to discard any attributes with non-string values (currently not supported).
+        let attributes = container.failsafeDecodeIfPresent(lossyList: [OrderItemAttribute].self, forKey: .attributes)
+
+        self.init(taxID: taxID,
+                  rateCode: rateCode,
+                  rateID: rateID,
+                  label: label,
+                  isCompoundTaxRate: isCompoundTaxRate,
+                  totalTax: totalTax,
+                  totalShippingTax: totalShippingTax,
+                  ratePercent: ratePercent,
+                  attributes: attributes)
+    }
 }
 
 /// Defines all of the OrderTaxLine's CodingKeys.

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -277,7 +277,8 @@ final class OrderMapperTests: XCTestCase {
         // Attributes with `_` prefix in the name are skipped.
         let expectedAttributes: [OrderItemAttribute] = [
             .init(metaID: 6377, name: "Color", value: "Orange"),
-            .init(metaID: 6378, name: "Brand", value: "Woo")
+            .init(metaID: 6378, name: "Brand", value: "Woo"),
+            .init(metaID: 6743, name: "Amount", value: "$22.00")
         ]
         XCTAssertEqual(variationLineItem.attributes, expectedAttributes)
         // `parent_name` is used instead of `name` in the API line item response.

--- a/Networking/NetworkingTests/Responses/order-with-faulty-attributes.json
+++ b/Networking/NetworkingTests/Responses/order-with-faulty-attributes.json
@@ -54,7 +54,7 @@
               }
             },
             "id" : 3666,
-            "key" : "_measurement_data",
+            "key" : "measurement_data",
             "value" : {
               "_measurement_needed" : 2.2999999999999998,
               "_measurement_needed_unit" : "kg",
@@ -63,7 +63,7 @@
                 "unit" : "kg"
               }
             },
-            "display_key" : "_measurement_data"
+            "display_key" : "measurement_data"
           }
         ],
         "parent_name" : null,

--- a/Networking/NetworkingTests/Responses/order-with-line-item-attributes.json
+++ b/Networking/NetworkingTests/Responses/order-with-line-item-attributes.json
@@ -102,6 +102,13 @@
                         "value": "1",
                         "display_key": "_reduced_stock",
                         "display_value": "1"
+                    },
+                    {
+                        "id": 6743,
+                        "key": "wc_gc_giftcard_amount",
+                        "value": "22",
+                        "display_key": "Amount",
+                        "display_value": "&#36;22.00"
                     }
                 ],
                 "sku": "pen",

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.5
 -----
 [Internal] Products: Simplify Product Editing experiment is removed; there should be no changes to the existing product creation/editing behavior. [https://github.com/woocommerce/woocommerce-ios/pull/9602]
+- [*] Orders: Parses HTML-encoded characters and removes extraneous, non-attribute meta data from the list of attributes for an item in an order. [https://github.com/woocommerce/woocommerce-ios/pull/9603]
 
 13.4
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8961
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This improves how order item attributes are displayed in order details:

- Any HTML-encoded characters are parsed and displayed correctly, e.g. the `$` sign.
- Removes extra, invalid order item meta from the list of attributes, e.g. `Any wc-gc-giftcards`.

### Changes

* Updates `OrderItemAttribute` to parse any HTML in the `value`.
* Discards extra order item meta from the list of attributes:
   * Updates `OrderItemAttribute` to stop using failsafe decoding for the `value`. This led to empty string values for any order item meta with values other than strings (e.g. meta added by the Gift Card extension). In the UI, this is displayed as an attribute with value `Any [key]` which doesn't make sense for non-attribute item meta such as `wc-gc-giftcards`. Now, we let the decoding fail for specific `OrderItemAttributes` in those cases.
   * Instead, this PR adds a new failsafe decoding method `failsafeDecodeIfPresent(lossyList:forKey:)` to `KeyedDecodingContainer+Woo.swift`. In this method, which takes an array of elements, any elements that can't be decoded are discarded from the list (instead of throwing).
   * Updates `OrderItem` to use the new failsafe decoding for its attributes.
   * Adds explicit decoding to `OrderFeeLine` and `OrderTaxLine`, so we can use the failsafe decoding for their attributes.
* Updates unit tests. The changes to the `order-with-faulty-attributes.json` mock ensures that the test `test_order_line_item_attributes_handle_unexpected_formatted_attributes()` checks that faulty attributes are discarded. (Previously the attribute was filtered out because it had a private meta key, i.e. the key started with an underscore.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. On a store with the Gift Cards extension installed, create an order for a gift card (purchase a gift card on the store or manually create an order for a gift card product in wp-admin).
2. In the app, open the Orders tab.
3. Select the order with a gift card product.
4. Confirm the attributes for the gift card are readable and show the expected details.

You can also confirm that all orders load correctly in the Orders tab, and any order items with other attributes (e.g. product variations or items with add-ons) show the expected list of attributes in order details.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
<img src="https://user-images.githubusercontent.com/18119390/221019091-53ac8cb7-e6a6-435b-9dd1-ed61a205b122.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/235751716-5123ba8f-2156-4143-83d1-c3537fae0e35.png" width="300px">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
