### PR TITLE
[UI Tests] - Add simple payment using cash test

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -170,6 +170,7 @@ struct SimplePaymentsAmount: View {
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)
+            .accessibilityIdentifier(Accessibility.nextButton)
 
             LazyNavigationLink(destination: summaryView(), isActive: $viewModel.navigateToSummary) {
                 EmptyView()
@@ -219,6 +220,10 @@ private extension SimplePaymentsAmount {
         static func amountFontSize(scale: CGFloat) -> CGFloat {
             56 * scale
         }
+    }
+
+    enum Accessibility {
+        static let nextButton = "next-button"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummary.swift
@@ -286,6 +286,7 @@ private struct TakePaymentSection: View {
             })
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
             .padding()
+            .accessibilityIdentifier(SimplePaymentsSummary.Accessibility.takePaymentButton)
 
         }
         .background(Color(.listForeground(modal: false)).ignoresSafeArea())
@@ -300,6 +301,10 @@ private extension SimplePaymentsSummary {
         static let verticalSummarySpacing: CGFloat = 8.0
         static let verticalNoteSpacing: CGFloat = 22.0
         static let noSpacing: CGFloat = 0.0
+    }
+
+    enum Accessibility {
+        static let takePaymentButton = "take-payment-button"
     }
 
     enum Localization {

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -82,7 +82,9 @@ public final class PaymentsScreen: ScreenObject {
 
     @discardableResult
     public func verifyOrderCompletedToastDisplayed() throws -> Self {
-        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Order completed'")).firstMatch.exists)
+        let orderCompletedToast = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Reader'")).firstMatch
+        XCTAssertTrue(orderCompletedToast.exists)
+
         return self
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -10,6 +10,22 @@ public final class PaymentsScreen: ScreenObject {
         $0.cells["card-reader-manuals"]
     }
 
+    private let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["next-button"]
+    }
+
+    private let takePaymentButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["take-payment-button"]
+    }
+
+    private let cashPaymentButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["payment-methods-view-cash-row"]
+    }
+
+    private let markAsPaidButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Mark as Paid"]
+    }
+
     private let learnMoreButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Learn more about In‑Person Payments"]
     }
@@ -21,6 +37,10 @@ public final class PaymentsScreen: ScreenObject {
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
     private var cardReaderManualsButton: XCUIElement { cardReaderManualsButtonGetter(app) }
     private var learnMoreButton: XCUIElement { learnMoreButtonGetter(app) }
+    private var nextButton: XCUIElement { nextButtonGetter(app) }
+    private var takePaymentButton: XCUIElement { takePaymentButtonGetter(app) }
+    private var cashPaymentButton: XCUIElement { cashPaymentButtonGetter(app) }
+    private var markAsPaidButton: XCUIElement { markAsPaidButtonGetter(app) }
     private var IPPDocumentationHeaderText: XCUIElement { IPPDocumentationHeaderTextGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
@@ -38,6 +58,34 @@ public final class PaymentsScreen: ScreenObject {
 
     public func tapLearnMoreIPPLink() throws -> Self {
         learnMoreButton.tap()
+        return self
+    }
+
+    public func tapCollectPayment() throws -> Self {
+        collectPaymentButton.tap()
+        return self
+    }
+
+    public func enterPaymentAmount() throws -> Self {
+        app.enterText(text: "5")
+        nextButton.tap()
+        return self
+    }
+
+    public func takeCashPayment() throws -> Self {
+        takePaymentButton.waitForIsHittable(timeout: 10)
+        takePaymentButton.tap()
+
+        cashPaymentButton.waitForIsHittable(timeout: 10)
+        cashPaymentButton.tap()
+
+        markAsPaidButton.tap()
+        return self
+    }
+
+    @discardableResult
+    public func verifyOrderCompletedToastDisplayed() throws -> Self {
+        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Order completed'")).firstMatch.exists)
         return self
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -82,7 +82,7 @@ public final class PaymentsScreen: ScreenObject {
 
     @discardableResult
     public func verifyOrderCompletedToastDisplayed() throws -> Self {
-        let orderCompletedToast = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Reader'")).firstMatch
+        let orderCompletedToast = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Order completed'")).firstMatch
         XCTAssertTrue(orderCompletedToast.exists)
 
         return self

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -66,8 +66,8 @@ public final class PaymentsScreen: ScreenObject {
         return self
     }
 
-    public func enterPaymentAmount() throws -> Self {
-        app.enterText(text: "5")
+    public func enterPaymentAmount(_ amount: String) throws -> Self {
+        app.enterText(text: amount)
         nextButton.tap()
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -73,11 +73,8 @@ public final class PaymentsScreen: ScreenObject {
     }
 
     public func takeCashPayment() throws -> Self {
-        takePaymentButton.waitForIsHittable(timeout: 10)
-        takePaymentButton.tap()
-
-        cashPaymentButton.waitForIsHittable(timeout: 10)
-        cashPaymentButton.tap()
+        takePaymentButton.waitAndTap()
+        cashPaymentButton.waitAndTap()
 
         markAsPaidButton.tap()
         return self

--- a/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
+++ b/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
@@ -154,7 +154,10 @@ extension XCUIElement {
         """)
     }
 
-    /// timeout: timeout value, if not specified defaults to 10
+    /**
+     Waits the specified amount of time for the element's isHittable property to be true, and then taps it.
+     - Parameter timeout: timeout value, if not specified defaults to 10
+     */
     public func waitAndTap(timeout: Double = 10) {
         self.waitForIsHittable(timeout: timeout)
         self.tap()

--- a/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
+++ b/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
@@ -153,4 +153,10 @@ extension XCUIElement {
         '\(firstSubstring)' and '\(secondSubstring)' does not appear on label!
         """)
     }
+
+    /// timeout: timeout value, if not specified defaults to 10
+    public func waitAndTap(timeout: Double = 10) {
+        self.waitForIsHittable(timeout: timeout)
+        self.tap()
+    }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1282,6 +1282,10 @@
 		80A643022A010F2100F65C0C /* connection_tokens.json in Resources */ = {isa = PBXBuildFile; fileRef = 80A643012A010F2100F65C0C /* connection_tokens.json */; };
 		80A643042A011A6E00F65C0C /* account_summary.json in Resources */ = {isa = PBXBuildFile; fileRef = 80A643032A011A6E00F65C0C /* account_summary.json */; };
 		80A643062A011A8800F65C0C /* payment_gateways.json in Resources */ = {isa = PBXBuildFile; fileRef = 80A643052A011A8800F65C0C /* payment_gateways.json */; };
+		80A6430A2A02529A00F65C0C /* create_simple_payment.json in Resources */ = {isa = PBXBuildFile; fileRef = 80A643092A02529A00F65C0C /* create_simple_payment.json */; };
+		80A6430C2A02650A00F65C0C /* take_simple_payment.json in Resources */ = {isa = PBXBuildFile; fileRef = 80A6430B2A02650A00F65C0C /* take_simple_payment.json */; };
+		80A6430E2A026D0800F65C0C /* complete_cash_simple_payment.json in Resources */ = {isa = PBXBuildFile; fileRef = 80A6430D2A026D0800F65C0C /* complete_cash_simple_payment.json */; };
+		80A643122A0270F100F65C0C /* orders_complete_simple_payment.json in Resources */ = {isa = PBXBuildFile; fileRef = 80A643112A0270F100F65C0C /* orders_complete_simple_payment.json */; };
 		80AD2CA22782B4EB00A63DE8 /* products_list_1.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AD2CA12782B4EB00A63DE8 /* products_list_1.json */; };
 		80AD2CA427858BAB00A63DE8 /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AD2CA327858BAB00A63DE8 /* StatsTests.swift */; };
 		80AD2CA627859B4400A63DE8 /* reports_leaderboards_stats_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AD2CA527859B4400A63DE8 /* reports_leaderboards_stats_day.json */; };
@@ -3517,6 +3521,10 @@
 		80A643012A010F2100F65C0C /* connection_tokens.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = connection_tokens.json; sourceTree = "<group>"; };
 		80A643032A011A6E00F65C0C /* account_summary.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = account_summary.json; sourceTree = "<group>"; };
 		80A643052A011A8800F65C0C /* payment_gateways.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = payment_gateways.json; sourceTree = "<group>"; };
+		80A643092A02529A00F65C0C /* create_simple_payment.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = create_simple_payment.json; sourceTree = "<group>"; };
+		80A6430B2A02650A00F65C0C /* take_simple_payment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = take_simple_payment.json; sourceTree = "<group>"; };
+		80A6430D2A026D0800F65C0C /* complete_cash_simple_payment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = complete_cash_simple_payment.json; sourceTree = "<group>"; };
+		80A643112A0270F100F65C0C /* orders_complete_simple_payment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_complete_simple_payment.json; sourceTree = "<group>"; };
 		80AD2CA12782B4EB00A63DE8 /* products_list_1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_list_1.json; sourceTree = "<group>"; };
 		80AD2CA327858BAB00A63DE8 /* StatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
 		80AD2CA527859B4400A63DE8 /* reports_leaderboards_stats_day.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reports_leaderboards_stats_day.json; sourceTree = "<group>"; };
@@ -7494,9 +7502,12 @@
 			isa = PBXGroup;
 			children = (
 				800A5B982755BADA009DE2CD /* accounts.json */,
-				80A643012A010F2100F65C0C /* connection_tokens.json */,
 				80A643032A011A6E00F65C0C /* account_summary.json */,
+				80A643012A010F2100F65C0C /* connection_tokens.json */,
 				80A643052A011A8800F65C0C /* payment_gateways.json */,
+				80A643092A02529A00F65C0C /* create_simple_payment.json */,
+				80A6430B2A02650A00F65C0C /* take_simple_payment.json */,
+				80A6430D2A026D0800F65C0C /* complete_cash_simple_payment.json */,
 			);
 			path = payments;
 			sourceTree = "<group>";
@@ -8751,6 +8762,7 @@
 				CCF27B39280EF98F00B755E1 /* orders_3337.json */,
 				800A5B9A2755E0B9009DE2CD /* orders_any.json */,
 				800A5B9F27562EE5009DE2CD /* orders_processing.json */,
+				80A643112A0270F100F65C0C /* orders_complete_simple_payment.json */,
 			);
 			path = orders;
 			sourceTree = "<group>";
@@ -10714,6 +10726,7 @@
 				C0A37CB8282957EB00E0826D /* orders_3337_add_customer_details.json in Resources */,
 				800A5BBE27586AEF009DE2CD /* products_reviews_6163.json in Resources */,
 				FE6BCDFC26A9D0E700D96FE2 /* users_me.json in Resources */,
+				80A643122A0270F100F65C0C /* orders_complete_simple_payment.json in Resources */,
 				80A643042A011A6E00F65C0C /* account_summary.json in Resources */,
 				80CC810329E673AB00CA1687 /* products_add_new_physical_2129.json in Resources */,
 				CCF27B3A280EF98F00B755E1 /* orders_3337.json in Resources */,
@@ -10727,6 +10740,7 @@
 				800A5BA6275719E5009DE2CD /* orders_2201_refunds.json in Resources */,
 				80A643062A011A8800F65C0C /* payment_gateways.json in Resources */,
 				800A5BA827586126009DE2CD /* products_2129.json in Resources */,
+				80A6430A2A02529A00F65C0C /* create_simple_payment.json in Resources */,
 				CC2A08022862400100510C4B /* orders_3337_add_shipping.json in Resources */,
 				800A5BC027586AFC009DE2CD /* products_reviews_6164.json in Resources */,
 				800A5BC5275889ED009DE2CD /* reports_revenue_stats_day.json in Resources */,
@@ -10735,11 +10749,13 @@
 				800A5BC8275889ED009DE2CD /* reports_revenue_stats_year.json in Resources */,
 				CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */,
 				800A5BBC27586AE1009DE2CD /* products_reviews_6162.json in Resources */,
+				80A6430E2A026D0800F65C0C /* complete_cash_simple_payment.json in Resources */,
 				80A643022A010F2100F65C0C /* connection_tokens.json in Resources */,
 				800A5B6127548F53009DE2CD /* sites_posts_password.json in Resources */,
 				800A5BB427586A0E009DE2CD /* products_reviews_6155.json in Resources */,
 				800A5B5F27548F31009DE2CD /* site_info_wordpress_com.json in Resources */,
 				80B8D3452785A08900FE6E6B /* products_list_2.json in Resources */,
+				80A6430C2A02650A00F65C0C /* take_simple_payment.json in Resources */,
 				800A5BBA27586AC8009DE2CD /* products_reviews_6161.json in Resources */,
 				80AD2CA827859B7D00A63DE8 /* reports_leaderboards_stats_week.json in Resources */,
 			);

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_complete_simple_payment.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_complete_simple_payment.json
@@ -1,0 +1,115 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "/wc/v3/orders/630&_method=get"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 630,
+                "parent_id": 0,
+                "status": "completed",
+                "currency": "USD",
+                "version": "7.6.1",
+                "prices_include_tax": false,
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "discount_total": "0.00",
+                "discount_tax": "0.00",
+                "shipping_total": "0.00",
+                "shipping_tax": "0.00",
+                "cart_tax": "0.00",
+                "total": "5.00",
+                "total_tax": "0.00",
+                "customer_id": 0,
+                "order_key": "wc_order_xxx",
+                "billing": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "email": "",
+                    "phone": ""
+                },
+                "shipping": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "phone": ""
+                },
+                "payment_method": "",
+                "payment_method_title": "",
+                "transaction_id": "",
+                "customer_ip_address": "",
+                "customer_user_agent": "",
+                "created_via": "rest-api",
+                "customer_note": "",
+                "date_completed": "{{now format=customformat}}",
+                "date_paid": "{{now format=customformat}}",
+                "cart_hash": "",
+                "number": "630",
+                "meta_data": [],
+                "line_items": [],
+                "tax_lines": [],
+                "shipping_lines": [],
+                "fee_lines": [
+                    {
+                        "id": 475,
+                        "name": "Simple Payments",
+                        "tax_class": "",
+                        "tax_status": "taxable",
+                        "amount": "",
+                        "total": "5.00",
+                        "total_tax": "0.00",
+                        "taxes": [],
+                        "meta_data": []
+                    }
+                ],
+                "coupon_lines": [],
+                "refunds": [],
+                "payment_url": "https://automatticwidgets.wpcomstaging.com/checkout/order-pay/630/?pay_for_order=true&key=wc_order_xxx",
+                "is_editable": false,
+                "needs_payment": false,
+                "needs_processing": false,
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "date_completed_gmt": "{{now format=customformat}}",
+                "date_paid_gmt": "{{now format=customformat}}",
+                "gift_cards": [],
+                "currency_symbol": "$",
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders/630"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/payments/complete_cash_simple_payment.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/payments/complete_cash_simple_payment.json
@@ -1,0 +1,115 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/orders/630%26_method%3Dpost"
+            },
+            {
+                "contains": "%7B%22status%22%3A%22completed"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 630,
+                "parent_id": 0,
+                "status": "completed",
+                "currency": "USD",
+                "version": "7.6.1",
+                "prices_include_tax": false,
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "discount_total": "0.00",
+                "discount_tax": "0.00",
+                "shipping_total": "0.00",
+                "shipping_tax": "0.00",
+                "cart_tax": "0.00",
+                "total": "5.00",
+                "total_tax": "0.00",
+                "customer_id": 0,
+                "order_key": "wc_order_xxx",
+                "billing": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "email": "",
+                    "phone": ""
+                },
+                "shipping": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "phone": ""
+                },
+                "payment_method": "",
+                "payment_method_title": "",
+                "transaction_id": "",
+                "customer_ip_address": "",
+                "customer_user_agent": "",
+                "created_via": "rest-api",
+                "customer_note": "",
+                "date_completed": "{{now format=customformat}}",
+                "date_paid": "{{now format=customformat}}",
+                "cart_hash": "",
+                "number": "630",
+                "meta_data": [],
+                "line_items": [],
+                "tax_lines": [],
+                "shipping_lines": [],
+                "fee_lines": [
+                    {
+                        "id": 475,
+                        "name": "Simple Payments",
+                        "tax_class": "",
+                        "tax_status": "taxable",
+                        "amount": "",
+                        "total": "5.00",
+                        "total_tax": "0.00",
+                        "taxes": [],
+                        "meta_data": []
+                    }
+                ],
+                "coupon_lines": [],
+                "refunds": [],
+                "payment_url": "https://automatticwidgets.wpcomstaging.com/checkout/order-pay/630/?pay_for_order=true&key=wc_order_xxx",
+                "is_editable": false,
+                "needs_payment": false,
+                "needs_processing": false,
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "date_completed_gmt": "{{now format=customformat}}",
+                "date_paid_gmt": "{{now format=customformat}}",
+                "gift_cards": [],
+                "currency_symbol": "$",
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders/630"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/payments/create_simple_payment.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/payments/create_simple_payment.json
@@ -1,0 +1,115 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/orders%26_method%3Dpost"
+            },
+            {
+                "contains": "%22Simple%20Payments%22"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 630,
+                "parent_id": 0,
+                "status": "auto-draft",
+                "currency": "USD",
+                "version": "7.6.1",
+                "prices_include_tax": false,
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "discount_total": "0.00",
+                "discount_tax": "0.00",
+                "shipping_total": "0.00",
+                "shipping_tax": "0.00",
+                "cart_tax": "0.00",
+                "total": "5.00",
+                "total_tax": "0.00",
+                "customer_id": 0,
+                "order_key": "wc_order_xxx",
+                "billing": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "email": "",
+                    "phone": ""
+                },
+                "shipping": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "phone": ""
+                },
+                "payment_method": "",
+                "payment_method_title": "",
+                "transaction_id": "",
+                "customer_ip_address": "",
+                "customer_user_agent": "",
+                "created_via": "rest-api",
+                "customer_note": "",
+                "date_completed": null,
+                "date_paid": null,
+                "cart_hash": "",
+                "number": "630",
+                "meta_data": [],
+                "line_items": [],
+                "tax_lines": [],
+                "shipping_lines": [],
+                "fee_lines": [
+                    {
+                        "id": 475,
+                        "name": "Simple Payments",
+                        "tax_class": "",
+                        "tax_status": "taxable",
+                        "amount": "",
+                        "total": "5.00",
+                        "total_tax": "0.00",
+                        "taxes": [],
+                        "meta_data": []
+                    }
+                ],
+                "coupon_lines": [],
+                "refunds": [],
+                "payment_url": "https://automatticwidgets.wpcomstaging.com/checkout/order-pay/630/?pay_for_order=true&key=wc_order_xxx",
+                "is_editable": true,
+                "needs_payment": false,
+                "needs_processing": false,
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "date_completed_gmt": null,
+                "date_paid_gmt": null,
+                "gift_cards": [],
+                "currency_symbol": "$",
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders/630"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/payments/take_simple_payment.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/payments/take_simple_payment.json
@@ -1,0 +1,115 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/orders/630%26_method%3Dpost"
+            },
+            {
+                "contains": "%22Simple%20Payments%22"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 630,
+                "parent_id": 0,
+                "status": "pending",
+                "currency": "USD",
+                "version": "7.6.1",
+                "prices_include_tax": false,
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "discount_total": "0.00",
+                "discount_tax": "0.00",
+                "shipping_total": "0.00",
+                "shipping_tax": "0.00",
+                "cart_tax": "0.00",
+                "total": "5.00",
+                "total_tax": "0.00",
+                "customer_id": 0,
+                "order_key": "wc_order_xxx",
+                "billing": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "email": "",
+                    "phone": ""
+                },
+                "shipping": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "phone": ""
+                },
+                "payment_method": "",
+                "payment_method_title": "",
+                "transaction_id": "",
+                "customer_ip_address": "",
+                "customer_user_agent": "",
+                "created_via": "rest-api",
+                "customer_note": "",
+                "date_completed": null,
+                "date_paid": null,
+                "cart_hash": "",
+                "number": "630",
+                "meta_data": [],
+                "line_items": [],
+                "tax_lines": [],
+                "shipping_lines": [],
+                "fee_lines": [
+                    {
+                        "id": 475,
+                        "name": "Simple Payments",
+                        "tax_class": "",
+                        "tax_status": "taxable",
+                        "amount": "",
+                        "total": "5.00",
+                        "total_tax": "0.00",
+                        "taxes": [],
+                        "meta_data": []
+                    }
+                ],
+                "coupon_lines": [],
+                "refunds": [],
+                "payment_url": "https://automatticwidgets.wpcomstaging.com/checkout/order-pay/630/?pay_for_order=true&key=wc_order_xxx",
+                "is_editable": true,
+                "needs_payment": false,
+                "needs_processing": false,
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "date_completed_gmt": null,
+                "date_paid_gmt": null,
+                "gift_cards": [],
+                "currency_symbol": "$",
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders/630"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -25,4 +25,12 @@ final class PaymentsTests: XCTestCase {
         try PaymentsScreen().tapLearnMoreIPPLink()
             .verifyIPPDocumentationLoadedInWebView()
     }
+
+    func test_complete_cash_simple_payment() throws {
+        try PaymentsScreen().tapCollectPayment()
+            .enterPaymentAmount()
+            .takeCashPayment()
+            .verifyOrderCompletedToastDisplayed()
+            .verifyPaymentsScreenLoaded()
+    }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -28,7 +28,7 @@ final class PaymentsTests: XCTestCase {
 
     func test_complete_cash_simple_payment() throws {
         try PaymentsScreen().tapCollectPayment()
-            .enterPaymentAmount()
+            .enterPaymentAmount("5")
             .takeCashPayment()
             .verifyOrderCompletedToastDisplayed()
             .verifyPaymentsScreenLoaded()


### PR DESCRIPTION
## Description
This PR adds a new test, `test_complete_cash_simple_payment()`. The test tests a simple payment flow using cash, and the flow is:
1. Go to Payments screen
2. Collect payment > Enter Amount > Take Payment
3. Select the first payment method, cash and mark the order as complete
4. Validate that the order completed toast is displayed and that test returns back to the main payments screen

The PR also includes 4 new mock files so that no errors are returned on the UI.

## Testing instructions
New test `test_complete_cash_simple_payment()` should work locally and in CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
