### PR TITLE
[Product Bundles] Show product SKU in bundled products list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Payments: Products are removed directly from an order when its count is below one, instead of opening an extra screen to remove it. [https://github.com/woocommerce/woocommerce-ios/pull/9624]
 - [*] Orders: Parses HTML-encoded characters and removes extraneous, non-attribute meta data from the list of attributes for an item in an order. [https://github.com/woocommerce/woocommerce-ios/pull/9603]
 - [*] Products: Adds the component descriptions to the list of components in a composite product (using the Composite Products extension). [https://github.com/woocommerce/woocommerce-ios/pull/9634]
+- [*] Products: Adds the product SKU to the bundled products list in product details, for Bundle products (using the Product Bundles extension). [https://github.com/woocommerce/woocommerce-ios/pull/9626]
 
 13.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -51,7 +51,7 @@ struct BundledProductsList: View {
                             .accessibilityHidden(true)
                             .padding(.leading)
 
-                        TitleAndSubtitleRow(title: bundledProduct.title, subtitle: bundledProduct.stockStatus)
+                        TitleAndSubtitleRow(title: bundledProduct.title, subtitle: bundledProduct.subtitle)
                             .accessibilityElement(children: .combine)
                     }
                     .padding(.horizontal, insets: safeAreaInsets)
@@ -80,9 +80,9 @@ private enum Layout {
 struct BundledProductsList_Previews: PreviewProvider {
 
     static let viewModel = BundledProductsListViewModel(bundledProducts: [
-        .init(id: 1, title: "Beanie with Logo", stockStatus: "In stock", imageURL: nil),
-        .init(id: 2, title: "T-Shirt with Logo", stockStatus: "In stock", imageURL: nil),
-        .init(id: 3, title: "Hoodie with Logo", stockStatus: "Out of stock", imageURL: nil)
+        .init(id: 1, title: "Beanie with Logo", stockStatus: "In stock", sku: "beanie-with-logo", imageURL: nil),
+        .init(id: 2, title: "T-Shirt with Logo", stockStatus: "In stock", sku: "t-shirt-with-logo", imageURL: nil),
+        .init(id: 3, title: "Hoodie with Logo", stockStatus: "Out of stock", sku: nil, imageURL: nil)
     ])
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -18,8 +18,20 @@ final class BundledProductsListViewModel: ObservableObject {
         /// Stock status of the bundled product
         let stockStatus: String
 
+        /// SKU of the bundled product
+        let sku: String?
+
         /// URL of the bundled product's image, if any
         let imageURL: URL?
+
+        /// Subtitle: Stock status and SKU of the bundled product
+        var subtitle: String {
+            guard let sku, sku.isNotEmpty else {
+                return stockStatus
+            }
+            let skuLabel = String.localizedStringWithFormat(Localization.skuFormat, sku)
+            return stockStatus + "\n" + skuLabel
+        }
     }
 
     /// View title
@@ -60,10 +72,12 @@ private extension BundledProductsListViewModel {
     ///
     static func getViewModels(for bundleItems: [ProductBundleItem], with products: [Product], siteID: Int64) -> [BundledProduct] {
         bundleItems.map { bundleItem in
-            BundledProduct(id: bundleItem.bundledItemID,
-                           title: bundleItem.title,
-                           stockStatus: bundleItem.stockStatus.description,
-                           imageURL: products.first(where: { $0.productID == bundleItem.productID })?.imageURL) // URL for bundle item's first image
+            let product = products.first(where: { $0.productID == bundleItem.productID })
+            return BundledProduct(id: bundleItem.bundledItemID,
+                                  title: bundleItem.title,
+                                  stockStatus: bundleItem.stockStatus.description,
+                                  sku: product?.sku,
+                                  imageURL: product?.imageURL) // URL for bundle item's first image
         }
     }
 
@@ -112,5 +126,7 @@ extension BundledProductsListViewModel {
         static let title = NSLocalizedString("Bundled Products", comment: "Title for the bundled products screen")
         static let infoNotice = NSLocalizedString("You can edit bundled products in the web dashboard.",
                                                   comment: "Info notice at the bottom of the bundled products screen")
+        static let skuFormat = NSLocalizedString("SKU: %1$@",
+                                                 comment: "SKU label for a product in the bundled products screen. The variable shows the SKU of the product.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -61,7 +61,7 @@ extension BundledProductsListViewModel {
         let viewModels = BundledProductsListViewModel.getViewModels(for: bundleItems, with: products, siteID: siteID)
         self.init(bundledProducts: viewModels)
 
-        // Re-sync bundled products to get product images if needed
+        // Re-sync bundled products to get product details if needed
         synchronizeBundledProductsIfNeeded(for: bundleItems, siteID: siteID, stores: stores)
     }
 }
@@ -96,15 +96,17 @@ private extension BundledProductsListViewModel {
         return controller.fetchedObjects
     }
 
-    /// Synchronizes the products matching the provided Product Bundle Items, to retrieve their product images
+    /// Synchronizes the products matching the provided Product Bundle Items, to retrieve their product images and/or SKUs
     ///
     func synchronizeBundledProductsIfNeeded(for bundleItems: [ProductBundleItem], siteID: Int64, stores: StoresManager) {
-        // We only need to sync if the bundled products are missing images
-        guard bundledProducts.filter({ $0.imageURL == nil }).isNotEmpty else { return }
+        // We only need to sync if the bundled products are missing images or SKUs
+        guard bundledProducts.filter({ $0.imageURL == nil || $0.sku == nil }).isNotEmpty else {
+            return
+        }
 
         // Sync all bundled products, with the understanding that this should be a small set of products.
-        // That way, if we're performing a sync we'll sync all products, in case any of the stored image URLs have changed.
-        // We can revisit this if needed, to limit the sync to only products that are missing an image URL.
+        // That way, if we're performing a sync we'll sync all products, in case any of the stored image URLs or SKUs have changed.
+        // We can revisit this if needed, to limit the sync to only products that are missing an image URL or SKU.
         let action = ProductAction.retrieveProducts(siteID: siteID, productIDs: bundleItems.map { $0.productID }) { [weak self] result in
             guard let self else { return }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9620
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When using the Product Bundles extension: This adds the product SKU (when it exists) for each product in the bundled products list in product details. Any products without an SKU show only the stock status, as before.

### Changes

* Updates `BundledProductsListViewModel.BundledProduct` to include an SKU and a subtitle with both the stock status and SKU, if available.
* Updates `BundledProductsList` to display the subtitle for each bundled product.
* Re-syncs the products if any of the bundled products are missing an image or SKU (since we get those details from the products).
* Add unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Install and activate the Product Bundles extension on your store.
2. Create at least one Bundle type product, and add some products to the list of bundled products in wp-admin.
3. In the app, open the Products tab.
4. Select the Bundle product to open product details.
5. Select "Bundled products" to open the bundled product list, and confirm that each product shows its stock status and SKU, if it has one.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPhone 14 Pro - 2023-05-03 at 18 08 20](https://user-images.githubusercontent.com/8658164/235989959-752f6578-0405-4313-80b1-7a340ff01a94.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-03 at 18 05 37](https://user-images.githubusercontent.com/8658164/235989971-ae2d122c-eab4-43aa-b3e4-7a7c6725618c.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
