### PR TITLE
[UI Tests] Support switch element for both iOS 16.2 and 16.4

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
@@ -41,10 +41,26 @@ public final class CustomerDetailsScreen: ScreenObject {
     public func enterCustomerDetails(name: String) throws -> UnifiedOrderScreen {
         billingFirstNameField.tap()
         billingFirstNameField.typeText(name)
-        addressToggle.tap()
+        addressToggleSet(to: "1")
         shippingFirstNameField.tap()
         shippingFirstNameField.typeText(name)
         doneButton.tap()
         return try UnifiedOrderScreen()
     }
+
+    @discardableResult
+    func addressToggleSet(to value: String) -> Bool {
+        // If the switch state is not as needed, tap.
+        if addressToggle.value as! String != value {
+            addressToggle.tap()
+        }
+
+        // If the switch state is still not as needed, tap its inner switch, if it's hittable
+        if addressToggle.value as! String != value && addressToggle.switches.firstMatch.isHittable {
+            addressToggle.switches.firstMatch.tap()
+        }
+
+        return addressToggle.value as! String == value
+    }
+
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
@@ -55,7 +55,8 @@ public final class CustomerDetailsScreen: ScreenObject {
             addressToggle.tap()
         }
 
-        // If the switch state is still not as needed, tap its inner switch, if it's hittable
+        // If the switch state is still not as needed, tap its inner switch, if it's hittable.
+        // See https://github.com/woocommerce/woocommerce-ios/pull/9629 for more details.
         if addressToggle.value as! String != value && addressToggle.switches.firstMatch.isHittable {
             addressToggle.switches.firstMatch.tap()
         }


### PR DESCRIPTION
### Why
AFAIK, there's only one switch involved in UI tests, and it's this one:

<img width="394" alt="Screenshot 2023-05-03 at 23 32 58" src="https://user-images.githubusercontent.com/73365754/236043076-2722451e-f1fc-4049-9a89-19f7ac5371e3.png">

This is how it's represented in elements tree:

```
Switch, 0x7f93ff01bf80, {{0.0, 717.7}, {390.0, 45.7}}, identifier: 'order-creation-customer-details-shipping-address-toggle', label: 'Add a different shipping address', value: 0
  StaticText, 0x7f93ff01c0a0, {{16.0, 730.3}, {247.3, 20.3}}, label: 'Add a different shipping address'
  Switch, 0x7f93ff01c1c0, {{325.0, 725.0}, {51.0, 31.0}}, value: 0
```

As can be seen, the switch with `order-creation-customer-details-shipping-address-toggle` identifier (occupying full screen width) contains a child StaticText and a Switch (occupying only the actual switch width). In our tests, the locator for switch relies on the identifier, so it returns the "main" or "parent" switch.

After updating to Xcode 14.3 (and iOS 16.4) locally, the tap on switch stopped working, because in iOS 16.4, XCTest will **tap the centre of the parent switch** (which consists of the StaticText and a Switch), which actually means tapping somewhere in the StaticText:

```
t =    58.99s     Check for interrupting elements affecting "order-creation-customer-details-shipping-address-toggle" Switch
t =    59.12s     Synthesize event
t =    59.17s         Scroll element to visible
t =    59.18s         Find the "order-creation-customer-details-shipping-address-toggle" Switch
t =    59.35s         Computed hit point {195, 485.16668701171875} after scrolling to visible
```

Naturally, such tap did not result in toggle. While for iOS 16.2 (and earlier) it automatically tapped the inner switch itself:

```
t =   158.95s     Check for interrupting elements affecting "order-creation-customer-details-shipping-address-toggle" Switch
t =   159.09s     Synthesize event
t =   159.14s         Scroll element to visible
t =   159.15s         Find the "order-creation-customer-details-shipping-address-toggle" Switch
t =   159.32s         Computed hit point {350.5, 485.16668701171875} after scrolling to visible
```

Since Xcode will be updated on Buildkite to 16.4 eventually, I've added a support for both iOS 16.4 and 16.2.

### How
While the "inner" switch element exists in both iOS 16.2 and 16.4, it's not considered hittable in iOS 16.2, even when it's visible, so it can't be tapped there. But it's considered hittable (when on screen) in iOS 16.4.

My first idea was to update the locator for the `addressToggleGetter` switch so that it will return `$0.switches["order-creation-customer-details-shipping-address-toggle"].switches.firstMatch` if it's hittable, and if not, return the old `$0.switches["order-creation-customer-details-shipping-address-toggle"]`. However, while it worked in the `init` stage (when the screen is just opened and the switch is visible (aka hittable)), it did not work during the test, because the keyboard was still shown after entering the customer name, thus covering the switch, so both parent and child switch were existing but not hittable.

I went for this approach:
1. Tap the "main" switch, which included an automatic scroll to visible before tapping it. If we're on iOS 16.2, it's all what's needed.
2. If the switch is still not in the needed state after the tap (which means the center of "main" switch was tapped), tap the inner switch.

### Testing
- CI is green
- Optionally, update to Xcode 14.3 locally, and check that the test works for both iOS 16.2 and 16.4.
