### PR TITLE
Remove `loginMagicLinkEmphasis` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -29,8 +29,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .loginErrorNotifications:
             return true
-        case .loginMagicLinkEmphasis:
-            return false
         case .loginMagicLinkEmphasisM2:
             return true
         case .promptToEnableCodInIppOnboarding:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -50,10 +50,6 @@ public enum FeatureFlag: Int {
     ///
     case loginErrorNotifications
 
-    /// Whether to prefer magic link to password in the login flow
-    ///
-    case loginMagicLinkEmphasis
-
     /// Whether to show the magic link as a secondary button instead of a table view cell on the password screen
     ///
     case loginMagicLinkEmphasisM2

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -6,7 +6,6 @@ import struct Networking.Settings
 extension WordPressAuthenticator {
     static func initializeWithCustomConfigs(dotcomAuthScheme: String = ApiCredentials.dotcomAuthScheme,
                                             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
-        let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
         let isManualErrorHandlingEnabled = featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin)
@@ -27,7 +26,7 @@ extension WordPressAuthenticator {
                                                                 enableUnifiedAuth: true,
                                                                 continueWithSiteAddressFirst: false,
                                                                 isWPComLoginRequiredForSiteCredentialsLogin: false,
-                                                                isWPComMagicLinkPreferredToPassword: isWPComMagicLinkPreferredToPassword,
+                                                                isWPComMagicLinkPreferredToPassword: false,
                                                                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen:
                                                                     isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen,
                                                                 enableWPComLoginOnlyInPrologue: false,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9618 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We still have a few feature flags in the app from 2022 Q3 experiments, and we are removing the ones that are already disabled and looking into data for the ones that are currently enabled.

This PR focused on removing `loginMagicLinkEmphasis` feature flag. This would help simplify the `WordPressAuthenticator` initialization logic. The feature flag is used to determine whether the magic link flow should be preferred to the password flow after logging in with a WPCOM email.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Log in flow

- Log out if needed
- Tap `Log in`
- Enter a WPCOM site address
- Enter a non-A8C WPCOM email that has a password (not passwordless) --> the password form should be shown, instead of the magic link requested screen
- Proceed to log in --> login should work as before

### Get started flow

- Log out if needed
- Tap `Get Started`
- Enter a non-A8C WPCOM email that has a password (not passwordless) --> the password form should be shown, instead of the magic link requested screen
- Proceed to log in --> login should work as before

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
