### PR TITLE
Update wording on the Jetpack banner to better communicate Jetpack's benefits

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsBanner.swift
@@ -93,8 +93,11 @@ struct JetpackBenefitsBanner: View {
 
 private extension JetpackBenefitsBanner {
     enum Localization {
-        static let title = NSLocalizedString("Get the full experience with Jetpack", comment: "Title of the Jetpack benefits banner.")
-        static let subtitle = NSLocalizedString("See the benefits", comment: "Subtitle of the Jetpack benefits banner.")
+        static let title = NSLocalizedString("Get order notifications and more", comment: "Title of the Jetpack benefits banner.")
+        static let subtitle = NSLocalizedString(
+            "Stay updated and boost store security. Explore Jetpack now.",
+            comment: "Subtitle of the Jetpack benefits banner."
+        )
     }
 
     enum Layout {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Internal discussion: p1683261510783229/1682075420.271799-slack-C0354HSNUJH.
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Lately, we've seen several reviews from users saying push notifications don't work for them. We suppose that these users might have corrupted Jetpack installations and didn't realize that. A proposal is to update the Jetpack banner wording to get more attention from users and better communicate that push notifications don't work because their sites don't have Jetpack.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a self-hosted Woo store without Jetpack.
- On the dashboard screen, notice that the Jetpack banner title says `Get order notifications and more `, with the description `Stay updated and boost store security. Explore Jetpack now.`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/236387516-15f22086-1df4-4e88-b690-e48959d77599.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.