### PR TITLE
[Privacy Choices] Privacy Screen Redesign

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -16,9 +16,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hwi-He-cKY">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hwi-He-cKY">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="tLZ-3e-cJY" id="uum-dx-Yau"/>
                                     <outlet property="delegate" destination="tLZ-3e-cJY" id="Ig0-wR-2Ms"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -196,7 +196,7 @@ private extension PrivacySettingsViewController {
     func configureAnalyticsInfo(cell: BasicTableViewCell) {
         cell.imageView?.image = nil
         cell.textLabel?.text = NSLocalizedString(
-            "These cookies allow us to optimize performance by collecting information on how users interact with our websites.",
+            "These cookies allow us to optimize performance by collecting information on how users interact with our mobile apps.",
             comment: "Analytics toggle description in the privacy screen."
         )
         configureInfo(cell: cell)
@@ -461,7 +461,7 @@ extension PrivacySettingsViewController: UITableViewDelegate {
 extension PrivacySettingsViewController {
     enum Localization {
         static let tableTitle = NSLocalizedString("We value your privacy. " +
-                                                  "Your personal data is used to optimize our website, improve security, " +
+                                                  "Your personal data is used to optimize our mobile apps, improve security, " +
                                                   "conduct analytics and marketing activities, and enhance your user experience.",
                                                   comment: "Main description on the privacy screen.")
         static let tracking = NSLocalizedString("Tracking", comment: "Title of the tracking section on the privacy screen")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -178,7 +178,6 @@ private extension PrivacySettingsViewController {
     func configureAnalytics(cell: SwitchTableViewCell) {
         // image
         cell.imageView?.image = nil
-        cell.imageView?.tintColor = .text
 
         // text
         cell.title = NSLocalizedString(
@@ -329,7 +328,12 @@ private extension PrivacySettingsViewController {
 
         let container = UIView(frame: .init(x: 0, y: 0, width: Int(self.tableView.frame.width), height: 0))
         container.addSubview(label)
-        container.pinSubviewToSafeArea(label, insets: Constants.headerTitleInsets)
+        NSLayoutConstraint.activate([
+            container.readableContentGuide.leadingAnchor.constraint(equalTo: label.leadingAnchor, constant: -Constants.headerTitleInsets.left),
+            container.readableContentGuide.trailingAnchor.constraint(equalTo: label.trailingAnchor, constant: Constants.headerTitleInsets.right),
+            container.readableContentGuide.topAnchor.constraint(equalTo: label.topAnchor, constant: -Constants.headerTitleInsets.top),
+            container.readableContentGuide.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: Constants.headerTitleInsets.bottom),
+        ])
         return container
     }
 
@@ -473,7 +477,7 @@ private struct Constants {
     static let rowHeight = CGFloat(44)
     static let separatorInset = CGFloat(16)
     static let sectionHeight = CGFloat(18)
-    static let headerTitleInsets = UIEdgeInsets(top: 16, left: 16, bottom: 32, right: 16)
+    static let headerTitleInsets = UIEdgeInsets(top: 16, left: 14, bottom: 32, right: 14)
     static let footerPadding = CGFloat(24)
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -407,6 +407,11 @@ extension PrivacySettingsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        // Add a greater padding for the new privacy choices redesign.
+        if isPrivacyChoicesEnabled {
+            return Constants.footerPadding
+        }
+
         // Give some breathing room to the table.
         let lastSection = sections.count - 1
         if section == lastSection {
@@ -469,6 +474,7 @@ private struct Constants {
     static let separatorInset = CGFloat(16)
     static let sectionHeight = CGFloat(18)
     static let headerTitleInsets = UIEdgeInsets(top: 16, left: 16, bottom: 32, right: 16)
+    static let footerPadding = CGFloat(24)
 }
 
 private struct Section {


### PR DESCRIPTION
Closes: #9606

# Why

This PR adjusts the "Privacy Settings" screen to adapt the new grouped table view style that we have been introducing in the newer screens.

This PR does not add the new "More Privacy Options" section because it will be added in a different PR #9608 

# Demo

Normal | Landscape
---- | ----
<img width="440" alt="normal" src="https://user-images.githubusercontent.com/562080/236392359-4be52fd4-3d6c-44c8-a9b3-a5e6a59fd12b.png"> | <img width="440" alt="landscape" src="https://user-images.githubusercontent.com/562080/236392366-e54e64ec-21e5-45e8-8b42-136ae5800c63.png">
Dark | Big Fonts
<img width="440" alt="dark" src="https://user-images.githubusercontent.com/562080/236392459-29e34735-16dd-4e61-b5ab-b2f796a8603f.png"> | <img width="440" alt="big-font" src="https://user-images.githubusercontent.com/562080/236392458-4c43621f-de39-40b6-b25e-e5c3d941829a.png">


# Testing instructions

- Go to the Hub Tab
- Go to the Settings Section
- Go to the Privacy row
- See that the screen with the new style.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
