### PR TITLE
Add CouponRow and CouponSelector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponRow.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Represent a single coupon row in the Product section of a New Order in the CouponSelectorView
+///
+struct CouponRow: View {
+    @ObservedObject var viewModel: CouponRowViewModel
+
+    /// Accessibility hint describing the coupon row tap gesture.
+    let accessibilityHint: String
+
+    init(viewModel: CouponRowViewModel,
+         accessibilityHint: String = "") {
+        self.viewModel = viewModel
+        self.accessibilityHint = accessibilityHint
+    }
+
+    var body: some View {
+        Button(action: {
+            viewModel.isSelected.toggle()
+        }) {
+            HStack {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(viewModel.couponCode)
+                        .bodyStyle()
+                    Text(viewModel.summary)
+                        .subheadlineStyle()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                Spacer()
+                if viewModel.isSelected {
+                    Image(uiImage: UIImage.checkmarkImage)
+                        .foregroundColor(Color(.accent))
+                        .imageScale(.large)
+                }
+            }
+            .frame(minHeight: Constants.height)
+        }
+        .accessibilityLabel(viewModel.couponAccessibilityLabel)
+        .accessibilityHint(accessibilityHint)
+    }
+
+    private enum Constants {
+        static let height: CGFloat = 36
+    }
+}
+
+struct CouponRow_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = CouponRowViewModel(couponCode: "FREESHIPPING",
+                                           summary: "Free shipping for all orders.")
+        CouponRow(viewModel: viewModel)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponRowViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Yosemite
+import WooFoundation
+
+/// View model for `CouponRow`
+///
+final class CouponRowViewModel: ObservableObject, Identifiable {
+    private let currencyFormatter: CurrencyFormatter
+
+    /// Unique ID for the view model.
+    ///
+    let id: Int64
+
+    // MARK: Coupon properties
+
+    /// Code of the coupon
+    ///
+    let couponCode: String
+
+    /// Summary of the coupon
+    ///
+    let summary: String
+
+    /// Selected coupon
+    ///
+    @Published var isSelected = false
+
+    /// Custom accessibility label for coupon
+    ///
+    var couponAccessibilityLabel: String {
+        [couponCode, summary]
+            .compactMap({ $0 })
+            .joined(separator: ". ")
+    }
+
+    init(id: Int64? = nil,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         couponCode: String,
+         summary: String) {
+        self.id = id ?? Int64(UUID().uuidString.hashValue)
+        self.currencyFormatter = currencyFormatter
+        self.couponCode = couponCode
+        self.summary = summary
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponSelectorView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct CouponSelectorView: View {
+    /// View model to drive the view.
+    ///
+    @ObservedObject var viewModel: CouponSelectorViewModel
+
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
+    /// Defines whether the view is presented.
+    ///
+    @Binding var isPresented: Bool
+
+    /// Environment presentation mode
+    ///
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+
+    /// Selected coupon
+    ///
+    @State private var selectedCoupon: CouponRowViewModel?
+
+
+    var body: some View {
+        NavigationView {
+            VStack (spacing: .zero) {
+                List {
+                    ForEach(viewModel.couponRows) { rowViewModel in
+                        createCouponRow(rowViewModel: rowViewModel)
+                            .padding(Constants.defaultPadding)
+                    }
+                }
+                .padding(.horizontal, insets: safeAreaInsets)
+                .listStyle(PlainListStyle())
+            }
+            .navigationTitle("Choose Coupon")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        isPresented.toggle()
+                        presentationMode.wrappedValue.dismiss()
+                        // TODO: add steps to clear all coupon selection
+                    }
+                }
+            }
+            .wooNavigationBarStyle()
+        }
+    }
+
+    /// Creates the `CouponRow` for a coupon
+    ///
+    @ViewBuilder private func createCouponRow(rowViewModel: CouponRowViewModel) -> some View {
+        CouponRow(viewModel: rowViewModel)
+    }
+}
+
+private extension CouponSelectorView {
+    enum Constants {
+        static let defaultPadding: CGFloat = 8
+    }
+}
+
+struct CouponSelectorView_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = CouponSelectorViewModel(siteID: 123)
+        CouponSelectorView(viewModel: viewModel,
+                           isPresented: .constant(true))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSelector/CouponSelectorViewModel.swift
@@ -1,0 +1,92 @@
+import Combine
+import Yosemite
+import protocol Storage.StorageManagerType
+import Experiments
+
+/// View model for `CouponSelectorView
+/// `
+final class CouponSelectorViewModel: ObservableObject {
+    private let siteID: Int64
+
+    /// Storage to fetch product list
+    ///
+    private let storageManager: StorageManagerType
+
+    /// Stores to sync product list
+    ///
+    private let stores: StoresManager
+
+    /// All active coupons
+    ///
+    @Published private var coupons: [Coupon] = []
+
+    /// View models for each coupon row
+    ///
+    @Published private(set) var couponRows: [CouponRowViewModel] = []
+
+    /// Selected coupon to be added to an order
+    ///
+    @Published private var selectedCoupon: Coupon?
+
+    /// Closure to be invoked when a coupon is selected
+    ///
+    private let onCouponSelected: ((Coupon) -> Void)?
+
+
+    /// Coupons Results Controller.
+    ///
+    private lazy var couponResultsController: ResultsController<StorageCoupon> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
+                                          ascending: false)
+
+        return ResultsController<StorageCoupon>(storageManager: storageManager,
+                                                matching: predicate,
+                                                sortedBy: [descriptor])
+    }()
+
+    /// Initializer for single selection
+    ///
+    init(siteID: Int64,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores,
+         onCouponSelected: ((Coupon) -> Void)? = nil) {
+        self.siteID = siteID
+        self.storageManager = storageManager
+        self.stores = stores
+        self.onCouponSelected = onCouponSelected
+
+        configureCouponResultsController()
+    }
+
+    func selectCoupon(_ coupon: Coupon) {
+        selectedCoupon = coupon
+    }
+}
+
+// MARK: - Configuration
+private extension CouponSelectorViewModel {
+    /// Configure results controller
+    ///
+    func configureCouponResultsController() {
+        do {
+            try couponResultsController.performFetch()
+            loadCoupons()
+        } catch {
+            DDLogError("⛔️ Error fetching coupons for new order: \(error)")
+        }
+    }
+
+
+    /// Fetch coupons from storage and loads only active coupons
+    func loadCoupons() {
+        let activeCoupons = couponResultsController.fetchedObjects.filter { coupon in
+            coupon.expiryStatus() == .active
+        }
+
+        couponRows = activeCoupons.map { coupon in
+            CouponRowViewModel(couponCode: coupon.code,
+                               summary: coupon.summary())
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1148,6 +1148,10 @@
 		57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */; };
 		57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */; };
 		581D5052274AA2480089B6AD /* View+AutofocusTextModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581D5051274AA2480089B6AD /* View+AutofocusTextModifier.swift */; };
+		621AB4B729E93E0A001D8AEA /* CouponSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621AB4B629E93E0A001D8AEA /* CouponSelectorView.swift */; };
+		627C44E629EBC5EE001A2B59 /* CouponRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627C44E529EBC5EE001A2B59 /* CouponRow.swift */; };
+		627C44E829EBC94D001A2B59 /* CouponRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627C44E729EBC94D001A2B59 /* CouponRowViewModel.swift */; };
+		62C5805E29ED4FE50000988F /* CouponSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C5805D29ED4FE50000988F /* CouponSelectorViewModel.swift */; };
 		682210ED2909666600814E14 /* CustomerSearchUICommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682210EC2909666600814E14 /* CustomerSearchUICommandTests.swift */; };
 		6827140F28A3988300E6E3F6 /* DismissableNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */; };
 		6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */; };
@@ -3336,6 +3340,10 @@
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		581D5051274AA2480089B6AD /* View+AutofocusTextModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AutofocusTextModifier.swift"; sourceTree = "<group>"; };
+		621AB4B629E93E0A001D8AEA /* CouponSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponSelectorView.swift; sourceTree = "<group>"; };
+		627C44E529EBC5EE001A2B59 /* CouponRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponRow.swift; sourceTree = "<group>"; };
+		627C44E729EBC94D001A2B59 /* CouponRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponRowViewModel.swift; sourceTree = "<group>"; };
+		62C5805D29ED4FE50000988F /* CouponSelectorViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponSelectorViewModel.swift; sourceTree = "<group>"; };
 		682210EC2909666600814E14 /* CustomerSearchUICommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommandTests.swift; sourceTree = "<group>"; };
 		6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableNoticeView.swift; sourceTree = "<group>"; };
 		6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledTextViewTableViewCell.swift; sourceTree = "<group>"; };
@@ -5715,6 +5723,7 @@
 		03FBDA9B263AD47200ACE257 /* Coupons */ = {
 			isa = PBXGroup;
 			children = (
+				627C44E429EBC5D9001A2B59 /* CouponSelector */,
 				DE74F2A127E41D4F0002FE59 /* EnableAnalytics */,
 				DE7B479127A38ABC0018742E /* CouponDetails */,
 				4572641527F1EABE004E1F95 /* Add and Edit Coupons */,
@@ -7077,6 +7086,17 @@
 				57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */,
 			);
 			path = TitleAndEditableValueTableViewCell;
+			sourceTree = "<group>";
+		};
+		627C44E429EBC5D9001A2B59 /* CouponSelector */ = {
+			isa = PBXGroup;
+			children = (
+				621AB4B629E93E0A001D8AEA /* CouponSelectorView.swift */,
+				62C5805D29ED4FE50000988F /* CouponSelectorViewModel.swift */,
+				627C44E529EBC5EE001A2B59 /* CouponRow.swift */,
+				627C44E729EBC94D001A2B59 /* CouponRowViewModel.swift */,
+			);
+			path = CouponSelector;
 			sourceTree = "<group>";
 		};
 		682210EB2909664800814E14 /* Customer */ = {
@@ -10918,6 +10938,7 @@
 				CC13C0CB278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift in Sources */,
 				020732042988AB7B000A53C2 /* DomainContactInfoForm.swift in Sources */,
 				DE2FE595292737330018040A /* JetpackSetupView.swift in Sources */,
+				62C5805E29ED4FE50000988F /* CouponSelectorViewModel.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				CCF4346E290AE1F900B4475A /* ProductsOnboardingAnnouncementCardViewModel.swift in Sources */,
@@ -11249,6 +11270,7 @@
 				45912FE32526642200982948 /* ProductFormViewController+Helpers.swift in Sources */,
 				B55D4C0620B6027200D7A50F /* AuthenticationManager.swift in Sources */,
 				451A04F02386F7B500E368C9 /* ProductImageCollectionViewCell.swift in Sources */,
+				627C44E629EBC5EE001A2B59 /* CouponRow.swift in Sources */,
 				AEACCB6D2785FF4A000D01F0 /* NavigationRow.swift in Sources */,
 				DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */,
 				CC857C7529B23AE100E19D1E /* BundledProductsListViewModel.swift in Sources */,
@@ -11408,6 +11430,7 @@
 				0304E36628BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift in Sources */,
 				CE1F512B206985DF00C6C810 /* PaddedLabel.swift in Sources */,
 				26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */,
+				627C44E829EBC94D001A2B59 /* CouponRowViewModel.swift in Sources */,
 				26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */,
 				7421344A210A323C00C13890 /* WooAnalyticsStat.swift in Sources */,
 				4567389D2745497C00743054 /* OrderStatusFilterViewController.swift in Sources */,
@@ -11976,6 +11999,7 @@
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
+				621AB4B729E93E0A001D8AEA /* CouponSelectorView.swift in Sources */,
 				028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
 				020DD0AF294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9111 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds `CouponRow` and `CouponSelector` to allow single/multi-selection of coupon codes to be added to an order.

### Classes added

* `CouponRow` and `CouponRowViewModel` - A SwiftUI view representing a single coupon row. It shows only the coupon code and summary and a checkmark on the right when it's selected.
* `CouponSelectorView` - A SwiftUI view that loads up the `CouponRow` in a NavigationView.
* `CouponSelectorViewModel` - Fetches the coupons from a site and populates only active (not expired) coupons in the `CouponRow`.

### Scope limitation

Due to time constraints, these are the features that have yet to be added:

- Keep track of single/multi coupon selections in `CouponSelectorViewModel`
- SyncCoordinator in `CouponSelectorViewModel`
- Move the Coupon section out of `OrderPaymentSection`, create a Coupon Section in `EditableViewModel` so we can pass in the site ID to the `CouponSelectorViewModel`
- Coupon validation
- Order total amount sync
- Search bar/filter coupons
- Coupon list pagination
- Localization and accessibility
- Unit tests


## Testing instructions

I'm not sure if the screen can be tested right now without changes being made to `OrderPaymentSection` and `EditableViewModel`. The screen recording attached below shows a brief idea of how it looks like when I loaded up the screen.

## Screen recording

https://user-images.githubusercontent.com/40906847/236664492-7b449c5e-cf9b-4f89-b8dc-de429ad06628.mp4


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
