### PR TITLE
Product description AI: show a badge in "add product" store onboarding task behind a feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -83,6 +83,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productDescriptionAI:
             return true
+        case .productDescriptionAIFromStoreOnboarding:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .readOnlyGiftCards:
             return true
         case .hideStoreOnboardingTaskList:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -176,9 +176,13 @@ public enum FeatureFlag: Int {
     ///
     case readOnlySubscriptions
 
-    /// Enables generating product description using AI.
+    /// Enables generating product description using AI from product description editor.
     ///
     case productDescriptionAI
+
+    /// Enables generating product description using AI from store onboarding.
+    ///
+    case productDescriptionAIFromStoreOnboarding
 
     /// Enables read-only support for the Gift Cards extension
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -66,7 +66,8 @@ struct StoreOnboardingTaskView: View {
                             if let badgeText = viewModel.badgeText {
                                 BadgeView(text: badgeText,
                                           customizations: .init(textColor: .init(uiColor: .secondaryLabel),
-                                                                backgroundColor: .init(uiColor: .systemGray6)))
+                                                                backgroundColor: .init(uiColor: .init(light: .systemGray6,
+                                                                                                      dark: .systemGray5))))
                             }
                         }
                         Spacer()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -61,6 +61,13 @@ struct StoreOnboardingTaskView: View {
                                 .redacted(reason: isRedacted ? .placeholder : [])
                                 // This size modifier is necessary so that the subtitle is never truncated.
                                 .fixedSize(horizontal: false, vertical: true)
+
+                            // Optional badge.
+                            if let badgeText = viewModel.badgeText {
+                                BadgeView(text: badgeText,
+                                          customizations: .init(textColor: .init(uiColor: .secondaryLabel),
+                                                                backgroundColor: .init(uiColor: .systemGray6)))
+                            }
                         }
                         Spacer()
                         // Chevron icon
@@ -100,27 +107,38 @@ struct StoreOnboardingTaskView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             Group {
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .addFirstProduct)),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .addFirstProduct),
+                                                         isEligibleForProductDescriptionAI: false),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .launchStore)),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .addFirstProduct),
+                                                         isEligibleForProductDescriptionAI: true),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .customizeDomains)),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .launchStore),
+                                                         isEligibleForProductDescriptionAI: false),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .payments)),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .customizeDomains),
+                                                         isEligibleForProductDescriptionAI: false),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: true, type: .payments)),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .payments),
+                                                         isEligibleForProductDescriptionAI: false),
+                                        showDivider: true,
+                                        isRedacted: false,
+                                        onTap: { _ in })
+
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: true, type: .payments),
+                                                         isEligibleForProductDescriptionAI: false),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -107,38 +107,33 @@ struct StoreOnboardingTaskView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             Group {
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .addFirstProduct),
-                                                         isEligibleForProductDescriptionAI: false),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .addFirstProduct)),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
                 StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .addFirstProduct),
-                                                         isEligibleForProductDescriptionAI: true),
+                                                         badgeText: "✨ AI content generator available."),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .launchStore),
-                                                         isEligibleForProductDescriptionAI: false),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .launchStore)),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .customizeDomains),
-                                                         isEligibleForProductDescriptionAI: false),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .customizeDomains)),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .payments),
-                                                         isEligibleForProductDescriptionAI: false),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: false, type: .payments)),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })
 
-                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: true, type: .payments),
-                                                         isEligibleForProductDescriptionAI: false),
+                StoreOnboardingTaskView(viewModel: .init(task: .init(isComplete: true, type: .payments)),
                                         showDivider: true,
                                         isRedacted: false,
                                         onTap: { _ in })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
@@ -17,24 +17,24 @@ struct StoreOnboardingTaskViewModel: Identifiable, Equatable {
         switch task.type {
         case .storeDetails:
             icon = .storeDetailsImage
-            title = Localication.StoreDetails.title
-            subtitle = Localication.StoreDetails.subtitle
+            title = Localization.StoreDetails.title
+            subtitle = Localization.StoreDetails.subtitle
         case .addFirstProduct:
             icon = .addProductImage
-            title = Localication.AddFirstProduct.title
-            subtitle = Localication.AddFirstProduct.subtitle
+            title = Localization.AddFirstProduct.title
+            subtitle = Localization.AddFirstProduct.subtitle
         case .launchStore:
             icon = .launchStoreImage
-            title = Localication.LaunchStore.title
-            subtitle = Localication.LaunchStore.subtitle
+            title = Localization.LaunchStore.title
+            subtitle = Localization.LaunchStore.subtitle
         case .customizeDomains:
             icon = .customizeDomainsImage
-            title = Localication.CustomizeDomains.title
-            subtitle = Localication.CustomizeDomains.subtitle
+            title = Localization.CustomizeDomains.title
+            subtitle = Localization.CustomizeDomains.subtitle
         case .payments, .woocommercePayments:
             icon = .getPaidImage
-            title = Localication.Payments.title
-            subtitle = Localication.Payments.subtitle
+            title = Localization.Payments.title
+            subtitle = Localization.Payments.subtitle
         case .unsupported:
             icon = .checkCircleImage
             title = ""
@@ -45,7 +45,7 @@ struct StoreOnboardingTaskViewModel: Identifiable, Equatable {
 
 
 extension StoreOnboardingTaskViewModel {
-    enum Localication {
+    enum Localization {
         enum StoreDetails {
             static let title = NSLocalizedString(
                 "Tell us more about your store",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
@@ -7,38 +7,46 @@ struct StoreOnboardingTaskViewModel: Identifiable, Equatable {
     let icon: UIImage
     let title: String
     let subtitle: String
+    let badgeText: String?
 
     var isComplete: Bool {
         task.isComplete
     }
 
-    init(task: StoreOnboardingTask) {
+    init(task: StoreOnboardingTask, isEligibleForProductDescriptionAI: Bool) {
         self.task = task
         switch task.type {
         case .storeDetails:
             icon = .storeDetailsImage
             title = Localization.StoreDetails.title
             subtitle = Localization.StoreDetails.subtitle
+            badgeText = nil
         case .addFirstProduct:
             icon = .addProductImage
             title = Localization.AddFirstProduct.title
             subtitle = Localization.AddFirstProduct.subtitle
+            badgeText = isEligibleForProductDescriptionAI ?
+            Localization.AddFirstProduct.badgeText: nil
         case .launchStore:
             icon = .launchStoreImage
             title = Localization.LaunchStore.title
             subtitle = Localization.LaunchStore.subtitle
+            badgeText = nil
         case .customizeDomains:
             icon = .customizeDomainsImage
             title = Localization.CustomizeDomains.title
             subtitle = Localization.CustomizeDomains.subtitle
+            badgeText = nil
         case .payments, .woocommercePayments:
             icon = .getPaidImage
             title = Localization.Payments.title
             subtitle = Localization.Payments.subtitle
+            badgeText = nil
         case .unsupported:
             icon = .checkCircleImage
             title = ""
             subtitle = ""
+            badgeText = nil
         }
     }
 }
@@ -65,6 +73,10 @@ extension StoreOnboardingTaskViewModel {
             static let subtitle = NSLocalizedString(
                 "Start selling by adding products or services to your store.",
                 comment: "Subtitle of the store onboarding task to add the first product."
+            )
+            static let badgeText = NSLocalizedString(
+                "✨ AI content generator available.",
+                comment: "Badge of the store onboarding task to add the first product when the store is eligible for Jetpack AI."
             )
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
@@ -13,40 +13,34 @@ struct StoreOnboardingTaskViewModel: Identifiable, Equatable {
         task.isComplete
     }
 
-    init(task: StoreOnboardingTask, isEligibleForProductDescriptionAI: Bool) {
+    init(task: StoreOnboardingTask, badgeText: String? = nil) {
         self.task = task
+        self.badgeText = badgeText
         switch task.type {
         case .storeDetails:
             icon = .storeDetailsImage
             title = Localization.StoreDetails.title
             subtitle = Localization.StoreDetails.subtitle
-            badgeText = nil
         case .addFirstProduct:
             icon = .addProductImage
             title = Localization.AddFirstProduct.title
             subtitle = Localization.AddFirstProduct.subtitle
-            badgeText = isEligibleForProductDescriptionAI ?
-            Localization.AddFirstProduct.badgeText: nil
         case .launchStore:
             icon = .launchStoreImage
             title = Localization.LaunchStore.title
             subtitle = Localization.LaunchStore.subtitle
-            badgeText = nil
         case .customizeDomains:
             icon = .customizeDomainsImage
             title = Localization.CustomizeDomains.title
             subtitle = Localization.CustomizeDomains.subtitle
-            badgeText = nil
         case .payments, .woocommercePayments:
             icon = .getPaidImage
             title = Localization.Payments.title
             subtitle = Localization.Payments.subtitle
-            badgeText = nil
         case .unsupported:
             icon = .checkCircleImage
             title = ""
             subtitle = ""
-            badgeText = nil
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -56,6 +56,7 @@ class StoreOnboardingViewModel: ObservableObject {
     private let siteID: Int64
 
     private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
 
     private var state: State
 
@@ -87,6 +88,7 @@ class StoreOnboardingViewModel: ObservableObject {
         self.state = .loading
         self.defaults = defaults
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
         isHideStoreOnboardingTaskListFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList)
 
         Publishers.CombineLatest3($noTasksAvailableForDisplay,
@@ -130,6 +132,9 @@ private extension StoreOnboardingViewModel {
         async let shouldManuallyAppendLaunchStoreTask = isFreeTrialPlan
         let tasksFromServer: [StoreOnboardingTask] = try await fetchTasks()
         let isEligibleForProductDescriptionAI: Bool = {
+            guard featureFlagService.isFeatureFlagEnabled(.productDescriptionAIFromStoreOnboarding) else {
+                return false
+            }
             let eligibilityChecker = ProductFormAIEligibilityChecker(site: stores.sessionManager.defaultSite)
             return eligibilityChecker.isFeatureEnabled(.description)
         }()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -135,7 +135,7 @@ private extension StoreOnboardingViewModel {
             guard featureFlagService.isFeatureFlagEnabled(.productDescriptionAIFromStoreOnboarding) else {
                 return false
             }
-            let eligibilityChecker = ProductFormAIEligibilityChecker(site: stores.sessionManager.defaultSite)
+            let eligibilityChecker = ProductFormAIEligibilityChecker(site: stores.sessionManager.defaultSite, featureFlagService: featureFlagService)
             return eligibilityChecker.isFeatureEnabled(.description)
         }()
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -15,27 +15,42 @@ struct BadgeView: View {
         }
     }
 
+    /// UI customizations for the badge.
+    struct Customizations {
+        let textColor: Color
+        let backgroundColor: Color
+
+        init(textColor: Color = Color(.textBrand),
+             backgroundColor: Color = Color(.wooCommercePurple(.shade0))) {
+            self.textColor = textColor
+            self.backgroundColor = backgroundColor
+        }
+    }
+
     private let text: String
+    private let customizations: Customizations
 
     init(type: BadgeType) {
         text = type.title.uppercased()
+        customizations = .init()
     }
 
-    init(text: String) {
+    init(text: String, customizations: Customizations = .init()) {
         self.text = text
+        self.customizations = customizations
     }
 
     var body: some View {
         Text(text)
             .bold()
-            .foregroundColor(Color(.textBrand))
+            .foregroundColor(customizations.textColor)
             .captionStyle()
             .padding(.leading, Layout.horizontalPadding)
             .padding(.trailing, Layout.horizontalPadding)
             .padding(.top, Layout.verticalPadding)
             .padding(.bottom, Layout.verticalPadding)
             .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                .fill(Color(.wooCommercePurple(.shade0)))
+                .fill(customizations.backgroundColor)
             )
     }
 }
@@ -61,6 +76,7 @@ struct BadgeView_Previews: PreviewProvider {
             BadgeView(type: .new)
             BadgeView(type: .tip)
             BadgeView(text: "Custom text")
+            BadgeView(text: "Customized colors", customizations: .init(textColor: .green, backgroundColor: .orange))
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,6 +21,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isIPPUKExpansionEnabled: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
     private let isProductDescriptionAIEnabled: Bool
+    private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
     private let isHideStoreOnboardingTaskListFeatureEnabled: Bool
 
@@ -43,6 +44,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isIPPUKExpansionEnabled: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
          isProductDescriptionAIEnabled: Bool = false,
+         isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
          isHideStoreOnboardingTaskListFeatureEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
@@ -64,6 +66,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isIPPUKExpansionEnabled = isIPPUKExpansionEnabled
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
+        self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.isHideStoreOnboardingTaskListFeatureEnabled = isHideStoreOnboardingTaskListFeatureEnabled
     }
@@ -108,6 +111,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isReadOnlySubscriptionsEnabled
         case .productDescriptionAI:
             return isProductDescriptionAIEnabled
+        case .productDescriptionAIFromStoreOnboarding:
+            return isProductDescriptionAIFromStoreOnboardingEnabled
         case .readOnlyGiftCards:
             return isReadOnlyGiftCardsEnabled
         case .hideStoreOnboardingTaskList:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
@@ -15,7 +15,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
         let task: StoreOnboardingTask = .init(isComplete: true, type: .addFirstProduct)
 
         // When
-        let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
+        let sut = StoreOnboardingTaskViewModel(task: task)
 
         // Then
         XCTAssertEqual(true, sut.isComplete)
@@ -26,7 +26,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
         let task: StoreOnboardingTask = .init(isComplete: true, type: .addFirstProduct)
 
         // When
-        let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
+        let sut = StoreOnboardingTaskViewModel(task: task)
 
         // Then
         XCTAssertEqual(task, sut.task)
@@ -34,7 +34,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
 
     func test_the_icon_is_correct_for_different_type_of_tasks() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
+            let sut = StoreOnboardingTaskViewModel(task: task)
             switch task.type {
             case .storeDetails:
                 XCTAssertEqual(sut.icon, .storeDetailsImage)
@@ -54,7 +54,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
 
     func test_the_title_is_correct_for_different_type_of_tasks() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
+            let sut = StoreOnboardingTaskViewModel(task: task)
             switch task.type {
             case .storeDetails:
                 XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.StoreDetails.title)
@@ -74,7 +74,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
 
     func test_the_subtitle_is_correct_for_different_type_of_tasks() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
+            let sut = StoreOnboardingTaskViewModel(task: task)
             switch task.type {
             case .storeDetails:
                 XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.StoreDetails.subtitle)
@@ -92,22 +92,17 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
         }
     }
 
-    func test_the_badge_text_is_correct_for_different_type_of_tasks_when_site_is_not_eligible_for_description_AI() {
+    func test_the_badge_text_is_set_to_nil_without_badgeText_parameter() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
+            let sut = StoreOnboardingTaskViewModel(task: task)
             XCTAssertNil(sut.badgeText)
         }
     }
 
-    func test_the_badge_text_is_correct_for_different_type_of_tasks_when_site_is_eligible_for_description_AI() {
+    func test_the_badge_text_is_set_to_badgeText_parameter() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: true)
-            switch task.type {
-            case .addFirstProduct:
-                XCTAssertEqual(sut.badgeText, StoreOnboardingTaskViewModel.Localization.AddFirstProduct.badgeText)
-            default:
-                XCTAssertNil(sut.badgeText)
-            }
+            let sut = StoreOnboardingTaskViewModel(task: task, badgeText: "Tap")
+            XCTAssertEqual(sut.badgeText, "Tap")
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
@@ -57,15 +57,15 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
             let sut = StoreOnboardingTaskViewModel(task: task)
             switch task.type {
             case .storeDetails:
-                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localication.StoreDetails.title)
+                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.StoreDetails.title)
             case .addFirstProduct:
-                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localication.AddFirstProduct.title)
+                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.AddFirstProduct.title)
             case .launchStore:
-                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localication.LaunchStore.title)
+                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.LaunchStore.title)
             case .customizeDomains:
-                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localication.CustomizeDomains.title)
+                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.CustomizeDomains.title)
             case .payments, .woocommercePayments:
-                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localication.Payments.title)
+                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.Payments.title)
             case .unsupported:
                 XCTAssertEqual(sut.title, "")
             }
@@ -77,15 +77,15 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
             let sut = StoreOnboardingTaskViewModel(task: task)
             switch task.type {
             case .storeDetails:
-                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localication.StoreDetails.subtitle)
+                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.StoreDetails.subtitle)
             case .addFirstProduct:
-                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localication.AddFirstProduct.subtitle)
+                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.AddFirstProduct.subtitle)
             case .launchStore:
-                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localication.LaunchStore.subtitle)
+                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.LaunchStore.subtitle)
             case .customizeDomains:
-                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localication.CustomizeDomains.subtitle)
+                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.CustomizeDomains.subtitle)
             case .payments, .woocommercePayments:
-                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localication.Payments.subtitle)
+                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.Payments.subtitle)
             case .unsupported:
                 XCTAssertEqual(sut.subtitle, "")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
@@ -15,7 +15,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
         let task: StoreOnboardingTask = .init(isComplete: true, type: .addFirstProduct)
 
         // When
-        let sut = StoreOnboardingTaskViewModel(task: task)
+        let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
 
         // Then
         XCTAssertEqual(true, sut.isComplete)
@@ -26,7 +26,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
         let task: StoreOnboardingTask = .init(isComplete: true, type: .addFirstProduct)
 
         // When
-        let sut = StoreOnboardingTaskViewModel(task: task)
+        let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
 
         // Then
         XCTAssertEqual(task, sut.task)
@@ -34,7 +34,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
 
     func test_the_icon_is_correct_for_different_type_of_tasks() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task)
+            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
             switch task.type {
             case .storeDetails:
                 XCTAssertEqual(sut.icon, .storeDetailsImage)
@@ -54,7 +54,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
 
     func test_the_title_is_correct_for_different_type_of_tasks() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task)
+            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
             switch task.type {
             case .storeDetails:
                 XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.StoreDetails.title)
@@ -74,7 +74,7 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
 
     func test_the_subtitle_is_correct_for_different_type_of_tasks() {
         for task in tasks {
-            let sut = StoreOnboardingTaskViewModel(task: task)
+            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
             switch task.type {
             case .storeDetails:
                 XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.StoreDetails.subtitle)
@@ -88,6 +88,25 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
                 XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.Payments.subtitle)
             case .unsupported:
                 XCTAssertEqual(sut.subtitle, "")
+            }
+        }
+    }
+
+    func test_the_badge_text_is_correct_for_different_type_of_tasks_when_site_is_not_eligible_for_description_AI() {
+        for task in tasks {
+            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: false)
+            XCTAssertNil(sut.badgeText)
+        }
+    }
+
+    func test_the_badge_text_is_correct_for_different_type_of_tasks_when_site_is_eligible_for_description_AI() {
+        for task in tasks {
+            let sut = StoreOnboardingTaskViewModel(task: task, isEligibleForProductDescriptionAI: true)
+            switch task.type {
+            case .addFirstProduct:
+                XCTAssertEqual(sut.badgeText, StoreOnboardingTaskViewModel.Localization.AddFirstProduct.badgeText)
+            default:
+                XCTAssertNil(sut.badgeText)
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -651,11 +651,13 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Given
         stores.updateDefaultStore(storeID: 6)
         stores.updateDefaultStore(.fake().copy(siteID: 6, isWordPressComStore: true))
+        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIEnabled: true,
+                                                        isProductDescriptionAIFromStoreOnboardingEnabled: true)
         let sut = StoreOnboardingViewModel(siteID: 0,
                                            isExpanded: true,
                                            stores: stores,
                                            defaults: defaults,
-                                           featureFlagService: MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true))
+                                           featureFlagService: featureFlagService)
         let tasks: [StoreOnboardingTask] = [
             .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .addFirstProduct),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -616,6 +616,100 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertTrue(sut.tasksForDisplay.count == 4)
     }
 
+    @MainActor
+    func test_the_badge_text_is_nil_for_all_tasks_when_productDescriptionAIFromStoreOnboarding_feature_is_disabled() async {
+        // Given
+        stores.updateDefaultStore(storeID: 6)
+        stores.updateDefaultStore(.fake().copy(siteID: 6, isWordPressComStore: true))
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults,
+                                           featureFlagService: MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: false))
+        let tasks: [StoreOnboardingTask] = [
+            .init(isComplete: false, type: .storeDetails),
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
+        ]
+        mockLoadOnboardingTasks(result: .success(tasks))
+        mockLoadSiteCurrentPlan(result: .failure(MockError()))
+
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.count == 5)
+        sut.tasksForDisplay.forEach { taskViewModel in
+            XCTAssertNil(taskViewModel.badgeText)
+        }
+    }
+
+    @MainActor
+    func test_the_badge_text_is_not_nil_for_addFirstProduct_task_when_store_is_wpcom() async {
+        // Given
+        stores.updateDefaultStore(storeID: 6)
+        stores.updateDefaultStore(.fake().copy(siteID: 6, isWordPressComStore: true))
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults,
+                                           featureFlagService: MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true))
+        let tasks: [StoreOnboardingTask] = [
+            .init(isComplete: false, type: .storeDetails),
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
+        ]
+        mockLoadOnboardingTasks(result: .success(tasks))
+        mockLoadSiteCurrentPlan(result: .failure(MockError()))
+
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.count == 5)
+        sut.tasksForDisplay.forEach { taskViewModel in
+            switch taskViewModel.task.type {
+            case .addFirstProduct:
+                XCTAssertEqual(taskViewModel.badgeText, StoreOnboardingTaskViewModel.Localization.AddFirstProduct.badgeText)
+            default:
+                XCTAssertNil(taskViewModel.badgeText)
+            }
+        }
+    }
+
+    @MainActor
+    func test_the_badge_text_is_not_nil_for_addFirstProduct_task_when_store_is_not_wpcom() async {
+        // Given
+        stores.updateDefaultStore(storeID: 6)
+        stores.updateDefaultStore(.fake().copy(siteID: 6, isWordPressComStore: false))
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults,
+                                           featureFlagService: MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true))
+        let tasks: [StoreOnboardingTask] = [
+            .init(isComplete: false, type: .storeDetails),
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
+        ]
+        mockLoadOnboardingTasks(result: .success(tasks))
+
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.count == 5)
+        sut.tasksForDisplay.forEach { taskViewModel in
+            XCTAssertNil(taskViewModel.badgeText)
+        }
+    }
+
     // MARK: completedAllStoreOnboardingTasks user defaults
 
     func test_completedAllStoreOnboardingTasks_is_nil_when_there_are_pending_tasks() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For i2 of product description AI, we're making the feature more discoverable for new merchants first, then pre-existing merchants. In the "Add your first product" onboarding task, we're showing a badge about the AI-generated content feature.

## How

Since I'm not sure if we can ship this part of i2 this week, I created a feature flag `productDescriptionAIFromStoreOnboarding` for the emphasis on new stores.

- In `StoreOnboardingTaskViewModel`, an optional property `badgeText: String?` was added. A badge text is shown for the "Add product" onboarding text when the store is eligible for description AI. Then in `StoreOnboardingTaskView`, a badge view is shown when a task's `badgeText` is non-nil
- In `StoreOnboardingViewModel`, `isEligibleForProductDescriptionAI` to `StoreOnboardingTaskViewModel` is determined by the new feature flag, and `ProductFormAIEligibilityChecker`
- `BadgeView` component is currently shown in fixed colors. In order to customize the text & background colors, a `Customizations` struct was added with default values

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### WPCOM store

Please note that the dark mode color of the badge is currently blended into the background. I asked a question in design: NMncL2ViLjomfLhuyEhVM1-fi-229:69465

- Log in to a WPCOM store that still has some pending onboarding tasks --> on the My store tab, the store setup card should be shown. if the "Add your first product" task is already complete, tap `View all` to see it in the expanded state. The "Add your first product" task should have a badge about the AI content generator

### non-WPCOM store

- Log in to a non-WPCOM store that still has some pending onboarding tasks --> on the My store tab, the store setup card should be shown. if the "Add your first product" task is already complete, tap `View all` to see it in the expanded state. The "Add your first product" task should **not** have a badge about the AI content generator

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

non-WPCOM store | WPCOM store - light | WPCOM store - dark
-- | -- | --
![Simulator Screen Shot - iPhone 14 - 2023-05-08 at 10 08 01](https://user-images.githubusercontent.com/1945542/236725552-6d5eca6c-30d6-4642-9800-4c5766f6b8fe.png) | ![Simulator Screen Shot - iPhone 14 - 2023-05-08 at 21 29 50](https://user-images.githubusercontent.com/1945542/236837103-644bd4c4-b86d-41fa-aaf3-8e2f5badc85e.png) | ![Simulator Screen Shot - iPhone 14 - 2023-05-08 at 21 29 34](https://user-images.githubusercontent.com/1945542/236837092-061d11d1-8551-4713-adb3-894d12038683.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.