### PR TITLE
Add `.addProductToOrderViaSKUScanner` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -67,6 +67,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .addCouponToOrder:
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
+        case .addProductToOrderViaSKUScanner:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productBundles:
             return true
         case .freeTrial:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -147,7 +147,7 @@ public enum FeatureFlag: Int {
     ///Ability to add coupon to order
     ///
     case addCouponToOrder
-    
+
     /// Enables the ability to add products to orders by SKU scanning 
     ///
     case addProductToOrderViaSKUScanner

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -147,6 +147,10 @@ public enum FeatureFlag: Int {
     ///Ability to add coupon to order
     ///
     case addCouponToOrder
+    
+    /// Enables the ability to add products to orders by SKU scanning 
+    ///
+    case addProductToOrderViaSKUScanner
 
     /// Whether to enable product bundle settings in product details
     ///


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-ios/issues/9658
Closes: https://github.com/woocommerce/woocommerce-ios/issues/9649

### Description
As part of the work needed for supporting adding products to orders via SKU scanning (M1), we're adding a feature flag to hide any changes behind it.

### Changes
Adds the `.addProductToOrderViaSKUScanner` feature flag