### PR TITLE
Add SKU product scan button to order view

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -68,7 +68,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .addCouponToOrder:
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         case .addProductToOrderViaSKUScanner:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .productBundles:
             return true
         case .freeTrial:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -64,7 +64,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Indicates whether adding a product to the order via SKU scanning is enabled
     ///
-    var isAddProductToOrderViaBarcodeScannerEnabled: Bool {
+    var isAddProductToOrderViaSKUScannerEnabled: Bool {
         featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -62,6 +62,12 @@ final class EditableOrderViewModel: ObservableObject {
         featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) && flow == .creation
     }
 
+    /// Indicates whether adding a product to the order via SKU scanning is enabled
+    ///
+    var isAddProductToOrderViaBarcodeScannerEnabled: Bool {
+        featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner)
+    }
+
     var title: String {
         switch flow {
         case .creation:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -306,7 +306,7 @@ private struct ProductsSection: View {
                 }, content: {
                     EmptyView()
                 })
-                .renderedIf(viewModel.isAddProductToOrderViaBarcodeScannerEnabled)
+                .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -97,6 +97,8 @@ struct OrderForm: View {
     ///
     var dismissHandler: (() -> Void) = {}
 
+    // TODO-gm: Move the FF here
+
     @ObservedObject var viewModel: EditableOrderViewModel
 
     /// Fix for breaking navbar button
@@ -221,6 +223,9 @@ private struct MultipleLinesMessage: View {
 private struct ProductsSection: View {
     let scroll: ScrollViewProxy
 
+    // TODO-gm: Extract the flag to the EditableOrderViewModel via injecting it into Orderform
+    let isAddProductToOrderViaBarcodeScannerEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner)
+
     /// View model to drive the view content
     @ObservedObject var viewModel: EditableOrderViewModel
 
@@ -231,9 +236,17 @@ private struct ProductsSection: View {
     ///
     @State private var showAddProduct: Bool = false
 
+    /// Defines whether `AddProductViaBarcodeScanner` modal is presented.
+    ///
+    @State private var showAddProductViaBarcodeScanner: Bool = false
+
     /// ID for Add Product button
     ///
     @Namespace var addProductButton
+
+    /// ID for Add Product via Barcode Scanner button
+    ///
+    @Namespace var addProductViaBarcodeScannerButton
 
     ///   Environment safe areas
     ///
@@ -288,6 +301,17 @@ private struct ProductsSection: View {
                         navigationButtonID = UUID()
                     }
                 })
+                Button(OrderForm.Localization.addProductViaBarcodeScanner) {
+                    showAddProductViaBarcodeScanner.toggle()
+                }
+                .accessibilityIdentifier(OrderForm.Accessibility.addProductViaBarcodeScannerButtonIdentifier)
+                .buttonStyle(PlusButtonStyle())
+                .sheet(isPresented: $showAddProductViaBarcodeScanner, onDismiss: {
+                    scroll.scrollTo(addProductViaBarcodeScannerButton)
+                }, content: {
+                    EmptyView()
+                })
+                .renderedIf(isAddProductToOrderViaBarcodeScannerEnabled)
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()
@@ -313,6 +337,8 @@ private extension OrderForm {
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating or editing an order")
         static let addProducts = NSLocalizedString("Add Products",
                                                    comment: "Title text of the button that allows to add multiple products when creating or editing an order")
+        static let addProductViaBarcodeScanner = NSLocalizedString("Add Product via barcode",
+                                                                   comment: "Title text of the button to add a single product via scanning its barcode")
         static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
                                                                    comment: "Accessibility hint for selecting a product in an order form")
     }
@@ -322,6 +348,7 @@ private extension OrderForm {
         static let cancelButtonIdentifier = "new-order-cancel-button"
         static let doneButtonIdentifier = "edit-order-done-button"
         static let addProductButtonIdentifier = "new-order-add-product-button"
+        static let addProductViaBarcodeScannerButtonIdentifier = "new-order-add-product-via-barcode-scanner-button"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -231,17 +231,17 @@ private struct ProductsSection: View {
     ///
     @State private var showAddProduct: Bool = false
 
-    /// Defines whether `AddProductViaBarcodeScanner` modal is presented.
+    /// Defines whether `AddProductViaSKUScanner` modal is presented.
     ///
-    @State private var showAddProductViaBarcodeScanner: Bool = false
+    @State private var showAddProductViaSKUScanner: Bool = false
 
     /// ID for Add Product button
     ///
     @Namespace var addProductButton
 
-    /// ID for Add Product via Barcode Scanner button
+    /// ID for Add Product via SKU Scanner button
     ///
-    @Namespace var addProductViaBarcodeScannerButton
+    @Namespace var addProductViaSKUScannerButton
 
     ///   Environment safe areas
     ///
@@ -296,13 +296,13 @@ private struct ProductsSection: View {
                         navigationButtonID = UUID()
                     }
                 })
-                Button(OrderForm.Localization.addProductViaBarcodeScanner) {
-                    showAddProductViaBarcodeScanner.toggle()
+                Button(OrderForm.Localization.addProductViaSKUScanner) {
+                    showAddProductViaSKUScanner.toggle()
                 }
-                .accessibilityIdentifier(OrderForm.Accessibility.addProductViaBarcodeScannerButtonIdentifier)
+                .accessibilityIdentifier(OrderForm.Accessibility.addProductViaSKUScannerButtonIdentifier)
                 .buttonStyle(PlusButtonStyle())
-                .sheet(isPresented: $showAddProductViaBarcodeScanner, onDismiss: {
-                    scroll.scrollTo(addProductViaBarcodeScannerButton)
+                .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
+                    scroll.scrollTo(addProductViaSKUScannerButton)
                 }, content: {
                     EmptyView()
                 })
@@ -332,8 +332,8 @@ private extension OrderForm {
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating or editing an order")
         static let addProducts = NSLocalizedString("Add Products",
                                                    comment: "Title text of the button that allows to add multiple products when creating or editing an order")
-        static let addProductViaBarcodeScanner = NSLocalizedString("Add Product via barcode",
-                                                                   comment: "Title text of the button to add a single product via scanning its barcode")
+        static let addProductViaSKUScanner = NSLocalizedString("Add Product via SKU scanner",
+                                                                   comment: "Title text of the button to add a single product via SKU scanning")
         static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
                                                                    comment: "Accessibility hint for selecting a product in an order form")
     }
@@ -343,7 +343,7 @@ private extension OrderForm {
         static let cancelButtonIdentifier = "new-order-cancel-button"
         static let doneButtonIdentifier = "edit-order-done-button"
         static let addProductButtonIdentifier = "new-order-add-product-button"
-        static let addProductViaBarcodeScannerButtonIdentifier = "new-order-add-product-via-barcode-scanner-button"
+        static let addProductViaSKUScannerButtonIdentifier = "new-order-add-product-via-sku-scanner-button"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -97,8 +97,6 @@ struct OrderForm: View {
     ///
     var dismissHandler: (() -> Void) = {}
 
-    // TODO-gm: Move the FF here
-
     @ObservedObject var viewModel: EditableOrderViewModel
 
     /// Fix for breaking navbar button
@@ -223,9 +221,6 @@ private struct MultipleLinesMessage: View {
 private struct ProductsSection: View {
     let scroll: ScrollViewProxy
 
-    // TODO-gm: Extract the flag to the EditableOrderViewModel via injecting it into Orderform
-    let isAddProductToOrderViaBarcodeScannerEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner)
-
     /// View model to drive the view content
     @ObservedObject var viewModel: EditableOrderViewModel
 
@@ -311,7 +306,7 @@ private struct ProductsSection: View {
                 }, content: {
                     EmptyView()
                 })
-                .renderedIf(isAddProductToOrderViaBarcodeScannerEnabled)
+                .renderedIf(viewModel.isAddProductToOrderViaBarcodeScannerEnabled)
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -23,6 +23,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isProductDescriptionAIEnabled: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
     private let isHideStoreOnboardingTaskListFeatureEnabled: Bool
+    private let isAddProductToOrderViaSKUScannerEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -44,7 +45,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isReadOnlySubscriptionsEnabled: Bool = false,
          isProductDescriptionAIEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
-         isHideStoreOnboardingTaskListFeatureEnabled: Bool = false) {
+         isHideStoreOnboardingTaskListFeatureEnabled: Bool = false,
+         isAddProductToOrderViaSKUScannerEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -66,6 +68,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.isHideStoreOnboardingTaskListFeatureEnabled = isHideStoreOnboardingTaskListFeatureEnabled
+        self.isAddProductToOrderViaSKUScannerEnabled = isAddProductToOrderViaSKUScannerEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -112,6 +115,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isReadOnlyGiftCardsEnabled
         case .hideStoreOnboardingTaskList:
             return isHideStoreOnboardingTaskListFeatureEnabled
+        case .addProductToOrderViaSKUScanner:
+            return isAddProductToOrderViaSKUScannerEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -486,6 +486,24 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.paymentDataViewModel.supportsAddingCouponToOrder)
     }
 
+    // MARK: - Add Products to Order via SKU Scanner Tests
+
+    func test_add_product_to_order_via_sku_scanner_feature_flag_is_enabled_then_feature_support_returns_true() {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))
+
+        // Then
+        XCTAssertTrue(viewModel.isAddProductToOrderViaSKUScannerEnabled)
+    }
+
+    func test_add_product_to_order_via_sku_scanner_feature_flag_is_disabled_then_feature_support_returns_false() {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: false))
+
+        // Then
+        XCTAssertFalse(viewModel.isAddProductToOrderViaSKUScannerEnabled)
+    }
+
     // MARK: - Payment Section Tests
 
     func test_payment_section_is_updated_when_products_update() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -488,7 +488,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     // MARK: - Add Products to Order via SKU Scanner Tests
 
-    func test_add_product_to_order_via_sku_scanner_feature_flag_is_enabled_then_feature_support_returns_true() {
+    func test_add_product_to_order_via_sku_scanner_when_feature_flag_is_enabled_then_feature_support_returns_true() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))
 


### PR DESCRIPTION
Part of: #9658 
Closes: #9650

Based on #9661, which should be merged first.

## Description

This PR adds a new `+ Add Product via SKU scanner` button to the Order form view, which only renders when the feature flag is on. The button will trigger the scanning action (to be implemented), but for the moment just shows an empty modal screen.

This button is temporary while we decide which design we'll actually use. Ref: p1683288027009159-slack-C0354HSNUJH

I opted for using the "SKU scanning" naming across the different variables rather than "barcode scanning" as we can scan many more standards than static barcodes, but happy to change it as needed.

## Changes
- Adds a new button to the Order form view.
- Adds Unit Tests to confirm the view model property changes accordingly based on feature flag on/off
- Adds the `!isUITesting` flag to skip UI testing while the feature is being developed, as we do not have final design yet.

| Before | After |
|--------|--------|
| <img width=450 src="https://user-images.githubusercontent.com/3812076/236798184-a93b619c-3c5c-40cc-99b5-a0cedad6ab35.png"> | <img width=450 src="https://user-images.githubusercontent.com/3812076/236798574-41efbfaf-ca38-45f4-b766-1a168db700d9.png">  |

## Testing instructions
* Go to Orders > `+` > See `+ Add Product via SKU scanner` > Tap the button
* See an empty view
* Pull-down to dismiss

