### PR TITLE
[Privacy Policy] Adds More Privacy Section

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -97,6 +97,11 @@ extension WooConstants {
         ///
         case privacy = "https://automattic.com/privacy/"
 
+        /// More Privacy Documentation URL.
+        /// TODO: Replace with the real one once it is built https://github.com/woocommerce/woomobile-private/issues/286
+        ///
+        case morePrivacyDocumentation = "https://wordpress.com/support/tracking-opt-outs/"
+
         /// Privacy policy for California users URL
         ///
         case californiaPrivacy = "https://automattic.com/privacy/#california-consumer-privacy-act-ccpa"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -130,12 +130,14 @@ private extension PrivacySettingsViewController {
         if isPrivacyChoicesEnabled {
             return sections = [
                 Section(title: Localization.tracking, footer: nil, rows: [.analytics, .analyticsInfo]),
-                Section(title: Localization.morePrivacyOptions, footer: Localization.morePrivacyOptionsFooter, rows: [.analytics, .analyticsInfo]),
+                Section(title: Localization.morePrivacyOptions, footer: Localization.morePrivacyOptionsFooter, rows: [.morePrivacy, .morePrivacyInfo]),
                 Section(title: Localization.reports, footer: nil, rows: [.reportCrashes, .crashInfo])
             ]
         } else {
             return sections = [
-                Section(title: nil, footer: nil, rows: [.collectInfo, .shareInfo, .shareInfoPolicy, .privacyInfo, .privacyPolicy, .thirdPartyInfo, .thirdPartyPolicy]),
+                Section(title: nil,
+                        footer: nil,
+                        rows: [.collectInfo, .shareInfo, .shareInfoPolicy, .privacyInfo, .privacyPolicy, .thirdPartyInfo, .thirdPartyPolicy]),
                 Section(title: nil, footer: nil, rows: [.reportCrashes, .crashInfo])
             ]
         }
@@ -155,6 +157,10 @@ private extension PrivacySettingsViewController {
             configureAnalytics(cell: cell)
         case let cell as BasicTableViewCell where row == .analyticsInfo:
             configureAnalyticsInfo(cell: cell)
+        case let cell as BasicTableViewCell where row == .morePrivacy:
+            configureMorePrivacy(cell: cell)
+        case let cell as BasicTableViewCell where row == .morePrivacyInfo:
+            configureMorePrivacyInfo(cell: cell)
         case let cell as SwitchTableViewCell where row == .collectInfo:
             configureCollectInfo(cell: cell)
         case let cell as BasicTableViewCell where row == .shareInfo:
@@ -201,6 +207,22 @@ private extension PrivacySettingsViewController {
             "These cookies allow us to optimize performance by collecting information on how users interact with our mobile apps.",
             comment: "Analytics toggle description in the privacy screen."
         )
+        configureInfo(cell: cell)
+    }
+
+    func configureMorePrivacy(cell: BasicTableViewCell) {
+        cell.imageView?.image = nil
+        cell.textLabel?.text = NSLocalizedString(
+            "Advertising Option",
+            comment: "More Privacy Options section title in the privacy screen."
+        )
+    }
+
+    func configureMorePrivacyInfo(cell: BasicTableViewCell) {
+        cell.imageView?.image = nil
+        cell.textLabel?.text = NSLocalizedString("More Privacy Options Available. Check here to learn more.",
+                                                 comment: "More Privacy toggle section in the privacy screen.")
+        cell.accessoryType = .disclosureIndicator
         configureInfo(cell: cell)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -130,7 +130,7 @@ private extension PrivacySettingsViewController {
         if isPrivacyChoicesEnabled {
             return sections = [
                 Section(title: Localization.tracking, footer: nil, rows: [.analytics, .analyticsInfo]),
-                Section(title: Localization.morePrivacyOptions, footer: Localization.morePrivacyOptionsFooter, rows: [.morePrivacy, .morePrivacyInfo]),
+                Section(title: Localization.morePrivacyOptions, footer: Localization.morePrivacyOptionsFooter, rows: [.morePrivacy]),
                 Section(title: Localization.reports, footer: nil, rows: [.reportCrashes, .crashInfo])
             ]
         } else {
@@ -157,10 +157,8 @@ private extension PrivacySettingsViewController {
             configureAnalytics(cell: cell)
         case let cell as BasicTableViewCell where row == .analyticsInfo:
             configureAnalyticsInfo(cell: cell)
-        case let cell as BasicTableViewCell where row == .morePrivacy:
+        case let cell as HeadlineLabelTableViewCell where row == .morePrivacy:
             configureMorePrivacy(cell: cell)
-        case let cell as BasicTableViewCell where row == .morePrivacyInfo:
-            configureMorePrivacyInfo(cell: cell)
         case let cell as SwitchTableViewCell where row == .collectInfo:
             configureCollectInfo(cell: cell)
         case let cell as BasicTableViewCell where row == .shareInfo:
@@ -210,12 +208,13 @@ private extension PrivacySettingsViewController {
         configureInfo(cell: cell)
     }
 
-    func configureMorePrivacy(cell: BasicTableViewCell) {
+    func configureMorePrivacy(cell: HeadlineLabelTableViewCell) {
         cell.imageView?.image = nil
-        cell.textLabel?.text = NSLocalizedString(
-            "Advertising Option",
-            comment: "More Privacy Options section title in the privacy screen."
-        )
+        cell.update(style: .subheadline,
+                    headline: NSLocalizedString("Advertising Option", comment: "More Privacy Options section title in the privacy screen."),
+                    body: NSLocalizedString("More Privacy Options Available. Check here to learn more.",
+                                            comment: "More Privacy toggle section in the privacy screen."))
+        cell.accessoryType = .disclosureIndicator
     }
 
     func configureMorePrivacyInfo(cell: BasicTableViewCell) {
@@ -534,7 +533,6 @@ private enum Row: CaseIterable {
     case analytics
     case analyticsInfo
     case morePrivacy
-    case morePrivacyInfo
     case collectInfo
     case privacyInfo
     case privacyPolicy
@@ -552,9 +550,7 @@ private enum Row: CaseIterable {
         case .analyticsInfo:
             return BasicTableViewCell.self
         case .morePrivacy:
-            return BasicTableViewCell.self
-        case .morePrivacyInfo:
-            return BasicTableViewCell.self
+            return HeadlineLabelTableViewCell.self
         case .collectInfo:
             return SwitchTableViewCell.self
         case .privacyInfo:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -121,19 +121,22 @@ private extension PrivacySettingsViewController {
         if isPrivacyChoicesEnabled {
             tableView.tableHeaderView = createTableHeaderView()
             tableView.updateHeaderHeight()
+            tableView.sectionFooterHeight = UITableView.automaticDimension
+            tableView.estimatedSectionFooterHeight = 100
         }
     }
 
     func configureSections() {
         if isPrivacyChoicesEnabled {
             return sections = [
-                Section(title: Localization.tracking, rows: [.analytics, .analyticsInfo]),
-                Section(title: Localization.reports, rows: [.reportCrashes, .crashInfo])
+                Section(title: Localization.tracking, footer: nil, rows: [.analytics, .analyticsInfo]),
+                Section(title: Localization.morePrivacyOptions, footer: Localization.morePrivacyOptionsFooter, rows: [.analytics, .analyticsInfo]),
+                Section(title: Localization.reports, footer: nil, rows: [.reportCrashes, .crashInfo])
             ]
         } else {
             return sections = [
-                Section(title: nil, rows: [.collectInfo, .shareInfo, .shareInfoPolicy, .privacyInfo, .privacyPolicy, .thirdPartyInfo, .thirdPartyPolicy]),
-                Section(title: nil, rows: [.reportCrashes, .crashInfo])
+                Section(title: nil, footer: nil, rows: [.collectInfo, .shareInfo, .shareInfoPolicy, .privacyInfo, .privacyPolicy, .thirdPartyInfo, .thirdPartyPolicy]),
+                Section(title: nil, footer: nil, rows: [.reportCrashes, .crashInfo])
             ]
         }
     }
@@ -410,20 +413,32 @@ extension PrivacySettingsViewController: UITableViewDataSource {
         sections[section].title
     }
 
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        // Add a greater padding for the new privacy choices redesign.
-        if isPrivacyChoicesEnabled {
-            return Constants.footerPadding
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard let footer = sections[section].footer else {
+            return nil
         }
 
-        // Give some breathing room to the table.
-        let lastSection = sections.count - 1
-        if section == lastSection {
-            return UITableView.automaticDimension
-        }
+        var attr = NSMutableAttributedString(string: footer, attributes: [.foregroundColor: UIColor.textSubtle, .font: UIFont.caption1])
+        attr.setAsLink(textToFind: "Cookie Policy", linkURL: "https://automattic.com/cookies/")
+        attr.setAsLink(textToFind: "Privacy Policy", linkURL: "https://automattic.com/privacy/")
 
-        // iOS 11 table bug. Must return a tiny value to collapse `nil` or `empty` section footers.
-        return CGFloat.leastNonzeroMagnitude
+        let textView = UITextView(frame: .zero)
+        textView.font = .caption1
+        textView.textColor = .textSubtle
+        textView.attributedText = attr
+        textView.textContainer.maximumNumberOfLines = 0
+        textView.backgroundColor = .clear
+        textView.textContainerInset = Constants.footerInsets
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.delegate = self
+
+        var linkTextAttributes = textView.linkTextAttributes ?? [:]
+        linkTextAttributes[.underlineColor] = UIColor.clear
+        linkTextAttributes[.foregroundColor] = UIColor.primary
+        textView.linkTextAttributes = linkTextAttributes
+
+        return textView
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -470,6 +485,11 @@ extension PrivacySettingsViewController {
                                                   comment: "Main description on the privacy screen.")
         static let tracking = NSLocalizedString("Tracking", comment: "Title of the tracking section on the privacy screen")
         static let reports = NSLocalizedString("Reports", comment: "Title of the report section on the privacy screen")
+        static let morePrivacyOptions = NSLocalizedString("More Privacy Options", comment: "Title of the more privacy options section on the privacy screen")
+        static let morePrivacyOptionsFooter = NSLocalizedString("To learn more about how we use your data to optimize our mobile apps, " +
+                                                                "enhance your experience, and deliver relevant marketing, " +
+                                                                "learn more in our Privacy Policy and Cookie Policy." + "\n",
+                                                                comment: "Footer of the more privacy options section on the privacy screen")
     }
 }
 
@@ -478,17 +498,21 @@ private struct Constants {
     static let separatorInset = CGFloat(16)
     static let sectionHeight = CGFloat(18)
     static let headerTitleInsets = UIEdgeInsets(top: 16, left: 14, bottom: 32, right: 14)
-    static let footerPadding = CGFloat(24)
+    static let footerInsets = UIEdgeInsets(top: 8, left: 16, bottom: 16, right: 16)
+    static let footerPadding = CGFloat(44)
 }
 
 private struct Section {
     let title: String?
+    let footer: String?
     let rows: [Row]
 }
 
 private enum Row: CaseIterable {
     case analytics
     case analyticsInfo
+    case morePrivacy
+    case morePrivacyInfo
     case collectInfo
     case privacyInfo
     case privacyPolicy
@@ -504,6 +528,10 @@ private enum Row: CaseIterable {
         case .analytics:
             return SwitchTableViewCell.self
         case .analyticsInfo:
+            return BasicTableViewCell.self
+        case .morePrivacy:
+            return BasicTableViewCell.self
+        case .morePrivacyInfo:
             return BasicTableViewCell.self
         case .collectInfo:
             return SwitchTableViewCell.self
@@ -528,5 +556,12 @@ private enum Row: CaseIterable {
 
     var reuseIdentifier: String {
         return type.reuseIdentifier
+    }
+}
+
+extension PrivacySettingsViewController: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        print("Link tapped")
+        return false
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -365,8 +365,8 @@ private extension PrivacySettingsViewController {
     ///
     func createMorePrivacyFooterView(text: String) -> UIView {
         var attr = NSMutableAttributedString(string: text, attributes: [.foregroundColor: UIColor.textSubtle, .font: UIFont.caption1])
-        attr.setAsLink(textToFind: "Cookie Policy", linkURL: "https://automattic.com/cookies/")
-        attr.setAsLink(textToFind: "Privacy Policy", linkURL: "https://automattic.com/privacy/")
+        attr.setAsLink(textToFind: Localization.cookiePolicy, linkURL: WooConstants.URLs.cookie.rawValue)
+        attr.setAsLink(textToFind: Localization.privacyPolicy, linkURL: WooConstants.URLs.privacy.rawValue)
 
         let textView = UITextView(frame: .zero)
         textView.font = .caption1
@@ -424,6 +424,24 @@ private extension PrivacySettingsViewController {
     ///
     func presentPrivacyPolicyWebView() {
         WebviewHelper.launch(WooConstants.URLs.privacy.asURL(), with: self)
+    }
+
+    /// Presents a URL modally.
+    ///
+    func presentURL(_ url: URL) {
+        let safariViewController = SFSafariViewController(url: url)
+        present(safariViewController, animated: true)
+    }
+
+    func trackURLPresentation(_ url: URL) {
+        switch url.absoluteString {
+        case WooConstants.URLs.cookie.rawValue:
+            ServiceLocator.analytics.track(.settingsThirdPartyLearnMoreTapped)
+        case WooConstants.URLs.privacy.rawValue:
+            ServiceLocator.analytics.track(.settingsPrivacyPolicyTapped)
+        default:
+            break
+        }
     }
 }
 
@@ -493,6 +511,8 @@ extension PrivacySettingsViewController: UITableViewDelegate {
         case .privacyPolicy:
             ServiceLocator.analytics.track(.settingsPrivacyPolicyTapped)
             presentPrivacyPolicyWebView()
+        case .morePrivacy:
+            presentURL(WooConstants.URLs.morePrivacyDocumentation.asURL())
         default:
             break
         }
@@ -516,6 +536,8 @@ extension PrivacySettingsViewController {
                                                                 "enhance your experience, and deliver relevant marketing, " +
                                                                 "learn more in our Privacy Policy and Cookie Policy." + "\n",
                                                                 comment: "Footer of the more privacy options section on the privacy screen")
+        static let cookiePolicy = NSLocalizedString("Cookie Policy", comment: "Cookie Policy text on the privacy screen")
+        static let privacyPolicy = NSLocalizedString("Privacy Policy", comment: "Privacy Policy text on the privacy screen")
     }
 }
 
@@ -584,7 +606,8 @@ private enum Row: CaseIterable {
 
 extension PrivacySettingsViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        print("Link tapped")
+        presentURL(URL)
+        trackURLPresentation(URL)
         return false
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -361,6 +361,32 @@ private extension PrivacySettingsViewController {
         return container
     }
 
+    /// Footer view for the More Privacy Section.
+    ///
+    func createMorePrivacyFooterView(text: String) -> UIView {
+        var attr = NSMutableAttributedString(string: text, attributes: [.foregroundColor: UIColor.textSubtle, .font: UIFont.caption1])
+        attr.setAsLink(textToFind: "Cookie Policy", linkURL: "https://automattic.com/cookies/")
+        attr.setAsLink(textToFind: "Privacy Policy", linkURL: "https://automattic.com/privacy/")
+
+        let textView = UITextView(frame: .zero)
+        textView.font = .caption1
+        textView.textColor = .textSubtle
+        textView.attributedText = attr
+        textView.textContainer.maximumNumberOfLines = 0
+        textView.backgroundColor = .clear
+        textView.textContainerInset = Constants.footerInsets
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.delegate = self
+
+        var linkTextAttributes = textView.linkTextAttributes ?? [:]
+        linkTextAttributes[.underlineColor] = UIColor.clear
+        linkTextAttributes[.foregroundColor] = UIColor.primary
+        textView.linkTextAttributes = linkTextAttributes
+
+        return textView
+    }
+
     // MARK: Actions
     //
     func collectInfoWasUpdated(newValue: Bool) {
@@ -438,28 +464,7 @@ extension PrivacySettingsViewController: UITableViewDataSource {
         guard let footer = sections[section].footer else {
             return nil
         }
-
-        var attr = NSMutableAttributedString(string: footer, attributes: [.foregroundColor: UIColor.textSubtle, .font: UIFont.caption1])
-        attr.setAsLink(textToFind: "Cookie Policy", linkURL: "https://automattic.com/cookies/")
-        attr.setAsLink(textToFind: "Privacy Policy", linkURL: "https://automattic.com/privacy/")
-
-        let textView = UITextView(frame: .zero)
-        textView.font = .caption1
-        textView.textColor = .textSubtle
-        textView.attributedText = attr
-        textView.textContainer.maximumNumberOfLines = 0
-        textView.backgroundColor = .clear
-        textView.textContainerInset = Constants.footerInsets
-        textView.isEditable = false
-        textView.isScrollEnabled = false
-        textView.delegate = self
-
-        var linkTextAttributes = textView.linkTextAttributes ?? [:]
-        linkTextAttributes[.underlineColor] = UIColor.clear
-        linkTextAttributes[.foregroundColor] = UIColor.primary
-        textView.linkTextAttributes = linkTextAttributes
-
-        return textView
+        return createMorePrivacyFooterView(text: footer)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/HeadlineLabelTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/HeadlineLabelTableViewCell.swift
@@ -13,6 +13,9 @@ final class HeadlineLabelTableViewCell: UITableViewCell {
         /// Bold title with no margin against the body. Hard colors. This is the default.
         case compact
         /// Normal body title with a margin against the body. The title uses body style while
+        /// the body uses subheadline style.
+        case subheadline
+        /// Normal body title with a margin against the body. The title uses body style while
         /// the body uses secondary style.
         case regular
         /// Title with body style and body with secondary style.
@@ -59,6 +62,11 @@ private extension HeadlineLabelTableViewCell {
             headlineLabel?.applyHeadlineStyle()
             bodyLabel?.applyBodyStyle()
             headlineToBodyConstraint.constant = 0
+        case .subheadline:
+            headlineLabel?.applyBodyStyle()
+            bodyLabel?.applySubheadlineStyle()
+            bodyLabel?.textColor = .textSubtle
+            headlineToBodyConstraint.constant = Dimensions.margin
         case .regular:
             headlineLabel?.applyBodyStyle()
             bodyLabel?.applySecondaryBodyStyle()


### PR DESCRIPTION
closes #9608
part of #9610

# Why

This PR adds the **More Privacy Options** section on the Privacy Settings screen. This PR uses a template URL for the **"Adverting Options"** URL, as it is still being built in https://github.com/woocommerce/woomobile-private/issues/286

# How

- Everything is pretty standard, except for the fact that I'm using a `TextView` in order to detect the "Cookie Policy" and "Privacy Policy" Links. The only downside is that the text is selectable, but I don't consider this to be a problem. 

- Additionally, I'm adding a new style to `HeadlineLabelTableViewCell` to be able to reuse its UI Layout in this PR.

# Demo

https://user-images.githubusercontent.com/562080/236939906-9152a971-beab-4580-841b-43776dafe6ca.mov

# Testing Steps

- Open the app and navigate to the Hub -> Settings -> Privacy Settings
- See that the "More Privacy Options" section is present
- See that you can tap the "Advertising Option" row. It should open a temporary Wordpress.com document
- See that you can tap the "Privacy Policy" link.
- See that you can tap the "Cookie Policy" link.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.