### PR TITLE
[Privacy Choices] Privacy Screen UX Improvements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -578,9 +578,9 @@ extension PrivacySettingsViewController {
         static let cookiePolicy = NSLocalizedString("Cookie Policy", comment: "Cookie Policy text on the privacy screen")
         static let privacyPolicy = NSLocalizedString("Privacy Policy", comment: "Privacy Policy text on the privacy screen")
 
-        static let errorFetchingAnalyticsState = NSLocalizedString("There was an error fetching your account settings",
+        static let errorFetchingAnalyticsState = NSLocalizedString("There was an error fetching your privacy settings",
                                                                    comment: "Error notice when failing to fetch account settings on the privacy screen.")
-        static let errorUpdatingAnalyticsState = NSLocalizedString("There was an error updating your account settings",
+        static let errorUpdatingAnalyticsState = NSLocalizedString("There was an error updating your privacy settings",
                                                                    comment: "Error notice when failing to update account settings on the privacy screen.")
         static let retry = NSLocalizedString("Retry", comment: "Retry button title for the privacy screen notices")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -366,7 +366,7 @@ private extension PrivacySettingsViewController {
     /// Footer view for the More Privacy Section.
     ///
     func createMorePrivacyFooterView(text: String) -> UIView {
-        var attr = NSMutableAttributedString(string: text, attributes: [.foregroundColor: UIColor.textSubtle, .font: UIFont.caption1])
+        let attr = NSMutableAttributedString(string: text, attributes: [.foregroundColor: UIColor.textSubtle, .font: UIFont.caption1])
         attr.setAsLink(textToFind: Localization.cookiePolicy, linkURL: WooConstants.URLs.cookie.rawValue)
         attr.setAsLink(textToFind: Localization.privacyPolicy, linkURL: WooConstants.URLs.privacy.rawValue)
 
@@ -478,6 +478,7 @@ private extension PrivacySettingsViewController {
                             notificationInfo: info,
                             actionTitle: Localization.retry) { [weak self] in
             guard let self else { return }
+            self.collectInfo = optInValue
             self.collectInfoWasUpdated(newValue: optInValue)
         }
         ServiceLocator.noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -405,6 +405,7 @@ private extension PrivacySettingsViewController {
             case .success:
                 ServiceLocator.analytics.setUserHasOptedOut(userOptedOut)
             case .failure:
+                self?.collectInfo = !newValue // Revert to the previous value to keep the UI consistent.
                 self?.presentErrorUpdatingAccountSettingsNotice(optInValue: newValue)
             }
         }


### PR DESCRIPTION
Closes: #9611 #9667

# Why

This PR adds some UX improvements to the Privacy Settings screen, specifically it:

- Make sure the `Analytics` toggle always reflects the correct state of the account settings.
- Show a notice + a retry when failing to get the latest account settings state.
- Show a notice + a retry when failing to update the account settings state.
- Remove analytics tracking when toggling the state.

# Demo

## Fetch Error Notice

https://user-images.githubusercontent.com/562080/236993536-da0ab4fc-32dc-413d-a8ec-7d15fabf415a.mov

## Update Error Notice

https://user-images.githubusercontent.com/562080/236993547-ed3d7202-a0e4-495c-961f-2cb0236edebb.mov

# Testing Steps

- Go to the Privacy Settings Screen without an active connection.
- See that an error notice is presented.

----

- Go to the Privacy Settings Screen.
- Turn off the network connection
- Try to toggle the analytics setting.
- See that an error notice is presented.
- See that the analytics toggle goes back to its original value.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
