### PR TITLE
Authenticate with Google without the Google SDK in non-production builds

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -97,6 +97,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .euShippingNotification:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .sdkLessGoogleSignIn:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -207,4 +207,8 @@ public enum FeatureFlag: Int {
     /// Enables EU Bound notifications inside the Shipping Labels feature
     ///
     case euShippingNotification
+
+    /// Do not use the Google SDK when authenticating through a Google account.
+    ///
+    case sdkLessGoogleSignIn
 }

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -40,7 +40,8 @@ extension WordPressAuthenticator {
                                                                 enableManualSiteCredentialLogin: true,
                                                                 enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
-                                                                enableSiteAddressLoginOnlyInPrologue: true)
+                                                                enableSiteAddressLoginOnlyInPrologue: true,
+                                                                googleLoginWithoutSDK: featureFlagService.isFeatureFlagEnabled(.sdkLessGoogleSignIn))
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)


### PR DESCRIPTION
## Description

In the latest WordPress and Jetpack release (22.2), we have been using [our own implementation of the flow to authenticate with the WordPress.com backend using a Google account](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/741). It's working well so it's time to roll it out to other apps.

However, I don't feel comfortable adopting it full turkey without a remote feature flag to disable it if we discover issues. @pmusolino mentioned there'll soon be support for remote feature flags, so in the meantime I'd like to break the ground and introduce:

- A build-time feature flags
- The logic to read it when configuring the authenticator layer

I expect that, once the remote feature flags will be available, we'll be able to migrate most of this set to the new system.

In the meantime, the few people on internal builds using Google accounts will run through the new flow.

## Testing instructions

Run the app on the Simulator, add a breakpoint into `GoogleAuthenticator.swift` at line 134 (`Shift Cmd O` to open the jump bar to fuzzy find the file since it's buried in the Pods, then `Cmd L 134` to jump to that line) where the switch between flows occur and verify the SDK-less flow runs.

<img width="1677" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/1218433/00f9b00c-5fcc-47dd-b5ff-9523eacecf50">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
