### PR TITLE
SwiftUI wrapper view for SKU scanner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -306,6 +306,7 @@ private struct ProductsSection: View {
                 }, content: {
                     ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
                         print("SKU found: \(detectedBarcode)")
+                        showAddProductViaSKUScanner.toggle()
                     })
                 })
                 .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -405,3 +405,21 @@ private extension ProductSelectorView.Configuration {
         )
     }
 }
+
+// MARK: - SKU scanning
+
+private struct ProductSKUInputScannerView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = ProductSKUInputScannerViewController
+    
+    let onBarcodeScanned: ((String) -> Void)?
+    
+    func makeUIViewController(context: Context) -> ProductSKUInputScannerViewController {
+        ProductSKUInputScannerViewController(onBarcodeScanned: { barcode in
+            onBarcodeScanned?(barcode)
+        })
+    }
+    
+    func updateUIViewController(_ uiViewController: ProductSKUInputScannerViewController, context: Context) {
+        // no-op
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -304,7 +304,9 @@ private struct ProductsSection: View {
                 .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
                     scroll.scrollTo(addProductViaSKUScannerButton)
                 }, content: {
-                    EmptyView()
+                    ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
+                        print("SKU found: \(detectedBarcode)")
+                    })
                 })
                 .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
             }
@@ -410,15 +412,15 @@ private extension ProductSelectorView.Configuration {
 
 private struct ProductSKUInputScannerView: UIViewControllerRepresentable {
     typealias UIViewControllerType = ProductSKUInputScannerViewController
-    
+
     let onBarcodeScanned: ((String) -> Void)?
-    
+
     func makeUIViewController(context: Context) -> ProductSKUInputScannerViewController {
         ProductSKUInputScannerViewController(onBarcodeScanned: { barcode in
             onBarcodeScanned?(barcode)
         })
     }
-    
+
     func updateUIViewController(_ uiViewController: ProductSKUInputScannerViewController, context: Context) {
         // no-op
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9658
Closes: #9651

Based on #9662 , which should be merged first. 

## Description

This PR creates a `UIViewControllerRepresentable` wrapper around `ProductSKUInputScannerViewController`, so we can use it as a SwiftUI `View` within its Order section and test its behaviour.

## Testing instructions

1. On a physical device, go to Settings > Woo > and confirm that `Allow Woo to access: Camera` permissions is enabled (permissions check will be dealt with on a [different PR](https://github.com/woocommerce/woocommerce-ios/issues/9677)).
2. Go to Orders > `+` > `+ Add Product via SKU scanner` > See how the scanning view appears
3. Scan the following code:

![today-03-05-2023-test-qr-static-text](https://user-images.githubusercontent.com/3812076/237013607-d5c2c5a5-38f7-4369-9161-ae81cdb8b0e2.jpg)

4. See how the view is dismissed and Xcode's console displays the following:
```
SKU found: long-sleeve vintage cotton t-shirt
```

Alternatively you can also create your own code with any free tool [like this one](https://www.barcode-generator.org/), as each standard has different characteristics, for example a `Code 128` standard will return something like `SKU found: 0471152470100` as its encoding is not set to be 1:1 with the input:

![today-09-05-2023-test-barcode-static](https://user-images.githubusercontent.com/3812076/237015381-79ba8381-dffb-4735-be0f-7d5302681d02.png)

## Screenshots

https://user-images.githubusercontent.com/3812076/237012893-0c22d872-29fc-4c4b-9cee-2ab4c9b8234b.mp4