### PR TITLE
[UI Tests] - Update assertion to verify payments screen

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -90,7 +90,8 @@ public final class PaymentsScreen: ScreenObject {
 
     @discardableResult
     public func verifyPaymentsScreenLoaded() throws -> PaymentsScreen {
-        XCTAssertTrue(collectPaymentButton.waitForExistence(timeout: 15))
+        collectPaymentButton.waitForExistence(timeout: 15)
+        XCTAssertTrue(isLoaded)
         return self
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -90,7 +90,7 @@ public final class PaymentsScreen: ScreenObject {
 
     @discardableResult
     public func verifyPaymentsScreenLoaded() throws -> PaymentsScreen {
-        XCTAssertTrue(isLoaded)
+        XCTAssertTrue(collectPaymentButton.waitForExistence(timeout: 15))
         return self
     }
 


### PR DESCRIPTION
## Description
`test_load_payments_universal_link ` test was failing (after retry) in [this build](https://buildkite.com/automattic/woocommerce-ios/builds/13083). And the failure is it wasn't able to get `isHittable` state of the "Collect Payment" button on this screen (even though it's clearly visible):
![image](https://user-images.githubusercontent.com/17252150/237061354-6fb32df0-456b-4f00-8eeb-8a20f5eb70f5.png)

In this PR, I updated the assertion to use `collectPaymentButton.waitForExistence(timeout: 15)` instead of `isLoaded` with a timeout of 15 seconds in case it was due to the slowness in CI. 

## Testing instructions
CI should pass 