### PR TITLE
[Product Bundles] Fix bundle stock status and quantity overrides

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.6
 -----
 - [*] Product form > description editor: fix the extra bottom inset after hiding the keyboard either manually (available on a tablet) or applying an AI-generated product description. [https://github.com/woocommerce/woocommerce-ios/pull/9638]
+- [*] Products: Fixes stock statuses for Product Bundles so that backordered bundles and bundle stock quantities are displayed as expected. [https://github.com/woocommerce/woocommerce-ios/pull/9681]
 
 13.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -197,11 +197,11 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             price = product.price
         }
 
-        // If product is a product bundle with a bundle stock status, use that as the product stock status.
+        // If product is a product bundle with insufficient bundle stock, use that as the product stock status.
         let stockStatusKey: String = {
             switch (productBundlesEnabled, product.productType, product.bundleStockStatus) {
-            case (true, .bundle, .some(let bundleStockStatus)):
-                return bundleStockStatus.rawValue
+            case (true, .bundle, .insufficientStock):
+                return ProductStockStatus.insufficientStock.rawValue
             default:
                 return product.stockStatusKey
             }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -217,6 +217,16 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             }
         }()
 
+        // If product is a product bundle with a bundle stock quantity, override product `manageStock` setting.
+        let manageStock: Bool = {
+            switch (productBundlesEnabled, product.productType, product.bundleStockQuantity) {
+            case (true, .bundle, .some):
+                return true
+            default:
+                return product.manageStock
+            }
+        }()
+
         self.init(id: id,
                   productOrVariationID: product.productID,
                   name: product.name,
@@ -224,7 +234,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   price: price,
                   stockStatusKey: stockStatusKey,
                   stockQuantity: stockQuantity,
-                  manageStock: product.manageStock,
+                  manageStock: manageStock,
                   quantity: quantity,
                   canChangeQuantity: canChangeQuantity,
                   imageURL: product.imageURL,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -339,7 +339,7 @@ class ProductRowViewModelTests: XCTestCase {
 
     func test_bundle_stock_quantity_used_for_product_bundles_when_feature_flag_enabled() {
         // Given
-        let product = Product.fake().copy(productTypeKey: "bundle", manageStock: true, stockQuantity: 5, stockStatusKey: "instock", bundleStockQuantity: 1)
+        let product = Product.fake().copy(productTypeKey: "bundle", manageStock: false, stockQuantity: 5, stockStatusKey: "instock", bundleStockQuantity: 1)
 
         // When
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, productBundlesEnabled: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -296,7 +296,7 @@ class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedStockText)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
-    func test_bundle_stock_status_used_for_product_bundles_when_feature_flag_enabled() {
+    func test_bundle_stock_status_used_for_product_bundles_when_insufficient_stock_and_feature_flag_enabled() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "instock", bundleStockStatus: .insufficientStock)
 
@@ -305,6 +305,19 @@ class ProductRowViewModelTests: XCTestCase {
 
         // Then
         let expectedStockText = ProductStockStatus.insufficientStock.description
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockText),
+                      "Expected label to contain \"\(expectedStockText)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
+    }
+
+    func test_product_stock_status_used_for_product_bundles_when_backordered_and_feature_flag_enabled() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "onbackorder", bundleStockStatus: .inStock)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, productBundlesEnabled: true)
+
+        // Then
+        let expectedStockText = ProductStockStatus.onBackOrder.description
         XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockText),
                       "Expected label to contain \"\(expectedStockText)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -140,6 +140,25 @@ final class ProductsTabProductViewModelTests: XCTestCase {
                       "Expected details text to include \(expectedStockText) but it was \(detailsText) instead")
     }
 
+    func test_details_for_product_bundle_contain_product_stock_status_when_product_is_backordered_and_feature_flag_enabled() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle",
+                                          manageStock: false,
+                                          stockQuantity: 5,
+                                          stockStatusKey: "onbackorder",
+                                          bundleStockStatus: .inStock,
+                                          bundleStockQuantity: 0)
+
+        // When
+        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: true)
+        let detailsText = viewModel.detailsAttributedString.string
+
+        // Then
+        let expectedStockText = ProductStockStatus.onBackOrder.description
+        XCTAssertTrue(detailsText.contains(expectedStockText),
+                      "Expected details text to include \(expectedStockText) but it was \(detailsText) instead")
+    }
+
     func test_details_for_product_bundle_contain_product_stock_status_when_bundle_not_in_stock_and_feature_flag_disabled() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle",
@@ -154,24 +173,6 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         let detailsText = viewModel.detailsAttributedString.string
 
         // Then
-        let expectedStockText = ProductStockStatus.inStock.description
-        XCTAssertTrue(detailsText.contains(expectedStockText))
-    }
-
-    func test_details_for_product_bundle_contain_stock_status_without_quantity_when_bundle_stock_quantity_is_nil_and_feature_flag_enabled() {
-        // Arrange
-        let product = Product.fake().copy(productTypeKey: "bundle",
-                                          manageStock: true,
-                                          stockQuantity: 5,
-                                          stockStatusKey: "instock",
-                                          bundleStockStatus: .inStock,
-                                          bundleStockQuantity: nil)
-
-        // Action
-        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: true)
-        let detailsText = viewModel.detailsAttributedString.string
-
-        // Assert
         let expectedStockText = ProductStockStatus.inStock.description
         XCTAssertTrue(detailsText.contains(expectedStockText))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9663
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes how the product stock status and quantity are displayed for product bundles:

* Only overrides the product stock status when the bundle stock status is "insufficient stock." In other cases, the product's stock status will be used. (This ensures that stock statuses like "on backorder" are displayed correctly.)
* Always displays the bundle stock quantity when it's set (for "in stock" products). Previously, the `ProductRow` wasn't overriding the product's `manageStock` property to always display this.

### Changes

* In `ProductFormDataModel+ProductsTabProductViewModel.swift`:
   * Moves the product bundle stock text logic to a separate method to make it clearer.
   * Only overrides the product's `stockStatus` when the `bundleStockStatus` is `insufficientStock`.
* In `ProductRowViewModel`:
   * Only overrides the `product.stockStatusKey` when the `product.bundleStockStatus` is `insufficientStock`.
   * Sets `manageStock` to `true` when `product.bundleStockQuantity` is not nil, so the quantity is displayed when the stock text is created.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a product bundle with at least one bundled product, and the product bundle's stock status set to "on backorder."
2. Create another product bundle with at least one bundled product. In the product bundle's inventory settings, make sure "Track stock quantity for this product" **is not** selected. In the product inventory settings for the bundled product, make sure "Track stock quantity for this product" **is** selected.
3. Build and run the app.
4. Open the Products tab, find the product bundles in the list, and confirm the stock statuses match wp-admin ("on back order" for the backordered product bundle, and showing a stock quantity for the other product bundles).
5. Create a new order.
6. Select "Add product," find the product bundles in the list, and confirm the stock statuses match wp-admin.

You can also test other statuses (in stock with no stock quantity for bundled products, out of stock, insufficient stock) to confirm they continue to work as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
/|Before|After
-|-|-
Products tab (with product search)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-09 at 13 18 30](https://github.com/woocommerce/woocommerce-ios/assets/8658164/ca997b2f-2c16-4532-9a10-dd5d798b9b67)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-09 at 13 11 50](https://github.com/woocommerce/woocommerce-ios/assets/8658164/2fdfedb2-0d8e-4263-9876-70b5903d228c)
`ProductRow` (in order creation)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-09 at 13 18 41](https://github.com/woocommerce/woocommerce-ios/assets/8658164/0aede5ef-f149-4917-ab5e-06d5e18b4a23)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-09 at 13 16 35](https://github.com/woocommerce/woocommerce-ios/assets/8658164/45f3e8da-76d1-4b43-a522-2f1f2f40eb35)

Stock statuses in wp-admin for comparison:

<img src="https://github.com/woocommerce/woocommerce-ios/assets/8658164/423430e1-599c-4007-a542-02362be75fc5" width="500px">




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
