### PR TITLE
[Subscriptions] Track when Subscriptions is tapped for product or variation separately

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -351,6 +351,12 @@ extension WooAnalyticsEvent {
         static func quantityRulesTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationDetailViewQuantityRulesTapped, properties: [:])
         }
+
+        /// Tracks when the merchant taps the Subscriptions row for a product variation.
+        ///
+        static func subscriptionsTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationViewSubscriptionsTapped, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -592,6 +592,7 @@ public enum WooAnalyticsStat: String {
     case productVariationDetailUpdateSuccess = "product_variation_update_success"
     case productVariationDetailUpdateError = "product_variation_update_error"
     case productVariationDetailViewQuantityRulesTapped = "product_variation_view_quantity_rules_tapped"
+    case productVariationViewSubscriptionsTapped = "product_variation_view_subscriptions_tapped"
 
     case productVariationBulkUpdateSectionTapped = "product_variation_bulk_update_section_tapped"
     case productVariationBulkUpdateFieldTapped = "product_variation_bulk_update_field_tapped"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLogger.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLogger.swift
@@ -27,4 +27,8 @@ struct ProductFormEventLogger: ProductFormEventLoggerProtocol {
     func logQuantityRulesTapped() {
         ServiceLocator.analytics.track(event: .ProductDetail.quantityRulesTapped())
     }
+
+    func logSubscriptionsTapped() {
+        ServiceLocator.analytics.track(event: .ProductDetail.subscriptionsTapped())
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLoggerProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLoggerProtocol.swift
@@ -20,4 +20,7 @@ protocol ProductFormEventLoggerProtocol {
 
     /// Called to log an event when the quantity rules row is tapped.
     func logQuantityRulesTapped()
+
+    /// Called to log an event when the subscriptions row is tapped.
+    func logSubscriptionsTapped()
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -458,7 +458,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isActionable else {
                     return
                 }
-                ServiceLocator.analytics.track(event: .ProductDetail.subscriptionsTapped())
+                eventLogger.logSubscriptionsTapped()
                 showSubscriptionSettings()
             case .noVariationsWarning:
                 return // This warning is not actionable.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormEventLogger.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormEventLogger.swift
@@ -27,4 +27,8 @@ struct ProductVariationFormEventLogger: ProductFormEventLoggerProtocol {
     func logQuantityRulesTapped() {
         ServiceLocator.analytics.track(event: .Variations.quantityRulesTapped())
     }
+
+    func logSubscriptionsTapped() {
+        ServiceLocator.analytics.track(event: .Variations.subscriptionsTapped())
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9669
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a new analytics event to track when Subscriptions is opened in variation details:

* `product_variation_view_subscriptions_tapped` (Registration: 1588-gh-tracks-events-registration)

This is now tracked separately from the existing event for product details (`product_details_view_subscriptions_tapped`).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. With the WooCommerce Subscriptions extension installed and activated, create a new simple subscription product and a new variable subscription product (with at least one variation).
2. Build and run the app.
3. Go to the Products tab.
4. Select a simple subscription product.
5. Tap the Subscriptions row and confirm the event `product_details_view_subscriptions_tapped` is tracked.
6. Go back to the Products tab and select a variable subscription product.
7. Select Variations to open the variation list.
8. Select a variation to open variation details.
9. Tap the Subscriptions row and confirm the event `product_variation_view_subscriptions_tapped` is tracked.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
