### PR TITLE
EU-Bound Shipping Notice: Add banner to Customs view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -18,12 +18,12 @@ struct ShippingLabelCustomsFormList: View {
             ScrollView {
                 EUShippingNoticeBanner(width: geometry.size.width)
                     .onDismiss {
-                        // TODO
+                        viewModel.bannerDismissTapped()
                     }
                     .onLearnMore { instructionsURL in
-                        // TODO
+                        viewModel.bannerLearnMoreTapped(instructionsURL: instructionsURL)
                     }
-                    .renderedIf(true)
+                    .renderedIf(viewModel.shouldDisplayShippingNotice)
                     .fixedSize(horizontal: false, vertical: true)
 
                 ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -16,6 +16,16 @@ struct ShippingLabelCustomsFormList: View {
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
+                EUShippingNoticeBanner(width: geometry.size.width)
+                    .onDismiss {
+                        // TODO
+                    }
+                    .onLearnMore { instructionsURL in
+                        // TODO
+                    }
+                    .renderedIf(true)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
                     ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,
                                                   packageNumber: index + 1,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -15,8 +15,8 @@ final class ShippingCustomsFormListHostingController: UIHostingController<Shippi
                                                               shouldDisplayShippingNotice: shouldDisplayShippingNotice)
         super.init(rootView: .init(viewModel: viewModel, onCompletion: onCompletion))
 
-        rootView.onLearnMoreTapped = { [weak self] instructionsURL in
-            self?.presentShippingInstructionsView(instructionsURL: instructionsURL)
+        rootView.onLearnMoreTapped = { [weak self] in
+            self?.presentShippingInstructionsView()
         }
     }
 
@@ -24,12 +24,9 @@ final class ShippingCustomsFormListHostingController: UIHostingController<Shippi
         fatalError("init(coder:) has not been implemented")
     }
 
-    func presentShippingInstructionsView(instructionsURL: URL?) {
-        let configuration = WebViewControllerConfiguration(url: instructionsURL)
-        configuration.secureInteraction = true
-        let webKitVC = WebKitViewController(configuration: configuration)
-        let nc = WooNavigationController(rootViewController: webKitVC)
-        present(nc, animated: true)
+    func presentShippingInstructionsView() {
+        let instructionsURL = WooConstants.URLs.shippingCustomsInstructionsForEUCountries.asURL()
+        WebviewHelper.launch(instructionsURL, with: self)
     }
 }
 
@@ -38,7 +35,7 @@ struct ShippingLabelCustomsFormList: View {
     @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
 
-    var onLearnMoreTapped: (URL?) -> Void = { _ in }
+    var onLearnMoreTapped: () -> Void = {}
 
     init(viewModel: ShippingLabelCustomsFormListViewModel,
          onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void) {
@@ -54,8 +51,8 @@ struct ShippingLabelCustomsFormList: View {
                     .onDismiss {
                         viewModel.bannerDismissTapped()
                     }
-                    .onLearnMore { instructionsURL in
-                        onLearnMoreTapped(instructionsURL)
+                    .onLearnMore {
+                        onLearnMoreTapped()
                     }
                     .renderedIf(viewModel.shouldDisplayShippingNotice)
                     .fixedSize(horizontal: false, vertical: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -1,6 +1,25 @@
 import SwiftUI
 import Yosemite
 
+final class ShippingCustomsFormListHostingController: UIHostingController<ShippingLabelCustomsFormList> {
+    init(order: Order,
+         customsForms: [ShippingLabelCustomsForm],
+         destinationCountry: Country,
+         countries: [Country],
+         onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void,
+         shouldDisplayShippingNotice: Bool = false) {
+        let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
+                                                              customsForms: customsForms,
+                                                              destinationCountry: destinationCountry,
+                                                              countries: countries)
+        super.init(rootView: .init(viewModel: viewModel, onCompletion: onCompletion))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 struct ShippingLabelCustomsFormList: View {
     @Environment(\.presentationMode) var presentation
     @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -13,10 +13,22 @@ final class ShippingCustomsFormListHostingController: UIHostingController<Shippi
                                                               destinationCountry: destinationCountry,
                                                               countries: countries)
         super.init(rootView: .init(viewModel: viewModel, onCompletion: onCompletion))
+
+        rootView.onLearnMoreTapped = { [weak self] instructionsURL in
+            self?.presentShippingInstructionsView(instructionsURL: instructionsURL)
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func presentShippingInstructionsView(instructionsURL: URL?) {
+        let configuration = WebViewControllerConfiguration(url: instructionsURL)
+        configuration.secureInteraction = true
+        let webKitVC = WebKitViewController(configuration: configuration)
+        let nc = WooNavigationController(rootViewController: webKitVC)
+        present(nc, animated: true)
     }
 }
 
@@ -24,6 +36,8 @@ struct ShippingLabelCustomsFormList: View {
     @Environment(\.presentationMode) var presentation
     @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
+
+    var onLearnMoreTapped: (URL?) -> Void = { _ in }
 
     init(viewModel: ShippingLabelCustomsFormListViewModel,
          onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void) {
@@ -40,7 +54,7 @@ struct ShippingLabelCustomsFormList: View {
                         viewModel.bannerDismissTapped()
                     }
                     .onLearnMore { instructionsURL in
-                        viewModel.bannerLearnMoreTapped(instructionsURL: instructionsURL)
+                        onLearnMoreTapped(instructionsURL)
                     }
                     .renderedIf(viewModel.shouldDisplayShippingNotice)
                     .fixedSize(horizontal: false, vertical: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -6,12 +6,13 @@ final class ShippingCustomsFormListHostingController: UIHostingController<Shippi
          customsForms: [ShippingLabelCustomsForm],
          destinationCountry: Country,
          countries: [Country],
-         onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void,
-         shouldDisplayShippingNotice: Bool = false) {
+         shouldDisplayShippingNotice: Bool,
+         onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void) {
         let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
                                                               customsForms: customsForms,
                                                               destinationCountry: destinationCountry,
-                                                              countries: countries)
+                                                              countries: countries,
+                                                              shouldDisplayShippingNotice: shouldDisplayShippingNotice)
         super.init(rootView: .init(viewModel: viewModel, onCompletion: onCompletion))
 
         rootView.onLearnMoreTapped = { [weak self] instructionsURL in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -83,6 +83,18 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     }
 }
 
+// MARK: - Banner
+//
+extension ShippingLabelCustomsFormListViewModel {
+    func bannerDismissTapped() {
+        
+    }
+
+    func bannerLearnMoreTapped(instructionsURL: URL?) {
+        
+    }
+}
+
 // MARK: - Validation
 //
 private extension ShippingLabelCustomsFormListViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -53,11 +53,14 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     /// References to keep the Combine subscriptions alive with the class.
     ///
     private var cancellables: Set<AnyCancellable> = []
+    
+    let shouldDisplayShippingNotice: Bool
 
     init(order: Order,
          customsForms: [ShippingLabelCustomsForm],
          destinationCountry: Country,
          countries: [Country],
+         shouldDisplayShippingNotice: Bool = false,
          stores: StoresManager = ServiceLocator.stores) {
         self.order = order
         self.multiplePackagesDetected = customsForms.count > 1
@@ -71,6 +74,7 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
             return ServiceLocator.currencySettings.symbol(from: currencyCode)
         }()
         self.currencySymbol = currencySymbol
+        self.shouldDisplayShippingNotice = shouldDisplayShippingNotice
         self.inputViewModels = customsForms.map { .init(customsForm: $0,
                                                         destinationCountry: destinationCountry,
                                                         countries: countries,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -91,10 +91,6 @@ extension ShippingLabelCustomsFormListViewModel {
     func bannerDismissTapped() {
         shouldDisplayShippingNotice = false
     }
-
-    func bannerLearnMoreTapped(instructionsURL: URL?) {
-
-    }
 }
 
 // MARK: - Validation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -18,6 +18,10 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     ///
     @Published private(set) var doneButtonEnabled: Bool = false
 
+    /// Whether shipping notice banner should be displayed.
+    ///
+    @Published private(set) var shouldDisplayShippingNotice: Bool = false
+
     /// Associated order of the shipping label.
     ///
     private let order: Order
@@ -53,8 +57,6 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     /// References to keep the Combine subscriptions alive with the class.
     ///
     private var cancellables: Set<AnyCancellable> = []
-    
-    let shouldDisplayShippingNotice: Bool
 
     init(order: Order,
          customsForms: [ShippingLabelCustomsForm],
@@ -87,11 +89,11 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
 //
 extension ShippingLabelCustomsFormListViewModel {
     func bannerDismissTapped() {
-        
+        shouldDisplayShippingNotice = false
     }
 
     func bannerLearnMoreTapped(instructionsURL: URL?) {
-        
+
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -476,7 +476,7 @@ private extension ShippingLabelFormViewController {
                                                        customsForms: viewModel.customsForms,
                                                        destinationCountry: country,
                                                        countries: viewModel.countries,
-                                                       shouldDisplayShippingNotice: viewModel.shouldDisplayShippingNotice)
+                                                       shouldDisplayShippingNotice: viewModel.isEUShippingNotificationEnabled)
         let formList = ShippingLabelCustomsFormList(viewModel: vm) { [weak self] forms in
             self?.viewModel.handleCustomsFormsValueChanges(customsForms: forms, isValidated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -475,7 +475,8 @@ private extension ShippingLabelFormViewController {
         let vm = ShippingLabelCustomsFormListViewModel(order: viewModel.order,
                                                        customsForms: viewModel.customsForms,
                                                        destinationCountry: country,
-                                                       countries: viewModel.countries)
+                                                       countries: viewModel.countries,
+                                                       shouldDisplayShippingNotice: viewModel.shouldDisplayShippingNotice)
         let formList = ShippingLabelCustomsFormList(viewModel: vm) { [weak self] forms in
             self?.viewModel.handleCustomsFormsValueChanges(customsForms: forms, isValidated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -472,15 +472,15 @@ private extension ShippingLabelFormViewController {
               let country = viewModel.countries.first(where: { $0.code == countryCode }) else {
             fatalError("⛔️ Destination country is not found")
         }
-        let vm = ShippingLabelCustomsFormListViewModel(order: viewModel.order,
-                                                       customsForms: viewModel.customsForms,
-                                                       destinationCountry: country,
-                                                       countries: viewModel.countries,
-                                                       shouldDisplayShippingNotice: viewModel.isEUShippingNotificationEnabled)
-        let formList = ShippingLabelCustomsFormList(viewModel: vm) { [weak self] forms in
+        let hostingVC = ShippingCustomsFormListHostingController(order: viewModel.order,
+                                                                             customsForms: viewModel.customsForms,
+                                                                             destinationCountry: country,
+                                                                             countries: viewModel.countries,
+                                                                             shouldDisplayShippingNotice: viewModel.isEUShippingNotificationEnabled,
+                                                                             onCompletion: { [weak self] forms in
             self?.viewModel.handleCustomsFormsValueChanges(customsForms: forms, isValidated: true)
-        }
-        let hostingVC = UIHostingController(rootView: formList)
+        })
+
         navigationController?.show(hostingVC, sender: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -170,7 +170,7 @@ final class ShippingLabelFormViewModel {
 
     /// Flag to indicate if the view should display the EU shipping notice.
     ///
-    private let isEUShippingNotificationEnabled: Bool
+    let isEUShippingNotificationEnabled: Bool
 
     init(order: Order,
          originAddress: Address?,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -8,7 +8,7 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
 
     /// Closure to be invoked when the "Learn more" button is pressed.
     ///
-    private var onLearnMoreTapped: ((URL?) -> Void)? = nil
+    private var onLearnMoreTapped: (() -> Void)? = nil
 
     /// Closure to be invoked when the "Dismiss" button is pressed.
     ///
@@ -23,8 +23,8 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
     func makeUIView(context: Context) -> UIViewType {
         let topBannerView = EUShippingNoticeTopBannerFactory.createTopBanner {
             onDismissTapped?()
-        } onLearnMorePressed: { instructionsURL in
-            onLearnMoreTapped?(instructionsURL)
+        } onLearnMorePressed: {
+            onLearnMoreTapped?()
         }
 
         context.coordinator.bannerWrapper.width = width
@@ -50,7 +50,7 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
 
     /// Returns a copy of the view with `onLearnMoreTapped` handling.
     ///
-    func onLearnMore(_ handler: @escaping (URL?) -> Void) -> EUShippingNoticeBanner {
+    func onLearnMore(_ handler: @escaping () -> Void) -> EUShippingNoticeBanner {
         var copy = self
         copy.onLearnMoreTapped = handler
         return copy

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -39,6 +39,22 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
     func updateUIView(_ uiView: UIView, context: Context) {
         context.coordinator.bannerWrapper.width = width
     }
+
+    /// Returns a copy of the view with `onDismissTapped` handling.
+    ///
+    func onDismiss(_ handler: @escaping Callback) -> EUShippingNoticeBanner {
+        var copy = self
+        copy.onDismiss = handler
+        return copy
+    }
+
+    /// Returns a copy of the view with `onLearnMoreTapped` handling.
+    ///
+    func onLearnMore(_ handler: @escaping Callback) -> EUShippingNoticeBanner {
+        var copy = self
+        copy.onGiveFeedback = handler
+        return copy
+    }
 }
 
 extension EUShippingNoticeBanner {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -8,11 +8,11 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
 
     /// Closure to be invoked when the "Learn more" button is pressed.
     ///
-    private var onGiveFeedback: Callback? = nil
+    private var onLearnMoreTapped: ((URL?) -> Void)? = nil
 
     /// Closure to be invoked when the "Dismiss" button is pressed.
     ///
-    private var onDismiss: Callback? = nil
+    private var onDismissTapped: (() -> Void)? = nil
 
     /// Create a view with the desired `width`. Needed to calculate a correct view `height` later.
     ///
@@ -21,7 +21,15 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UIViewType {
-        fatalError("makeUIView(context:) has not been implemented")
+        let topBannerView = EUShippingNoticeTopBannerFactory.createTopBanner {
+            onDismissTapped?()
+        } onLearnMorePressed: { instructionsURL in
+            onLearnMoreTapped?(instructionsURL)
+        }
+
+        context.coordinator.bannerWrapper.width = width
+        context.coordinator.bannerWrapper.setBanner(topBannerView)
+        return context.coordinator.bannerWrapper
     }
 
     func makeCoordinator() -> Coordinator {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -42,17 +42,17 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
 
     /// Returns a copy of the view with `onDismissTapped` handling.
     ///
-    func onDismiss(_ handler: @escaping Callback) -> EUShippingNoticeBanner {
+    func onDismiss(_ handler: @escaping () -> Void) -> EUShippingNoticeBanner {
         var copy = self
-        copy.onDismiss = handler
+        copy.onDismissTapped = handler
         return copy
     }
 
     /// Returns a copy of the view with `onLearnMoreTapped` handling.
     ///
-    func onLearnMore(_ handler: @escaping Callback) -> EUShippingNoticeBanner {
+    func onLearnMore(_ handler: @escaping (URL?) -> Void) -> EUShippingNoticeBanner {
         var copy = self
-        copy.onGiveFeedback = handler
+        copy.onLearnMoreTapped = handler
         return copy
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -6,6 +6,20 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
     ///
     private let width: CGFloat
 
+    /// Closure to be invoked when the "Learn more" button is pressed.
+    ///
+    private var onGiveFeedback: Callback? = nil
+
+    /// Closure to be invoked when the "Dismiss" button is pressed.
+    ///
+    private var onDismiss: Callback? = nil
+
+    /// Create a view with the desired `width`. Needed to calculate a correct view `height` later.
+    ///
+    init(width: CGFloat) {
+        self.width = width
+    }
+
     func makeUIView(context: Context) -> UIViewType {
         fatalError("makeUIView(context:) has not been implemented")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftUI
+
+struct EUShippingNoticeBanner: UIViewRepresentable {
+    /// Desired `width` of the view.
+    ///
+    private let width: CGFloat
+
+    func makeUIView(context: Context) -> UIViewType {
+        fatalError("makeUIView(context:) has not been implemented")
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(bannerWrapper: TopBannerWrapperView())
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.bannerWrapper.width = width
+    }
+}
+
+extension EUShippingNoticeBanner {
+    /// Hold state across `SwiftUI` lifecycle passes.
+    ///
+    struct Coordinator {
+        /// Banner wrapper that will contain a `TopBannerView`.
+        ///
+        let bannerWrapper: TopBannerWrapperView
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1520,6 +1520,7 @@
 		B6440FB6292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */; };
 		B6440FB9292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */; };
 		B651474527D644FF00C9C4E6 /* CustomerNoteSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */; };
+		B65496342A0B291A003D29E1 /* EUShippingNoticeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65496332A0B291A003D29E1 /* EUShippingNoticeBanner.swift */; };
 		B66D6CEC29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */; };
 		B687940C27699D420092BCA0 /* RefundFeesCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B687940B27699D410092BCA0 /* RefundFeesCalculationUseCase.swift */; };
 		B6930BDA293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6930BD9293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift */; };
@@ -3791,6 +3792,7 @@
 		B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeSelection.swift; sourceTree = "<group>"; };
 		B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeSelectionTests.swift; sourceTree = "<group>"; };
 		B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerNoteSection.swift; sourceTree = "<group>"; };
+		B65496332A0B291A003D29E1 /* EUShippingNoticeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EUShippingNoticeBanner.swift; sourceTree = "<group>"; };
 		B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeData.swift; sourceTree = "<group>"; };
 		B687940B27699D410092BCA0 /* RefundFeesCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesCalculationUseCase.swift; sourceTree = "<group>"; };
 		B6930BD9293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubLastQuarterRangeData.swift; sourceTree = "<group>"; };
@@ -4822,6 +4824,7 @@
 				023D69C52589BF5F00F7DA72 /* Print Shipping Label */,
 				0298430B259351F100979CAE /* ShippingLabelsTopBannerFactory.swift */,
 				53284F4A66A725F479CD9584 /* EUShippingNoticeTopBannerFactory.swift */,
+				B65496332A0B291A003D29E1 /* EUShippingNoticeBanner.swift */,
 				456396A425C81C72001F1A26 /* Create Shipping Label Form */,
 			);
 			path = "Shipping Labels";
@@ -12075,6 +12078,7 @@
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
 				03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,
+				B65496342A0B291A003D29E1 /* EUShippingNoticeBanner.swift in Sources */,
 				B946881029B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift in Sources */,
 				027EB56C29C05F4B003CE551 /* StoreOnboardingLaunchStoreView.swift in Sources */,
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,


### PR DESCRIPTION
Closes #9592 

Why
==========
Following the changes in #9591, we must display the EU Shipping notice banner inside the Customs form view too. This banner needs to work a bit differently from the one we see in the Shipping label creation form. We will always show the banner there if it's a US-to-EU shipping scenario, we will also have additional behaviors inside this same Customs view, but they will be introduced in the following PRs.

How
==========
Uses the same `EUShippingNoticeTopBannerFactory` to create the EU Shipping notice banner. However, since the Customs form view uses SwiftUI, a `UIViewRepresentable` implementation called `EUShippingNoticeBanner` is required to declare the banner inside SwiftUI code. 

Given that the Customs form will always show the banner when it's a US-to-EU shipping scenario, the dismiss button for the banner doesn't need to persist the dismiss action. Also, since we still don't have the origin and destination country validation, the Feature Flag controls the banner visibility. 

With that said, the idea for the upcoming changes is to validate the country configuration inside the `ShippingLabelFormViewModel` as the origin and destination addresses are changed and pass to the Customs form if it's a US-to-EU scenario or not, which is why the `ShippingLabelCustomsFormListViewModel` now contains a `shouldDisplayShippingNotice` initializer parameter.
  
Screen Capture
==========
https://github.com/woocommerce/woocommerce-ios/assets/5920403/5a6a3895-3720-497a-bb05-e435ec87e2d7

How to Test
==========
### Scenario 1
1. Open the app with a site containing the Shipping Labels plugin configured
2. Open the order details of an order with the `processing` status
3. Hit the `Create Shipping Label` button
4. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
5. Verify that the Banner is correctly displayed inside the view
6. Verify that hitting the dismiss button works and dismiss the banner
7. Verify that hitting the learn more button opens a web view with the USPS instructions page

### Scenario 2
1. Disable the `euShippingNotification` flag
2. Open the app with a site containing the Shipping Labels plugin configured
3. Open the order details of an order with the `processing` status
4. Hit the `Create Shipping Label` button
5. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
6. Verify that the Banner DOES NOT show up inside the view

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.