### PR TITLE
[Privacy Choices] Support non-JP Sites on Privacy Settings Screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -80,7 +80,9 @@ class PrivacySettingsViewController: UIViewController {
 private extension PrivacySettingsViewController {
 
     func loadAccountSettings(completion: (()-> Void)? = nil) {
+        // If we can't find an account(non-jp sites), lets use the saved state.
         guard let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount else {
+            collectInfo = ServiceLocator.analytics.userHasOptedIn
             completion?()
             return
         }
@@ -394,7 +396,9 @@ private extension PrivacySettingsViewController {
     func collectInfoWasUpdated(newValue: Bool) {
         let userOptedOut = !newValue
 
+        // If we can't find an account(non-jp sites), lets commit the change immediately.
         guard let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount else {
+            ServiceLocator.analytics.setUserHasOptedOut(userOptedOut)
             return
         }
 


### PR DESCRIPTION
Closes: #9646 

# Why

Prior to this PR non-jetpack sites were not able to opt out from analytics tracking. This PR makes sure that that is no longer the case.

# How

When we detect that there is no saved account, we now access `ServiceLocator.analytics.userHasOptedIn` directly, instead of just aborting the flow.

# Testing Steps

- Logout to a non-jetpack site. (You can use JurassicNinja for this)
- Navigate to the Privacy Settings Screen
- Validate that you can turn off(and on) the analytics toggle.

---
- [x] have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
