### PR TITLE
New local notification contents for store creation and free trial plans

### DIFF
--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -58,14 +58,20 @@ struct LocalNotification {
 
     /// The action type in a local notification.
     enum Action: String {
-        case openPlansPage
+        case explore
+        case subscribe
+        case upgrade
         case none
 
         /// The title of the action in a local notification.
         var title: String {
             switch self {
-            case .openPlansPage:
-                return Localization.openPlansPage
+            case .explore:
+                return Localization.Actions.explore
+            case .subscribe:
+                return Localization.Actions.subscribe
+            case .upgrade:
+                return Localization.Actions.upgrade
             case .none:
                 return ""
             }
@@ -86,17 +92,17 @@ extension LocalNotification {
 
         switch scenario {
         case .oneDayBeforeFreeTrialExpires(let expiryDate):
-            let title = String.localizedStringWithFormat(Localization.oneDayBeforeFreeTrialExpiresTitle, name)
+            let title = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.title, name)
             let dateFormatStyle = Date.FormatStyle()
                 .weekday(.wide)
                 .month(.wide)
                 .day(.defaultDigits)
             let displayDate = expiryDate.formatted(dateFormatStyle)
-            let message = String.localizedStringWithFormat(Localization.oneDayBeforeFreeTrialExpiresMessage, displayDate)
+            let message = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.body, displayDate)
             self.init(title: title,
                       body: message,
                       scenario: scenario,
-                      actions: .init(category: .storeCreation, actions: [.openPlansPage]))
+                      actions: .init(category: .storeCreation, actions: [.upgrade]))
         default:
             return nil
         }
@@ -105,19 +111,32 @@ extension LocalNotification {
 
 private extension LocalNotification {
     enum Localization {
-        static let oneDayBeforeFreeTrialExpiresTitle = NSLocalizedString(
-            "Time’s almost up, %1$@",
-            comment: "Title of the local notification to remind the user of expiring free trial plan." +
-            "The placeholder is the name of the user."
-        )
-        static let oneDayBeforeFreeTrialExpiresMessage = NSLocalizedString(
-            "Your free trial of Woo Express ends tomorrow (%1$@). Now’s the time to own your future – pick a plan and get ready to grow.",
-            comment: "Message on the local notification to remind the user of the expiring free trial plan." +
-            "The placeholder is the expiry date of the trial plan."
-        )
-        static let openPlansPage = NSLocalizedString(
-            "Upgrade",
-            comment: "Action on the local notification to remind the user of the expiring free trial plan."
-        )
+        enum OneDayBeforeFreeTrialExpires {
+            static let title = NSLocalizedString(
+                "Time’s almost up, %1$@",
+                comment: "Title of the local notification to remind the user of expiring free trial plan." +
+                "The placeholder is the name of the user."
+            )
+            static let body = NSLocalizedString(
+                "Your free trial of Woo Express ends tomorrow (%1$@). Now’s the time to own your future – pick a plan and get ready to grow.",
+                comment: "Message on the local notification to remind the user of the expiring free trial plan." +
+                "The placeholder is the expiry date of the trial plan."
+            )
+        }
+
+        enum Actions {
+            static let explore = NSLocalizedString(
+                "Explore",
+                comment: "Action on the local notification to remind the user of a newly created store."
+            )
+            static let subscribe = NSLocalizedString(
+                "Subscribe",
+                comment: "Action on the local notification to suggest the user to subscribe to the trial plan."
+            )
+            static let upgrade = NSLocalizedString(
+                "Upgrade",
+                comment: "Action on the local notification to remind the user of the expiring free trial plan."
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -17,7 +17,7 @@ struct LocalNotification {
     /// Its raw value is used for the identifier of a local notification and also the event property for analytics.
     enum Scenario {
         case storeCreationComplete
-        case oneDayAfterStoreCreationNameWithoutFreeTrial
+        case oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: String)
         case oneDayBeforeFreeTrialExpires(expiryDate: Date)
         case oneDayAfterFreeTrialExpires
         // The following notifications are deprecated and are canceled in the first release.
@@ -90,34 +90,85 @@ extension LocalNotification {
             return name
         }()
 
+        let title: String
+        let body: String
+        let actions: [Action]
+        let category: Category
+
         switch scenario {
+        case .storeCreationComplete:
+            title = Localization.StoreCreationComplete.title
+            body = String.localizedStringWithFormat(Localization.StoreCreationComplete.body, name)
+            actions = [.explore]
+            category = .storeCreation
+
+        case .oneDayAfterStoreCreationNameWithoutFreeTrial(let storeName):
+            title = Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.title
+            body = String.localizedStringWithFormat(
+                Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.body,
+                name,
+                storeName
+            )
+            category = .storeCreation
+            actions = [.subscribe]
+
         case .oneDayBeforeFreeTrialExpires(let expiryDate):
-            let title = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.title, name)
+            title = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.title, name)
             let dateFormatStyle = Date.FormatStyle()
                 .weekday(.wide)
                 .month(.wide)
                 .day(.defaultDigits)
             let displayDate = expiryDate.formatted(dateFormatStyle)
-            let message = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.body, displayDate)
-            self.init(title: title,
-                      body: message,
-                      scenario: scenario,
-                      actions: .init(category: .storeCreation, actions: [.upgrade]))
+            body = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.body, displayDate)
+            category = .storeCreation
+            actions = [.upgrade]
+
         case .oneDayAfterFreeTrialExpires:
-            let title = Localization.OneDayAfterFreeTrialExpires.title
-            let message = String.localizedStringWithFormat(Localization.OneDayAfterFreeTrialExpires.body, name)
-            self.init(title: title,
-                      body: message,
-                      scenario: scenario,
-                      actions: .init(category: .storeCreation, actions: [.upgrade]))
+            title = Localization.OneDayAfterFreeTrialExpires.title
+            body = String.localizedStringWithFormat(Localization.OneDayAfterFreeTrialExpires.body, name)
+            category = .storeCreation
+            actions = [.upgrade]
+
         default:
             return nil
         }
+
+        self.init(title: title,
+                  body: body,
+                  scenario: scenario,
+                  actions: .init(category: category, actions: actions))
     }
 }
 
 private extension LocalNotification {
     enum Localization {
+        enum StoreCreationComplete {
+            static let title = NSLocalizedString(
+                "Your store is ready!",
+                comment: "Title of the local notification about a newly created store"
+            )
+            static let body = NSLocalizedString(
+                "Hi %1$@, Welcome to your 14-day free trial of Woo Express – " +
+                "everything you need to start and grow a successful online business, " +
+                "all in one place. Ready to explore?",
+                comment: "Message on the local notification about a newly created store." +
+                "The placeholder is the name of the user."
+            )
+        }
+
+        enum OneDayAfterStoreCreationNameWithoutFreeTrial {
+            static let title = NSLocalizedString(
+                "Your store is waiting!",
+                comment: "Title of the local notification suggesting a trial plan subscription."
+            )
+            static let body = NSLocalizedString(
+                "Hi %1$@, %2$@ is ready for you! Start your 14-day free trial " +
+                "of Woo Express right in just one click to start your online business.",
+                comment: "Message on the local notification suggesting a trial plan subscription." +
+                "The placeholders are the name of the user and the store name."
+            )
+        }
+
         enum OneDayBeforeFreeTrialExpires {
             static let title = NSLocalizedString(
                 "Time’s almost up, %1$@!",

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -62,7 +62,6 @@ struct LocalNotification {
         case explore
         case subscribe
         case upgrade
-        case none
 
         /// The title of the action in a local notification.
         var title: String {
@@ -73,8 +72,6 @@ struct LocalNotification {
                 return Localization.Actions.subscribe
             case .upgrade:
                 return Localization.Actions.upgrade
-            case .none:
-                return ""
             }
         }
     }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -1,4 +1,5 @@
 import Foundation
+import protocol Yosemite.StoresManager
 
 /// Content for a local notification to be converted to `UNNotificationContent`.
 struct LocalNotification {
@@ -80,10 +81,13 @@ struct LocalNotification {
 }
 
 extension LocalNotification {
-    init?(scenario: Scenario) {
+    init?(scenario: Scenario,
+          stores: StoresManager = ServiceLocator.stores,
+          timeZone: TimeZone = .current,
+          locale: Locale = .current) {
         /// Name to display in notifications
         let name: String = {
-            let sessionManager = ServiceLocator.stores.sessionManager
+            let sessionManager = stores.sessionManager
             guard let name = sessionManager.defaultAccount?.displayName, name.isNotEmpty else {
                 return sessionManager.defaultCredentials?.username ?? ""
             }
@@ -114,7 +118,7 @@ extension LocalNotification {
 
         case .oneDayBeforeFreeTrialExpires(let expiryDate):
             title = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.title, name)
-            let dateFormatStyle = Date.FormatStyle()
+            let dateFormatStyle = Date.FormatStyle(locale: locale, timeZone: timeZone)
                 .weekday(.wide)
                 .month(.wide)
                 .day(.defaultDigits)
@@ -140,7 +144,7 @@ extension LocalNotification {
     }
 }
 
-private extension LocalNotification {
+extension LocalNotification {
     enum Localization {
         enum StoreCreationComplete {
             static let title = NSLocalizedString(

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -15,17 +15,40 @@ struct LocalNotification {
 
     /// The scenario for the local notification.
     /// Its raw value is used for the identifier of a local notification and also the event property for analytics.
-    enum Scenario: String, CaseIterable {
-        case storeCreationComplete = "store_creation_complete"
-        case oneDayAfterStoreCreationNameWithoutFreeTrial = "one_day_after_store_creation_name_without_free_trial"
-        case oneDayBeforeFreeTrialExpires = "one_day_before_free_trial_expires"
-        case oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"
+    enum Scenario {
+        case storeCreationComplete
+        case oneDayAfterStoreCreationNameWithoutFreeTrial
+        case oneDayBeforeFreeTrialExpires(expiryDate: Date)
+        case oneDayAfterFreeTrialExpires
         // The following notifications are deprecated and are canceled in the first release.
-        case loginSiteAddressError = "site_address_error"
-        case invalidEmailFromSiteAddressLogin = "site_address_email_error"
-        case invalidEmailFromWPComLogin = "wpcom_email_error"
-        case invalidPasswordFromSiteAddressWPComLogin = "site_address_wpcom_password_error"
-        case invalidPasswordFromWPComLogin = "wpcom_password_error"
+        case loginSiteAddressError
+        case invalidEmailFromSiteAddressLogin
+        case invalidEmailFromWPComLogin
+        case invalidPasswordFromSiteAddressWPComLogin
+        case invalidPasswordFromWPComLogin
+
+        var identifier: String {
+            switch self {
+            case .storeCreationComplete:
+                return "store_creation_complete"
+            case .oneDayAfterStoreCreationNameWithoutFreeTrial:
+                return "one_day_after_store_creation_name_without_free_trial"
+            case .oneDayBeforeFreeTrialExpires:
+                return "one_day_before_free_trial_expires"
+            case .oneDayAfterFreeTrialExpires:
+                return "one_day_after_free_trial_expires"
+            case .loginSiteAddressError:
+                return "site_address_error"
+            case .invalidEmailFromSiteAddressLogin:
+                return "site_address_email_error"
+            case .invalidEmailFromWPComLogin:
+                return "wpcom_email_error"
+            case .invalidPasswordFromSiteAddressWPComLogin:
+                return "site_address_wpcom_password_error"
+            case .invalidPasswordFromWPComLogin:
+                return "wpcom_password_error"
+            }
+        }
     }
 
     /// The category of actions for a local notification.

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -103,6 +103,13 @@ extension LocalNotification {
                       body: message,
                       scenario: scenario,
                       actions: .init(category: .storeCreation, actions: [.upgrade]))
+        case .oneDayAfterFreeTrialExpires:
+            let title = Localization.OneDayAfterFreeTrialExpires.title
+            let message = String.localizedStringWithFormat(Localization.OneDayAfterFreeTrialExpires.body, name)
+            self.init(title: title,
+                      body: message,
+                      scenario: scenario,
+                      actions: .init(category: .storeCreation, actions: [.upgrade]))
         default:
             return nil
         }
@@ -113,7 +120,7 @@ private extension LocalNotification {
     enum Localization {
         enum OneDayBeforeFreeTrialExpires {
             static let title = NSLocalizedString(
-                "Time’s almost up, %1$@",
+                "Time’s almost up, %1$@!",
                 comment: "Title of the local notification to remind the user of expiring free trial plan." +
                 "The placeholder is the name of the user."
             )
@@ -121,6 +128,18 @@ private extension LocalNotification {
                 "Your free trial of Woo Express ends tomorrow (%1$@). Now’s the time to own your future – pick a plan and get ready to grow.",
                 comment: "Message on the local notification to remind the user of the expiring free trial plan." +
                 "The placeholder is the expiry date of the trial plan."
+            )
+        }
+
+        enum OneDayAfterFreeTrialExpires {
+            static let title = NSLocalizedString(
+                "Your trial has ended.",
+                comment: "Title of the local notification to remind the user of the expired free trial plan."
+            )
+            static let body = NSLocalizedString(
+                "%1$@, we have paused your store, but you can continue by picking a plan that suits you best.",
+                comment: "Message on the local notification to remind the user of the expired free trial plan." +
+                "The placeholder is the name of the user."
             )
         }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -339,13 +339,13 @@ extension PushNotificationsManager {
                 content.categoryIdentifier = categoryIdentifier
             }
 
-            let request = UNNotificationRequest(identifier: notification.scenario.rawValue,
+            let request = UNNotificationRequest(identifier: notification.scenario.identifier,
                                                 content: content,
                                                 trigger: trigger)
             do {
                 try await center.add(request)
                 ServiceLocator.analytics.track(.loginLocalNotificationScheduled, withProperties: [
-                    "type": notification.scenario.rawValue
+                    "type": notification.scenario.identifier
                 ])
             } catch {
                 DDLogError("⛔️ Unable to request a local notification: \(error)")
@@ -355,7 +355,7 @@ extension PushNotificationsManager {
 
     func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
         let center = UNUserNotificationCenter.current()
-        center.removePendingNotificationRequests(withIdentifiers: scenarios.map { $0.rawValue })
+        center.removePendingNotificationRequests(withIdentifiers: scenarios.map { $0.identifier })
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2054,6 +2054,7 @@
 		DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */; };
 		DECE13FC27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */; };
 		DECE1400279A595200816ECD /* Coupon+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13FF279A595200816ECD /* Coupon+Woo.swift */; };
+		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
 		DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */; };
 		DEE183ED292BD900008818AB /* JetpackSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */; };
@@ -4333,6 +4334,7 @@
 		DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndStatusTableViewCell.swift; sourceTree = "<group>"; };
 		DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndSubtitleAndStatusTableViewCell.xib; sourceTree = "<group>"; };
 		DECE13FF279A595200816ECD /* Coupon+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+Woo.swift"; sourceTree = "<group>"; };
+		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
 		DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageAttributes.swift; sourceTree = "<group>"; };
 		DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupViewModelTests.swift; sourceTree = "<group>"; };
@@ -8011,6 +8013,7 @@
 			isa = PBXGroup;
 			children = (
 				B5718D6421B56B3F0026C9F0 /* PushNotificationsManagerTests.swift */,
+				DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -12426,6 +12429,7 @@
 				02645D8227BA20A30065DC68 /* InboxViewModelTests.swift in Sources */,
 				57ABE36824EB048A00A64F49 /* MockSwitchStoreUseCase.swift in Sources */,
 				311F827626CD8AB100DF5BAD /* MockCardReaderSettingsAlerts.swift in Sources */,
+				DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */,
 				02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */,
 				45C8B25B231521510002FA77 /* CustomerNoteTableViewCellTests.swift in Sources */,
 				B5980A6721AC91AA00EBF596 /* BundleWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -17,7 +17,10 @@ extension SessionManager {
 
     /// Create an instance of unit testing.
     ///
-    static func makeForTesting(authenticated: Bool = false, isWPCom: Bool = true, defaultRoles: [User.Role] = [.administrator]) -> SessionManager {
+    static func makeForTesting(authenticated: Bool = false,
+                               isWPCom: Bool = true,
+                               defaultRoles: [User.Role] = [.administrator],
+                               displayName: String = "") -> SessionManager {
         let manager = SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
         // Force setting to `nil` if `authenticated` is `false` so that any auto-loaded credentials
         // will be removed.
@@ -27,6 +30,7 @@ extension SessionManager {
         manager.defaultCredentials = authenticated ? credentials : nil
         manager.setStoreId(nil)
         manager.defaultRoles = defaultRoles
+        manager.defaultAccount = Account(userID: 123, displayName: displayName, email: "", username: credentials.username, gravatarUrl: nil)
         return manager
     }
 }

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -20,7 +20,7 @@ extension SessionManager {
     static func makeForTesting(authenticated: Bool = false,
                                isWPCom: Bool = true,
                                defaultRoles: [User.Role] = [.administrator],
-                               displayName: String = "") -> SessionManager {
+                               displayName: String? = nil) -> SessionManager {
         let manager = SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
         // Force setting to `nil` if `authenticated` is `false` so that any auto-loaded credentials
         // will be removed.
@@ -30,7 +30,9 @@ extension SessionManager {
         manager.defaultCredentials = authenticated ? credentials : nil
         manager.setStoreId(nil)
         manager.defaultRoles = defaultRoles
-        manager.defaultAccount = Account(userID: 123, displayName: displayName, email: "", username: credentials.username, gravatarUrl: nil)
+        if let displayName {
+            manager.defaultAccount = Account(userID: 123, displayName: displayName, email: "", username: credentials.username, gravatarUrl: nil)
+        }
         return manager
     }
 }

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -34,7 +34,11 @@ final class LocalNotificationTests: XCTestCase {
         assertEqual(LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.title, notification.title)
         assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
         assertEqual([LocalNotification.Action.subscribe], notification.actions?.actions)
-        let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.body, testName, storeName)
+        let expectedBody = String.localizedStringWithFormat(
+            LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.body,
+            testName,
+            storeName
+        )
         assertEqual(expectedBody, notification.body)
     }
 

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import WooCommerce
+
+final class LocalNotificationTests: XCTestCase {
+
+    func test_storeCreationComplete_scenario_returns_correct_notification_contents() throws {
+        // Given
+        let scenario = LocalNotification.Scenario.storeCreationComplete
+        let testName = "Miffy"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
+
+        // When
+        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores))
+
+        // Then
+        assertEqual(LocalNotification.Localization.StoreCreationComplete.title, notification.title)
+        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
+        assertEqual([LocalNotification.Action.explore], notification.actions?.actions)
+        let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.StoreCreationComplete.body, testName)
+        assertEqual(expectedBody, notification.body)
+    }
+
+    func test_oneDayAfterStoreCreationNameWithoutFreeTrial_scenario_returns_correct_notification_contents() throws {
+        // Given
+        let storeName = "BunnyLand"
+        let scenario = LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName)
+        let testName = "Miffy"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
+
+        // When
+        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores))
+
+        // Then
+        assertEqual(LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.title, notification.title)
+        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
+        assertEqual([LocalNotification.Action.subscribe], notification.actions?.actions)
+        let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.body, testName, storeName)
+        assertEqual(expectedBody, notification.body)
+    }
+
+    func test_oneDayBeforeFreeTrialExpires_scenario_returns_correct_notification_contents() throws {
+        // Given
+        let date = Date(timeIntervalSince1970: 1683692966) // GMT: Wed, 10 May
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+        let locale = Locale(identifier: "en-US")
+        let scenario = LocalNotification.Scenario.oneDayBeforeFreeTrialExpires(expiryDate: date)
+        let testName = "Miffy"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
+
+        // When
+        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores, timeZone: timeZone, locale: locale))
+
+        // Then
+        let expectedTitle = String.localizedStringWithFormat(LocalNotification.Localization.OneDayBeforeFreeTrialExpires.title, testName)
+        let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.OneDayBeforeFreeTrialExpires.body, "Wednesday, May 10")
+        assertEqual(expectedTitle, notification.title)
+        assertEqual(expectedBody, notification.body)
+        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
+        assertEqual([LocalNotification.Action.upgrade], notification.actions?.actions)
+    }
+
+    func test_oneDayAfterFreeTrialExpires_scenario_returns_correct_notification_contents() throws {
+        // Given
+        let scenario = LocalNotification.Scenario.oneDayAfterFreeTrialExpires
+        let testName = "Miffy"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
+
+        // When
+        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores))
+
+        // Then
+        let expectedTitle = LocalNotification.Localization.OneDayAfterFreeTrialExpires.title
+        let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.OneDayAfterFreeTrialExpires.body, testName)
+        assertEqual(expectedTitle, notification.title)
+        assertEqual(expectedBody, notification.body)
+        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
+        assertEqual([LocalNotification.Action.upgrade], notification.actions?.actions)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9665 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the contents for the new cases of local notifications for the store creation flow.
The `Scenario` enum has been updated to accept associated values, so the identifier is a computed variable now instead of raw values.

Since the implementations for the notifications are not done yet, unit tests were added for confidence.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just unit tests passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
