### PR TITLE
SKU scanner camera permissions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1254,11 +1254,7 @@ extension EditableOrderViewModel {
     }
 
     func requestCameraAccess(onCompletion: @escaping ((Bool) -> Void)) {
-        permissionChecker.requestAccess(for: .video, completionHandler: { isPermissionGranted in
-            if isPermissionGranted {
-                onCompletion(isPermissionGranted)
-            }}
-        )
+        permissionChecker.requestAccess(for: .video, completionHandler: onCompletion)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1233,7 +1233,7 @@ private extension EditableOrderViewModel {
 
 extension EditableOrderViewModel {
 
-    enum CurrentPermission {
+    enum CapturePermissionStatus {
         case permitted
         case notPermitted
         case notDetermined
@@ -1241,7 +1241,7 @@ extension EditableOrderViewModel {
 
     /// Returns the current app permission status to capture media
     ///
-    var cameraPermissionStatus: CurrentPermission {
+    var capturePermissionStatus: CapturePermissionStatus {
         let authStatus = permissionChecker.authorizationStatus(for: .video)
         switch authStatus {
         case .authorized:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -14,7 +14,7 @@ final class EditableOrderViewModel: ObservableObject {
     private let storageManager: StorageManagerType
     private let currencyFormatter: CurrencyFormatter
     private let featureFlagService: FeatureFlagService
-    private let permissionChecker: CaptureDevicePermissionChecker
+    let permissionChecker: CaptureDevicePermissionChecker
 
     private var cancellables: Set<AnyCancellable> = []
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -304,18 +304,19 @@ private struct ProductsSection: View {
                     let capturePermissionStatus = viewModel.capturePermissionStatus
                     switch capturePermissionStatus {
                     case .notPermitted:
-                        DDLogDebug("Capture permission status: Denied or restricted \(capturePermissionStatus.hashValue)")
+                        logPermissionStatus(status: .notPermitted)
                         self.showPermissionsSheet = true
                     case .notDetermined:
-                        DDLogDebug("Capture permission status: Not determined \(capturePermissionStatus.hashValue)")
+                        logPermissionStatus(status: .notDetermined)
                         viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
                             if isPermissionGranted {
                                 showAddProductViaSKUScanner.toggle()
+                                logPermissionStatus(status: .permitted)
                             }
-                            DDLogDebug("Capture permission granted: \(isPermissionGranted)")
                         })
                     case .permitted:
                         showAddProductViaSKUScanner.toggle()
+                        logPermissionStatus(status: .permitted)
                     }
                 }
                 .accessibilityIdentifier(OrderForm.Accessibility.addProductViaSKUScannerButtonIdentifier)
@@ -451,6 +452,10 @@ private extension ProductsSection {
             return
         }
         UIApplication.shared.open(settingsURL)
+    }
+
+    func logPermissionStatus(status: EditableOrderViewModel.CapturePermissionStatus) {
+        DDLogDebug("Capture permission status: \(status)")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -310,12 +310,12 @@ private struct ProductsSection: View {
                         logPermissionStatus(status: .notDetermined)
                         viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
                             if isPermissionGranted {
-                                showAddProductViaSKUScanner.toggle()
+                                showAddProductViaSKUScanner = true
                                 logPermissionStatus(status: .permitted)
                             }
                         })
                     case .permitted:
-                        showAddProductViaSKUScanner.toggle()
+                        showAddProductViaSKUScanner = true
                         logPermissionStatus(status: .permitted)
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -302,14 +302,17 @@ private struct ProductsSection: View {
                 })
                 Button(OrderForm.Localization.addProductViaSKUScanner) {
                     let authStatus = viewModel.cameraPermissionStatus
-
                     switch authStatus {
                     case .denied, .restricted:
                         DDLogDebug("Auth status: denied or restricted")
                         self.showPermissionsSheet = true
                     case .notDetermined:
                         DDLogDebug("Auth status: not determined")
-                        break
+                        viewModel.permissionChecker.requestAccess(for: .video, completionHandler: { isPermissionGranted in
+                            if isPermissionGranted {
+                                showAddProductViaSKUScanner.toggle()
+                            }
+                        })
                     case .authorized:
                         DDLogDebug("Auth status: ok")
                         showAddProductViaSKUScanner.toggle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -449,7 +449,10 @@ private extension ProductSelectorView.Configuration {
 
 private extension ProductsSection {
     func openSettingsAction() {
-        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        UIApplication.shared.open(settingsURL)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -301,19 +301,20 @@ private struct ProductsSection: View {
                     }
                 })
                 Button(OrderForm.Localization.addProductViaSKUScanner) {
-                    switch viewModel.capturePermissionStatus {
+                    let capturePermissionStatus = viewModel.capturePermissionStatus
+                    switch capturePermissionStatus {
                     case .notPermitted:
-                        DDLogDebug("Auth status: denied or restricted")
+                        DDLogDebug("Capture permission status: Denied or restricted \(capturePermissionStatus.hashValue)")
                         self.showPermissionsSheet = true
                     case .notDetermined:
-                        DDLogDebug("Auth status: not determined")
+                        DDLogDebug("Capture permission status: Not determined \(capturePermissionStatus.hashValue)")
                         viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
                             if isPermissionGranted {
                                 showAddProductViaSKUScanner.toggle()
                             }
+                            DDLogDebug("Capture permission granted: \(isPermissionGranted)")
                         })
                     case .permitted:
-                        DDLogDebug("Auth status: ok")
                         showAddProductViaSKUScanner.toggle()
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -372,10 +372,10 @@ private extension OrderForm {
         static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
                                                                    comment: "Accessibility hint for selecting a product in an order form")
         static let permissionsTitle =
-        NSLocalizedString("Camera permissions", comment: "Title of alert that links to settings for camera access.")
-        static let permissionsMessage = NSLocalizedString("Please change your camera permissions in device settings.",
-                                                          comment: "Message of alert that links to settings for camera access.")
-        static let permissionsOpenSettings = NSLocalizedString("Open Settings", comment: "Button title to open device settings in an alert")
+        NSLocalizedString("Camera permissions", comment: "Title of the action sheet button that links to settings for camera access")
+        static let permissionsMessage = NSLocalizedString("Please change your camera permissions in device settings",
+                                                          comment: "Message of the action sheet button that links to settings for camera access")
+        static let permissionsOpenSettings = NSLocalizedString("Open Settings", comment: "Button title to open device settings in an action sheet")
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -301,8 +301,8 @@ private struct ProductsSection: View {
                     }
                 })
                 Button(OrderForm.Localization.addProductViaSKUScanner) {
-                    let permissionChecker = AVCaptureDevicePermissionChecker()
-                    let authStatus = permissionChecker.authorizationStatus(for: .video)
+                    let authStatus = viewModel.cameraPermissionStatus
+
                     switch authStatus {
                     case .denied, .restricted:
                         DDLogDebug("Auth status: denied or restricted")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -301,8 +301,7 @@ private struct ProductsSection: View {
                     }
                 })
                 Button(OrderForm.Localization.addProductViaSKUScanner) {
-                    let authStatus = viewModel.cameraPermissionStatus
-                    switch authStatus {
+                    switch viewModel.capturePermissionStatus {
                     case .notPermitted:
                         DDLogDebug("Auth status: denied or restricted")
                         self.showPermissionsSheet = true

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -303,21 +303,19 @@ private struct ProductsSection: View {
                 Button(OrderForm.Localization.addProductViaSKUScanner) {
                     let authStatus = viewModel.cameraPermissionStatus
                     switch authStatus {
-                    case .denied, .restricted:
+                    case .notPermitted:
                         DDLogDebug("Auth status: denied or restricted")
                         self.showPermissionsSheet = true
                     case .notDetermined:
                         DDLogDebug("Auth status: not determined")
-                        viewModel.permissionChecker.requestAccess(for: .video, completionHandler: { isPermissionGranted in
+                        viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
                             if isPermissionGranted {
                                 showAddProductViaSKUScanner.toggle()
                             }
                         })
-                    case .authorized:
+                    case .permitted:
                         DDLogDebug("Auth status: ok")
                         showAddProductViaSKUScanner.toggle()
-                    default:
-                        DDLogDebug("Unknown case")
                     }
                 }
                 .accessibilityIdentifier(OrderForm.Accessibility.addProductViaSKUScannerButtonIdentifier)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -338,7 +338,7 @@ private struct ProductsSection: View {
                     message: Text(OrderForm.Localization.permissionsMessage),
                      buttons: [
                         .default(Text(OrderForm.Localization.permissionsOpenSettings), action: {
-                             UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                            openSettingsAction()
                          }),
                          .cancel()
                      ]
@@ -441,6 +441,12 @@ private extension ProductSelectorView.Configuration {
             "Opens list of product variations.",
             comment: "Accessibility hint for selecting a variable product in the Add Product screen"
         )
+    }
+}
+
+private extension ProductsSection {
+    func openSettingsAction() {
+        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -373,7 +373,8 @@ private extension OrderForm {
                                                                    comment: "Accessibility hint for selecting a product in an order form")
         static let permissionsTitle =
         NSLocalizedString("Camera permissions", comment: "Title of the action sheet button that links to settings for camera access")
-        static let permissionsMessage = NSLocalizedString("Please change your camera permissions in device settings",
+        static let permissionsMessage = NSLocalizedString("Camera access is required for SKU scanning. " +
+                                                          "Please enable camera permissions in your device settings",
                                                           comment: "Message of the action sheet button that links to settings for camera access")
         static let permissionsOpenSettings = NSLocalizedString("Open Settings", comment: "Button title to open device settings in an action sheet")
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
@@ -3,7 +3,8 @@ import AVFoundation
 
 /// A mock implementation of `CaptureDevicePermissionChecker` protocol.
 final class MockCaptureDevicePermissionChecker {
-    private let authorizationStatus: AVAuthorizationStatus
+    private var authorizationStatus: AVAuthorizationStatus
+    private var updatedAuthorizationStatus: AVAuthorizationStatus? = nil
     private var isAccessGranted: Bool = false
 
     init(authorizationStatus: AVAuthorizationStatus) {
@@ -13,6 +14,10 @@ final class MockCaptureDevicePermissionChecker {
     func whenRequestingAccess(thenReturn isGranted: Bool) {
         isAccessGranted = isGranted
     }
+
+    func whenRequestingAccess(setAuthorizationStatus status: AVAuthorizationStatus) {
+        updatedAuthorizationStatus = status
+    }
 }
 
 extension MockCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
@@ -21,6 +26,9 @@ extension MockCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
     }
 
     func requestAccess(for mediaType: AVMediaType, completionHandler handler: @escaping (_ isGranted: Bool) -> Void) {
+        if let updatedAuthorizationStatus = updatedAuthorizationStatus {
+            authorizationStatus = updatedAuthorizationStatus
+        }
         handler(isAccessGranted)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1514,21 +1514,89 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
     }
 
-    // TODO-gm: Failing async test
-    func test_permissions() {
+    func test_requestCameraAccess_when_permission_is_granted_then_true_is_passed_to_the_completion_handler() {
         // Given
         let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        permissionChecker.whenRequestingAccess(thenReturn: true)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
 
         // When
-        let isPermissionGranted: Bool = waitFor { promise in
-            permissionChecker.requestAccess(for: .video, completionHandler: { _ in
-                    promise(true)
+        let permissionWasGranted: Bool = waitFor { promise in
+            viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
+                promise(isPermissionGranted)
             })
         }
+
         // Then
-        XCTAssertTrue(isPermissionGranted)
-        //XCTAssertEqual(viewModel.capturePermissionStatus, .permitted)
+        XCTAssertTrue(permissionWasGranted)
+    }
+
+    func test_requestCameraAccess_when_permission_is_denied_then_false_is_passed_to_the_completion_handler() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        permissionChecker.whenRequestingAccess(thenReturn: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // When
+        let permissionWasGranted: Bool = waitFor { promise in
+            viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
+                promise(isPermissionGranted)
+            })
+        }
+
+        // Then
+        XCTAssertFalse(permissionWasGranted)
+    }
+
+    func test_requestCameraAccess_when_permission_is_granted_then_capturePermissionStatus_is_permitted() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        permissionChecker.whenRequestingAccess(setAuthorizationStatus: .authorized)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // When
+        waitFor { promise in
+            viewModel.requestCameraAccess(onCompletion: { _ in
+                promise(())
+            })
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.capturePermissionStatus, .permitted)
+    }
+
+    func test_requestCameraAccess_when_permission_is_denied_then_capturePermissionStatus_is_notPermitted() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        permissionChecker.whenRequestingAccess(setAuthorizationStatus: .denied)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // When
+        waitFor { promise in
+            viewModel.requestCameraAccess(onCompletion: { _ in
+                promise(())
+            })
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
+    }
+
+    func test_requestCameraAccess_when_permission_is_restricted_then_capturePermissionStatus_is_notPermitted() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        permissionChecker.whenRequestingAccess(setAuthorizationStatus: .restricted)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // When
+        waitFor { promise in
+            viewModel.requestCameraAccess(onCompletion: { _ in
+                promise(())
+            })
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1481,6 +1481,38 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(viewModel.multipleLinesMessage)
     }
+
+    func test_cameraPermissionStatus_is_notDetermined_when_no_permission_is_checked() {
+        // Given, Then
+        XCTAssertEqual(viewModel.cameraPermissionStatus, .notDetermined)
+    }
+
+    func test_cameraPermissionStatus_is_permitted_when_permissionChecker_is_authorized() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .authorized)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // Then
+        XCTAssertEqual(viewModel.cameraPermissionStatus, .permitted)
+    }
+
+    func test_cameraPermissionStatus_is_notPermitted_when_permissionChecker_is_denied() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .denied)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // Then
+        XCTAssertEqual(viewModel.cameraPermissionStatus, .notPermitted)
+    }
+
+    func test_cameraPermissionStatus_is_notPermitted_when_permissionChecker_is_restricted() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .restricted)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // Then
+        XCTAssertEqual(viewModel.cameraPermissionStatus, .notPermitted)
+    }
 }
 
 private extension MockStorageManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1482,36 +1482,53 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.multipleLinesMessage)
     }
 
-    func test_cameraPermissionStatus_is_notDetermined_when_no_permission_is_checked() {
+    func test_capturePermissionStatus_is_notDetermined_when_no_permission_is_checked() {
         // Given, Then
-        XCTAssertEqual(viewModel.cameraPermissionStatus, .notDetermined)
+        XCTAssertEqual(viewModel.capturePermissionStatus, .notDetermined)
     }
 
-    func test_cameraPermissionStatus_is_permitted_when_permissionChecker_is_authorized() {
+    func test_capturePermissionStatus_is_permitted_when_permissionChecker_is_authorized() {
         // Given
         let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .authorized)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
 
         // Then
-        XCTAssertEqual(viewModel.cameraPermissionStatus, .permitted)
+        XCTAssertEqual(viewModel.capturePermissionStatus, .permitted)
     }
 
-    func test_cameraPermissionStatus_is_notPermitted_when_permissionChecker_is_denied() {
+    func test_capturePermissionStatus_is_notPermitted_when_permissionChecker_is_denied() {
         // Given
         let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .denied)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
 
         // Then
-        XCTAssertEqual(viewModel.cameraPermissionStatus, .notPermitted)
+        XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
     }
 
-    func test_cameraPermissionStatus_is_notPermitted_when_permissionChecker_is_restricted() {
+    func test_capturePermissionStatus_is_notPermitted_when_permissionChecker_is_restricted() {
         // Given
         let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .restricted)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
 
         // Then
-        XCTAssertEqual(viewModel.cameraPermissionStatus, .notPermitted)
+        XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
+    }
+
+    // TODO-gm: Failing async test
+    func test_permissions() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // When
+        let isPermissionGranted: Bool = waitFor { promise in
+            permissionChecker.requestAccess(for: .video, completionHandler: { _ in
+                    promise(true)
+            })
+        }
+        // Then
+        XCTAssertTrue(isPermissionGranted)
+        //XCTAssertEqual(viewModel.capturePermissionStatus, .permitted)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Part of: #9658 
Closes: #9677
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR handles device camera permissions when we need to display the SKU scanner view, as this requires for merchants to give explicit permissions to the app in order to access the camera.

Caveat: In the case of permissions, like camera or microphone access, the system kills the app when we change the permissions in the settings, to ensure that the app respects the new state. This is a privacy and security feature of iOS: If the app is running when the user changes the permission, the system kills the app to make sure it can't keep using the permission if it was revoked, or vice versa.

## Testing instructions
* On a physical device, go to Settings > Woo > Confirm that `Allow Woo to access: Camera` is turned off.

<img width="450" alt="Screenshot 2023-05-10 at 13 22 43" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/580c87e2-0f98-48fd-a53b-59924b915ea8">


* Run the app. 
* Go to `Orders` > `+` > `+ Add Product via SKU scanner` > See how a modal view appears with the following options:
  * Open Settings
  * Cancel

<img width="450" alt="Screenshot 2023-05-10 at 13 25 26" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/61d78e29-2fee-4656-a0b1-e6e61ad2eeb6">


Along with this, the following will also be logged to the debug console:
```
2023-05-10 16:59:07.681153+0700 WooCommerce[30328:44000718] Capture permission status: permitted
```

* Tap on `Open Settings` > and enable `Allow Woo to access: Camera`
* Run the app again
* Go to `Orders` > `+` > `+ Add Product via SKU scanner` > See how the scanning view appears without asking for permissions.
* The view can either be dismissed, or scan any barcode to trigger the callback, for example the following:

![today-03-05-2023-test-qr-static-text](https://user-images.githubusercontent.com/3812076/237013607-d5c2c5a5-38f7-4369-9161-ae81cdb8b0e2.jpg)
