### PR TITLE
Disable Universal Links UI Tests

### DIFF
--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -26,7 +26,8 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
-        "StatsTests\/testStatsScreenLoad()"
+        "UniversalLinksTests\/test_load_orders_universal_link()",
+        "UniversalLinksTests\/test_load_payments_universal_link()"
       ],
       "target" : {
         "containerPath" : "container:WooCommerce.xcodeproj",


### PR DESCRIPTION
## Description
Universal links UI tests are flaky failing quite a number of builds in the last few days (the link opens on webview instead of app). Disabling them for now because of the issue. This PR includes changes to the test plan to disable the two universal links test cases and also removing one test case that actually does not exist (`"StatsTests\/testStatsScreenLoad()"`) from the list of disabled tests.

## Testing instructions
CI should be green.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
