### PR TITLE
EU-Bound Shipping Notice: Persist banner dismiss state

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -31,7 +31,8 @@ extension Storage.GeneralAppSettings {
         lastEligibilityErrorInfo: NullableCopiableProp<EligibilityErrorInfo> = .copy,
         lastJetpackBenefitsBannerDismissedTime: NullableCopiableProp<Date> = .copy,
         featureAnnouncementCampaignSettings: CopiableProp<[FeatureAnnouncementCampaign: FeatureAnnouncementCampaignSettings]> = .copy,
-        sitesWithAtLeastOneIPPTransactionFinished: CopiableProp<Set<Int64>> = .copy
+        sitesWithAtLeastOneIPPTransactionFinished: CopiableProp<Set<Int64>> = .copy,
+        isEUShippingNoticeDismissed: CopiableProp<Bool> = .copy
     ) -> Storage.GeneralAppSettings {
         let installationDate = installationDate ?? self.installationDate
         let feedbacks = feedbacks ?? self.feedbacks
@@ -44,6 +45,7 @@ extension Storage.GeneralAppSettings {
         let lastJetpackBenefitsBannerDismissedTime = lastJetpackBenefitsBannerDismissedTime ?? self.lastJetpackBenefitsBannerDismissedTime
         let featureAnnouncementCampaignSettings = featureAnnouncementCampaignSettings ?? self.featureAnnouncementCampaignSettings
         let sitesWithAtLeastOneIPPTransactionFinished = sitesWithAtLeastOneIPPTransactionFinished ?? self.sitesWithAtLeastOneIPPTransactionFinished
+        let isEUShippingNoticeDismissed = isEUShippingNoticeDismissed ?? self.isEUShippingNoticeDismissed
 
         return Storage.GeneralAppSettings(
             installationDate: installationDate,
@@ -56,7 +58,8 @@ extension Storage.GeneralAppSettings {
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime,
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
-            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished
+            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
         )
     }
 }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -56,6 +56,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var sitesWithAtLeastOneIPPTransactionFinished: Set<Int64>
 
+    /// Whether the EU Shipping Notice was dismissed.
+    ///
+    public var isEUShippingNoticeDismissed: Bool
+
     public init(installationDate: Date?,
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
@@ -66,7 +70,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
                 lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
                 lastJetpackBenefitsBannerDismissedTime: Date? = nil,
                 featureAnnouncementCampaignSettings: [FeatureAnnouncementCampaign: FeatureAnnouncementCampaignSettings],
-                sitesWithAtLeastOneIPPTransactionFinished: Set<Int64>) {
+                sitesWithAtLeastOneIPPTransactionFinished: Set<Int64>,
+                isEUShippingNoticeDismissed: Bool) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
@@ -78,6 +83,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         self.isInAppPurchasesSwitchEnabled = isInAppPurchasesSwitchEnabled
         self.isTapToPayOnIPhoneSwitchEnabled = isTapToPayOnIPhoneSwitchEnabled
         self.sitesWithAtLeastOneIPPTransactionFinished = sitesWithAtLeastOneIPPTransactionFinished
+        self.isEUShippingNoticeDismissed = isEUShippingNoticeDismissed
     }
 
     public static var `default`: Self {
@@ -90,7 +96,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
               knownCardReaders: [],
               lastEligibilityErrorInfo: nil,
               featureAnnouncementCampaignSettings: [:],
-              sitesWithAtLeastOneIPPTransactionFinished: [])
+              sitesWithAtLeastOneIPPTransactionFinished: [],
+              isEUShippingNoticeDismissed: false)
     }
 
     /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
@@ -120,7 +127,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
-            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished
+            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
         )
     }
 
@@ -141,7 +149,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             featureAnnouncementCampaignSettings: updatedSettings,
-            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished
+            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
         )
     }
 }
@@ -167,6 +176,7 @@ extension GeneralAppSettings {
             forKey: .featureAnnouncementCampaignSettings) ?? [:]
         self.sitesWithAtLeastOneIPPTransactionFinished = try container.decodeIfPresent(Set<Int64>.self,
                                                                                         forKey: .sitesWithAtLeastOneIPPTransactionFinished) ?? Set<Int64>([])
+        self.isEUShippingNoticeDismissed = try container.decodeIfPresent(Bool.self, forKey: .isEUShippingNoticeDismissed) ?? false
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -72,7 +72,8 @@ final class GeneralAppSettingsTests: XCTestCase {
                                                   lastEligibilityErrorInfo: eligibilityInfo,
                                                   lastJetpackBenefitsBannerDismissedTime: jetpackBannerDismissedDate,
                                                   featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
-                                                  sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished)
+                                                  sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
+                                                  isEUShippingNoticeDismissed: false)
 
         let previousEncodedSettings = try JSONEncoder().encode(previousSettings)
         var previousSettingsJson = try JSONSerialization.jsonObject(with: previousEncodedSettings, options: .allowFragments) as? [String: Any]
@@ -109,7 +110,8 @@ private extension GeneralAppSettingsTests {
                                   lastEligibilityErrorInfo: EligibilityErrorInfo? = nil,
                                   lastJetpackBenefitsBannerDismissedTime: Date? = nil,
                                   featureAnnouncementCampaignSettings: [Campaign: CampaignSettings] = [:],
-                                  sitesWithAtLeastOneIPPTransactionFinished: Set<Int64> = []
+                                  sitesWithAtLeastOneIPPTransactionFinished: Set<Int64> = [],
+                                  isEUShippingNoticeDismissed: Bool = false
     ) -> GeneralAppSettings {
         GeneralAppSettings(installationDate: installationDate,
                            feedbacks: feedbacks,
@@ -121,6 +123,7 @@ private extension GeneralAppSettingsTests {
                            lastEligibilityErrorInfo: lastEligibilityErrorInfo,
                            lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime,
                            featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
-                           sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished)
+                           sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
+                           isEUShippingNoticeDismissed: isEUShippingNoticeDismissed)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -566,7 +566,12 @@ private extension ShippingLabelFormViewController {
 
         let topBannerView = EUShippingNoticeTopBannerFactory.createTopBanner(
             onDismissPressed: {
-                self.hideTopBannerView()
+                let action = AppSettingsAction.setEUShippingNoticeDismissState(isDismissed: true) { result in
+                    guard let self = self, case .success = result else {
+                        return
+                    }
+                    self.hideTopBannerView()
+                }
             },
             onLearnMorePressed: { instructionsURL in
                 self.presentShippingInstructionsView(instructionsURL: instructionsURL)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -15,7 +15,19 @@ final class ShippingLabelFormViewController: UIViewController {
 
     /// Top banner that notices about shipping constraints.
     ///
-    private var topBannerView: TopBannerView?
+    private lazy var topBannerView: TopBannerView = {
+        EUShippingNoticeTopBannerFactory.createTopBanner(
+                onDismissPressed: { [weak self] in
+                    self?.viewModel.setEUShippingNoticeDismissState(isDismissed: true) { [weak self] success in
+                        if success {
+                            self?.hideTopBannerView()
+                        }
+                    }
+                },
+                onLearnMorePressed: { [weak self] in
+                    self?.presentShippingInstructionsView()
+                })
+    }()
 
     /// Assign this closure to be notified after a shipping label is successfully purchased
     ///
@@ -567,30 +579,13 @@ private extension ShippingLabelFormViewController {
                 return
             }
 
-            let topBannerView = self.createEUShippingNoticeBannerView()
-            self.topBannerView = topBannerView
+            let topBannerView = self.topBannerView
             let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(self.tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
             headerContainer.addSubview(topBannerView)
             headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
             self.tableView.tableHeaderView = headerContainer
             self.tableView.updateHeaderHeight()
         }
-    }
-
-    /// Creates the Shipping Notice Top banner with the appropriate actions.
-    ///
-    func createEUShippingNoticeBannerView() -> TopBannerView {
-        EUShippingNoticeTopBannerFactory.createTopBanner(
-            onDismissPressed: { [weak self] in
-                self?.viewModel.setEUShippingNoticeDismissState(isDismissed: true) { success in
-                    if success {
-                        self.hideTopBannerView()
-                    }
-                }
-            },
-            onLearnMorePressed: { [weak self] in
-                self?.presentShippingInstructionsView()
-            })
     }
 
     /// Presents a Web view containing the new EU Shipping instructions.
@@ -607,8 +602,7 @@ private extension ShippingLabelFormViewController {
             return
         }
 
-        topBannerView?.removeFromSuperview()
-        topBannerView = nil
+        topBannerView.removeFromSuperview()
         tableView.tableHeaderView = nil
         tableView.updateHeaderHeight()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -559,7 +559,7 @@ private extension ShippingLabelFormViewController {
 // MARK: - Top Banner
 //
 private extension ShippingLabelFormViewController {
-    /// Creates a Top Banner View containing the EU Shipping Notice.
+    /// Present a Top Banner View containing the EU Shipping Notice.
     ///
     func showTopBannerView() {
         viewModel.shouldDisplayEUShippingNotice { [weak self] shouldDisplay in
@@ -567,7 +567,7 @@ private extension ShippingLabelFormViewController {
                 return
             }
 
-            let topBannerView = self.createTopBannerView()
+            let topBannerView = self.createEUShippingNoticeBannerView()
             self.topBannerView = topBannerView
             let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(self.tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
             headerContainer.addSubview(topBannerView)
@@ -577,7 +577,9 @@ private extension ShippingLabelFormViewController {
         }
     }
 
-    func createTopBannerView() -> TopBannerView {
+    /// Creates the Shipping Notice Top banner with the appropriate actions.
+    ///
+    func createEUShippingNoticeBannerView() -> TopBannerView {
         EUShippingNoticeTopBannerFactory.createTopBanner(
             onDismissPressed: {
                 self.viewModel.setEUShippingNoticeDismissState(isDismissed: true) { success in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -560,27 +560,28 @@ private extension ShippingLabelFormViewController {
 //
 private extension ShippingLabelFormViewController {
     func showTopBannerView() {
-        guard viewModel.shouldDisplayShippingNotice else {
-            return
-        }
+        viewModel.shouldDisplayEUShippingNotice { [weak self] shouldDisplay in
+            guard let self = self, shouldDisplay else {
+                return
+            }
 
-        let topBannerView = createTopBannerView()
-        self.topBannerView = topBannerView
-        let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
-        headerContainer.addSubview(topBannerView)
-        headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
-        tableView.tableHeaderView = headerContainer
-        tableView.updateHeaderHeight()
+            let topBannerView = self.createTopBannerView()
+            self.topBannerView = topBannerView
+            let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(self.tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
+            headerContainer.addSubview(topBannerView)
+            headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
+            self.tableView.tableHeaderView = headerContainer
+            self.tableView.updateHeaderHeight()
+        }
     }
 
     func createTopBannerView() -> TopBannerView {
         EUShippingNoticeTopBannerFactory.createTopBanner(
             onDismissPressed: {
-                let action = AppSettingsAction.setEUShippingNoticeDismissState(isDismissed: true) { result in
-                    guard case .success = result else {
-                        return
+                self.viewModel.setEUShippingNoticeDismissState(isDismissed: true) { success in
+                    if success {
+                        self.hideTopBannerView()
                     }
-                    self.hideTopBannerView()
                 }
             },
             onLearnMorePressed: { instructionsURL in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -564,10 +564,20 @@ private extension ShippingLabelFormViewController {
             return
         }
 
-        let topBannerView = EUShippingNoticeTopBannerFactory.createTopBanner(
+        let topBannerView = createTopBannerView()
+        self.topBannerView = topBannerView
+        let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
+        headerContainer.addSubview(topBannerView)
+        headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
+        tableView.tableHeaderView = headerContainer
+        tableView.updateHeaderHeight()
+    }
+
+    func createTopBannerView() -> TopBannerView {
+        EUShippingNoticeTopBannerFactory.createTopBanner(
             onDismissPressed: {
                 let action = AppSettingsAction.setEUShippingNoticeDismissState(isDismissed: true) { result in
-                    guard let self = self, case .success = result else {
+                    guard case .success = result else {
                         return
                     }
                     self.hideTopBannerView()
@@ -576,12 +586,6 @@ private extension ShippingLabelFormViewController {
             onLearnMorePressed: { instructionsURL in
                 self.presentShippingInstructionsView(instructionsURL: instructionsURL)
             })
-        self.topBannerView = topBannerView
-        let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
-        headerContainer.addSubview(topBannerView)
-        headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
-        tableView.tableHeaderView = headerContainer
-        tableView.updateHeaderHeight()
     }
 
     func presentShippingInstructionsView(instructionsURL: URL?) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -575,7 +575,7 @@ private extension ShippingLabelFormViewController {
     ///
     func showTopBannerView() {
         viewModel.shouldDisplayEUShippingNotice { [weak self] shouldDisplay in
-            guard let self = self, shouldDisplay else {
+            guard let self, shouldDisplay else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -18,7 +18,7 @@ final class ShippingLabelFormViewController: UIViewController {
     private lazy var topBannerView: TopBannerView = {
         EUShippingNoticeTopBannerFactory.createTopBanner(
                 onDismissPressed: { [weak self] in
-                    self?.viewModel.setEUShippingNoticeDismissState(isDismissed: true) { [weak self] success in
+                    self?.viewModel.dismissEUShippingNotice { [weak self] success in
                         if success {
                             self?.hideTopBannerView()
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -168,7 +168,11 @@ final class ShippingLabelFormViewModel {
         }
     }
 
-    let shouldDisplayShippingNotice: Bool
+    var shouldDisplayShippingNotice: Bool {
+        return false
+    }
+
+    let isEUShippingNotificationEnabled: Bool
 
     init(order: Order,
          originAddress: Address?,
@@ -196,7 +200,7 @@ final class ShippingLabelFormViewModel {
         self.stores = stores
         self.storageManager = storageManager
         self.userDefaults = userDefaults
-        self.shouldDisplayShippingNotice = featureFlagService.isFeatureFlagEnabled(.euShippingNotification)
+        self.isEUShippingNotificationEnabled = featureFlagService.isFeatureFlagEnabled(.euShippingNotification)
 
         state.sections = generateInitialSections()
         syncShippingLabelAccountSettings()
@@ -877,6 +881,21 @@ extension ShippingLabelFormViewModel {
     private enum PurchaseError: Error {
         case labelDetailsMissing
         case invalidPackageDetails
+    }
+}
+
+// MARK: - Shipping Notice dismiss state handling
+extension ShippingLabelFormViewModel {
+    func setEUShippingNoticeDismissState(isDismissed: Bool, onCompletion: (Bool) -> Void) {
+        let action = AppSettingsAction.setEUShippingNoticeDismissState(isDismissed: isDismissed) { result in
+            switch result {
+            case .success:
+                onCompletion(true)
+            case .failure:
+                onCompletion(false)
+            }
+        }
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -168,11 +168,7 @@ final class ShippingLabelFormViewModel {
         }
     }
 
-    var shouldDisplayShippingNotice: Bool {
-        return false
-    }
-
-    let isEUShippingNotificationEnabled: Bool
+    private let isEUShippingNotificationEnabled: Bool
 
     init(order: Order,
          originAddress: Address?,
@@ -886,11 +882,24 @@ extension ShippingLabelFormViewModel {
 
 // MARK: - Shipping Notice dismiss state handling
 extension ShippingLabelFormViewModel {
-    func setEUShippingNoticeDismissState(isDismissed: Bool, onCompletion: (Bool) -> Void) {
+    func setEUShippingNoticeDismissState(isDismissed: Bool,
+                                         onCompletion: @escaping (Bool) -> Void) {
         let action = AppSettingsAction.setEUShippingNoticeDismissState(isDismissed: isDismissed) { result in
             switch result {
             case .success:
                 onCompletion(true)
+            case .failure:
+                onCompletion(false)
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    func shouldDisplayEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
+        let action = AppSettingsAction.loadEUShippingNoticeDismissState { result in
+            switch result {
+            case .success(let dismissState):
+                onCompletion(dismissState && self.isEUShippingNotificationEnabled)
             case .failure:
                 onCompletion(false)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -898,10 +898,15 @@ extension ShippingLabelFormViewModel {
     }
 
     func shouldDisplayEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
+        guard isEUShippingNotificationEnabled else {
+            onCompletion(false)
+            return
+        }
+
         let action = AppSettingsAction.loadEUShippingNoticeDismissState { result in
             switch result {
             case .success(let dismissed):
-                onCompletion(!dismissed && self.isEUShippingNotificationEnabled)
+                onCompletion(!dismissed)
             case .failure:
                 onCompletion(false)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -898,8 +898,8 @@ extension ShippingLabelFormViewModel {
     func shouldDisplayEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
         let action = AppSettingsAction.loadEUShippingNoticeDismissState { result in
             switch result {
-            case .success(let dismissState):
-                onCompletion(dismissState && self.isEUShippingNotificationEnabled)
+            case .success(let dismissed):
+                onCompletion(!dismissed && self.isEUShippingNotificationEnabled)
             case .failure:
                 onCompletion(false)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -884,9 +884,8 @@ extension ShippingLabelFormViewModel {
 
 // MARK: - Shipping Notice dismiss state handling
 extension ShippingLabelFormViewModel {
-    func setEUShippingNoticeDismissState(isDismissed: Bool,
-                                         onCompletion: @escaping (Bool) -> Void) {
-        let action = AppSettingsAction.setEUShippingNoticeDismissState(isDismissed: isDismissed) { result in
+    func dismissEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
+        let action = AppSettingsAction.dismissEUShippingNotice { result in
             switch result {
             case .success:
                 onCompletion(true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -898,8 +898,7 @@ extension ShippingLabelFormViewModel {
 
     func shouldDisplayEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
         guard isEUShippingNotificationEnabled else {
-            onCompletion(false)
-            return
+            return onCompletion(false)
         }
 
         let action = AppSettingsAction.loadEUShippingNoticeDismissState { result in

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -141,6 +141,14 @@ public enum AppSettingsAction: Action {
     ///
     case loadJetpackBenefitsBannerVisibility(currentTime: Date, calendar: Calendar, onCompletion: (Bool) -> Void)
 
+    /// Sets the dismiss state for the EU Shipping Notice.
+    ///
+    case setEUShippingNoticeDismissState(isDismissed: Bool, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Loads the most recent dismiss state for the EU Shipping Notice.
+    ///
+    case loadEUShippingNoticeDismissState(onCompletion: (Result<Bool, Error>) -> Void)
+
     // MARK: - General Store Settings
 
     /// Sets telemetry availability status information.

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -143,7 +143,7 @@ public enum AppSettingsAction: Action {
 
     /// Sets the dismiss state for the EU Shipping Notice.
     ///
-    case setEUShippingNoticeDismissState(isDismissed: Bool, onCompletion: (Result<Void, Error>) -> Void)
+    case dismissEUShippingNotice(onCompletion: (Result<Void, Error>) -> Void)
 
     /// Loads the most recent dismiss state for the EU Shipping Notice.
     ///

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -192,8 +192,8 @@ public class AppSettingsStore: Store {
             loadFirstInPersonPaymentsTransactionDate(siteID: siteID, using: cardReaderType, onCompletion: completion)
         case .storeInPersonPaymentsTransactionIfFirst(siteID: let siteID, cardReaderType: let cardReaderType):
             storeInPersonPaymentsTransactionIfFirst(siteID: siteID, using: cardReaderType)
-        case .setEUShippingNoticeDismissState(let isDismissed, let onCompletion):
-            setEUShippingNoticeDismissState(isDismissed: isDismissed, onCompletion: onCompletion)
+        case .dismissEUShippingNotice(let onCompletion):
+            setEUShippingNoticeDismissState(isDismissed: true, onCompletion: onCompletion)
         case .loadEUShippingNoticeDismissState(let onCompletion):
             loadEUShippingNoticeDismissState(onCompletion: onCompletion)
         }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -320,6 +320,24 @@ private extension AppSettingsStore {
         }
         onCompletion(numberOfDaysSinceLastDismissal >= 5)
     }
+
+    /// Sets the EU Shipping Notice dismissal state into `GeneralAppSettings`
+    ///
+    func setEUShippingNoticeDismissState(isDismissed: Bool, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            try generalAppSettings.setValue(isDismissed, for: \.isEUShippingNoticeDismissed)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+
+    }
+
+    /// Loads the current Order Add-Ons beta feature switch state from `GeneralAppSettings`
+    ///
+    func loadEUShippingNoticeDismissState(onCompletion: (Result<Bool, Error>) -> Void) {
+        onCompletion(.success(generalAppSettings.value(for: \.isEUShippingNoticeDismissed)))
+    }
 }
 
 // MARK: - In Person Payments Actions

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -337,7 +337,7 @@ private extension AppSettingsStore {
 
     }
 
-    /// Loads the current Order Add-Ons beta feature switch state from `GeneralAppSettings`
+    /// Loads the EU Shipping Notice dismissal state from `GeneralAppSettings`
     ///
     func loadEUShippingNoticeDismissState(onCompletion: (Result<Bool, Error>) -> Void) {
         onCompletion(.success(generalAppSettings.value(for: \.isEUShippingNoticeDismissed)))

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -192,6 +192,10 @@ public class AppSettingsStore: Store {
             loadFirstInPersonPaymentsTransactionDate(siteID: siteID, using: cardReaderType, onCompletion: completion)
         case .storeInPersonPaymentsTransactionIfFirst(siteID: let siteID, cardReaderType: let cardReaderType):
             storeInPersonPaymentsTransactionIfFirst(siteID: siteID, using: cardReaderType)
+        case .setEUShippingNoticeDismissState(let isDismissed, let onCompletion):
+            setEUShippingNoticeDismissState(isDismissed: isDismissed, onCompletion: onCompletion)
+        case .loadEUShippingNoticeDismissState(let onCompletion):
+            loadEUShippingNoticeDismissState(onCompletion: onCompletion)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -164,7 +164,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
                                           isTapToPayOnIPhoneSwitchEnabled: false,
                                           knownCardReaders: [],
                                           featureAnnouncementCampaignSettings: [:],
-                                          sitesWithAtLeastOneIPPTransactionFinished: [])
+                                          sitesWithAtLeastOneIPPTransactionFinished: [],
+                                          isEUShippingNoticeDismissed: false)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .ordersCreation)
 
         // When
@@ -233,8 +234,8 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             isTapToPayOnIPhoneSwitchEnabled: false,
             knownCardReaders: [],
             featureAnnouncementCampaignSettings: [:],
-            sitesWithAtLeastOneIPPTransactionFinished: []
-        )
+            sitesWithAtLeastOneIPPTransactionFinished: [],
+            isEUShippingNoticeDismissed: false)
         return settings
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1209,7 +1209,8 @@ private extension AppSettingsStoreTests {
             isTapToPayOnIPhoneSwitchEnabled: false,
             knownCardReaders: [],
             featureAnnouncementCampaignSettings: [:],
-            sitesWithAtLeastOneIPPTransactionFinished: []
+            sitesWithAtLeastOneIPPTransactionFinished: [],
+            isEUShippingNoticeDismissed: false
         )
         return (settings, feedback)
     }
@@ -1224,7 +1225,8 @@ private extension AppSettingsStoreTests {
             isTapToPayOnIPhoneSwitchEnabled: false,
             knownCardReaders: [],
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
-            sitesWithAtLeastOneIPPTransactionFinished: []
+            sitesWithAtLeastOneIPPTransactionFinished: [],
+            isEUShippingNoticeDismissed: false
         )
         return settings
     }


### PR DESCRIPTION
Part of #9591 

Why
==========
When inside the `Create Shipping Label` view, we want the EU Shipping Notice to only appear when it wasn't dismissed.

How
==========
Define a `set` and `load` App Settings action allowing to persist when the banner was dismissed, and connect those actions to the banner creation and presentation.

How to Test
==========
1. Open the app using a store with the `Shipping Labels` plugin activated
2. Open the Order Details of an order with the `Processing` status
3. Hit the `Create Shipping Label` button
4. Verify that the Banner is correctly displayed inside the view
5. Verify that hitting the dismiss button works and the Banner no longer appears no matter what

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.