### PR TITLE
[Privacy Choices] Adds Privacy Banner UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -41,7 +41,7 @@ struct PrivacyBanner: View {
     ///
     let goToSettingsAction: (() -> ())
 
-    /// Closure to be invoked when the go to settings button is pressed.
+    /// Closure to be invoked when the save button is pressed.
     ///
     let saveAction: (() -> ())
 
@@ -93,11 +93,13 @@ private extension PrivacyBanner {
         static let goToSettings = NSLocalizedString("Go to Settings", comment: "Title for the 'Go To Settings' button in the privacy banner")
         static let save = NSLocalizedString("Save", comment: "Title for the 'Save' button in the privacy banner")
         static let bannerSubtitle = NSLocalizedString(
-            "We process your personal data to optimize our mobile apps and marketing activities based on your consent and our legitimate interest.",
+            "Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app " +
+            "(and your experience) in various ways. Some uses of your data we absolutely need in order to make things work, and others you can " +
+            "customize from your Settings.",
             comment: "Title for the privacy banner"
         )
         static let toggleSubtitle = NSLocalizedString(
-            "These cookies allow us to optimize performance by collecting information on how users interact with our mobile apps.",
+            "Allow us to optimize performance by collecting information on how users interact with our mobile apps.",
             comment: "Description for the analytics toggle in the privacy banner"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -1,0 +1,86 @@
+import Foundation
+import UIKit
+import SwiftUI
+
+/// Hosting Controller for the Privacy Banner View
+///
+final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
+    init() {
+        super.init(rootView: PrivacyBanner())
+    }
+
+    /// Needed for protocol conformance.
+    ///
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+/// Banner View for the privacy settings.
+///
+struct PrivacyBanner: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
+
+            Text(Localization.bannerTitle)
+                .headlineStyle()
+
+            Text(Localization.bannerSubtitle)
+                .foregroundColor(Color(.text))
+                .subheadlineStyle()
+
+            Toggle(Localization.analytics, isOn: .constant(true))
+                .tint(Color(.primary))
+                .bodyStyle()
+                .padding(.vertical)
+
+            Text(Localization.toggleSubtitle)
+                .subheadlineStyle()
+
+            HStack {
+                Button(Localization.goToSettings) {
+                    print("Tapped Settings")
+                }
+                .buttonStyle(SecondaryButtonStyle())
+
+
+                Button(Localization.save) {
+                    print("Tapped Save")
+                }
+                .buttonStyle(PrimaryButtonStyle())
+            }
+            .padding(.vertical)
+        }
+        .padding()
+    }
+}
+
+// MARK: Definitions
+private extension PrivacyBanner {
+    enum Localization {
+        static let bannerTitle = NSLocalizedString("Manage Privacy", comment: "Title for the privacy banner")
+        static let analytics = NSLocalizedString("Analytics", comment: "Title for the analytics toggle in the privacy banner")
+        static let goToSettings = NSLocalizedString("Go to Settings", comment: "Title for the 'Go To Settings' button in the privacy banner")
+        static let save = NSLocalizedString("Save", comment: "Title for the 'Save' button in the privacy banner")
+        static let bannerSubtitle = NSLocalizedString(
+            "We process your personal data to optimize our mobile apps and marketing activities based on your consent and our legitimate interest.",
+            comment: "Title for the privacy banner"
+        )
+        static let toggleSubtitle = NSLocalizedString(
+            "These cookies allow us to optimize performance by collecting information on how users interact with our mobile apps.",
+            comment: "Description for the analytics toggle in the privacy banner"
+        )
+    }
+
+    enum Layout {
+        static let mainVerticalSpacing = CGFloat(8)
+    }
+}
+
+struct PrivacyBanner_Previews: PreviewProvider {
+    static var previews: some View {
+        PrivacyBanner()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -5,8 +5,9 @@ import SwiftUI
 /// Hosting Controller for the Privacy Banner View
 ///
 final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
-    init() {
-        super.init(rootView: PrivacyBanner())
+
+    init(goToSettingsAction: @escaping (() -> ()), saveAction: @escaping (() -> ())) {
+        super.init(rootView: PrivacyBanner(goToSettingsAction: goToSettingsAction, saveAction: saveAction))
     }
 
     /// Needed for protocol conformance.
@@ -14,12 +15,19 @@ final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
 }
 
 /// Banner View for the privacy settings.
 ///
 struct PrivacyBanner: View {
+    /// Closure to be invoked when the go to settings button is pressed.
+    ///
+    let goToSettingsAction: (() -> ())
+
+    /// Closure to be invoked when the go to settings button is pressed.
+    ///
+    let saveAction: (() -> ())
+
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
 
@@ -80,7 +88,7 @@ private extension PrivacyBanner {
 
 struct PrivacyBanner_Previews: PreviewProvider {
     static var previews: some View {
-        PrivacyBanner()
+        PrivacyBanner(goToSettingsAction: {}, saveAction: {})
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import SwiftUI
+import WordPressUI
 
 /// Hosting Controller for the Privacy Banner View
 ///
@@ -14,6 +15,22 @@ final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
     ///
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // Needed when presented via the `BottomSheetViewController`
+        preferredContentSize = .init(width: 0, height: view.intrinsicContentSize.height)
+    }
+}
+
+extension PrivacyBannerViewController: DrawerPresentable {
+    var collapsedHeight: DrawerHeight {
+        return .intrinsicHeight
+    }
+
+    var expandedHeight: DrawerHeight {
+        return .intrinsicHeight
     }
 }
 
@@ -58,7 +75,11 @@ struct PrivacyBanner: View {
                 }
                 .buttonStyle(PrimaryButtonStyle())
             }
-            .padding(.vertical)
+            .padding(.top)
+
+            /// Push all content to the top
+            ///
+            Spacer()
         }
         .padding()
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -726,6 +726,7 @@
 		267C01CF29E89E1700FCC97B /* StorePlanSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */; };
 		267C01D129E9B18E00FCC97B /* StorePlanSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267C01D029E9B18E00FCC97B /* StorePlanSynchronizerTests.swift */; };
 		267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */; };
+		267F60132A0C24D700CD1E4E /* PrivacyBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267F60122A0C24D700CD1E4E /* PrivacyBannerViewController.swift */; };
 		26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */; };
 		26838356296F702B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838355296F702B00CCF60A /* GenerateAllVariationsPresenter.swift */; };
 		26838358296F9A1E00CCF60A /* GenerateAllVariationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838357296F9A1E00CCF60A /* GenerateAllVariationsUseCase.swift */; };
@@ -2987,6 +2988,7 @@
 		267C01D029E9B18E00FCC97B /* StorePlanSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanSynchronizerTests.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGeneratorTests.swift; sourceTree = "<group>"; };
+		267F60122A0C24D700CD1E4E /* PrivacyBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerViewController.swift; sourceTree = "<group>"; };
 		26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationsOptionPresenter.swift; sourceTree = "<group>"; };
 		26838355296F702B00CCF60A /* GenerateAllVariationsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateAllVariationsPresenter.swift; sourceTree = "<group>"; };
 		26838357296F9A1E00CCF60A /* GenerateAllVariationsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateAllVariationsUseCase.swift; sourceTree = "<group>"; };
@@ -9005,6 +9007,7 @@
 			isa = PBXGroup;
 			children = (
 				CE22E3F62170E23C005A6BEF /* PrivacySettingsViewController.swift */,
+				267F60122A0C24D700CD1E4E /* PrivacyBannerViewController.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -11580,6 +11583,7 @@
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				B9E4364C287587D300883CFA /* FeatureAnnouncementCardView.swift in Sources */,
+				267F60132A0C24D700CD1E4E /* PrivacyBannerViewController.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
 				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,


### PR DESCRIPTION
Closes: #9612

# Why

This PR adds the UI for the Ptivacy Banner.

**Note: The UI is not connected yet.**

# Screenshots

Light | Dark
--- | ---
<img width="435" alt="ligh" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/0ca1cc70-8472-4bbf-bd11-3d36210faa6f"> |  <img width="433" alt="dark" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/8f729427-9a30-497f-bf5e-cbe223697db3">
Big Font | Landscape
<img width="445" alt="big" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/f51fcbe4-2653-45c1-9513-a2b1cb8c3b30"> |  <img width="445" alt="landscape" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/123718be-d5ba-47a5-b1f1-aa93e0ebe285">


# Testing Steps

- Add the following code on the `DashboardViewController.viewDidLoad`

```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
    let vc = PrivacyBannerViewController(goToSettingsAction: {}, saveAction: {})
    let bottomSheet = BottomSheetViewController(childViewController: vc)
    bottomSheet.show(from: self)
}
```

- Launch the app 
- See the banner appear after 5 secconds.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
