### PR TITLE
EU-Bound Shipping Notice: Configure mutable banner visibility condition

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 
 class EUCustomsScenarioValidator {
-    static func validate(origin: ShippingLabelAddress, destination: ShippingLabelAddress) -> Bool {
+    static func validate(origin: ShippingLabelAddress?, destination: ShippingLabelAddress?) -> Bool {
         return true
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Yosemite
+
+class EUCustomsScenarioValidator {
+    static func validate(origin: ShippingLabelAddress, destination: ShippingLabelAddress) -> Bool {
+        return true
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
@@ -1,8 +1,13 @@
 import Foundation
 import Yosemite
 
+/// Validation logic for Shipping scenarios with specific EU Customs.
+///
+/// Refer to [USPS instructions](https://www.usps.com/international/new-eu-customs-rules.htm) for more context.
+///
 class EUCustomsScenarioValidator {
     static func validate(origin: ShippingLabelAddress?, destination: ShippingLabelAddress?) -> Bool {
+        // TODO: Implement validation logic for EU Customs scenarios.
         return true
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -562,15 +562,17 @@ private extension ShippingLabelFormViewController {
 private extension ShippingLabelFormViewController {
     func observeEUShippingNoticeVisibilityChanges() {
         viewModel.$shouldPresentEUShippingNotice
-            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] shouldPresent in
                 guard let self = self else { return }
 
                 if shouldPresent {
                     self.showTopBannerView()
+                } else {
+                    self.hideTopBannerView()
                 }
-            }
+
+            }.store(in: &viewModel.subscriptions)
     }
 
     /// Present a Top Banner View containing the EU Shipping Notice.
@@ -583,6 +585,19 @@ private extension ShippingLabelFormViewController {
         headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
         self.tableView.tableHeaderView = headerContainer
         self.tableView.updateHeaderHeight()
+    }
+
+    /// Removes the Top Banner View from the table view header.
+    ///
+    func hideTopBannerView() {
+        guard tableView.tableHeaderView != nil else {
+            return
+        }
+
+        topBannerView?.removeFromSuperview()
+        topBannerView = nil
+        tableView.tableHeaderView = nil
+        tableView.updateHeaderHeight()
     }
 
     /// Creates the Shipping Notice Top banner with the appropriate actions.
@@ -609,19 +624,6 @@ private extension ShippingLabelFormViewController {
         let webKitVC = WebKitViewController(configuration: configuration)
         let nc = WooNavigationController(rootViewController: webKitVC)
         self.present(nc, animated: true)
-    }
-
-    /// Removes the Top Banner View from the table view header.
-    ///
-    func hideTopBannerView() {
-        guard tableView.tableHeaderView != nil else {
-            return
-        }
-
-        topBannerView?.removeFromSuperview()
-        topBannerView = nil
-        tableView.tableHeaderView = nil
-        tableView.updateHeaderHeight()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -590,12 +590,11 @@ private extension ShippingLabelFormViewController {
     /// Present a Top Banner View containing the EU Shipping Notice.
     ///
     func showTopBannerView() {
-        let topBannerView = self.topBannerView
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(self.tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topBannerView)
         headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
-        self.tableView.tableHeaderView = headerContainer
-        self.tableView.updateHeaderHeight()
+        tableView.tableHeaderView = headerContainer
+        tableView.updateHeaderHeight()
     }
 
     /// Removes the Top Banner View from the table view header.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -576,7 +576,7 @@ private extension ShippingLabelFormViewController {
         viewModel.$shouldPresentEUShippingNotice
             .removeDuplicates()
             .sink { [weak self] shouldPresent in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if shouldPresent {
                     self.showTopBannerView()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -590,8 +590,7 @@ private extension ShippingLabelFormViewController {
     /// Present a Top Banner View containing the EU Shipping Notice.
     ///
     func showTopBannerView() {
-        let topBannerView = self.createEUShippingNoticeBannerView()
-        self.topBannerView = topBannerView
+        let topBannerView = self.topBannerView
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(self.tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topBannerView)
         headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
@@ -606,7 +605,7 @@ private extension ShippingLabelFormViewController {
             return
         }
 
-        topBannerView?.removeFromSuperview()
+        topBannerView.removeFromSuperview()
         tableView.tableHeaderView = nil
         tableView.updateHeaderHeight()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -899,7 +899,7 @@ extension ShippingLabelFormViewModel {
                 return
             }
 
-            // TODO: will trigger a validation checking if it's an EU country destination
+            // TODO: will trigger a validation checking if it's an US-to-EU
             let isEUCountryScenario = true
 
             self.shouldPresentEUShippingNotice = isEUCountryScenario && self.isEUShippingNotificationEnabled
@@ -918,7 +918,7 @@ extension ShippingLabelFormViewModel {
         stores.dispatch(action)
     }
 
-    func verifyEUShippingNoticeDismissState(onCompletion: @escaping (Bool) -> Void) {
+    private func verifyEUShippingNoticeDismissState(onCompletion: @escaping (Bool) -> Void) {
         guard isEUShippingNotificationEnabled else {
             onCompletion(false)
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -892,7 +892,7 @@ extension ShippingLabelFormViewModel {
 
 // MARK: - Shipping Notice dismiss state handling
 extension ShippingLabelFormViewModel {
-    func updateEUShippingNoticeVisibility() {
+    private func updateEUShippingNoticeVisibility() {
         verifyEUShippingNoticeDismissState { [weak self] dismissed in
             guard let self = self, dismissed else {
                 self?.shouldPresentEUShippingNotice = false

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -899,10 +899,7 @@ extension ShippingLabelFormViewModel {
                 return
             }
 
-            // TODO: will trigger a validation checking if it's an US-to-EU
-            let isEUCountryScenario = true
-
-            self.shouldPresentEUShippingNotice = isEUCountryScenario && self.isEUShippingNotificationEnabled
+            self.shouldPresentEUShippingNotice = EUCustomsScenarioValidator.validate(origin: self.originAddress, destination: self.destinationAddress)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -209,6 +209,7 @@ final class ShippingLabelFormViewModel {
         syncPackageDetails()
         fetchCountries()
         monitorAccountSettingsResultsController()
+        updateEUShippingNoticeVisibility()
     }
 
     func handleOriginAddressValueChanges(address: ShippingLabelAddress?, validated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -891,16 +891,15 @@ extension ShippingLabelFormViewModel {
 extension ShippingLabelFormViewModel {
     func updateEUShippingNoticeVisibility() {
         verifyEUShippingNoticeDismissState { [weak self] dismissed in
-            guard let self = self else {
+            guard let self = self, dismissed else {
+                self?.shouldPresentEUShippingNotice = false
                 return
             }
             
             // TODO: will trigger a validation checking if it's an EU country destination
             let isEUCountryScenario = true
             
-            self.shouldPresentEUShippingNotice = isEUCountryScenario
-            && self.isEUShippingNotificationEnabled
-            && !dismissed
+            self.shouldPresentEUShippingNotice = isEUCountryScenario && self.isEUShippingNotificationEnabled
         }
     }
     

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -167,8 +167,12 @@ final class ShippingLabelFormViewModel {
             onChange?()
         }
     }
-
+    
     /// Flag to indicate if the view should display the EU shipping notice.
+    ///
+    @Published private(set) var shouldPresentEUShippingNotice: Bool = false
+
+    /// Flag to indicate if the `.euShippingNotification` feature is activated.
     ///
     private let isEUShippingNotificationEnabled: Bool
 
@@ -884,6 +888,21 @@ extension ShippingLabelFormViewModel {
 
 // MARK: - Shipping Notice dismiss state handling
 extension ShippingLabelFormViewModel {
+    func updateEUShippingNoticeVisibility() {
+        verifyEUShippingNoticeDismissState { [weak self] dismissed in
+            guard let self = self else {
+                return
+            }
+            
+            // TODO: will trigger a validation checking if it's an EU country destination
+            let isEUCountryScenario = true
+            
+            self.shouldPresentEUShippingNotice = isEUCountryScenario
+            && self.isEUShippingNotificationEnabled
+            && !dismissed
+        }
+    }
+    
     func setEUShippingNoticeDismissState(isDismissed: Bool,
                                          onCompletion: @escaping (Bool) -> Void) {
         let action = AppSettingsAction.setEUShippingNoticeDismissState(isDismissed: isDismissed) { result in
@@ -897,7 +916,7 @@ extension ShippingLabelFormViewModel {
         stores.dispatch(action)
     }
 
-    func shouldDisplayEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
+    private func verifyEUShippingNoticeDismissState(onCompletion: @escaping (Bool) -> Void) {
         let action = AppSettingsAction.loadEUShippingNoticeDismissState { result in
             switch result {
             case .success(let dismissed):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -225,6 +225,7 @@ final class ShippingLabelFormViewModel {
         handleCarrierAndRatesValueChanges(selectedRates: [], editable: false)
 
         updateRowsForCustomsIfNeeded()
+        updateEUShippingNoticeVisibility()
 
         if dataState == .validated, let address {
             userDefaults[.storePhoneNumber] = address.phone
@@ -242,6 +243,7 @@ final class ShippingLabelFormViewModel {
         handleCarrierAndRatesValueChanges(selectedRates: [], editable: false)
 
         updateRowsForCustomsIfNeeded()
+        updateEUShippingNoticeVisibility()
 
         if dateState == .validated {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "destination_address_complete"])

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -176,6 +176,8 @@ final class ShippingLabelFormViewModel {
     ///
     private let isEUShippingNotificationEnabled: Bool
 
+    var subscriptions = Set<AnyCancellable>()
+
     init(order: Order,
          originAddress: Address?,
          destinationAddress: Address?,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import Combine
 import WooFoundation
 import protocol Storage.StorageManagerType
 import protocol Experiments.FeatureFlagService

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1538,6 +1538,7 @@
 		B6F3796C293794A000718561 /* AnalyticsHubYearToDateRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3796B293794A000718561 /* AnalyticsHubYearToDateRangeData.swift */; };
 		B6F3796E293796BC00718561 /* AnalyticsHubWeekToDateRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3796D293796BC00718561 /* AnalyticsHubWeekToDateRangeData.swift */; };
 		B6F37970293798ED00718561 /* AnalyticsHubTodayRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3796F293798ED00718561 /* AnalyticsHubTodayRangeData.swift */; };
+		B6FEFFF12A0DDC0000C0F546 /* EUCustomsScenarioValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FEFFF02A0DDC0000C0F546 /* EUCustomsScenarioValidator.swift */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		B90C65CD29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */; };
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
@@ -3811,6 +3812,7 @@
 		B6F3796B293794A000718561 /* AnalyticsHubYearToDateRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubYearToDateRangeData.swift; sourceTree = "<group>"; };
 		B6F3796D293796BC00718561 /* AnalyticsHubWeekToDateRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubWeekToDateRangeData.swift; sourceTree = "<group>"; };
 		B6F3796F293798ED00718561 /* AnalyticsHubTodayRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTodayRangeData.swift; sourceTree = "<group>"; };
+		B6FEFFF02A0DDC0000C0F546 /* EUCustomsScenarioValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EUCustomsScenarioValidator.swift; sourceTree = "<group>"; };
 		B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentOnboardingStateCache.swift; sourceTree = "<group>"; };
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
@@ -6655,6 +6657,7 @@
 				456396A525C81C9A001F1A26 /* ShippingLabelFormViewController.swift */,
 				456396A625C81C9A001F1A26 /* ShippingLabelFormViewController.xib */,
 				456396AD25C81D81001F1A26 /* ShippingLabelFormViewModel.swift */,
+				B6FEFFF02A0DDC0000C0F546 /* EUCustomsScenarioValidator.swift */,
 				4515C88A25D6BD520099C8E3 /* Shipping Address Validation */,
 				456C7EE825EE71C10016CBC6 /* Shipping Address Suggested Address */,
 				451A995B260E2E0A0059D135 /* Package Details */,
@@ -11999,6 +12002,7 @@
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				45D875D22611EA2100226C3F /* ListHeaderView.swift in Sources */,
 				DE2FE58D292617C30018040A /* SiteCredentialLoginViewModel.swift in Sources */,
+				B6FEFFF12A0DDC0000C0F546 /* EUCustomsScenarioValidator.swift in Sources */,
 				026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */,
 				4590B64C261C673B00A6FCE0 /* WeightFormatter.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,


### PR DESCRIPTION
Part of #9594

Why
==========
The objective of the EU-Bound Shipping Notice is to warn the user whenever a Shipping Label is under creation where the origin is the US and the destination is one of the EU countries inside the new Customs rules. To achieve this, we must react every time the `origin` and `destination` address change inside the Shipping Label Form. This PR introduces the changes necessary to achieve this goal in the upcoming PR.

How
==========
Introduces a published `shouldPresentEUShippingNotice` field that will dictate to the ViewController if the banner should be visible or not. Meanwhile, it introduces a function called `updateEUShippingNoticeVisibility` that will be triggered every time the ViewModel starts, or the origin/destination address is changed. This function will update `shouldPresentEUShippingNotice` and keep the banner visibility always correct.

It also introduces the `EUCustomsScenarioValidator`, but the validator is hardcoded always returning `true`. The logic implementation of this type will be introduced at https://github.com/woocommerce/woocommerce-ios/pull/9704.
  
How to Test
==========
### Scenario 1
2. Open the app with a site containing the Shipping Labels plugin configured
3. Open the order details of an order with the `processing` status
4. Hit the `Create Shipping Label` button
5. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
6. Verify that the Banner is correctly displayed inside the view
7. Verify that hitting the dismiss button works and dismiss the banner
8. Verify that hitting the learn more button opens a web view with the USPS instructions page

### Scenario 2
1. Adjust `EUCustomsScenarioValidator` to always return `false`
2. Open the app with a site containing the Shipping Labels plugin configured
3. Open the order details of an order with the `processing` status
4. Hit the `Create Shipping Label` button
5. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
6. Verify that the Banner DOES NOT show up inside the view

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.