### PR TITLE
Add support for retrieving product with exact match SKU

### DIFF
--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -63,6 +63,10 @@ public enum ProductAction: Action {
         pageSize: Int = ProductsRemote.Default.pageSize,
         onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
 
+    /// Retrieves the first Product with exact-match SKU
+    ///
+    case retrieveFirstProductMatchFromSKU(siteID: Int64, sku: String, onCompletion: (Result<Product, Error>) -> Void)
+
     /// Deletes all of the cached products.
     ///
     case resetStoredProducts(onCompletion: () -> Void)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -336,9 +336,8 @@ private extension ProductStore {
         remote.searchProductsBySKU(for: siteID,
                                    keyword: sku,
                                    pageNumber: Remote.Default.firstPageNumber,
-                                   pageSize: ProductStore.Constants.singleResultPageSize,
-                                   completion: { [weak self] result in
-            guard self != nil else { return }
+                                   pageSize: ProductsRemote.Default.pageSize,
+                                   completion: { result in
             switch result {
             case let .success(products):
                 guard let product = products.first(where: { $0.sku == sku }) else {
@@ -1026,11 +1025,5 @@ public enum ProductLoadError: Error, Equatable {
                 return .notFound
             }
         }
-    }
-}
-
-private extension ProductStore {
-    enum Constants {
-        static let singleResultPageSize: Int = 1
     }
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -333,7 +333,12 @@ private extension ProductStore {
     /// Retrieves the first product associated with a given siteID and exact-matching SKU (if any)
     ///
     func retrieveFirstProductMatchFromSKU(siteID: Int64, sku: String, onCompletion: @escaping (Result<Product, Error>) -> Void) {
-        remote.searchProductsBySKU(for: siteID, keyword: sku, pageNumber: Remote.Default.firstPageNumber, pageSize: 10, completion: { result in
+        remote.searchProductsBySKU(for: siteID,
+                                   keyword: sku,
+                                   pageNumber: Remote.Default.firstPageNumber,
+                                   pageSize: ProductStore.Constants.singleResultPageSize,
+                                   completion: { [weak self] result in
+            guard self != nil else { return }
             switch result {
             case let .success(products):
                 guard let product = products.first(where: { $0.sku == sku }) else {
@@ -1021,5 +1026,11 @@ public enum ProductLoadError: Error, Equatable {
                 return .notFound
             }
         }
+    }
+}
+
+private extension ProductStore {
+    enum Constants {
+        static let singleResultPageSize: Int = 1
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1817,7 +1817,7 @@ final class ProductStoreTests: XCTestCase {
 
     // MARK: - ProductAction.retrieveFirstProductMatchFromSKU
 
-    func test_retrieveFirstProductMatchFromSKU_retrieves_product_when_successful_SKU_match_then_returns_matched_product() throws {
+    func test_retrieveFirstProductMatchFromSKU_retrieves_product_when_successful_exact_SKU_match_then_returns_matched_product() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
@@ -1842,6 +1842,53 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(productMatch.productID, expectedProductID)
         XCTAssertEqual(productMatch.name, expectedProductName)
         XCTAssertEqual(productMatch.sku, expectedProductSKU)
+    }
+
+    func test_retrieveFirstProductMatchFromSKU_when_partial_SKU_match_then_returns_not_found_error() throws {
+        // Given
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
+
+        // The product that is expected to be in the search results
+        let expectedProductName = "Chocolate bars"
+        let expectedProductSKU = "chocobars"
+
+        // When
+        let productSKU = "choco"
+        let result = waitFor { promise in
+            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID,
+                                                                        sku: productSKU,
+                                                                        onCompletion: { product in
+                promise(product)
+            })
+            store.onAction(action)
+        }
+
+        let error = try XCTUnwrap(result.failure as? ProductLoadError)
+        XCTAssertEqual(result.isFailure, true)
+        XCTAssertEqual(error, ProductLoadError.notFound)
+    }
+
+    func test_retrieveFirstProductMatchFromSKU_when_unsuccessful_SKU_match_then_returns_not_found_error() throws {
+        // Given
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
+
+        // When
+        let productSKU = "non-existing-product-sku"
+        let result = waitFor { promise in
+            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID,
+                                                                        sku: productSKU,
+                                                                        onCompletion: { product in
+                promise(product)
+            })
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure as? ProductLoadError)
+        XCTAssertEqual(result.isFailure, true)
+        XCTAssertEqual(error, ProductLoadError.notFound)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1814,6 +1814,35 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertTrue(base.contains("Product features: Trendy, cool, fun"))
         XCTAssertTrue(base.contains("In language en-US"))
     }
+
+    // MARK: - ProductAction.retrieveFirstProductMatchFromSKU
+
+    func test_retrieveFirstProductMatchFromSKU_retrieves_product_when_successful_SKU_match_then_returns_matched_product() throws {
+        // Given
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
+
+        // The product that is expected to be in the search results
+        let expectedProductID: Int64 = 2783
+        let expectedProductName = "Chocolate bars"
+        let expectedProductSKU = "chocobars"
+
+        // When
+        let productSKU = "chocobars"
+        let result = waitFor { promise in
+            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID,
+                                                                        sku: productSKU,
+                                                                        onCompletion: { product in
+                promise(product)
+            })
+            store.onAction(action)
+        }
+
+        let productMatch = try XCTUnwrap(result.get())
+        XCTAssertEqual(productMatch.productID, expectedProductID)
+        XCTAssertEqual(productMatch.name, expectedProductName)
+        XCTAssertEqual(productMatch.sku, expectedProductSKU)
+    }
 }
 
 // MARK: - Private Helpers

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1849,10 +1849,6 @@ final class ProductStoreTests: XCTestCase {
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
 
-        // The product that is expected to be in the search results
-        let expectedProductName = "Chocolate bars"
-        let expectedProductSKU = "chocobars"
-
         // When
         let productSKU = "choco"
         let result = waitFor { promise in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: https://github.com/woocommerce/woocommerce-ios/issues/9658
Closes: #9655

## Description
This PR adds support for retrieving the first exact-matching SKU product from a store, as we want to avoid partial SKU matches when using the barcode scanner.

Added to this, we do not persist any data related to this search, each API call will be a new/fresh call to keep the remote as source of truth (Ref: p1683260266619189-slack-C025A8VV728)

## Changes
* Added `ProductAction.retrieveFirstProductMatchFromSKU` to the Product Store 
* This will return success with a `Product` model if there's an exact SKU match, or a "not found" error otherwise

## Testing instructions
There's no app usage of this new action yet, we can test by assuring that Unit Tests pass. Added tests for:
* Happy path: Finding a SKU exact-match should return the single product
* Unhappy path: Finding a SKU partial-match should return a "not found" error
* Unhappy path: Not finding an SKU match should return a "not found" error
