### PR TITLE
Store creation: send a local notification 5 minutes after starting to wait for the site to be ready

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -879,7 +879,7 @@ private extension StoreCreationCoordinator {
 
 private extension StoreCreationCoordinator {
     func scheduleLocalNotificationWhenStoreIsReady() {
-        guard let notification = LocalNotification(scenario: .storeCreationComplete, stores: stores) else {
+        guard let notification = LocalNotification(scenario: Constants.LocalNotificationScenario.storeCreationComplete, stores: stores) else {
             return
         }
         cancelLocalNotificationWhenStoreIsReady()
@@ -892,7 +892,7 @@ private extension StoreCreationCoordinator {
     }
 
     func cancelLocalNotificationWhenStoreIsReady() {
-        localNotificationScheduler.cancel(scenario: .storeCreationComplete)
+        localNotificationScheduler.cancel(scenario: Constants.LocalNotificationScenario.storeCreationComplete)
     }
 }
 
@@ -1008,6 +1008,11 @@ private extension StoreCreationCoordinator {
         // TODO: 8108 - update the identifier to production value when it's ready
         static let iapPlanIdentifier = "debug.woocommerce.ecommerce.monthly"
         static let webPlanIdentifier = "1021"
+
+        /// Local notification scenarios during store creation.
+        enum LocalNotificationScenario {
+            static let storeCreationComplete: LocalNotification.Scenario = .storeCreationComplete
+        }
     }
 
     /// Error scenarios when purchasing a WPCOM plan.

--- a/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Yosemite
+
+/// Handles the scheduling of local notifications with support of remote feature flags.
+final class LocalNotificationScheduler {
+    private let pushNotesManager: PushNotesManager
+    private let stores: StoresManager
+
+    init(pushNotesManager: PushNotesManager,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.pushNotesManager = pushNotesManager
+        self.stores = stores
+    }
+
+    /// Schedules a local notification behind an optional remote feature flag.
+    /// - Parameters:
+    ///   - notification: Local notification to schedule.
+    ///   - trigger: When the local notification is scheduled to arrive.
+    ///   - remoteFeatureFlag: If non-nil, the local notification is only scheduled when the remote feature flag is enabled (disabled by default).
+    ///     If nil, the local notification is always scheduled.
+    @MainActor
+    func schedule(notification: LocalNotification, trigger: UNNotificationTrigger?, remoteFeatureFlag: RemoteFeatureFlag?) async {
+        if let remoteFeatureFlag, await isRemoteFeatureFlagEnabled(remoteFeatureFlag) == false {
+                return
+            }
+        pushNotesManager.requestLocalNotification(notification,
+                                                  trigger: trigger)
+    }
+
+    /// Cancels a local notification of the given scenario.
+    /// - Parameter scenario: The scenario to cancel.
+    func cancel(scenario: LocalNotification.Scenario) {
+        pushNotesManager.cancelLocalNotification(scenarios: [scenario])
+    }
+}
+
+private extension LocalNotificationScheduler {
+    @MainActor
+    func isRemoteFeatureFlagEnabled(_ remoteFeatureFlag: RemoteFeatureFlag) async -> Bool {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(remoteFeatureFlag, defaultValue: false) { isEnabled in
+                continuation.resume(returning: isEnabled)
+            })
+        }
+    }
+}

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -40,6 +40,7 @@ class AuthenticatedState: StoresManagerState {
             CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             DataStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             DomainStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            FeatureFlagStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             InAppPurchaseStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             InboxNotesStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             JustInTimeMessageStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -274,6 +274,8 @@
 		026D4652295D763B0037F59A /* CountryCode+FlagEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D4651295D763B0037F59A /* CountryCode+FlagEmoji.swift */; };
 		026D4654295D79230037F59A /* CountryCode+FlagEmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D4653295D79230037F59A /* CountryCode+FlagEmojiTests.swift */; };
 		026D4A24280461960090164F /* LegacyCollectOrderPaymentUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D4A23280461960090164F /* LegacyCollectOrderPaymentUseCaseTests.swift */; };
+		026D68492A0E060A00D8C22C /* LocalNotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D68482A0E060A00D8C22C /* LocalNotificationScheduler.swift */; };
+		026D684B2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D684A2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift */; };
 		0270F47624D005B00005210A /* ProductFormViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0270F47524D005B00005210A /* ProductFormViewModelProtocol.swift */; };
 		0270F47824D006F60005210A /* ProductFormPresentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0270F47724D006F60005210A /* ProductFormPresentationStyle.swift */; };
 		027111422913B9FC00F5269A /* AccountCreationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027111412913B9FC00F5269A /* AccountCreationFormViewModelTests.swift */; };
@@ -2542,6 +2544,8 @@
 		026D4651295D763B0037F59A /* CountryCode+FlagEmoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CountryCode+FlagEmoji.swift"; sourceTree = "<group>"; };
 		026D4653295D79230037F59A /* CountryCode+FlagEmojiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CountryCode+FlagEmojiTests.swift"; sourceTree = "<group>"; };
 		026D4A23280461960090164F /* LegacyCollectOrderPaymentUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCollectOrderPaymentUseCaseTests.swift; sourceTree = "<group>"; };
+		026D68482A0E060A00D8C22C /* LocalNotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationScheduler.swift; sourceTree = "<group>"; };
+		026D684A2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationSchedulerTests.swift; sourceTree = "<group>"; };
 		0270C0A827069BEF00FC799F /* Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0270F47524D005B00005210A /* ProductFormViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModelProtocol.swift; sourceTree = "<group>"; };
 		0270F47724D006F60005210A /* ProductFormPresentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormPresentationStyle.swift; sourceTree = "<group>"; };
@@ -8025,6 +8029,7 @@
 			children = (
 				B5718D6421B56B3F0026C9F0 /* PushNotificationsManagerTests.swift */,
 				DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */,
+				026D684A2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -8203,6 +8208,7 @@
 				B5BBD6DD21B1703600E3207E /* PushNotificationsManager.swift */,
 				B555530C21B57DC300449E71 /* UserNotificationsCenterAdapter.swift */,
 				0221121D288973C20028F0AF /* LocalNotification.swift */,
+				026D68482A0E060A00D8C22C /* LocalNotificationScheduler.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -11122,6 +11128,7 @@
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
 				31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */,
 				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
+				026D68492A0E060A00D8C22C /* LocalNotificationScheduler.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */,
 				CCC284112768C18500F6CC8B /* ProductInOrder.swift in Sources */,
@@ -12495,6 +12502,7 @@
 				E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */,
 				CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */,
 				EEB221A729B9B5B300662A12 /* CouponLineDetailsViewModelTests.swift in Sources */,
+				026D684B2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift in Sources */,
 				0203C11C293058CB00EE61BF /* WebPurchasesForWPComPlansTests.swift in Sources */,
 				2683835A296F9C1A00CCF60A /* GenerateAllVariationsUseCaseTests.swift in Sources */,
 				020ACF8A299B746700B3638B /* DomainContactInfoFormViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -36,6 +36,9 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     private let localNotificationResponsesSubject = PassthroughSubject<UNNotificationResponse, Never>()
 
+    private(set) var requestedLocalNotifications: [LocalNotification] = []
+    private(set) var canceledLocalNotificationScenarios: [[LocalNotification.Scenario]] = []
+
     func resetBadgeCount(type: Note.Kind) {
 
     }
@@ -81,9 +84,11 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
+        requestedLocalNotifications.append(notification)
     }
 
     func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
+        canceledLocalNotificationScenarios.append(scenarios)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+@MainActor
+final class LocalNotificationSchedulerTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
+
+    func test_notification_is_scheduled_when_remote_feature_flag_is_enabled() async throws {
+        // Given
+        let pushNotesManager = MockPushNotificationsManager()
+        let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, completion):
+                // Remote feature flag is enabled.
+                completion(true)
+            }
+        }
+
+        // When
+        let notification = try XCTUnwrap(LocalNotification(scenario: .storeCreationComplete))
+        await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: .storeCreationCompleteNotification)
+
+        // Then
+        XCTAssertEqual(pushNotesManager.requestedLocalNotifications, [notification])
+    }
+
+    func test_notification_is_not_scheduled_when_remote_feature_flag_is_disabled() async throws {
+        // Given
+        let pushNotesManager = MockPushNotificationsManager()
+        let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, completion):
+                // Remote feature flag is disabled.
+                completion(false)
+            }
+        }
+
+        // When
+        let notification = try XCTUnwrap(LocalNotification(scenario: .storeCreationComplete))
+        await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: .storeCreationCompleteNotification)
+
+        // Then
+        XCTAssertEqual(pushNotesManager.requestedLocalNotifications, [])
+    }
+
+    func test_notification_is_scheduled_when_remote_feature_flag_is_not_specified() async throws {
+        // Given
+        let pushNotesManager = MockPushNotificationsManager()
+        let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
+
+        // When
+        let notification = try XCTUnwrap(LocalNotification(scenario: .storeCreationComplete))
+        await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: nil)
+
+        // Then
+        XCTAssertEqual(pushNotesManager.requestedLocalNotifications, [notification])
+    }
+}
+
+extension LocalNotification: Equatable {
+    public static func == (lhs: LocalNotification, rhs: LocalNotification) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.body == rhs.body &&
+        lhs.scenario == rhs.scenario &&
+        lhs.actions?.category == rhs.actions?.category &&
+        lhs.actions?.actions == rhs.actions?.actions
+    }
+}
+
+extension LocalNotification.Scenario: Equatable {
+    public static func ==(lhs: LocalNotification.Scenario, rhs: LocalNotification.Scenario) -> Bool {
+        switch (lhs, rhs) {
+        case (.storeCreationComplete, .storeCreationComplete),
+            (.oneDayAfterFreeTrialExpires, .oneDayAfterFreeTrialExpires),
+            (.loginSiteAddressError, .loginSiteAddressError),
+            (.invalidEmailFromSiteAddressLogin, .invalidEmailFromSiteAddressLogin),
+            (.invalidEmailFromWPComLogin, .invalidEmailFromWPComLogin),
+            (.invalidPasswordFromSiteAddressWPComLogin, .invalidPasswordFromSiteAddressWPComLogin),
+            (.invalidPasswordFromWPComLogin, .invalidPasswordFromWPComLogin):
+            return true
+        case let (.oneDayAfterStoreCreationNameWithoutFreeTrial(lhsStoreName), .oneDayAfterStoreCreationNameWithoutFreeTrial(rhsStoreName)):
+            return lhsStoreName == rhsStoreName
+        case let (.oneDayBeforeFreeTrialExpires(lhsExpiryDate), .oneDayBeforeFreeTrialExpires(rhsExpiryDate)):
+            return lhsExpiryDate == rhsExpiryDate
+        default:
+            return false
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -72,7 +72,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
 
 extension LocalNotification: Equatable {
     public static func == (lhs: LocalNotification, rhs: LocalNotification) -> Bool {
-        return lhs.title == rhs.title &&
+        lhs.title == rhs.title &&
         lhs.body == rhs.body &&
         lhs.scenario == rhs.scenario &&
         lhs.actions?.category == rhs.actions?.category &&


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9689 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Currently in store creation (free trial), it takes 1-2 minutes to wait for the site to be ready (Jetpack & Woo). As the Scenario  1 of the new local notifications experiment, we want to send a local notification when the newly created site is ready. However, as soon as the app leaves the foreground state (like switching to another app when the user might feel it's taking a long time), the code is also paused unless we implement some background tasks with nontrivial changes. @itsmeichigo suggested a simple solution to just send a local notification after a safe fixed time pe5sF9-1uQ-p2#comment-2112, and this PR implemented this approach to schedule a notification 5 minutes after starting to wait for the site.

## How

Since this feature is behind a newly introduced remote feature flag, I created `LocalNotificationScheduler` to perform the check on the remote flag using `FeatureFlagAction.isRemoteFeatureFlagEnabled` with a default value `false`. If the site waiting has timed out or becomes ready before the local notification arrives, the notification is canceled.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites: since the remote feature flags are still not deployed and remain `false`, some code changes are required to test this PR:
- In `LocalNotificationScheduler.schedule`, remove the whole condition on `isRemoteFeatureFlagEnabled(remoteFeatureFlag)` so that the remote feature flag isn't used
- In `StoreCreationCoordinator.scheduleLocalNotificationWhenStoreIsReady`, change the time interval `UNTimeIntervalNotificationTrigger(timeInterval:)` to be shorter if you don't want to wait for 5 minutes

---

- Log in with a WPCOM account
- Go to the Menu tab, and tap on the store picker
- At the end of the store list, tap `Add a store`
- Continue the steps to create a free trial site
- After seeing `login_local_notification_scheduled` logged in the console while the waiting screen is shown, background the app --> after the time interval you set for the local notification in the prerequisites, a local notification should be shown
- Tap on the local notification --> the waiting screen should remain a bit, and eventually either go to the success state or shows a timeout alert (a known issue pe5sF9-1vz-p2)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/92988e87-8ed2-42c2-a9d2-20e3f593d960" width="300" />
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.