### PR TITLE
Add scanned products to Order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1294,8 +1294,8 @@ extension EditableOrderViewModel {
             switch result {
             case let .success(product):
                 onCompletion(.success(product.productID))
-            case .failure:
-                onCompletion(.failure(NSError()))
+            case let .failure(error):
+                onCompletion(.failure(error))
             }
         })
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1278,7 +1278,6 @@ extension EditableOrderViewModel {
             guard let self = self else { return }
             switch result {
             case let .success(productID):
-                self.configureProductRowViewModels()
                 self.orderSynchronizer.setProduct.send(.init(product: .productID(productID), quantity: 1))
                 onCompletion(.success(()))
             case .failure:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1255,6 +1255,24 @@ extension EditableOrderViewModel {
     func requestCameraAccess(onCompletion: @escaping ((Bool) -> Void)) {
         permissionChecker.requestAccess(for: .video, completionHandler: onCompletion)
     }
+
+    /// Attempts to add a Product to the current Order by SKU search
+    ///
+    func addScannedProductToOrder(barcode sku: String?, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        guard let sku = sku else {
+            return
+        }
+
+        mapFromSKUtoProductID(sku: sku) { result in
+            onCompletion(.failure(NSError()))
+        }
+    }
+
+    /// Attempts to map SKU to product ID
+    ///
+    func mapFromSKUtoProductID(sku: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
+        onCompletion(.failure(NSError()))
+    }
 }
 
 // MARK: Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1293,10 +1293,8 @@ extension EditableOrderViewModel {
         let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: siteID, sku: sku, onCompletion: { result in
             switch result {
             case let .success(product):
-                print("🍉 Success: retrieved product ID \(product.productID) from sku \(sku)")
                 onCompletion(.success(product.productID))
             case .failure:
-                DDLogError("🍉 Failed to retrieve productID from sku \(sku)")
                 onCompletion(.failure(NSError()))
             }
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -304,6 +304,12 @@ final class EditableOrderViewModel: ObservableObject {
         orderSynchronizer.order.status
     }
 
+    /// Current OrderItems
+    /// 
+    var currentOrderItems: [OrderItem] {
+        orderSynchronizer.order.items
+    }
+
     /// Analytics engine.
     ///
     private let analytics: Analytics
@@ -1268,9 +1274,11 @@ extension EditableOrderViewModel {
             return onCompletion(.failure(ScannerError.nilSKU))
         }
 
-        mapFromSKUtoProductID(sku: sku) { result in
+        mapFromSKUtoProductID(sku: sku) { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case let .success(productID):
+                self.configureProductRowViewModels()
                 self.orderSynchronizer.setProduct.send(.init(product: .productID(productID), quantity: 1))
                 onCompletion(.success(()))
             case .failure:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -325,8 +325,10 @@ private struct ProductsSection: View {
                     scroll.scrollTo(addProductViaSKUScannerButton)
                 }, content: {
                     ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
-                        print("SKU found: \(detectedBarcode)")
-                        showAddProductViaSKUScanner.toggle()
+                        print("🍉 Detected SKU: \(detectedBarcode). Attempting to add to Order...")
+                        viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { _ in
+                            showAddProductViaSKUScanner.toggle()
+                        })
                     })
                 })
                 .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -325,7 +325,6 @@ private struct ProductsSection: View {
                     scroll.scrollTo(addProductViaSKUScannerButton)
                 }, content: {
                     ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
-                        print("🍉 Detected SKU: \(detectedBarcode). Attempting to add to Order...")
                         viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { _ in
                             showAddProductViaSKUScanner.toggle()
                         })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1672,6 +1672,43 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(successWasReceived)
     }
+
+    func test_addScannedProductToOrder_when_sku_found_then_succeeds_to_add_product_to_order() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+
+        stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
+            switch action {
+            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+                onCompletion(.success(product))
+            default:
+                XCTFail("Expected failure, got success")
+            }
+        })
+
+        // When
+        let successWasReceived: Bool = waitFor { promise in
+            self.viewModel.addScannedProductToOrder(barcode: "existingSKU", onCompletion: { result in
+                switch result {
+                case .success(()):
+                    promise(true)
+                default:
+                    XCTFail("Expected success, got failure")
+                }
+            })
+        }
+
+        // Then
+        XCTAssertTrue(successWasReceived)
+        XCTAssertEqual(viewModel.currentOrderItems.count, 1)
+        XCTAssertEqual(viewModel.productRows.count, 1)
+
+        guard let item = viewModel.currentOrderItems.first else {
+            return XCTFail("Expected 1 item, but got none")
+        }
+        XCTAssertEqual(item.productID, sampleProductID)
+    }
 }
 
 private extension MockStorageManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1597,11 +1597,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
     }
-    
+
     func test_addScannedProductToOrder_when_sku_is_nil_then_fails_to_add_product_and_returns_nilSKU_error() {
         // Given
         let nilSKU: String? = nil
-        
+
         // When
         var capturedErrors: [EditableOrderViewModel.ScannerError] = []
         viewModel.addScannedProductToOrder(barcode: nilSKU, onCompletion: { expectedError in
@@ -1612,11 +1612,11 @@ final class EditableOrderViewModelTests: XCTestCase {
                 XCTFail("Expected failure, got success")
             }
         })
-        
+
         // Then
         XCTAssertEqual(capturedErrors, [.nilSKU])
     }
-    
+
     func test_addScannedProductToOrder_when_sku_is_not_found_then_fails_to_add_product_and_returns_productNotFound_error() {
         // Given
         let nonExistingSKU = "choco"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1698,7 +1698,6 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)
-        XCTAssertEqual(viewModel.productRows.count, 1)
 
         guard let item = viewModel.currentOrderItems.first else {
             return XCTFail("Expected 1 item, but got none")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1597,6 +1597,19 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
     }
+
+    func test_mapFromSKUtoProductID_when_unable_to_map_then_returns_error() {
+        // When
+        let errorWasReceived: Bool = waitFor { promise in
+            self.viewModel.mapFromSKUtoProductID(sku: "", onCompletion: { error in
+                promise(error.isFailure)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(errorWasReceived)
+    }
+
 }
 
 private extension MockStorageManager {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/9658

Closes: #9653 
Closes: #9654 

## Description
This PR deals with adding scanned products to an Order, by sending the decoded SKU to the store and retuning either a match (the SKU belongs to an existing product), or an error. 

Some caveats:
- Error handling will be dealt on a different PR, for now we just return a message to the console and do nothing.
- Only products can be added at the moment (not variations).
- Scanning the same product twice will add it twice (as a different row), we need to discuss if this should just increase the existing quantity or keep it as it is.

## Changes
* Upon tapping the Order's view button, we call the `addScannedProductToOrder` method
* This will attempt to find a matching product SKU in the store, via the existing `retrieveFirstProductMatchFromSKU` action 
  * If finds a match, passes the product ID to the OrderSynchronizer and updates the Order with the product
  * If doesn't find a match, returns a `.productNotFound` error

## Testing instructions
* Have a product with a decoded SKU in your store:
  * The easiest way to add the decoded barcode to a product is going to your store via wp-admin > WooCommerce > Products > Edit a product (not a variation) > Add the following SKU: `5366554338033`
  * An alternative is to create one in [this website](https://www.barcode-generator.org/) > open the app > Products > Select a product > Inventory > Tap on the barcode icon > scan the barcode created previously > tap done > tap save.
* On a physical device, go to Orders > `+` > `+ Add Products via SKU scanner` and scan the following QR:

<img width=400 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/f50991ce-849a-4841-bc1f-d98fb87aab3b">

See that does not add any product to the Order, and in the console we can read:

```
🍉 Detected SKU: long-sleeve vintage cotton t-shirt. Attempting to add to Order...
🍉 Failed to retrieve productID from sku long-sleeve vintage cotton t-shirt
```

4. Now scan again the following QR if your product uses `5366554338033`, or your own barcode/QR if you have created your own:
<img width=400 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/106501cf-4cbf-45b3-86b2-5d7c84d85d5c">

See that the product is added to the Order, and in the console we can read:

```
🍉 Detected SKU: 5366554338033. Attempting to add to Order...
🍉 Success: retrieved product ID 21 from sku 5366554338033
```