### PR TITLE
Handle local notifications for trial plan expiration

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2323,6 +2323,7 @@ extension WooAnalyticsEvent {
         enum Source: String {
             case banner
             case upgradesScreen = "upgrades_screen"
+            case localNotification = "local_notification"
         }
 
         static func freeTrialUpgradeNowTapped(source: Source) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -50,7 +50,7 @@ struct LocalNotification {
                 return "wpcom_password_error"
             }
         }
-    
+
         enum IdentifierPrefix {
             static let oneDayBeforeFreeTrialExpires = "one_day_before_free_trial_expires"
             static let oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -35,9 +35,9 @@ struct LocalNotification {
             case .oneDayAfterStoreCreationNameWithoutFreeTrial:
                 return "one_day_after_store_creation_name_without_free_trial"
             case let .oneDayBeforeFreeTrialExpires(siteID, _):
-                return "one_day_before_free_trial_expires" + "\(siteID)"
+                return IdentifierPrefix.oneDayBeforeFreeTrialExpires + "\(siteID)"
             case .oneDayAfterFreeTrialExpires(let siteID):
-                return "one_day_after_free_trial_expires" + "\(siteID)"
+                return IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(siteID)"
             case .loginSiteAddressError:
                 return "site_address_error"
             case .invalidEmailFromSiteAddressLogin:
@@ -49,6 +49,11 @@ struct LocalNotification {
             case .invalidPasswordFromWPComLogin:
                 return "wpcom_password_error"
             }
+        }
+    
+        enum IdentifierPrefix {
+            static let oneDayBeforeFreeTrialExpires = "one_day_before_free_trial_expires"
+            static let oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"
         }
     }
 

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -114,7 +114,7 @@ extension LocalNotification {
             actions = [.subscribe]
 
         case let .oneDayBeforeFreeTrialExpires(_, expiryDate):
-            title = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.title, name)
+            title = Localization.OneDayBeforeFreeTrialExpires.title
             let dateFormatStyle = Date.FormatStyle(locale: locale, timeZone: timeZone)
                 .weekday(.wide)
                 .month(.wide)
@@ -145,7 +145,7 @@ extension LocalNotification {
     enum Localization {
         enum StoreCreationComplete {
             static let title = NSLocalizedString(
-                "Your store is ready!",
+                "🎉 Your store is ready!",
                 comment: "Title of the local notification about a newly created store"
             )
             static let body = NSLocalizedString(
@@ -159,7 +159,7 @@ extension LocalNotification {
 
         enum OneDayAfterStoreCreationNameWithoutFreeTrial {
             static let title = NSLocalizedString(
-                "Your store is waiting!",
+                "🛍️ Your store is waiting!",
                 comment: "Title of the local notification suggesting a trial plan subscription."
             )
             static let body = NSLocalizedString(
@@ -172,9 +172,8 @@ extension LocalNotification {
 
         enum OneDayBeforeFreeTrialExpires {
             static let title = NSLocalizedString(
-                "Time’s almost up, %1$@!",
-                comment: "Title of the local notification to remind the user of expiring free trial plan." +
-                "The placeholder is the name of the user."
+                "⏰ Time’s running out on your free trial!",
+                comment: "Title of the local notification to remind the user of expiring free trial plan."
             )
             static let body = NSLocalizedString(
                 "Your free trial of Woo Express ends tomorrow (%1$@). Now’s the time to own your future – pick a plan and get ready to grow.",
@@ -185,7 +184,7 @@ extension LocalNotification {
 
         enum OneDayAfterFreeTrialExpires {
             static let title = NSLocalizedString(
-                "Your trial has ended.",
+                "🌟 Keep your business going with our plan!",
                 comment: "Title of the local notification to remind the user of the expired free trial plan."
             )
             static let body = NSLocalizedString(

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -19,8 +19,8 @@ struct LocalNotification {
     enum Scenario {
         case storeCreationComplete
         case oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: String)
-        case oneDayBeforeFreeTrialExpires(expiryDate: Date)
-        case oneDayAfterFreeTrialExpires
+        case oneDayBeforeFreeTrialExpires(siteID: Int64, expiryDate: Date)
+        case oneDayAfterFreeTrialExpires(siteID: Int64)
         // The following notifications are deprecated and are canceled in the first release.
         case loginSiteAddressError
         case invalidEmailFromSiteAddressLogin
@@ -34,10 +34,10 @@ struct LocalNotification {
                 return "store_creation_complete"
             case .oneDayAfterStoreCreationNameWithoutFreeTrial:
                 return "one_day_after_store_creation_name_without_free_trial"
-            case .oneDayBeforeFreeTrialExpires:
-                return "one_day_before_free_trial_expires"
-            case .oneDayAfterFreeTrialExpires:
-                return "one_day_after_free_trial_expires"
+            case let .oneDayBeforeFreeTrialExpires(siteID, _):
+                return "one_day_before_free_trial_expires" + "\(siteID)"
+            case .oneDayAfterFreeTrialExpires(let siteID):
+                return "one_day_after_free_trial_expires" + "\(siteID)"
             case .loginSiteAddressError:
                 return "site_address_error"
             case .invalidEmailFromSiteAddressLogin:
@@ -113,7 +113,7 @@ extension LocalNotification {
             category = .storeCreation
             actions = [.subscribe]
 
-        case .oneDayBeforeFreeTrialExpires(let expiryDate):
+        case let .oneDayBeforeFreeTrialExpires(_, expiryDate):
             title = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.title, name)
             let dateFormatStyle = Date.FormatStyle(locale: locale, timeZone: timeZone)
                 .weekday(.wide)

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -59,20 +59,12 @@ struct LocalNotification {
 
     /// The action type in a local notification.
     enum Action: String {
-        case explore
-        case subscribe
-        case upgrade
+        // TODO: add any custom action if needed
+        case none
 
         /// The title of the action in a local notification.
         var title: String {
-            switch self {
-            case .explore:
-                return Localization.Actions.explore
-            case .subscribe:
-                return Localization.Actions.subscribe
-            case .upgrade:
-                return Localization.Actions.upgrade
-            }
+            return ""
         }
     }
 }
@@ -93,15 +85,12 @@ extension LocalNotification {
 
         let title: String
         let body: String
-        let actions: [Action]
-        let category: Category
+        let actions: CategoryActions? = nil
 
         switch scenario {
         case .storeCreationComplete:
             title = Localization.StoreCreationComplete.title
             body = String.localizedStringWithFormat(Localization.StoreCreationComplete.body, name)
-            actions = [.explore]
-            category = .storeCreation
 
         case .oneDayAfterStoreCreationNameWithoutFreeTrial(let storeName):
             title = Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.title
@@ -110,8 +99,6 @@ extension LocalNotification {
                 name,
                 storeName
             )
-            category = .storeCreation
-            actions = [.subscribe]
 
         case let .oneDayBeforeFreeTrialExpires(_, expiryDate):
             title = Localization.OneDayBeforeFreeTrialExpires.title
@@ -121,14 +108,10 @@ extension LocalNotification {
                 .day(.defaultDigits)
             let displayDate = expiryDate.formatted(dateFormatStyle)
             body = String.localizedStringWithFormat(Localization.OneDayBeforeFreeTrialExpires.body, displayDate)
-            category = .storeCreation
-            actions = [.upgrade]
 
         case .oneDayAfterFreeTrialExpires:
             title = Localization.OneDayAfterFreeTrialExpires.title
             body = String.localizedStringWithFormat(Localization.OneDayAfterFreeTrialExpires.body, name)
-            category = .storeCreation
-            actions = [.upgrade]
 
         default:
             return nil
@@ -137,7 +120,7 @@ extension LocalNotification {
         self.init(title: title,
                   body: body,
                   scenario: scenario,
-                  actions: .init(category: category, actions: actions))
+                  actions: actions)
     }
 }
 
@@ -191,21 +174,6 @@ extension LocalNotification {
                 "%1$@, we have paused your store, but you can continue by picking a plan that suits you best.",
                 comment: "Message on the local notification to remind the user of the expired free trial plan." +
                 "The placeholder is the name of the user."
-            )
-        }
-
-        enum Actions {
-            static let explore = NSLocalizedString(
-                "Explore",
-                comment: "Action on the local notification to remind the user of a newly created store."
-            )
-            static let subscribe = NSLocalizedString(
-                "Subscribe",
-                comment: "Action on the local notification to suggest the user to subscribe to the trial plan."
-            )
-            static let upgrade = NSLocalizedString(
-                "Upgrade",
-                comment: "Action on the local notification to remind the user of the expiring free trial plan."
             )
         }
     }

--- a/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
@@ -30,13 +30,11 @@ final class LocalNotificationScheduler {
             return
         }
 
-        Task {
-            if shouldSkipIfScheduled {
-                await pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
-            } else {
-                await pushNotesManager.requestLocalNotification(notification,
-                                                          trigger: trigger)
-            }
+        if shouldSkipIfScheduled {
+            await pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
+        } else {
+            await pushNotesManager.requestLocalNotification(notification,
+                                                      trigger: trigger)
         }
     }
 

--- a/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
@@ -27,14 +27,16 @@ final class LocalNotificationScheduler {
                   remoteFeatureFlag: RemoteFeatureFlag?,
                   shouldSkipIfScheduled: Bool = false) async {
         if let remoteFeatureFlag, await isRemoteFeatureFlagEnabled(remoteFeatureFlag) == false {
-                return
+            return
         }
 
-        if shouldSkipIfScheduled {
-            pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
-        } else {
-            pushNotesManager.requestLocalNotification(notification,
-                                                      trigger: trigger)
+        Task {
+            if shouldSkipIfScheduled {
+                await pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
+            } else {
+                await pushNotesManager.requestLocalNotification(notification,
+                                                          trigger: trigger)
+            }
         }
     }
 

--- a/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
@@ -18,13 +18,24 @@ final class LocalNotificationScheduler {
     ///   - trigger: When the local notification is scheduled to arrive.
     ///   - remoteFeatureFlag: If non-nil, the local notification is only scheduled when the remote feature flag is enabled (disabled by default).
     ///     If nil, the local notification is always scheduled.
+    ///   - shouldSkipIfScheduled: Make sure that no pending notifications have the same identifier
+    ///    before scheduling the notification.
+    ///    
     @MainActor
-    func schedule(notification: LocalNotification, trigger: UNNotificationTrigger?, remoteFeatureFlag: RemoteFeatureFlag?) async {
+    func schedule(notification: LocalNotification,
+                  trigger: UNNotificationTrigger?,
+                  remoteFeatureFlag: RemoteFeatureFlag?,
+                  shouldSkipIfScheduled: Bool = false) async {
         if let remoteFeatureFlag, await isRemoteFeatureFlagEnabled(remoteFeatureFlag) == false {
                 return
-            }
-        pushNotesManager.requestLocalNotification(notification,
-                                                  trigger: trigger)
+        }
+
+        if shouldSkipIfScheduled {
+            pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
+        } else {
+            pushNotesManager.requestLocalNotification(notification,
+                                                      trigger: trigger)
+        }
     }
 
     /// Cancels a local notification of the given scenario.

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -306,9 +306,7 @@ extension PushNotificationsManager {
 
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
         Task {
-            // TODO: 7318 - tech debt - replace `UNUserNotificationCenter.current()` with
-            // `configuration.userNotificationsCenter` for unit testing
-            let center = UNUserNotificationCenter.current()
+            let center = configuration.userNotificationsCenter
             let settings = await center.notificationSettings()
             guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
                 DDLogError("⛔️ Unable to request a local notification due to invalid authorization status: \(settings.authorizationStatus)")
@@ -355,9 +353,7 @@ extension PushNotificationsManager {
 
     func requestLocalNotificationIfNeeded(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
         Task {
-            // TODO: 7318 - tech debt - replace `UNUserNotificationCenter.current()` with
-            // `configuration.userNotificationsCenter` for unit testing
-            let center = UNUserNotificationCenter.current()
+            let center = configuration.userNotificationsCenter
             let pendingNotifications = await center.pendingNotificationRequests()
             let identifier = notification.scenario.identifier
             if pendingNotifications.map(\.identifier).contains(identifier) {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -353,6 +353,20 @@ extension PushNotificationsManager {
         }
     }
 
+    func requestLocalNotificationIfNeeded(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
+        Task {
+            // TODO: 7318 - tech debt - replace `UNUserNotificationCenter.current()` with
+            // `configuration.userNotificationsCenter` for unit testing
+            let center = UNUserNotificationCenter.current()
+            let pendingNotifications = await center.pendingNotificationRequests()
+            let identifier = notification.scenario.identifier
+            if pendingNotifications.map(\.identifier).contains(identifier) {
+                return
+            }
+            requestLocalNotification(notification, trigger: trigger)
+        }
+    }
+
     func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
         let center = UNUserNotificationCenter.current()
         center.removePendingNotificationRequests(withIdentifiers: scenarios.map { $0.identifier })

--- a/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
+++ b/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
@@ -16,6 +16,18 @@ protocol UserNotificationsCenterAdapter {
 
     /// Removes all push notifications that have been delivered or scheduled
     func removeAllNotifications()
+
+    // The application's user notification settings
+    func notificationSettings() async -> UNNotificationSettings
+
+    // Notification requests that have been scheduled for a future time or location and are waiting for their trigger to fire
+    func pendingNotificationRequests() async -> [UNNotificationRequest]
+
+    // Notification categories can be used to choose which actions will be displayed on which notifications.
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>)
+
+    // Adds a notification request to be presented at a scheduled time.
+    func add(_ request: UNNotificationRequest) async throws
 }
 
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -92,6 +92,13 @@ protocol PushNotesManager {
     ///   - trigger: if nil, the local notification is delivered immediately.
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?)
 
+    /// Requests a local notification to be scheduled under a given trigger if no pending notification of the same identifier exists.
+    /// Skips otherwise.
+    /// - Parameters:
+    ///   - notification: the notification content.
+    ///   - trigger: if nil, the local notification is delivered immediately.
+    func requestLocalNotificationIfNeeded(_ notification: LocalNotification, trigger: UNNotificationTrigger?)
+
     /// Cancels a local notification that was previously scheduled.
     /// - Parameter scenarios: the scenarios of the notification to be cancelled.
     func cancelLocalNotification(scenarios: [LocalNotification.Scenario])

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -90,14 +90,14 @@ protocol PushNotesManager {
     /// - Parameters:
     ///   - notification: the notification content.
     ///   - trigger: if nil, the local notification is delivered immediately.
-    func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?)
+    func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) async
 
     /// Requests a local notification to be scheduled under a given trigger if no pending notification of the same identifier exists.
     /// Skips otherwise.
     /// - Parameters:
     ///   - notification: the notification content.
     ///   - trigger: if nil, the local notification is delivered immediately.
-    func requestLocalNotificationIfNeeded(_ notification: LocalNotification, trigger: UNNotificationTrigger?)
+    func requestLocalNotificationIfNeeded(_ notification: LocalNotification, trigger: UNNotificationTrigger?) async
 
     /// Cancels a local notification that was previously scheduled.
     /// - Parameter scenarios: the scenarios of the notification to be cancelled.

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -318,7 +318,32 @@ private extension AppCoordinator {
     }
 
     func handleLocalNotificationResponse(_ response: UNNotificationResponse) {
-        // TODO: 9665 - handle actions on local notifications
+        let oneDayBeforeFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayBeforeFreeTrialExpires
+        let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires
+
+        switch response.notification.request.identifier {
+        case let identifier where identifier.hasPrefix(oneDayBeforeFreeTrialExpiresIdentifier):
+            guard let siteID = Int64(identifier.replacingOccurrences(of: oneDayBeforeFreeTrialExpiresIdentifier, with: "")) else {
+                return
+            }
+            openPlansPage(siteID: siteID)
+        case let identifier where identifier.hasPrefix(oneDayAfterFreeTrialExpiresIdentifier):
+            guard let siteID = Int64(identifier.replacingOccurrences(of: oneDayAfterFreeTrialExpiresIdentifier, with: "")) else {
+                return
+            }
+            openPlansPage(siteID: siteID)
+        default:
+            // TODO: 9665 - handle actions on other local notifications
+            break
+        }
+    }
+}
+
+/// Local notification handling helper methods.
+private extension AppCoordinator {
+    func openPlansPage(siteID: Int64) {
+        let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .localNotification)
+        window.rootViewController?.topmostPresentedViewController.present(controller, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -350,7 +350,6 @@ private extension AppCoordinator {
             let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .localNotification)
             self?.window.rootViewController?.topmostPresentedViewController.present(controller, animated: true)
         }
-        
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -23,6 +23,7 @@ final class AppCoordinator {
     private let loggedOutAppSettings: LoggedOutAppSettingsProtocol
     private let pushNotesManager: PushNotesManager
     private let featureFlagService: FeatureFlagService
+    private let switchStoreUseCase: SwitchStoreUseCaseProtocol
 
     private var storePickerCoordinator: StorePickerCoordinator?
     private var authStatesSubscription: AnyCancellable?
@@ -58,6 +59,7 @@ final class AppCoordinator {
         self.loggedOutAppSettings = loggedOutAppSettings
         self.pushNotesManager = pushNotesManager
         self.featureFlagService = featureFlagService
+        self.switchStoreUseCase = SwitchStoreUseCase(stores: stores, storageManager: storageManager)
 
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
 
@@ -344,8 +346,11 @@ private extension AppCoordinator {
 /// Local notification handling helper methods.
 private extension AppCoordinator {
     func openPlansPage(siteID: Int64) {
-        let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .localNotification)
-        window.rootViewController?.topmostPresentedViewController.present(controller, animated: true)
+        switchStoreUseCase.switchStore(with: siteID) { [weak self] _ in
+            let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .localNotification)
+            self?.window.rootViewController?.topmostPresentedViewController.present(controller, animated: true)
+        }
+        
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -323,12 +323,14 @@ private extension AppCoordinator {
 
         switch response.notification.request.identifier {
         case let identifier where identifier.hasPrefix(oneDayBeforeFreeTrialExpiresIdentifier):
-            guard let siteID = Int64(identifier.replacingOccurrences(of: oneDayBeforeFreeTrialExpiresIdentifier, with: "")) else {
+            guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+                  let siteID = Int64(identifier.replacingOccurrences(of: oneDayBeforeFreeTrialExpiresIdentifier, with: "")) else {
                 return
             }
             openPlansPage(siteID: siteID)
         case let identifier where identifier.hasPrefix(oneDayAfterFreeTrialExpiresIdentifier):
-            guard let siteID = Int64(identifier.replacingOccurrences(of: oneDayAfterFreeTrialExpiresIdentifier, with: "")) else {
+            guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+                  let siteID = Int64(identifier.replacingOccurrences(of: oneDayAfterFreeTrialExpiresIdentifier, with: "")) else {
                 return
             }
             openPlansPage(siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -92,14 +92,11 @@ private extension StorePlanSynchronizer {
         guard let siteID = site?.siteID else {
             return
         }
-        guard plan.isFreeTrial else {
+        guard plan.isFreeTrial, let expiryDate = plan.expiryDate else {
             /// cancels any scheduled notifications
             return cancelFreeTrialExpirationNotifications(siteID: siteID)
         }
 
-        guard let expiryDate = plan.expiryDate else {
-            return
-        }
         let oneDayTimeInterval: TimeInterval = 86400
 
         if expiryDate.timeIntervalSinceNow - oneDayTimeInterval > 0 {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -126,8 +126,6 @@ private extension StorePlanSynchronizer {
             return
         }
         triggerDateComponents.day = day - 1
-        triggerDateComponents.timeZone = .current
-        triggerDateComponents.calendar = .current
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDateComponents, repeats: false)
         Task {
             await localNotificationScheduler.schedule(notification: notification,
@@ -147,8 +145,6 @@ private extension StorePlanSynchronizer {
             return
         }
         triggerDateComponents.day = day + 1
-        triggerDateComponents.timeZone = .current
-        triggerDateComponents.calendar = .current
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDateComponents, repeats: false)
         Task {
             await localNotificationScheduler.schedule(notification: notification,

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -113,7 +113,10 @@ private extension StorePlanSynchronizer {
 
     func cancelFreeTrialExpirationNotifications(siteID: Int64) {
         localNotificationScheduler.cancel(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
-        localNotificationScheduler.cancel(scenario: .oneDayBeforeFreeTrialExpires(siteID: siteID, expiryDate: Date())) // placeholder date, irrelevant to the notification identifier
+        localNotificationScheduler.cancel(scenario: .oneDayBeforeFreeTrialExpires(
+            siteID: siteID,
+            expiryDate: Date() // placeholder date, irrelevant to the notification identifier
+        ))
     }
 
     func scheduleBeforeExpirationNotification(siteID: Int64, expiryDate: Date) {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -98,16 +98,16 @@ private extension StorePlanSynchronizer {
         }
 
         /// Normalizes expiry date to remove timezone difference
-        let timeZoneDifference = TimeZone.autoupdatingCurrent.secondsFromGMT()
+        let timeZoneDifference = TimeZone.current.secondsFromGMT()
         let normalizedDate = Date(timeInterval: -Double(timeZoneDifference), since: expiryDate)
         let oneDayTimeInterval: TimeInterval = 86400
 
         if normalizedDate.timeIntervalSinceNow - oneDayTimeInterval > 0 {
-            scheduleBeforeExpirationNotification(siteID: siteID, expiryDate: expiryDate)
+            scheduleBeforeExpirationNotification(siteID: siteID, expiryDate: normalizedDate)
         }
 
         if normalizedDate.timeIntervalSinceNow + oneDayTimeInterval > 0 {
-            scheduleAfterExpirationNotification(siteID: siteID, expiryDate: expiryDate)
+            scheduleAfterExpirationNotification(siteID: siteID, expiryDate: normalizedDate)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -102,7 +102,6 @@ private extension StorePlanSynchronizer {
             return
         }
 
-        cancelFreeTrialExpirationNotifications(siteID: siteID)
         scheduleBeforeExpirationNotification(siteID: siteID, expiryDate: expiryDate)
         scheduleAfterExpirationNotification(siteID: siteID, expiryDate: expiryDate)
     }
@@ -120,7 +119,7 @@ private extension StorePlanSynchronizer {
         }
         /// Scheduled for 1 day before the expiry date
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: expiryDate.timeIntervalSinceNow - 86400, repeats: false)
-        pushNotesManager.requestLocalNotification(notification, trigger: trigger)
+        pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
     }
 
     func scheduleAfterExpirationNotification(siteID: Int64, expiryDate: Date) {
@@ -129,6 +128,6 @@ private extension StorePlanSynchronizer {
         }
         /// Scheduled for 1 day after the expiry date
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: expiryDate.timeIntervalSinceNow + 86400, repeats: false)
-        pushNotesManager.requestLocalNotification(notification, trigger: trigger)
+        pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -97,13 +97,16 @@ private extension StorePlanSynchronizer {
             return cancelFreeTrialExpirationNotifications(siteID: siteID)
         }
 
+        /// Normalizes expiry date to remove timezone difference
+        let timeZoneDifference = TimeZone.autoupdatingCurrent.secondsFromGMT()
+        let normalizedDate = Date(timeInterval: -Double(timeZoneDifference), since: expiryDate)
         let oneDayTimeInterval: TimeInterval = 86400
 
-        if expiryDate.timeIntervalSinceNow - oneDayTimeInterval > 0 {
+        if normalizedDate.timeIntervalSinceNow - oneDayTimeInterval > 0 {
             scheduleBeforeExpirationNotification(siteID: siteID, expiryDate: expiryDate)
         }
 
-        if expiryDate.timeIntervalSinceNow + oneDayTimeInterval > 0 {
+        if normalizedDate.timeIntervalSinceNow + oneDayTimeInterval > 0 {
             scheduleAfterExpirationNotification(siteID: siteID, expiryDate: expiryDate)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradePlanCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradePlanCoordinatingController.swift
@@ -1,0 +1,94 @@
+import UIKit
+
+/// Controls navigation for the free trial upgrade plan flow. Meant to be presented modally
+///
+final class UpgradePlanCoordinatingController: WooNavigationController {
+
+    /// Current Site ID.
+    ///
+    private let siteID: Int64
+
+    /// Source of the action.
+    ///
+    private let source: WooAnalyticsEvent.FreeTrial.Source
+
+    /// Analytics provider.
+    ///
+    private let analytics: Analytics
+
+    /// Closure to be invoked when the plan is successfully upgraded.
+    ///
+    private let onSuccess: (() -> ())?
+
+    init(siteID: Int64,
+         source: WooAnalyticsEvent.FreeTrial.Source,
+         analytics: Analytics = ServiceLocator.analytics,
+         onSuccess: (() -> ())? = nil) {
+        self.siteID = siteID
+        self.source = source
+        self.analytics = analytics
+        self.onSuccess = onSuccess
+        super.init(nibName: nil, bundle: nil)
+        startNavigation()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Shows a web view for the merchant to update their site plan.
+    ///
+    private func startNavigation() {
+        analytics.track(event: .FreeTrial.freeTrialUpgradeNowTapped(source: source))
+
+        guard let upgradeURL = Constants.upgradeURL(siteID: siteID) else { return }
+        let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.upgradeNow,
+                                                         initialURL: upgradeURL,
+                                                         urlToTriggerExit: Constants.exitTrigger) { [weak self] in
+            self?.exitUpgradeFreeTrialFlowAfterUpgrade()
+        }
+
+        isModalInPresentation = true
+        let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
+        webViewController.navigationItem.leftBarButtonItem =  UIBarButtonItem(barButtonSystemItem: .cancel,
+                                                                              target: self,
+                                                                              action: #selector(exitUpgradeFreeTrialFlow))
+        setViewControllers([webViewController], animated: false)
+    }
+
+    /// Dismisses the upgrade now web view after the merchants successfully updates their plan.
+    ///
+    func exitUpgradeFreeTrialFlowAfterUpgrade() {
+        onSuccess?()
+        dismiss(animated: true)
+
+        analytics.track(event: .FreeTrial.planUpgradeSuccess(source: source))
+    }
+
+    /// Dismisses the upgrade now web view when the user abandons the flow.
+    ///
+    @objc func exitUpgradeFreeTrialFlow() {
+        dismiss(animated: true)
+
+        analytics.track(event: .FreeTrial.planUpgradeAbandoned(source: source))
+    }
+}
+
+private extension UpgradePlanCoordinatingController {
+    enum Constants {
+
+        /// URL Path invoked when a site is upgrade from a free trial.
+        ///
+        static let exitTrigger = "my-plan/trial-upgraded"
+
+        /// URL that allows merchants to upgrade their eCommerce plan.
+        ///
+        static func upgradeURL(siteID: Int64) -> URL? {
+            URL(string: "https://wordpress.com/plans/\(siteID)")
+        }
+    }
+
+    enum Localization {
+        static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title for the WebView when upgrading a free trial plan")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2061,6 +2061,7 @@
 		DECE13FC27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */; };
 		DECE1400279A595200816ECD /* Coupon+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13FF279A595200816ECD /* Coupon+Woo.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
+		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
 		DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */; };
 		DEE183ED292BD900008818AB /* JetpackSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */; };
@@ -4347,6 +4348,7 @@
 		DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndSubtitleAndStatusTableViewCell.xib; sourceTree = "<group>"; };
 		DECE13FF279A595200816ECD /* Coupon+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+Woo.swift"; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
+		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
 		DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageAttributes.swift; sourceTree = "<group>"; };
 		DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupViewModelTests.swift; sourceTree = "<group>"; };
@@ -6099,6 +6101,7 @@
 				264957A229C520860095AA4C /* UpgradesView.swift */,
 				261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */,
 				267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */,
+				DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */,
 			);
 			name = Upgrades;
 			path = Classes/ViewRelated/Upgrades;
@@ -11260,6 +11263,7 @@
 				74D0A5302139CF1300E2919F /* String+Helpers.swift in Sources */,
 				B9B7E2E629FBF96100F9CED1 /* ProductSelectorViewModelTracker.swift in Sources */,
 				0286B27F23C70557003D784B /* ColumnFlowLayout.swift in Sources */,
+				DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */,
 				DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */,
 				450C2CB624D1ABB200D570DD /* ProductImagesGalleryViewController.swift in Sources */,
 				B9EF083F2886CE3300D96C58 /* HostingTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -355,6 +355,48 @@ final class AppCoordinatorTests: XCTestCase {
         // Then
         _ = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginOnboardingShown.rawValue}))
     }
+
+    // MARK: - Handle local notification response
+
+    func test_plans_page_is_displayed_when_tapping_on_oneDayBeforeFreeTrialExpires_notification() throws {
+        // Given
+        let pushNotesManager = MockPushNotificationsManager()
+        let coordinator = makeCoordinator(window: window, pushNotesManager: pushNotesManager)
+        coordinator.start()
+        let siteID: Int64 = 123
+
+        // When
+        let response = try XCTUnwrap(MockNotificationResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            requestIdentifier: LocalNotification.Scenario.oneDayBeforeFreeTrialExpires(siteID: siteID, expiryDate: Date()).identifier)
+        )
+        pushNotesManager.sendLocalNotificationResponse(response)
+
+        // Then
+        waitUntil {
+            self.window.rootViewController?.topmostPresentedViewController is UpgradePlanCoordinatingController
+        }
+    }
+
+    func test_plans_page_is_displayed_when_tapping_on_oneDayAfterFreeTrialExpiresIdentifier_notification() throws {
+        // Given
+        let pushNotesManager = MockPushNotificationsManager()
+        let coordinator = makeCoordinator(window: window, pushNotesManager: pushNotesManager)
+        coordinator.start()
+        let siteID: Int64 = 123
+
+        // When
+        let response = try XCTUnwrap(MockNotificationResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            requestIdentifier: LocalNotification.Scenario.oneDayAfterFreeTrialExpires(siteID: siteID).identifier)
+        )
+        pushNotesManager.sendLocalNotificationResponse(response)
+
+        // Then
+        waitUntil {
+            self.window.rootViewController?.topmostPresentedViewController is UpgradePlanCoordinatingController
+        }
+    }
 }
 
 private extension AppCoordinatorTests {

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -37,6 +37,7 @@ final class MockPushNotificationsManager: PushNotesManager {
     private let localNotificationResponsesSubject = PassthroughSubject<UNNotificationResponse, Never>()
 
     private(set) var requestedLocalNotifications: [LocalNotification] = []
+    private(set) var requestedLocalNotificationsIfNeeded: [LocalNotification] = []
     private(set) var canceledLocalNotificationScenarios: [[LocalNotification.Scenario]] = []
 
     func resetBadgeCount(type: Note.Kind) {
@@ -85,6 +86,10 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
         requestedLocalNotifications.append(notification)
+    }
+
+    func requestLocalNotificationIfNeeded(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
+        requestedLocalNotificationsIfNeeded.append(notification)
     }
 
     func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -94,6 +94,8 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
         canceledLocalNotificationScenarios.append(scenarios)
+        requestedLocalNotifications.removeAll()
+        requestedLocalNotificationsIfNeeded.removeAll()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -38,6 +38,7 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     private(set) var requestedLocalNotifications: [LocalNotification] = []
     private(set) var requestedLocalNotificationsIfNeeded: [LocalNotification] = []
+    private(set) var triggersForRequestedLocalNotificationsIfNeeded: [UNNotificationTrigger] = []
     private(set) var canceledLocalNotificationScenarios: [[LocalNotification.Scenario]] = []
 
     func resetBadgeCount(type: Note.Kind) {
@@ -90,12 +91,16 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     func requestLocalNotificationIfNeeded(_ notification: LocalNotification, trigger: UNNotificationTrigger?) {
         requestedLocalNotificationsIfNeeded.append(notification)
+        if let trigger {
+            triggersForRequestedLocalNotificationsIfNeeded.append(trigger)
+        }
     }
 
     func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
         canceledLocalNotificationScenarios.append(scenarios)
         requestedLocalNotifications.removeAll()
         requestedLocalNotificationsIfNeeded.removeAll()
+        triggersForRequestedLocalNotificationsIfNeeded.removeAll()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
@@ -11,6 +11,12 @@ final class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
     ///
     var authorizationStatus: UNAuthorizationStatus = .notDetermined
 
+    var settingsCoder = MockNSCoder()
+
+    private(set) var notificationCategories: Set<UNNotificationCategory> = []
+
+    private var notificationRequests: [UNNotificationRequest] = []
+
     /// Indicates if `requestAuthorization` was called
     ///
     var requestAuthorizationWasCalled = false
@@ -46,5 +52,35 @@ final class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
         authorizationStatus = .notDetermined
         requestAuthorizationWasCalled = false
         requestAuthorizationIsSuccessful = false
+    }
+
+    func notificationSettings() async -> UNNotificationSettings {
+        UNNotificationSettings(coder: settingsCoder)!
+    }
+
+    func pendingNotificationRequests() async -> [UNNotificationRequest] {
+        notificationRequests
+    }
+
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {
+        notificationCategories = categories
+    }
+
+    func add(_ request: UNNotificationRequest) async throws {
+        notificationRequests.append(request)
+    }
+}
+
+/// Mock coder to initialize UNNotificationSettings
+///
+final class MockNSCoder: NSCoder {
+    var authorizationStatus = UNAuthorizationStatus.authorized.rawValue
+
+    override func decodeInt64(forKey key: String) -> Int64 {
+        return Int64(authorizationStatus)
+    }
+
+    override func decodeBool(forKey key: String) -> Bool {
+        return true
     }
 }

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -31,7 +31,6 @@ final class LocalNotificationTests: XCTestCase {
 
         // Then
         assertEqual(LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.title, notification.title)
-        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
         XCTAssertNil(notification.actions)
         let expectedBody = String.localizedStringWithFormat(
             LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.body,

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -47,7 +47,7 @@ final class LocalNotificationTests: XCTestCase {
         let date = Date(timeIntervalSince1970: 1683692966) // GMT: Wed, 10 May
         let timeZone = try XCTUnwrap(TimeZone(identifier: "GMT"))
         let locale = Locale(identifier: "en-US")
-        let scenario = LocalNotification.Scenario.oneDayBeforeFreeTrialExpires(expiryDate: date)
+        let scenario = LocalNotification.Scenario.oneDayBeforeFreeTrialExpires(siteID: 123, expiryDate: date)
         let testName = "Miffy"
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
 
@@ -55,7 +55,7 @@ final class LocalNotificationTests: XCTestCase {
         let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores, timeZone: timeZone, locale: locale))
 
         // Then
-        let expectedTitle = String.localizedStringWithFormat(LocalNotification.Localization.OneDayBeforeFreeTrialExpires.title, testName)
+        let expectedTitle = LocalNotification.Localization.OneDayBeforeFreeTrialExpires.title
         let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.OneDayBeforeFreeTrialExpires.body, "Wednesday, May 10")
         assertEqual(expectedTitle, notification.title)
         assertEqual(expectedBody, notification.body)
@@ -65,7 +65,7 @@ final class LocalNotificationTests: XCTestCase {
 
     func test_oneDayAfterFreeTrialExpires_scenario_returns_correct_notification_contents() throws {
         // Given
-        let scenario = LocalNotification.Scenario.oneDayAfterFreeTrialExpires
+        let scenario = LocalNotification.Scenario.oneDayAfterFreeTrialExpires(siteID: 123)
         let testName = "Miffy"
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
 

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -14,8 +14,7 @@ final class LocalNotificationTests: XCTestCase {
 
         // Then
         assertEqual(LocalNotification.Localization.StoreCreationComplete.title, notification.title)
-        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
-        assertEqual([LocalNotification.Action.explore], notification.actions?.actions)
+        XCTAssertNil(notification.actions)
         let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.StoreCreationComplete.body, testName)
         assertEqual(expectedBody, notification.body)
     }
@@ -33,7 +32,7 @@ final class LocalNotificationTests: XCTestCase {
         // Then
         assertEqual(LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.title, notification.title)
         assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
-        assertEqual([LocalNotification.Action.subscribe], notification.actions?.actions)
+        XCTAssertNil(notification.actions)
         let expectedBody = String.localizedStringWithFormat(
             LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.body,
             testName,
@@ -59,8 +58,7 @@ final class LocalNotificationTests: XCTestCase {
         let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.OneDayBeforeFreeTrialExpires.body, "Wednesday, May 10")
         assertEqual(expectedTitle, notification.title)
         assertEqual(expectedBody, notification.body)
-        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
-        assertEqual([LocalNotification.Action.upgrade], notification.actions?.actions)
+        XCTAssertNil(notification.actions)
     }
 
     func test_oneDayAfterFreeTrialExpires_scenario_returns_correct_notification_contents() throws {
@@ -77,7 +75,6 @@ final class LocalNotificationTests: XCTestCase {
         let expectedBody = String.localizedStringWithFormat(LocalNotification.Localization.OneDayAfterFreeTrialExpires.body, testName)
         assertEqual(expectedTitle, notification.title)
         assertEqual(expectedBody, notification.body)
-        assertEqual(LocalNotification.Category.storeCreation, notification.actions?.category)
-        assertEqual([LocalNotification.Action.upgrade], notification.actions?.actions)
+        XCTAssertNil(notification.actions)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
@@ -80,25 +80,6 @@ final class StorePlanSynchronizerTests: XCTestCase {
         XCTAssertEqual(synchronizer.planState, .failed)
     }
 
-    func test_synchronizer_schedules() {
-        // Given
-        let samplePlan = WPComSitePlan(hasDomainCredit: false)
-        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
-            switch action {
-            case .loadSiteCurrentPlan(_, let completion):
-                completion(.success(samplePlan))
-            default:
-                break
-            }
-        }
-
-        // When
-        let synchronizer = StorePlanSynchronizer(stores: stores)
-
-        // Then
-        XCTAssertEqual(synchronizer.planState, .loaded(samplePlan))
-    }
-
     func test_local_notifications_are_scheduled_if_the_site_has_trial_plan_with_expiry_date_at_least_2_days_away() {
         // Given
         let pushNotesManager = MockPushNotificationsManager()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9665 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the scheduling of local notifications for trial plan expiration, and the action when the notifications are tapped. Sorry for the many changes, the PR also handles updating push notification manager to make it testable.

Changes include:
- Removed custom actions from `LocalNotification` to use default actions for the local notifications as discussed in pe5sF9-1uQ-p2.
- Updated scenarios `oneDayBeforeFreeTrialExpires` and `oneDayAfterFreeTrialExpires`  to have site ID and updated their identifier accordingly. The reason is that we want to schedule and cancel notifications specific to each site.
- Updated `PushNotesManager` with a new method `requestLocalNotificationIfNeeded`. This method makes sure that only notifications that are not already scheduled can be added to the notification center.
- Updated `UserNotificationsCenterAdapter` and `PushNotificationsManager` for better testability`.
- Updated `StorePlanSynchronizer` to schedule or cancel local notifications based on the fetched site plans.
- Updated `AppCoordinator` to handle the tap on the local notifications.
- Restored `UpgradePlanCoordinatingController` for showing plan upgrade on web view.
- Updated unit tests.

Analytics will be updated in a separate PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisites: since the remote feature flags are still not deployed and remain `false`, some code changes are required to test this PR:
- In `LocalNotificationScheduler.schedule`, remove the whole condition on `isRemoteFeatureFlagEnabled(remoteFeatureFlag)` so that the remote feature flag isn't used
- Please also ensure you have access to a site running a trial plan that is not expired yet.

---

- Launch the app, log in, and switch to your test site if needed. For easier testing, please run the app on a physical device.
- Kill the app, open Settings, and change the time of the device to 1 day and 1 minute prior to the expiration date. The expiry date is at 0:00, so my expiry date is on May 19, then I should change the date to May 17, 23:59.
- Wait for 1 minute, then you should see a notification about the expiring trial plan. Tap on the notification, the app should be open, and a web view should be presented to upgrade your plan.
- Kill the app, change the time of your device to 1 day and 59 seconds after the expiration date. E.g: May 19, 23:59, given the above example.
- Wait for 1 minute, then you should see a notification about the expired trial plan. Tap on the notification, the app should be open, and a web view should be presented to upgrade your plan.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Expiring plan | Expired plan |
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/9ea0ce0b-91d9-4865-a443-a419efe7ed99" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/d580ec0b-3a1a-4952-a225-eeab9d5c9334" width=320 /> | 
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/0296ffe8-e58b-40e0-af53-e558c38abc50" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/d605b189-27d3-47ea-9f23-1f2929f8dd2d" width=320 /> |





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.