### PR TITLE
[Scan to Pay] Add Scan to Pay row to the Payment Methods screen

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -232,6 +232,10 @@ extension UIImage {
         UIImage(systemName: "wave.3.right.circle")?.withRenderingMode(.alwaysTemplate) ?? .creditCardImage
     }
 
+    static var scanToPayIcon: UIImage {
+        UIImage(systemName: "qrcode.viewfinder")?.withRenderingMode(.alwaysTemplate) ?? .creditCardImage
+    }
+
     /// Customize Icon
     ///
     static var customizeImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -84,6 +84,12 @@ struct PaymentMethodsView: View {
                                 viewModel.trackCollectByPaymentLink()
                             }
                         }
+
+                        if viewModel.showScanToPayRow {
+                            Divider()
+
+                            MethodRow(icon: .scanToPayIcon, title: Localization.scanToPay, accessibilityID: Accessibility.scanToPayMethod) {}
+                        }
                     }
                     .padding(.horizontal)
                     .background(Color(.listForeground(modal: false)))
@@ -216,6 +222,7 @@ extension PaymentMethodsView {
         static let tapToPay = NSLocalizedString("Tap to Pay on iPhone",
                                                 comment: "Tap to Pay on iPhone method title on the select payment method screen")
         static let link = NSLocalizedString("Share Payment Link", comment: "Payment Link method title on the select payment method screen")
+        static let scanToPay = NSLocalizedString("Scan to Pay", comment: "Scan to Pay method title on the select payment method screen")
         static let markAsPaidTitle = NSLocalizedString("Mark as Paid?", comment: "Alert title when selecting the cash payment method")
         static let markAsPaidButton = NSLocalizedString("Mark as Paid", comment: "Alert button when selecting the cash payment method")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the payment methods screen")
@@ -236,6 +243,7 @@ extension PaymentMethodsView {
         static let cardMethod = "payment-methods-view-card-row"
         static let tapToPayMethod = "payment-methods-view-tap-to-pay-row"
         static let paymentLink = "payment-methods-view-payment-link-row"
+        static let scanToPayMethod = "payment-methods-view-scan-to-pay-row"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -3,6 +3,7 @@ import Yosemite
 import Combine
 import UIKit
 import WooFoundation
+import Experiments
 
 import protocol Storage.StorageManagerType
 
@@ -44,6 +45,10 @@ final class PaymentMethodsViewModel: ObservableObject {
     ///
     var showPaymentLinkRow: Bool {
         paymentLink != nil
+    }
+
+    var showScanToPayRow: Bool {
+        featureFlagService.isFeatureFlagEnabled(.scanToPay) && paymentLink != nil
     }
 
     /// Defines if the Card Reader upsell banner should be shown based on country eligibility and dismissal/reminder preferences
@@ -90,6 +95,8 @@ final class PaymentMethodsViewModel: ObservableObject {
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
+    private let featureFlagService: FeatureFlagService
+
     /// Stored orders.
     /// We need to fetch this from our storage layer because we are only provide IDs as dependencies
     /// To keep previews/UIs decoupled from our business logic.
@@ -126,6 +133,7 @@ final class PaymentMethodsViewModel: ObservableObject {
         let analytics: Analytics
         let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
         let orderDurationRecorder: OrderDurationRecorderProtocol
+        let featureFlagService: FeatureFlagService
 
         init(presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
              cardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting = CardPresentPaymentsOnboardingPresenter(),
@@ -133,7 +141,8 @@ final class PaymentMethodsViewModel: ObservableObject {
              storage: StorageManagerType = ServiceLocator.storageManager,
              analytics: Analytics = ServiceLocator.analytics,
              cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration? = nil,
-             orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared) {
+             orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
+             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
             self.presentNoticeSubject = presentNoticeSubject
             self.cardPresentPaymentsOnboardingPresenter = cardPresentPaymentsOnboardingPresenter
             self.stores = stores
@@ -142,6 +151,7 @@ final class PaymentMethodsViewModel: ObservableObject {
             let configuration = cardPresentPaymentsConfiguration ?? CardPresentConfigurationLoader(stores: stores).configuration
             self.cardPresentPaymentsConfiguration = configuration
             self.orderDurationRecorder = orderDurationRecorder
+            self.featureFlagService = featureFlagService
         }
     }
 
@@ -165,6 +175,7 @@ final class PaymentMethodsViewModel: ObservableObject {
         storage = dependencies.storage
         analytics = dependencies.analytics
         cardPresentPaymentsConfiguration = dependencies.cardPresentPaymentsConfiguration
+        featureFlagService = dependencies.featureFlagService
         title = String(format: Localization.title, formattedTotal)
         showUpsellCardReaderFeatureBanner = cardPresentPaymentsConfiguration.isSupportedCountry
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -24,6 +24,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isReadOnlyGiftCardsEnabled: Bool
     private let isHideStoreOnboardingTaskListFeatureEnabled: Bool
     private let isAddProductToOrderViaSKUScannerEnabled: Bool
+    private let isScanToPayEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -46,7 +47,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
          isHideStoreOnboardingTaskListFeatureEnabled: Bool = false,
-         isAddProductToOrderViaSKUScannerEnabled: Bool = false) {
+         isAddProductToOrderViaSKUScannerEnabled: Bool = false,
+         isScanToPayEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -69,6 +71,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.isHideStoreOnboardingTaskListFeatureEnabled = isHideStoreOnboardingTaskListFeatureEnabled
         self.isAddProductToOrderViaSKUScannerEnabled = isAddProductToOrderViaSKUScannerEnabled
+        self.isScanToPayEnabled = isScanToPayEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -117,6 +120,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isHideStoreOnboardingTaskListFeatureEnabled
         case .addProductToOrderViaSKUScanner:
             return isAddProductToOrderViaSKUScannerEnabled
+        case .scanToPay:
+            return isScanToPayEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -593,6 +593,46 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.paymentLink)
     }
 
+    func test_scanToPayRow_is_hidden_if_payment_link_is_not_available() {
+        // Given
+        let viewModel = PaymentMethodsViewModel(paymentLink: nil,
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false)
+
+        // Then
+        XCTAssertFalse(viewModel.showScanToPayRow)
+        XCTAssertNil(viewModel.paymentLink)
+    }
+
+    func test_scanToPayRow_is_hidden_if_feature_flag_is_disabled() {
+        // Given
+        let paymentURL = URL(string: "http://www.automattic.com")
+        let dependencies = Dependencies(featureFlagService: MockFeatureFlagService(isScanToPayEnabled: false))
+        let viewModel = PaymentMethodsViewModel(paymentLink: paymentURL,
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
+                                                dependencies: dependencies)
+
+        // Then
+        XCTAssertFalse(viewModel.showScanToPayRow)
+    }
+
+    func test_scanToPayRow_is_shown_if_feature_flag_is_enabled_and_payment_link_not_nil() {
+        // Given
+        let paymentURL = URL(string: "http://www.automattic.com")
+        let dependencies = Dependencies(featureFlagService: MockFeatureFlagService(isScanToPayEnabled: true))
+        let viewModel = PaymentMethodsViewModel(paymentLink: paymentURL,
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
+                                                dependencies: dependencies)
+
+        // Then
+        XCTAssertTrue(viewModel.showScanToPayRow)
+    }
+
     func test_view_model_attempts_created_notice_after_sharing_link() {
         // Given
         let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9673
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the Scan to Pay row to the Payment Methods screen under the feature flag. At the moment there's no action connected to tapping on that row.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Make sure that the Scan to Pay row is added to the Payment Methods row in debug:

- Go to Menu
- Tap on Payments
- Tap on Collect Payment and follow the process
- The Scan to Pay row should be shown in the Payment Methods screen (see screenshot)

Repeat the process in the Release Build Configuration (you can change that by editing the WooCommerce schema). The Scan to Pay row should not be shown in the Payment Methods screen

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/ac29492d-cc8a-4e5e-a5fc-0db07f25f232" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
