### PR TITLE
EU-Bound Shipping Notice: Fix Shipping banner content

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -17,6 +17,7 @@ final class ShippingLabelFormViewController: UIViewController {
     ///
     private lazy var topBannerView: TopBannerView = {
         EUShippingNoticeTopBannerFactory.createTopBanner(
+                infoType: .warning,
                 onDismissPressed: { [weak self] in
                     self?.viewModel.dismissEUShippingNotice { [weak self] success in
                         if success {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -21,7 +21,7 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UIViewType {
-        let topBannerView = EUShippingNoticeTopBannerFactory.createTopBanner {
+        let topBannerView = EUShippingNoticeTopBannerFactory.createTopBanner(infoType: .instructions) {
             onDismissTapped?()
         } onLearnMorePressed: {
             onLearnMoreTapped?()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -5,23 +5,23 @@ final class EUShippingNoticeTopBannerFactory {
                                     onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
         return createTopBanner(contentText: Localization.warningInfo, onDismissPressed: onDismissPressed, onLearnMorePressed: onLearnMorePressed)
     }
-    
+
     static func createInstructionsBanner(onDismissPressed: @escaping () -> Void,
                                          onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
         return createTopBanner(contentText: Localization.instructionsInfo, onDismissPressed: onDismissPressed, onLearnMorePressed: onLearnMorePressed)
     }
-    
+
     private static func createTopBanner(contentText: String,
                                         onDismissPressed: @escaping () -> Void,
                                         onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
         let learnMoreAction = TopBannerViewModel.ActionButton(title: Localization.learnMore) { _ in
             onLearnMorePressed()
         }
-        
+
         let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) { _ in
             onDismissPressed()
         }
-        
+
         let viewModel = TopBannerViewModel(title: nil,
                                            infoText: contentText,
                                            icon: .infoOutlineImage,
@@ -35,8 +35,22 @@ final class EUShippingNoticeTopBannerFactory {
     }
 }
 
-private extension EUShippingNoticeTopBannerFactory {
-    enum Localization {
+extension EUShippingNoticeTopBannerFactory {
+    enum InfoType {
+        case warning
+        case instructions
+
+        var localizedRawValue: String {
+            switch self {
+            case .warning:
+                return Localization.warningInfo
+            case .instructions:
+                return Localization.instructionsInfo
+            }
+        }
+    }
+
+    private enum Localization {
         static let warningInfo = NSLocalizedString("When shipping to countries that follow European Union (EU) customs rules, " +
                                                    "you must provide a clear, specific description of every item. Otherwise, " +
                                                    "shipments may be delayed or interrupted at customs.",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -1,18 +1,29 @@
 import Foundation
 
 final class EUShippingNoticeTopBannerFactory {
-    static func createTopBanner(onDismissPressed: @escaping () -> Void,
-                                onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
+    static func createWarningBanner(onDismissPressed: @escaping () -> Void,
+                                    onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
+        return createTopBanner(contentText: Localization.warningInfo, onDismissPressed: onDismissPressed, onLearnMorePressed: onLearnMorePressed)
+    }
+    
+    static func createInstructionsBanner(onDismissPressed: @escaping () -> Void,
+                                         onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
+        return createTopBanner(contentText: Localization.instructionsInfo, onDismissPressed: onDismissPressed, onLearnMorePressed: onLearnMorePressed)
+    }
+    
+    private static func createTopBanner(contentText: String,
+                                        onDismissPressed: @escaping () -> Void,
+                                        onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
         let learnMoreAction = TopBannerViewModel.ActionButton(title: Localization.learnMore) { _ in
             onLearnMorePressed()
         }
-
+        
         let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) { _ in
             onDismissPressed()
         }
-
+        
         let viewModel = TopBannerViewModel(title: nil,
-                                           infoText: Localization.info,
+                                           infoText: contentText,
                                            icon: .infoOutlineImage,
                                            iconTintColor: .accent,
                                            isExpanded: true,
@@ -26,10 +37,15 @@ final class EUShippingNoticeTopBannerFactory {
 
 private extension EUShippingNoticeTopBannerFactory {
     enum Localization {
-        static let info = NSLocalizedString("When shipping to countries that follow European Union (EU) customs rules, " +
-                                            "you must provide a clear, specific description of every item. Otherwise, " +
-                                            "shipments may be delayed or interrupted at customs.",
-                                            comment: "The EU notice banner content describing why some countries require special customs description")
+        static let warningInfo = NSLocalizedString("When shipping to countries that follow European Union (EU) customs rules, " +
+                                                   "you must provide a clear, specific description of every item. Otherwise, " +
+                                                   "shipments may be delayed or interrupted at customs.",
+                                                   comment: "The EU notice banner content describing why some countries require special customs description")
+        static let instructionsInfo = NSLocalizedString("Shipping to countries that follow European Union (EU) customs rules now " +
+                                                        "requires you clearly describe every item. For example, if you are sending " +
+                                                        "clothing, you must indicate what type of clothing (e.g., men’s shirts, girl’s vest, boy’s jacket) " +
+                                                        "for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs. ",
+                                                        comment: "The EU notice banner content describing how the shipping customs shall be configured")
         static let learnMore = NSLocalizedString("Learn more", comment: "Label for the banner Learn more button")
         static let dismiss = NSLocalizedString("Dismiss", comment: "Label for the banner Dismiss button")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -1,19 +1,9 @@
 import Foundation
 
 final class EUShippingNoticeTopBannerFactory {
-    static func createWarningBanner(onDismissPressed: @escaping () -> Void,
-                                    onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
-        return createTopBanner(contentText: Localization.warningInfo, onDismissPressed: onDismissPressed, onLearnMorePressed: onLearnMorePressed)
-    }
-
-    static func createInstructionsBanner(onDismissPressed: @escaping () -> Void,
-                                         onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
-        return createTopBanner(contentText: Localization.instructionsInfo, onDismissPressed: onDismissPressed, onLearnMorePressed: onLearnMorePressed)
-    }
-
-    private static func createTopBanner(contentText: String,
-                                        onDismissPressed: @escaping () -> Void,
-                                        onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
+    static func createTopBanner(infoType: InfoType,
+                                onDismissPressed: @escaping () -> Void,
+                                onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
         let learnMoreAction = TopBannerViewModel.ActionButton(title: Localization.learnMore) { _ in
             onLearnMorePressed()
         }
@@ -23,7 +13,7 @@ final class EUShippingNoticeTopBannerFactory {
         }
 
         let viewModel = TopBannerViewModel(title: nil,
-                                           infoText: contentText,
+                                           infoText: infoType.content,
                                            icon: .infoOutlineImage,
                                            iconTintColor: .accent,
                                            isExpanded: true,
@@ -40,7 +30,7 @@ extension EUShippingNoticeTopBannerFactory {
         case warning
         case instructions
 
-        var localizedRawValue: String {
+        var content: String {
             switch self {
             case .warning:
                 return Localization.warningInfo


### PR DESCRIPTION
Closes #9722 

Why
==========
The EU Shipping notice banner displayed inside the Shipping Label creation form and Customs form should display different information. The Shipping Label one is a warning, meanwhile, the Customs form one contains instructions.

How
==========
Updates the `EUShippingNoticeTopBannerFactory` to support a `InfoType` parameter that will define if the Banner will be presented with instructions of warning content.

⚠️ The shrinking info issue gets more problematic with this description change. The fix for the text size issue is available in the upcoming PR: #9725

Screen Capture
==========
| Before  | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-15 at 21 29 34](https://github.com/woocommerce/woocommerce-ios/assets/5920403/72c3fcc1-646f-45fc-ae4b-60e1c467f090) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-15 at 21 27 26](https://github.com/woocommerce/woocommerce-ios/assets/5920403/95ad2195-2647-4cc8-90de-3093a569fcbd) |

How to Test
==========
1. Open the app with a site containing the Shipping Labels plugin configured
2. Open the order details of an order with the `processing` status
3. Hit the `Create Shipping Label` button
4. Configure the Origin and Destination address that meets the US to EU condition (e. g. US to Austria)
5. Verify that the banner is displayed with the same text as before
6. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
7. Verify that the Banner is correctly displayed inside the view with the new text matching the Figma designs

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.