### PR TITLE
EU-Bound Shipping Notice: Fix TopBannerView content shrinking issue

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeBanner.swift
@@ -38,6 +38,7 @@ struct EUShippingNoticeBanner: UIViewRepresentable {
 
     func updateUIView(_ uiView: UIView, context: Context) {
         context.coordinator.bannerWrapper.width = width
+        context.coordinator.bannerWrapper.invalidateIntrinsicContentSize()
     }
 
     /// Returns a copy of the view with `onDismissTapped` handling.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -17,6 +17,7 @@ final class EUShippingNoticeTopBannerFactory {
                                            icon: .infoOutlineImage,
                                            iconTintColor: .accent,
                                            isExpanded: true,
+                                           shouldWrapInfoText: false,
                                            topButton: .none,
                                            actionButtons: [learnMoreAction, dismissAction])
         let topBannerView = TopBannerView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -17,7 +17,7 @@ final class EUShippingNoticeTopBannerFactory {
                                            icon: .infoOutlineImage,
                                            iconTintColor: .accent,
                                            isExpanded: true,
-                                           shouldWrapInfoText: false,
+                                           shouldResizeInfo: false,
                                            topButton: .none,
                                            actionButtons: [learnMoreAction, dismissAction])
         let topBannerView = TopBannerView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -178,8 +178,8 @@ private extension TopBannerView {
         return iconInformationStackView
     }
 
-    func createLabelHolderStackView(wrapInfoText: Bool) -> UIStackView {
-        guard wrapInfoText else {
+    func createLabelHolderStackView(shouldResizeInfo: Bool) -> UIStackView {
+        guard shouldResizeInfo else {
             labelHolderStackView.addArrangedSubview(infoLabel)
             return labelHolderStackView
         }
@@ -207,7 +207,7 @@ private extension TopBannerView {
         // titleStackView will hidden if there is no title
         titleStackView.isHidden = viewModel.title == nil || viewModel.title?.isEmpty == true
 
-        let labelHolderStackView = createLabelHolderStackView(wrapInfoText: viewModel.shouldWrapInfoText)
+        let labelHolderStackView = createLabelHolderStackView(shouldResizeInfo: viewModel.shouldResizeInfo)
         let informationStackView = UIStackView(arrangedSubviews: [titleStackView, labelHolderStackView])
 
         informationStackView.axis = .vertical

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -178,7 +178,12 @@ private extension TopBannerView {
         return iconInformationStackView
     }
 
-    func createLabelHolderStackView() -> UIStackView {
+    func createLabelHolderStackView(wrapInfoText: Bool) -> UIStackView {
+        guard wrapInfoText else {
+            labelHolderStackView.addArrangedSubview(infoLabel)
+            return labelHolderStackView
+        }
+
         labelHolderStackView.addArrangedSubviews([
             createSeparatorView(height: Constants.labelHolderHeight, width: Constants.labelHolderLeftMargin),
             infoLabel,
@@ -202,7 +207,8 @@ private extension TopBannerView {
         // titleStackView will hidden if there is no title
         titleStackView.isHidden = viewModel.title == nil || viewModel.title?.isEmpty == true
 
-        let informationStackView = UIStackView(arrangedSubviews: [titleStackView, createLabelHolderStackView()])
+        let labelHolderStackView = createLabelHolderStackView(wrapInfoText: viewModel.shouldWrapInfoText)
+        let informationStackView = UIStackView(arrangedSubviews: [titleStackView, labelHolderStackView])
 
         informationStackView.axis = .vertical
         informationStackView.spacing = 9

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -37,7 +37,7 @@ struct TopBannerViewModel {
     let icon: UIImage?
     let iconTintColor: UIColor?
     let isExpanded: Bool
-    let shouldWrapInfoText: Bool
+    let shouldResizeInfo: Bool
     let topButton: TopButtonType
     let actionButtons: [ActionButton]
     let type: BannerType
@@ -47,7 +47,7 @@ struct TopBannerViewModel {
          icon: UIImage?,
          iconTintColor: UIColor? = nil,
          isExpanded: Bool = true,
-         shouldWrapInfoText: Bool = true,
+         shouldResizeInfo: Bool = true,
          topButton: TopButtonType,
          actionButtons: [ActionButton] = [],
          type: BannerType = .normal) {
@@ -59,6 +59,6 @@ struct TopBannerViewModel {
         self.topButton = topButton
         self.actionButtons = actionButtons
         self.type = type
-        self.shouldWrapInfoText = shouldWrapInfoText
+        self.shouldResizeInfo = shouldResizeInfo
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -37,6 +37,7 @@ struct TopBannerViewModel {
     let icon: UIImage?
     let iconTintColor: UIColor?
     let isExpanded: Bool
+    let shouldWrapInfoText: Bool
     let topButton: TopButtonType
     let actionButtons: [ActionButton]
     let type: BannerType
@@ -46,6 +47,7 @@ struct TopBannerViewModel {
          icon: UIImage?,
          iconTintColor: UIColor? = nil,
          isExpanded: Bool = true,
+         shouldWrapInfoText: Bool = true,
          topButton: TopButtonType,
          actionButtons: [ActionButton] = [],
          type: BannerType = .normal) {
@@ -57,5 +59,6 @@ struct TopBannerViewModel {
         self.topButton = topButton
         self.actionButtons = actionButtons
         self.type = type
+        self.shouldWrapInfoText = shouldWrapInfoText
     }
 }


### PR DESCRIPTION
Closes #9722 

Why
==========
We're using the `TopBannerView` component to present the EU Shipping Notice banner. But this component banner has a behavior of limiting the maximum space the main content can use. Since both banners for the EU Shipping scenario contain larger text bodies, the information shrinks to the point it gets tough to read. This PR introduces an option that allows disabling this shrinking behavior.

How
==========
The `TopBannerView`, when defining the internal content, creates a Stack view with the info label wrapped in two spacers that defines the maximum height of the stack itself. If the content requires more space, the text size will shrink until it fits. To avoid this without completely disabling the shrinking option from other banner usages across the app, this PR creates inside the `TopBannerViewModel` a parameter that will disable the shrinking by telling the `TopBannerView` not to add the spacers inside the content Stack view.

Screen Capture
==========
| Before  | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-15 at 21 27 26](https://github.com/woocommerce/woocommerce-ios/assets/5920403/95ad2195-2647-4cc8-90de-3093a569fcbd) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-15 at 19 54 45](https://github.com/woocommerce/woocommerce-ios/assets/5920403/672d237b-005f-4973-8e1c-d670e22edb96) |

How to Test
==========
1. Open the app with a site containing the Shipping Labels plugin configured
2. Open the order details of an order with the `processing` status
3. Hit the `Create Shipping Label` button
4. Configure the Origin and Destination address that meets the US to EU condition (e. g. US to Austria)
5. Verify that the banner is now displayed with no text shrinking
6. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
7. Verify that the Banner is correctly displayed inside the view with no text shrinking

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.