### PR TITLE
Add OrderList scanner button and Notice presenter

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -127,7 +127,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     /// Notice presentation handler
     ///
-    private var noticePresenter: NoticePresenter?
+    private var noticePresenter: NoticePresenter = DefaultNoticePresenter()
 
 
     // MARK: - View Lifecycle
@@ -331,10 +331,9 @@ extension OrderListViewController {
     }
 
     func showErrorNotice(with message: String, in viewController: UIViewController) {
-        noticePresenter = DefaultNoticePresenter()
         let notice = Notice(title: message, feedbackType: .error)
-        noticePresenter?.presentingViewController = viewController
-        noticePresenter?.enqueue(notice: notice)
+        noticePresenter.presentingViewController = viewController
+        noticePresenter.enqueue(notice: notice)
     }
 
     private func markOrderAsCompleted(resultID: FetchResultSnapshotObjectID) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -125,6 +125,10 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     ///
     private var freeTrialBannerPresenter: FreeTrialBannerPresenter?
 
+    /// Notice presentation handler
+    ///
+    private var noticePresenter: NoticePresenter?
+
 
     // MARK: - View Lifecycle
 
@@ -324,6 +328,13 @@ extension OrderListViewController {
         syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
             sender.endRefreshing()
         }
+    }
+
+    func showErrorNotice(with message: String, in viewController: UIViewController) {
+        noticePresenter = DefaultNoticePresenter()
+        let notice = Notice(title: message, feedbackType: .error)
+        noticePresenter?.presentingViewController = viewController
+        noticePresenter?.enqueue(notice: notice)
     }
 
     private func markOrderAsCompleted(resultID: FetchResultSnapshotObjectID) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9727

## Description
This PR adds the a scanning button to the Order list view navigation, following the new design specs for the barcode scanner feature ( pecCkj-F1-p2 ), as well as a Notice Presenter to inform the merchant of potential errors.

This button is hidden behind feature flag, so not the button nor the notice will show on Release config.

| Navigation Button | Error Notice |
|--------|--------|
| <img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/c77b02b7-539d-4dce-bee4-00de474fdfe8"> | <img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/7b84d1d8-5326-49ca-83b3-e190a83b06fd"> | 

## Testing instructions
- Go to Orders > See the new scanner navigation button > Tap it > See an error notice appearing in the bottom of the screen.
- The message is temporary until we actually use the notification to inform the user of potential errors.
