### PR TITLE
[Just in Time Messages] fix JITM warning and distribution of short messages

### DIFF
--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -89,7 +89,7 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
                         "selling_venues": profilerData.sellingStatus?.rawValue as Any?,
                         "other_platform": profilerData.sellingPlatforms as Any?
                     ].compactMapValues { $0 }
-                ]
+                ] as [String : Any]
             ]
         }
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -89,7 +89,7 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
                         "selling_venues": profilerData.sellingStatus?.rawValue as Any?,
                         "other_platform": profilerData.sellingPlatforms as Any?
                     ].compactMapValues { $0 }
-                ] as [String : Any]
+                ] as [String: Any]
             ]
         }
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -132,7 +132,7 @@ final class AggregateDataHelper {
             )
         }
 
-        var filtered = unsortedResult.filter { $0.quantity > 0 }
+        let filtered = unsortedResult.filter { $0.quantity > 0 }
 
         return filtered.sorted()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -565,8 +565,7 @@ private extension DashboardViewController {
     }
 
     private func dismissModalJustInTimeMessage() {
-        guard let modalJustInTimeMessageHostingController = modalJustInTimeMessageHostingController
-        else {
+        guard modalJustInTimeMessageHostingController != nil else {
             return
         }
         dismiss(animated: true)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -41,7 +41,7 @@ struct FeatureAnnouncementCardView: View {
                         .bodyStyle()
                         .padding(.bottom, viewModel.buttonTitle == nil ? Layout.bottomNoButtonPadding : Layout.largeSpacing)
                         .fixedSize(horizontal: false, vertical: true)
-
+                    Spacer()
                     if let buttonTitle = viewModel.buttonTitle {
                         Button(buttonTitle) {
                             viewModel.ctaTapped()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Recent changes to JITMs highlighted that sometimes messages weren't displayed correctly. Also, I merged some code which had a warning in it (that the unwrap of a modalHostingController was never used.)

This fixes the distribution, that warning, and a few other unrelated warnings which I spotted.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Test setup for this is non-trivial until the JITM message definitions are added - sorry! There are two options:

1. Proxyman/Charles breakpoint and modify the response (easier, but requires intervention for each request): PCYsg-Ffl-p2
2. Set up a WPcom sandbox and ephemeral site with test JITM definitions: P91TBi-a5J-p2

#### Using a proxy

Using Charles or Proxyman, set a breakpoint on the following endpoint pattern: `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&locale=*&path=/jetpack/v4/jitm*`

Modify the response JSON using the following sample JSON response: 

```
{
  "data": [
    {
      "content": {
        "message": "In-person card payments",
        "icon": "",
        "iconPath": null,
        "list": [],
        "description": "Please tell us more about your IPP experience",
        "classes": "",
        "title": "",
        "disclaimer": []
      },
      "CTA": {
        "message": "Take the Survey",
        "hook": "",
        "newWindow": true,
        "primary": true,
        "link": "https://woocommerce.com/mobile/payments/tap-to-pay"
      },
      "ttl": 300,
      "id": "woomobile_tap_to_pay_wcpay_ipp_survey",
      "feature_class": "woomobile_tap_to_pay_wcpay_ipp_survey",
      "expires": 30,
      "max_dismissal": 50,
      "activate_module": null,
      "is_dismissible": true,
      "is_user_created_by_partner": null,
      "message_expiration": null,
      "url": "https://jetpack.com/redirect/?source=jitm-woomobile_tap_to_pay_wcpay_ipp_survey",
      "jitm_stats_url": "https://pixel.wp.com/b.gif?v=wpcom2&rand=fe304a7d0cabbf0466f5d554a6f9de3a&x_jetpack-jitm=woomobile_tap_to_pay_wcpay_ipp_survey"
    }
  ]
}
```

#### Using a sandbox

A sample JITM definition (for the sandbox option) is below:

`public_html/wp-content/mu-plugins/0-sandbox.php`
```
<?php
function sandbox_jitm_rules( $rules, $cache ) {
	return array(
		( new \JITM\Message( 'woomobile_tap_to_pay_wcpay_ipp_survey', 'woomobile_tap_to_pay_wcpay_ipp_survey', $cache ) )
			->show( 'In-person card payments',
					'Please tell us more about your IPP experience' )
			->message_path( '/woomobile:my_store:admin_notices/' )
			->plugin_active( 'woocommerce-payments/woocommerce-payments.php' )
			->with_CTA( 'Take the Survey',
						'',
						'https://woocommerce.com/mobile/payments/tap-to-pay' )
			->for_sites_of_types( array( 'wpcom', 'jetpack', 'atomic' ) )
			->with_wc_country( 'US' )
			->max_dismissals( 50 )
			->show_again_after( 30 )
			->priority( 150 ),
	);
}
add_filter( 'jetpack_jitm_rules', 'sandbox_jitm_rules', 10, 2 );

```


### Testing in the app

Whichever route you choose:

#### Functionality: Deeplinking to Set up TTP
1. Launch the app
2. Observe that the JITM banner is shown, and has more space below the message than between the message and the title
3. Observe that the warning about not used variables is gone


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before
![before-jitm](https://github.com/woocommerce/woocommerce-ios/assets/2472348/9194fcc9-2acd-41e4-8d46-a8fc8bdcf6ed)


### After
![fixed-jitm](https://github.com/woocommerce/woocommerce-ios/assets/2472348/de6a99b2-b615-45e1-bae0-ba1f8c583634)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
