### PR TITLE
Support for creating new orders from scanned barcode

### DIFF
--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -130,7 +130,8 @@ private enum BarcodeScannerNoCameraPermissionAlert {
         NSLocalizedString("Allow camera access",
                           comment: "Title of alert that links to settings for camera access.")
         static let message =
-        NSLocalizedString("Please change your camera permissions in device settings.",
+        NSLocalizedString("Camera access is required for barcode scanning. " +
+                          "Please enable camera permissions in your device settings",
                           comment: "Message of alert that links to settings for camera access.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -318,9 +318,9 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     private let orderSynchronizer: OrderSynchronizer
 
+    /// Product ID given to the order when is created with a predetermined product, if any
     ///
-    ///
-    private let isCreatedFromScannedItem: Int64?
+    private let withInitialProductID: Int64?
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
@@ -333,7 +333,7 @@ final class EditableOrderViewModel: ObservableObject {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
-         isCreatedFromScannedItem: Int64? = nil) {
+         withInitialProductID: Int64? = nil) {
         self.siteID = siteID
         self.flow = flow
         self.stores = stores
@@ -344,7 +344,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.featureFlagService = featureFlagService
         self.orderDurationRecorder = orderDurationRecorder
         self.permissionChecker = permissionChecker
-        self.isCreatedFromScannedItem = isCreatedFromScannedItem
+        self.withInitialProductID = withInitialProductID
 
         // Set a temporary initial view model, as a workaround to avoid making it optional.
         // Needs to be reset before the view model is used.
@@ -927,7 +927,7 @@ private extension EditableOrderViewModel {
     /// Configures product row view models for each item in `orderDetails`.
     ///
     func configureProductRowViewModels() {
-        configureInitialOrderFromScannedProductIfNeeded()
+        configureInitialOrderFromScannedItemIfNeeded()
         updateProductsResultsController()
         updateProductVariationsResultsController()
         orderSynchronizer.orderPublisher
@@ -940,10 +940,10 @@ private extension EditableOrderViewModel {
             .assign(to: &$productRows)
     }
 
+    /// If given, sends a product to the Order synchronizer during the initial Order creation setup
     ///
-    ///
-    func configureInitialOrderFromScannedProductIfNeeded() {
-        guard let productID = self.isCreatedFromScannedItem else {
+    func configureInitialOrderFromScannedItemIfNeeded() {
+        guard let productID = self.withInitialProductID else {
             return
         }
         orderSynchronizer.setProduct.send(.init(product: .productID(productID), quantity: 1))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -927,7 +927,6 @@ private extension EditableOrderViewModel {
     /// Configures product row view models for each item in `orderDetails`.
     ///
     func configureProductRowViewModels() {
-        configureInitialOrderFromScannedItemIfNeeded()
         updateProductsResultsController()
         updateProductVariationsResultsController()
         orderSynchronizer.orderPublisher
@@ -938,12 +937,19 @@ private extension EditableOrderViewModel {
                 return self.createProductRows(items: items)
             }
             .assign(to: &$productRows)
+        configureInitialOrderFromScannedItemIfNeeded()
     }
 
     /// If given, sends a product to the Order synchronizer during the initial Order creation setup
     ///
     func configureInitialOrderFromScannedItemIfNeeded() {
         guard let productID = self.withInitialProductID else {
+            return
+        }
+
+        // Validate the scanned productID is an existing product
+        guard allProducts.contains(where: { $0.productID == productID }) else {
+            DDLogError("\(ScannerError.productNotFound)")
             return
         }
         orderSynchronizer.setProduct.send(.init(product: .productID(productID), quantity: 1))

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -67,6 +67,8 @@ final class OrdersRootViewController: UIViewController {
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
+    private var barcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
+
     // MARK: View Lifecycle
 
     init(siteID: Int64,
@@ -193,23 +195,22 @@ final class OrdersRootViewController: UIViewController {
             return
         }
 
-        let productScannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] scannedBarcode in
+        let productSKUBarcodeScannerCoordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                                                      onSKUBarcodeScanned: { [weak self] scannedBarcode in
             self?.handleScannedBarcode(scannedBarcode) { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case let .success(product):
-                    navigationController.popViewController(animated: true)
                     self.presentOrderCreationFlow(with: product.productID)
                 case .failure:
-                    navigationController.popViewController(animated: true)
                     self.displayErrorNotice()
                 }
             }
         })
-        navigationController.pushViewController(productScannerViewController, animated: true)
+        barcodeScannerCoordinator = productSKUBarcodeScannerCoordinator
+        productSKUBarcodeScannerCoordinator.start()
     }
 
-    
     /// Handles the result of scanning a barcode
     ///
     /// - Parameters:

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -157,14 +157,14 @@ final class OrdersRootViewController: UIViewController {
     /// We default to use -1 as sentinel value, due not having a Swift's Int64 optional primitive equivalent in Obj-C,
     /// and validate it when needed.
     ///
-    @objc func presentOrderCreationFlow(with initialItem: Int64 = -1) {
+    @objc func presentOrderCreationFlow(with initialProductID: Int64 = -1) {
         guard let navigationController = navigationController else {
             return
         }
 
-        let item: Int64? = validateSentinelValue(value: initialItem)
+        let productID: Int64? = validateSentinelValue(value: initialProductID)
 
-        let viewModel = EditableOrderViewModel(siteID: siteID, isCreatedFromScannedItem: item)
+        let viewModel = EditableOrderViewModel(siteID: siteID, withInitialProductID: productID)
         viewModel.onFinished = { [weak self] order in
             guard let self = self else { return }
 
@@ -198,11 +198,9 @@ final class OrdersRootViewController: UIViewController {
                 guard let self = self else { return }
                 switch result {
                 case let .success(product):
-                    print("🍉 start order creation flow with Product \(product.productID)")
                     navigationController.popViewController(animated: true)
                     self.presentOrderCreationFlow(with: product.productID)
                 case .failure:
-                    print("🍉 something went wrong")
                     navigationController.popViewController(animated: true)
                     self.handleError()
                 }
@@ -214,14 +212,11 @@ final class OrdersRootViewController: UIViewController {
     ///
     ///
     func handleScannedBarcode(_ scannedBarcode: String, onCompletion: @escaping ((Result<Product, Error>) -> Void)) {
-        print("🍉 barcode detected: \(scannedBarcode)")
         let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: siteID, sku: scannedBarcode) { result in
             switch result {
             case let .success(matchedProduct):
-                print("🍉 retrieval success: Product \(matchedProduct.productID)")
                 onCompletion(.success(matchedProduct))
             case let .failure(error):
-                print("🍉 retrieval error: \(error)")
                 onCompletion(.failure(error))
             }
         }
@@ -488,8 +483,10 @@ private extension OrdersRootViewController {
 
 // MARK: - Helpers
 private extension OrdersRootViewController {
-    /// Validates the passed value by returning nil or a value
+    /// Validates the passed value by returning nil if it's invalid, or the value if its valid
     ///
+    var invalidValue: Int64 { -1 }
+
     func validateSentinelValue(value: Int64) -> Int64? {
         value == -1 ? nil : value
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -155,8 +155,8 @@ final class OrdersRootViewController: UIViewController {
 
     /// Presents the Order Creation flow.
     ///
-    /// - parameter initialItem: Represents the product ID of an initial item to create the Order with, if given
-    /// We default to use -1 as sentinel value, due not having a Swift's Int64 optional primitive equivalent in Obj-C,
+    /// - parameter initialProductID: Represents the product ID of an initial item to create the Order with, if given
+    /// We default to use -1 as an invalid productID sentinel value, due not having a Swift's Int64 optional primitive equivalent in Obj-C,
     /// and validate it when needed.
     ///
     @objc func presentOrderCreationFlow(with initialProductID: Int64 = -1) {
@@ -491,14 +491,14 @@ private extension OrdersRootViewController {
     /// Validates the passed value by returning nil if it's invalid, or the passed value otherwise
     ///
     func validateSentinelValue(value: Int64) -> Int64? {
-        value == Constants.invalidValue ? nil : value
+        value == Constants.invalidProductID ? nil : value
     }
 }
 
 // MARK: - Constants
 private extension OrdersRootViewController {
     enum Constants {
-        static let invalidValue: Int64 = -1
+        static let invalidProductID: Int64 = -1
     }
     enum Localization {
         static let defaultOrderListTitle = NSLocalizedString("Orders", comment: "The title of the Orders tab.")

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -216,7 +216,7 @@ final class OrdersRootViewController: UIViewController {
     /// - Parameters:
     ///   - scannedBarcode: The scanned barcode
     ///   - onCompletion: The closure to be trigged when the scanning completes. Succeeds with a Product, or fails with an Error.
-    func handleScannedBarcode(_ scannedBarcode: String, onCompletion: @escaping ((Result<Product, Error>) -> Void)) {
+    private func handleScannedBarcode(_ scannedBarcode: String, onCompletion: @escaping ((Result<Product, Error>) -> Void)) {
         let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: siteID, sku: scannedBarcode) { result in
             switch result {
             case let .success(matchedProduct):

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -153,12 +153,18 @@ final class OrdersRootViewController: UIViewController {
 
     /// Presents the Order Creation flow.
     ///
-    @objc func presentOrderCreationFlow() {
+    /// - parameter initialItem: Represents the product ID of an initial item to create the Order with, if given
+    /// We default to use -1 as sentinel value, due not having a Swift's Int64 optional primitive equivalent in Obj-C,
+    /// and validate it when needed.
+    ///
+    @objc func presentOrderCreationFlow(with initialItem: Int64 = -1) {
         guard let navigationController = navigationController else {
             return
         }
 
-        let viewModel = EditableOrderViewModel(siteID: siteID)
+        let item: Int64? = validateSentinelValue(value: initialItem)
+
+        let viewModel = EditableOrderViewModel(siteID: siteID, isCreatedFromScannedItem: item)
         viewModel.onFinished = { [weak self] order in
             guard let self = self else { return }
 
@@ -194,7 +200,7 @@ final class OrdersRootViewController: UIViewController {
                 case let .success(product):
                     print("🍉 start order creation flow with Product \(product.productID)")
                     navigationController.popViewController(animated: true)
-                    self.presentOrderCreationFlow()
+                    self.presentOrderCreationFlow(with: product.productID)
                 case .failure:
                     print("🍉 something went wrong")
                     navigationController.popViewController(animated: true)
@@ -477,6 +483,15 @@ private extension OrdersRootViewController {
         }
 
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
+    }
+}
+
+// MARK: - Helpers
+private extension OrdersRootViewController {
+    /// Validates the passed value by returning nil or a value
+    ///
+    func validateSentinelValue(value: Int64) -> Int64? {
+        value == -1 ? nil : value
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -202,15 +202,19 @@ final class OrdersRootViewController: UIViewController {
                     self.presentOrderCreationFlow(with: product.productID)
                 case .failure:
                     navigationController.popViewController(animated: true)
-                    self.handleError()
+                    self.displayErrorNotice()
                 }
             }
         })
         navigationController.pushViewController(productScannerViewController, animated: true)
     }
 
+    
+    /// Handles the result of scanning a barcode
     ///
-    ///
+    /// - Parameters:
+    ///   - scannedBarcode: The scanned barcode
+    ///   - onCompletion: The closure to be trigged when the scanning completes. Succeeds with a Product, or fails with an Error.
     func handleScannedBarcode(_ scannedBarcode: String, onCompletion: @escaping ((Result<Product, Error>) -> Void)) {
         let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: siteID, sku: scannedBarcode) { result in
             switch result {
@@ -223,9 +227,9 @@ final class OrdersRootViewController: UIViewController {
         ServiceLocator.stores.dispatch(action)
     }
 
+    /// Presents an Error notice
     ///
-    ///
-    func handleError() {
+    private func displayErrorNotice() {
         let message = Localization.errorNoticeMessage
         ordersViewController.showErrorNotice(with: message, in: self)
     }
@@ -483,17 +487,18 @@ private extension OrdersRootViewController {
 
 // MARK: - Helpers
 private extension OrdersRootViewController {
-    /// Validates the passed value by returning nil if it's invalid, or the value if its valid
+    /// Validates the passed value by returning nil if it's invalid, or the passed value otherwise
     ///
-    var invalidValue: Int64 { -1 }
-
     func validateSentinelValue(value: Int64) -> Int64? {
-        value == -1 ? nil : value
+        value == Constants.invalidValue ? nil : value
     }
 }
 
 // MARK: - Constants
 private extension OrdersRootViewController {
+    enum Constants {
+        static let invalidValue: Int64 = -1
+    }
     enum Localization {
         static let defaultOrderListTitle = NSLocalizedString("Orders", comment: "The title of the Orders tab.")
         static let accessibilityLabelSearchOrders = NSLocalizedString("Search orders", comment: "Search Orders")

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -67,9 +67,6 @@ final class OrdersRootViewController: UIViewController {
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
-
-    private var skuBarcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
-
     // MARK: View Lifecycle
 
     init(siteID: Int64,
@@ -190,9 +187,7 @@ final class OrdersRootViewController: UIViewController {
             return
         }
 
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
-                                                              onSKUBarcodeScanned: { [weak self] scannedBarcode in
-
+        let productScannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] scannedBarcode in
             self?.handleScannedBarcode(scannedBarcode) { [weak self] result in
                 guard let self = self else { return }
                 switch result {
@@ -201,12 +196,12 @@ final class OrdersRootViewController: UIViewController {
                     self.presentOrderCreationFlow()
                 case .failure:
                     print("🍉 something went wrong")
+                    self.navigationController?.popViewController(animated: true)
                     self.handleError()
                 }
             }
         })
-        skuBarcodeScannerCoordinator = coordinator
-        coordinator.start()
+        navigationController.pushViewController(productScannerViewController, animated: true)
     }
 
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -193,10 +193,11 @@ final class OrdersRootViewController: UIViewController {
                 switch result {
                 case let .success(product):
                     print("🍉 start order creation flow with Product \(product.productID)")
+                    navigationController.popViewController(animated: true)
                     self.presentOrderCreationFlow()
                 case .failure:
                     print("🍉 something went wrong")
-                    self.navigationController?.popViewController(animated: true)
+                    navigationController.popViewController(animated: true)
                     self.handleError()
                 }
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1481,8 +1481,12 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.multipleLinesMessage)
     }
 
-    func test_capturePermissionStatus_is_notDetermined_when_no_permission_is_checked() {
-        // Given, Then
+    func test_capturePermissionStatus_is_notDetermined_when_permissionChecker_is_notDetermined() {
+        // Given
+        let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, permissionChecker: permissionChecker)
+
+        // Then
         XCTAssertEqual(viewModel.capturePermissionStatus, .notDetermined)
     }
 
@@ -1639,6 +1643,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             })
         }
 
+        // Then
         XCTAssertEqual(expectedError, .productNotFound)
     }
 
@@ -1703,6 +1708,36 @@ final class EditableOrderViewModelTests: XCTestCase {
             return XCTFail("Expected 1 item, but got none")
         }
         XCTAssertEqual(item.productID, sampleProductID)
+    }
+
+    func test_order_creation_when_withInitialProductID_is_nil_then_currentOrderItems_are_zero() {
+        // Given, When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, withInitialProductID: nil)
+
+        // Then
+        XCTAssertEqual(viewModel.currentOrderItems.count, 0)
+    }
+
+    func test_order_creation_when_withInitialProductID_is_not_nil_but_product_does_not_exist_then_currentOrderItems_are_zero() {
+        // Given, When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, withInitialProductID: sampleProductID)
+
+        // Then
+        XCTAssertEqual(viewModel.currentOrderItems.count, 0)
+    }
+
+    func test_order_creation_when_withInitialProductID_is_not_nil_and_product_exists_then_product_is_added_to_the_order() {
+        // Given, When
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+
+        // Confidence check
+        XCTAssertEqual(viewModel.currentOrderItems.count, 0)
+
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, withInitialProductID: sampleProductID)
+
+        // Then
+        XCTAssertEqual(viewModel.currentOrderItems.count, 1)
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/9658
Closes: #9728 

## Description
This PR deals with adding scanned products to an Order from the Order List view. If scanning is successful, the order creation flow starts, with the product as part of the newly-created order. If the barcode is not associated to an existing product, then we'll display an error notice instead, without starting the order creation flow.

Some caveats:

- Only products can be added at the moment (not variations).
- Scanning the same product more than once (Order List view, and then Order Editable view) will add it more than once as different rows.
- Extracting the duplicated scanner logic (Order List, Order Editable) to a single interface will be done on a different PR, as we're still deciding where we can start the scanning flow from.

## Changes
- Upon tapping the scanning icon, we use a `ProductSKUBarcodeScannerCoordinator` to manage the scanner navigation, as well as handling the permissions check, and alerts being presented.
- Upon scanning a barcode, we invoke a completion handler that will either trigger an error notice, or trigger the existing `presentOrderCreationFlow()`, but passing the product ID of the matched barcode as a parameter.
- We validate this product ID upon Order creation to confirm that the product exists, if does, we add it to the initial order.

## Screenshots

| 1: Permissions request | 2: Product not found | 3: Product added |
|--------|--------|--------|
| <img width=400 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/8b1dcd1b-6f3c-4df1-802e-bb6373864709"> | <img width=400 src="https://user-images.githubusercontent.com/3812076/238540381-7b84d1d8-5326-49ca-83b3-e190a83b06fd.png"> | <img width=400 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/e3940888-c7c0-4d32-971e-a5001a42c1cb"> | 


## Testing instructions
* Have a product with a decoded SKU in your store:
  * The easiest way to add the decoded barcode to a product is going to your store via wp-admin > WooCommerce > Products > Edit a product (not a variation) > Add the following SKU: `5366554338033`
  * An alternative is to create one in [this website](https://www.barcode-generator.org/) > open the app > Products > Select a product > Inventory > Tap on the barcode icon > scan the barcode created previously > tap done > tap save.

**Case 1: No permissions**
* On a physical device, go to Settings > Woo > and make sure `Allow Woo to access: Camera` is disabled.
* Run the app > go to Orders > Tap the scanner icon > See the "Allow camera permissions" alert.
  * Tapping "Close" will dismiss the alert.
  * Tapping "Settings" will redirect to the app settings.

**Case 2: Permissions granted, but no product match**
* On a physical device, go to Settings > Woo > and make sure `Allow Woo to access: Camera` is enabled.
* Run the app > go to Orders > Tap the scanner icon > and scan the following QR:

<img width=400 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/f50991ce-849a-4841-bc1f-d98fb87aab3b">

See that the scanner is dismissed and we're brought back to the Order list with an error notice, as the product couldn't be found.

**Case 3: Permissions granted, and product match**
* Now scan again the following QR if your product uses `5366554338033`, or your own barcode/QR if you have created your own:
<img width=400 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/106501cf-4cbf-45b3-86b2-5d7c84d85d5c">

See that the scanner is dismissed, and we start the order creation flow with the product is already added to the Order.