### PR TITLE
EU-Bound Shipping Notice: Fix EU notice visibility in Customs form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -489,7 +489,7 @@ private extension ShippingLabelFormViewController {
                                                                              customsForms: viewModel.customsForms,
                                                                              destinationCountry: country,
                                                                              countries: viewModel.countries,
-                                                                             shouldDisplayShippingNotice: viewModel.shouldPresentEUShippingNotice,
+                                                                             shouldDisplayShippingNotice: viewModel.isEUShippingConditionMet(),
                                                                              onCompletion: { [weak self] forms in
             self?.viewModel.handleCustomsFormsValueChanges(customsForms: forms, isValidated: true)
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -897,7 +897,7 @@ extension ShippingLabelFormViewModel {
     func isEUShippingConditionMet() -> Bool {
         EUCustomsScenarioValidator.validate(origin: self.originAddress, destination: self.destinationAddress)
     }
-    
+
     func dismissEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
         let action = AppSettingsAction.dismissEUShippingNotice { result in
             switch result {
@@ -909,7 +909,7 @@ extension ShippingLabelFormViewModel {
         }
         stores.dispatch(action)
     }
-    
+
     private func updateEUShippingNoticeVisibility() {
         verifyEUShippingNoticeDismissState { [weak self] dismissed in
             guard let self = self, dismissed else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -894,17 +894,10 @@ extension ShippingLabelFormViewModel {
 
 // MARK: - Shipping Notice dismiss state handling
 extension ShippingLabelFormViewModel {
-    private func updateEUShippingNoticeVisibility() {
-        verifyEUShippingNoticeDismissState { [weak self] dismissed in
-            guard let self = self, dismissed else {
-                self?.shouldPresentEUShippingNotice = false
-                return
-            }
-
-            self.shouldPresentEUShippingNotice = EUCustomsScenarioValidator.validate(origin: self.originAddress, destination: self.destinationAddress)
-        }
+    func isEUShippingConditionMet() -> Bool {
+        EUCustomsScenarioValidator.validate(origin: self.originAddress, destination: self.destinationAddress)
     }
-
+    
     func dismissEUShippingNotice(onCompletion: @escaping (Bool) -> Void) {
         let action = AppSettingsAction.dismissEUShippingNotice { result in
             switch result {
@@ -915,6 +908,17 @@ extension ShippingLabelFormViewModel {
             }
         }
         stores.dispatch(action)
+    }
+    
+    private func updateEUShippingNoticeVisibility() {
+        verifyEUShippingNoticeDismissState { [weak self] dismissed in
+            guard let self = self, dismissed else {
+                self?.shouldPresentEUShippingNotice = false
+                return
+            }
+
+            self.shouldPresentEUShippingNotice = self.isEUShippingConditionMet()
+        }
     }
 
     private func verifyEUShippingNoticeDismissState(onCompletion: @escaping (Bool) -> Void) {


### PR DESCRIPTION
Closes #9737 

Why
==========
Every EU Shipping notice can be dismissed anytime, but the one inside the Create Shipping Label form view persists the dismiss action and never shows it again. The Customs form notice, on the other side, shouldn't have this dismiss persisted, but display the banner every time the US-to-EU constraint is met. But due to a bug, the dismissed state inside the Create Shipping Label is affecting the Customs form and causing it to not show up when it should.

How
==========
Simply adjusts the Customs form parameter to receive only the `EUCustomsScenarioValidator` result as the banner visibility control instead of the Shipping Label creation form internal visibility state.

How to Test
==========
1. Open the app with a site containing the Shipping Labels plugin configured
2. Open the order details of an order with the `processing` status
3. Hit the `Create Shipping Label` button
4. Configure the Origin and Destination address that meets the US to EU condition (e. g. US to Austria)
5. Verify that the banner is now displayed. Dismiss it but keep the current address configuration.
6. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
7. Verify that the Banner is correctly displayed inside the view

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.