### PR TITLE
[Privacy Choices] Banner Presentation - Part 1

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -28,6 +28,7 @@ extension UserDefaults {
         case completedAllStoreOnboardingTasks
         case shouldHideStoreOnboardingTaskList
         case storePhoneNumber
+        case hasSavedPrivacyBannerSettings
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -170,6 +170,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.storePhoneNumber] = nil
         defaults[.completedAllStoreOnboardingTasks] = nil
         defaults[.shouldHideStoreOnboardingTaskList] = nil
+        defaults[.hasSavedPrivacyBannerSettings] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -137,6 +137,10 @@ final class DashboardViewController: UIViewController {
     ///
     private var freeTrialBannerPresenter: FreeTrialBannerPresenter?
 
+    /// Presenter for the privacy choices banner
+    ///
+    private lazy var privacyBannerPresenter = PrivacyBannerPresenter()
+
     // MARK: View Lifecycle
 
     init(siteID: Int64) {
@@ -167,6 +171,7 @@ final class DashboardViewController: UIViewController {
         observeAddProductTrigger()
         observeOnboardingVisibility()
         configureFreeTrialBannerPresenter()
+        presentPrivacyBannerIfNeeded()
 
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
@@ -658,6 +663,13 @@ private extension DashboardViewController {
 
         hostingController.didMove(toParent: self)
         hostingController.view.layoutIfNeeded()
+    }
+
+
+    /// Presents the privacy banner if needed.
+    ///
+    func presentPrivacyBannerIfNeeded() {
+        privacyBannerPresenter.presentIfNeeded(from: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 /// Type who informs us if the privacy banner should be shown or not.
 ///
@@ -21,7 +22,14 @@ struct PrivacyBannerPresentationUseCase {
     /// Currently it is shown if the user is in the EU zone & privacy choices have not been saved.
     ///
     func shouldShowPrivacyBanner() -> Bool {
-        // TODO: Implement
-        return true
+        let isCountryInEU = Country.EUCountryCodes.contains(countryCode)
+        let hasSavedPrivacySettings = defaults.hasSavedPrivacyBannerSettings
+        return isCountryInEU && !hasSavedPrivacySettings
+    }
+}
+
+private extension UserDefaults {
+    @objc dynamic var hasSavedPrivacyBannerSettings: Bool {
+        bool(forKey: Key.hasSavedPrivacyBannerSettings.rawValue)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Type who informs us if the privacy banner should be shown or not.
+///
+struct PrivacyBannerPresentationUseCase {
+
+    /// Users current location country code.
+    ///
+    private let countryCode: String
+
+    /// User Defaults database
+    ///
+    private let defaults: UserDefaults
+
+    init(countryCode: String, defaults: UserDefaults = UserDefaults.standard) {
+        self.countryCode = countryCode
+        self.defaults = defaults
+    }
+
+    /// Returns `true` if the privacy banner should be shown.
+    /// Currently it is shown if the user is in the EU zone & privacy choices have not been saved.
+    ///
+    func shouldShowPrivacyBanner() -> Bool {
+        // TODO: Implement
+        return true
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
@@ -22,7 +22,7 @@ struct PrivacyBannerPresentationUseCase {
     /// Currently it is shown if the user is in the EU zone & privacy choices have not been saved.
     ///
     func shouldShowPrivacyBanner() -> Bool {
-        let isCountryInEU = Country.EUCountryCodes.contains(countryCode)
+        let isCountryInEU = Country.GDPRCountryCodes.contains(countryCode)
         let hasSavedPrivacySettings = defaults.hasSavedPrivacyBannerSettings
         return isCountryInEU && !hasSavedPrivacySettings
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -4,7 +4,7 @@ import WordPressUI
 
 /// Type to handle the privacy banner presentation.
 ///
-final class PrivacySettingsBannerPresenter {
+final class PrivacyBannerPresenter {
 
     /// User Defaults database
     ///
@@ -29,6 +29,7 @@ final class PrivacySettingsBannerPresenter {
         }, saveAction: {
             print("Saved tapped") // TODO: perform network request
         })
+
 
         let bottomSheetViewController = BottomSheetViewController(childViewController: privacyBanner)
         bottomSheetViewController.show(from: viewController)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -17,6 +17,10 @@ final class PrivacyBannerPresenter {
     /// Present the banner when the appropriate conditions are met.
     ///
     func presentIfNeeded(from viewController: UIViewController) {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.privacyChoices) else {
+            return
+        }
+
         let countryCode = Locale.current.regionCode ?? "" // TODO: Switch for the real user country code.
         let useCase = PrivacyBannerPresentationUseCase(countryCode: countryCode, defaults: defaults)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsBannerPresenter.swift
@@ -1,0 +1,36 @@
+import Foundation
+import UIKit
+import WordPressUI
+
+/// Type to handle the privacy banner presentation.
+///
+final class PrivacySettingsBannerPresenter {
+
+    /// User Defaults database
+    ///
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = UserDefaults.standard) {
+        self.defaults = defaults
+    }
+
+    /// Present the banner when the appropriate conditions are met.
+    ///
+    func presentIfNeeded(from viewController: UIViewController) {
+        let countryCode = Locale.current.regionCode ?? "" // TODO: Switch for the real user country code.
+        let useCase = PrivacyBannerPresentationUseCase(countryCode: countryCode, defaults: defaults)
+
+        guard useCase.shouldShowPrivacyBanner() else {
+            return
+        }
+
+        let privacyBanner = PrivacyBannerViewController(goToSettingsAction: {
+            print("Go to settings tapped") // TODO: Navigate to settings
+        }, saveAction: {
+            print("Saved tapped") // TODO: perform network request
+        })
+
+        let bottomSheetViewController = BottomSheetViewController(childViewController: privacyBanner)
+        bottomSheetViewController.show(from: viewController)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
@@ -45,4 +45,9 @@ extension Country {
                                               "ES", "ESP", // Spain
                                               "SE", "SWE", // Sweden
                                               "CH", "CHE"] // Switzerland
+
+    /// GDPR Country Code definitions.
+    /// *Although the UK has departed from the EU as of January 2021, the GDPR was enacted before its withdrawal and is therefore considered a valid UK law.*
+    ///
+    static let GDPRCountryCodes = EUCountryCodes + ["GB"]
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
@@ -7,7 +7,7 @@ import Yosemite
 ///
 struct EUCustomsScenarioValidator {
     static func validate(origin: ShippingLabelAddress?, destination: ShippingLabelAddress?) -> Bool {
-        usCountryISOCode.contains(origin?.country ?? "") && Country.EUCountryCodes.contains(destination?.country ?? "")
+        usCountryISOCode.contains(origin?.country ?? "") && Country.countriesFollowingEUCustoms.contains(destination?.country ?? "")
     }
 
     private static let usCountryISOCode: Set<String> = ["US", "USA"] // United States of America
@@ -16,38 +16,38 @@ struct EUCustomsScenarioValidator {
 extension Country {
     /// EU Country Code definitions.
     ///
-    static let EUCountryCodes: Set<String> = ["AT", "AUT", // Austria
-                                              "BE", "BEL", // Belgium
-                                              "BG", "BGR", // Bulgaria
-                                              "HR", "HRV", // Croatia
-                                              "CY", "CYP", // Cyprus
-                                              "CZ", "CZE", // Czech Republic
-                                              "DK", "DNK", // Denmark
-                                              "EE", "EST", // Estonia
-                                              "FI", "FIN", // Finland
-                                              "FR", "FRA", // France
-                                              "DE", "DEU", // Germany
-                                              "GR", "GRC", // Greece
-                                              "HU", "HUN", // Hungary
-                                              "IE", "IRL", // Ireland
-                                              "IT", "ITA", // Italy
-                                              "LV", "LVA", // Latvia
-                                              "LT", "LTU", // Lithuania
-                                              "LU", "LUX", // Luxembourg
-                                              "MT", "MLT", // Malta
-                                              "NL", "NLD", // Netherlands
-                                              "NO", "NOR", // Norway
-                                              "PL", "POL", // Poland
-                                              "PT", "PRT", // Portugal
-                                              "RO", "ROU", // Romania
-                                              "SK", "SVK", // Slovakia
-                                              "SI", "SVN", // Slovenia
-                                              "ES", "ESP", // Spain
-                                              "SE", "SWE", // Sweden
-                                              "CH", "CHE"] // Switzerland
+    static let countriesFollowingEUCustoms: Set<String> = ["AT", "AUT", // Austria
+                                                           "BE", "BEL", // Belgium
+                                                           "BG", "BGR", // Bulgaria
+                                                           "HR", "HRV", // Croatia
+                                                           "CY", "CYP", // Cyprus
+                                                           "CZ", "CZE", // Czech Republic
+                                                           "DK", "DNK", // Denmark
+                                                           "EE", "EST", // Estonia
+                                                           "FI", "FIN", // Finland
+                                                           "FR", "FRA", // France
+                                                           "DE", "DEU", // Germany
+                                                           "GR", "GRC", // Greece
+                                                           "HU", "HUN", // Hungary
+                                                           "IE", "IRL", // Ireland
+                                                           "IT", "ITA", // Italy
+                                                           "LV", "LVA", // Latvia
+                                                           "LT", "LTU", // Lithuania
+                                                           "LU", "LUX", // Luxembourg
+                                                           "MT", "MLT", // Malta
+                                                           "NL", "NLD", // Netherlands
+                                                           "NO", "NOR", // Norway
+                                                           "PL", "POL", // Poland
+                                                           "PT", "PRT", // Portugal
+                                                           "RO", "ROU", // Romania
+                                                           "SK", "SVK", // Slovakia
+                                                           "SI", "SVN", // Slovenia
+                                                           "ES", "ESP", // Spain
+                                                           "SE", "SWE", // Sweden
+                                                           "CH", "CHE"] // Switzerland
 
     /// GDPR Country Code definitions.
     /// *Although the UK has departed from the EU as of January 2021, the GDPR was enacted before its withdrawal and is therefore considered a valid UK law.*
     ///
-    static let GDPRCountryCodes = EUCountryCodes + ["GB"]
+    static let GDPRCountryCodes = countriesFollowingEUCustoms + ["GB"]
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
@@ -7,37 +7,42 @@ import Yosemite
 ///
 struct EUCustomsScenarioValidator {
     static func validate(origin: ShippingLabelAddress?, destination: ShippingLabelAddress?) -> Bool {
-        usCountryISOCode.contains(origin?.country ?? "") && countriesFollowingEUCustoms.contains(destination?.country ?? "")
+        usCountryISOCode.contains(origin?.country ?? "") && Country.EUCountryCodes.contains(destination?.country ?? "")
     }
 
     private static let usCountryISOCode: Set<String> = ["US", "USA"] // United States of America
-    private static let countriesFollowingEUCustoms: Set<String> = ["AT", "AUT", // Austria
-                                                                   "BE", "BEL", // Belgium
-                                                                   "BG", "BGR", // Bulgaria
-                                                                   "HR", "HRV", // Croatia
-                                                                   "CY", "CYP", // Cyprus
-                                                                   "CZ", "CZE", // Czech Republic
-                                                                   "DK", "DNK", // Denmark
-                                                                   "EE", "EST", // Estonia
-                                                                   "FI", "FIN", // Finland
-                                                                   "FR", "FRA", // France
-                                                                   "DE", "DEU", // Germany
-                                                                   "GR", "GRC", // Greece
-                                                                   "HU", "HUN", // Hungary
-                                                                   "IE", "IRL", // Ireland
-                                                                   "IT", "ITA", // Italy
-                                                                   "LV", "LVA", // Latvia
-                                                                   "LT", "LTU", // Lithuania
-                                                                   "LU", "LUX", // Luxembourg
-                                                                   "MT", "MLT", // Malta
-                                                                   "NL", "NLD", // Netherlands
-                                                                   "NO", "NOR", // Norway
-                                                                   "PL", "POL", // Poland
-                                                                   "PT", "PRT", // Portugal
-                                                                   "RO", "ROU", // Romania
-                                                                   "SK", "SVK", // Slovakia
-                                                                   "SI", "SVN", // Slovenia
-                                                                   "ES", "ESP", // Spain
-                                                                   "SE", "SWE", // Sweden
-                                                                   "CH", "CHE"] // Switzerland
+}
+
+extension Country {
+    /// EU Country Code definitions.
+    ///
+    static let EUCountryCodes: Set<String> = ["AT", "AUT", // Austria
+                                              "BE", "BEL", // Belgium
+                                              "BG", "BGR", // Bulgaria
+                                              "HR", "HRV", // Croatia
+                                              "CY", "CYP", // Cyprus
+                                              "CZ", "CZE", // Czech Republic
+                                              "DK", "DNK", // Denmark
+                                              "EE", "EST", // Estonia
+                                              "FI", "FIN", // Finland
+                                              "FR", "FRA", // France
+                                              "DE", "DEU", // Germany
+                                              "GR", "GRC", // Greece
+                                              "HU", "HUN", // Hungary
+                                              "IE", "IRL", // Ireland
+                                              "IT", "ITA", // Italy
+                                              "LV", "LVA", // Latvia
+                                              "LT", "LTU", // Lithuania
+                                              "LU", "LUX", // Luxembourg
+                                              "MT", "MLT", // Malta
+                                              "NL", "NLD", // Netherlands
+                                              "NO", "NOR", // Norway
+                                              "PL", "POL", // Poland
+                                              "PT", "PRT", // Portugal
+                                              "RO", "ROU", // Romania
+                                              "SK", "SVK", // Slovakia
+                                              "SI", "SVN", // Slovenia
+                                              "ES", "ESP", // Spain
+                                              "SE", "SWE", // Sweden
+                                              "CH", "CHE"] // Switzerland
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -610,9 +610,9 @@
 		03EF250228C615A5006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF250128C615A5006A033E /* InPersonPaymentsMenuViewModel.swift */; };
 		03EF250428C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */; };
 		03EF250628C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF250528C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift */; };
-		03F5CB832A0C3A1A0026877A /* AnimatedPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F5CB822A0C3A1A0026877A /* AnimatedPlaceholder.swift */; };
 		03F5CAFF2A0BA37C0026877A /* JustInTimeMessageModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F5CAFE2A0BA37C0026877A /* JustInTimeMessageModal.swift */; };
 		03F5CB012A0BA3D40026877A /* ModalOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F5CB002A0BA3D40026877A /* ModalOverlay.swift */; };
+		03F5CB832A0C3A1A0026877A /* AnimatedPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F5CB822A0C3A1A0026877A /* AnimatedPlaceholder.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -652,6 +652,7 @@
 		2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AA7B3E20ED81C2004DA14F /* UserDefaults+Woo.swift */; };
 		260979792A12E20900442249 /* PrivacyBannerPresentationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */; };
+		2609797C2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2609797B2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift */; };
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
@@ -2886,9 +2887,9 @@
 		03EF250128C615A5006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModelTests.swift; sourceTree = "<group>"; };
 		03EF250528C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseCardReaderWebViewViewModel.swift; sourceTree = "<group>"; };
-		03F5CB822A0C3A1A0026877A /* AnimatedPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedPlaceholder.swift; sourceTree = "<group>"; };
 		03F5CAFE2A0BA37C0026877A /* JustInTimeMessageModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageModal.swift; sourceTree = "<group>"; };
 		03F5CB002A0BA3D40026877A /* ModalOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalOverlay.swift; sourceTree = "<group>"; };
+		03F5CB822A0C3A1A0026877A /* AnimatedPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedPlaceholder.swift; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -2925,6 +2926,7 @@
 		2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInputTransformerTests.swift; sourceTree = "<group>"; };
 		2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteOrderSynchronizerTests.swift; sourceTree = "<group>"; };
 		260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerPresentationUseCase.swift; sourceTree = "<group>"; };
+		2609797B2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerPresentationUseCaseTests.swift; sourceTree = "<group>"; };
 		260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModel.swift; sourceTree = "<group>"; };
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
@@ -5979,6 +5981,14 @@
 			path = Synchronizer;
 			sourceTree = "<group>";
 		};
+		2609797A2A13D2B500442249 /* Privacy */ = {
+			isa = PBXGroup;
+			children = (
+				2609797B2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift */,
+			);
+			path = Privacy;
+			sourceTree = "<group>";
+		};
 		2611EE57243A46C500A74490 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -8428,6 +8438,7 @@
 			children = (
 				BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */,
 				02AA586528531D0E0068B6F0 /* CloseAccountCoordinatorTests.swift */,
+				2609797A2A13D2B500442249 /* Privacy */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -12752,6 +12763,7 @@
 				02C2756F24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift in Sources */,
 				571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */,
 				45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */,
+				2609797C2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift in Sources */,
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
 				B958A7D128B5281800823EEF /* UniversalLinkRouterTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -651,6 +651,7 @@
 		2602A64A27BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */; };
 		2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AA7B3E20ED81C2004DA14F /* UserDefaults+Woo.swift */; };
+		260979792A12E20900442249 /* PrivacyBannerPresentationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */; };
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
@@ -2923,6 +2924,7 @@
 		2602A64527BDBEBA00B347F1 /* ProductInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInputTransformer.swift; sourceTree = "<group>"; };
 		2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInputTransformerTests.swift; sourceTree = "<group>"; };
 		2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteOrderSynchronizerTests.swift; sourceTree = "<group>"; };
+		260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerPresentationUseCase.swift; sourceTree = "<group>"; };
 		260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModel.swift; sourceTree = "<group>"; };
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
@@ -9026,6 +9028,7 @@
 			children = (
 				CE22E3F62170E23C005A6BEF /* PrivacySettingsViewController.swift */,
 				267F60122A0C24D700CD1E4E /* PrivacyBannerViewController.swift */,
+				260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -11933,6 +11936,7 @@
 				261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */,
 				45DB705A26124C710064A6CF /* TitleAndTextFieldRow.swift in Sources */,
 				DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */,
+				260979792A12E20900442249 /* PrivacyBannerPresentationUseCase.swift in Sources */,
 				DEF36DE82898D3CF00178AC2 /* JetpackSetupWebViewModel.swift in Sources */,
 				0270F47624D005B00005210A /* ProductFormViewModelProtocol.swift in Sources */,
 				268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -764,6 +764,7 @@
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
+		26B233D12A14208800926EAD /* PrivacySettingsBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B233D02A14208800926EAD /* PrivacySettingsBannerPresenter.swift */; };
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
 		26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */; };
 		26B3EC642745916F0075EAE6 /* BindableTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC632745916F0075EAE6 /* BindableTextField.swift */; };
@@ -3034,6 +3035,7 @@
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
+		26B233D02A14208800926EAD /* PrivacySettingsBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsBannerPresenter.swift; sourceTree = "<group>"; };
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
 		26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		26B3EC632745916F0075EAE6 /* BindableTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableTextField.swift; sourceTree = "<group>"; };
@@ -9039,6 +9041,7 @@
 			children = (
 				CE22E3F62170E23C005A6BEF /* PrivacySettingsViewController.swift */,
 				267F60122A0C24D700CD1E4E /* PrivacyBannerViewController.swift */,
+				26B233D02A14208800926EAD /* PrivacySettingsBannerPresenter.swift */,
 				260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */,
 			);
 			path = Privacy;
@@ -11890,6 +11893,7 @@
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				DE74F2A527E41D740002FE59 /* EnableAnalyticsView.swift in Sources */,
 				D85A3C5626C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift in Sources */,
+				26B233D12A14208800926EAD /* PrivacySettingsBannerPresenter.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,
 				B958A7C928B3D47B00823EEF /* Route.swift in Sources */,
 				CC53FB3A275697B000C4CA4F /* ProductRowViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -764,7 +764,7 @@
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
-		26B233D12A14208800926EAD /* PrivacySettingsBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B233D02A14208800926EAD /* PrivacySettingsBannerPresenter.swift */; };
+		26B233D12A14208800926EAD /* PrivacyBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B233D02A14208800926EAD /* PrivacyBannerPresenter.swift */; };
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
 		26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */; };
 		26B3EC642745916F0075EAE6 /* BindableTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC632745916F0075EAE6 /* BindableTextField.swift */; };
@@ -3035,7 +3035,7 @@
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
-		26B233D02A14208800926EAD /* PrivacySettingsBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsBannerPresenter.swift; sourceTree = "<group>"; };
+		26B233D02A14208800926EAD /* PrivacyBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerPresenter.swift; sourceTree = "<group>"; };
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
 		26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		26B3EC632745916F0075EAE6 /* BindableTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableTextField.swift; sourceTree = "<group>"; };
@@ -9041,7 +9041,7 @@
 			children = (
 				CE22E3F62170E23C005A6BEF /* PrivacySettingsViewController.swift */,
 				267F60122A0C24D700CD1E4E /* PrivacyBannerViewController.swift */,
-				26B233D02A14208800926EAD /* PrivacySettingsBannerPresenter.swift */,
+				26B233D02A14208800926EAD /* PrivacyBannerPresenter.swift */,
 				260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */,
 			);
 			path = Privacy;
@@ -11893,7 +11893,7 @@
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				DE74F2A527E41D740002FE59 /* EnableAnalyticsView.swift in Sources */,
 				D85A3C5626C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift in Sources */,
-				26B233D12A14208800926EAD /* PrivacySettingsBannerPresenter.swift in Sources */,
+				26B233D12A14208800926EAD /* PrivacyBannerPresenter.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,
 				B958A7C928B3D47B00823EEF /* Route.swift in Sources */,
 				CC53FB3A275697B000C4CA4F /* ProductRowViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import TestKit
+
+@testable import WooCommerce
+@testable import Yosemite
+
+final class PrivacyBannerPresentationUseCaseTests: XCTestCase {
+
+    func test_show_banner_is_true_when_conditions_are_met() throws {
+        // Given
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+
+        // When & Then
+        for euCode in Country.EUCountryCodes {
+            let useCase = PrivacyBannerPresentationUseCase(countryCode: euCode, defaults: defaults)
+            XCTAssertTrue(useCase.shouldShowPrivacyBanner())
+        }
+    }
+
+    func test_show_banner_is_false_when_country_is_outside_of_EU_and_choices_have_not_been_saved() throws {
+        // Given
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+        defaults[.hasSavedPrivacyBannerSettings] = false
+
+        // When
+        let useCase = PrivacyBannerPresentationUseCase(countryCode: "PE", defaults: defaults)
+
+        // Then
+        XCTAssertFalse(useCase.shouldShowPrivacyBanner())
+    }
+
+    func test_show_banner_is_false_when_country_is_inside_of_EU_and_choices_have_been_saved() throws {
+        // Given
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+        defaults[.hasSavedPrivacyBannerSettings] = true
+
+        // When
+        let useCase = PrivacyBannerPresentationUseCase(countryCode: "ES", defaults: defaults)
+
+        // Then
+        XCTAssertFalse(useCase.shouldShowPrivacyBanner())
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
@@ -11,7 +11,7 @@ final class PrivacyBannerPresentationUseCaseTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
 
         // When & Then
-        for euCode in Country.EUCountryCodes {
+        for euCode in Country.GDPRCountryCodes {
             let useCase = PrivacyBannerPresentationUseCase(countryCode: euCode, defaults: defaults)
             XCTAssertTrue(useCase.shouldShowPrivacyBanner())
         }


### PR DESCRIPTION
Part of #9613 

# Why

This PR kicks off the work for handling the privacy choices banner presentation.
Specifically, it shows the banner when:

- The device has EU locale: This will be changed later to the IP country code.
- The user has not saved privacy choices before: There is no way to save privacy choices, this will be done in a separate PR

# How

- Adds a `hasSavedPrivacyBannerSettings` user default setting to save the privacy banner state
- Adds a `PrivacyBannerPresentationUseCase` type that will be responsible for figuring out when the banner should be presented.
- Adds a `PrivacyBannerPresenter` to handle the actual banner presentation.
- Updates `EUCustomsScenarioValidator` to be able to use the EU country codes set there. In the future we may want to extract those country codes into a more general enum/type.

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/00ed3e38-9280-4674-a979-2d18f1441818

# Testing Steps

- Set your device locale to a country not in the EU zone EG: USA
- Launch the app
- See that no banner is presented

----

- Set your device locale to a country  in the EU zone EG: GB
- Launch the app
- See that the privacy banner is presented.

Note: The banner is presented with a little bit of extra space at the bottom. I'll be looking at improving that in a later PR!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
