### PR TITLE
[Product Bundles] Add Networking support for displaying product bundle hierarchy in order details

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -249,6 +249,16 @@ extension DotcomError {
         .empty
     }
 }
+extension Networking.DotcomSitePlugin {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.DotcomSitePlugin {
+        .init(
+            id: .fake(),
+            isActive: .fake()
+        )
+    }
+}
 extension Networking.DotcomUser {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -567,7 +577,8 @@ extension Networking.OrderItem {
             taxes: .fake(),
             total: .fake(),
             totalTax: .fake(),
-            attributes: .fake()
+            attributes: .fake(),
+            parent: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -653,6 +653,7 @@
 		CE50346021B5799F007573C6 /* SitePlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE50345F21B5799F007573C6 /* SitePlan.swift */; };
 		CE50346721B5DCBE007573C6 /* site-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = CE50346621B5DCBE007573C6 /* site-plan.json */; };
 		CE583A0E2109154500D73C1C /* OrderNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */; };
+		CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */ = {isa = PBXBuildFile; fileRef = CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */; };
 		CE6BFEE52236BF05005C79FB /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE42236BF05005C79FB /* Product.swift */; };
 		CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE72236D133005C79FB /* ProductDimensions.swift */; };
 		CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE92236E191005C79FB /* ProductType.swift */; };
@@ -1589,6 +1590,7 @@
 		CE50345F21B5799F007573C6 /* SitePlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePlan.swift; sourceTree = "<group>"; };
 		CE50346621B5DCBE007573C6 /* site-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-plan.json"; sourceTree = "<group>"; };
 		CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteMapper.swift; sourceTree = "<group>"; };
+		CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-bundled-line-items.json"; sourceTree = "<group>"; };
 		CE6BFEE42236BF05005C79FB /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		CE6BFEE72236D133005C79FB /* ProductDimensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDimensions.swift; sourceTree = "<group>"; };
 		CE6BFEE92236E191005C79FB /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
@@ -2562,6 +2564,7 @@
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
 				CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */,
 				CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */,
+				CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				0313651A28AE60E000EEE571 /* payment-gateway-cod.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
@@ -3357,6 +3360,7 @@
 				DEC2B093297AA60D003923FB /* category-without-data.json in Resources */,
 				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
 				68C87B342862D40E00A99054 /* setting-all-except-countries.json in Resources */,
+				CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */,
 				3158FE6026129ADD00E566B9 /* wcpay-account-none.json in Resources */,
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -712,7 +712,8 @@ extension Networking.OrderItem {
         taxes: CopiableProp<[OrderItemTax]> = .copy,
         total: CopiableProp<String> = .copy,
         totalTax: CopiableProp<String> = .copy,
-        attributes: CopiableProp<[OrderItemAttribute]> = .copy
+        attributes: CopiableProp<[OrderItemAttribute]> = .copy,
+        parent: NullableCopiableProp<Int64> = .copy
     ) -> Networking.OrderItem {
         let itemID = itemID ?? self.itemID
         let name = name ?? self.name
@@ -728,6 +729,7 @@ extension Networking.OrderItem {
         let total = total ?? self.total
         let totalTax = totalTax ?? self.totalTax
         let attributes = attributes ?? self.attributes
+        let parent = parent ?? self.parent
 
         return Networking.OrderItem(
             itemID: itemID,
@@ -743,7 +745,8 @@ extension Networking.OrderItem {
             taxes: taxes,
             total: total,
             totalTax: totalTax,
-            attributes: attributes
+            attributes: attributes,
+            parent: parent
         )
     }
 }

--- a/Networking/Networking/Model/DotcomSitePlugin.swift
+++ b/Networking/Networking/Model/DotcomSitePlugin.swift
@@ -10,6 +10,11 @@ public struct DotcomSitePlugin: Decodable, GeneratedFakeable, GeneratedCopiable 
 
     /// Whether the plugin is activated.
     public let isActive: Bool
+
+    public init(id: String, isActive: Bool) {
+        self.id = id
+        self.isActive = isActive
+    }
 }
 
 /// Defines all of the DotcomSitePlugin CodingKeys.

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -26,6 +26,12 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
 
     public let attributes: [OrderItemAttribute]
 
+    /// Item ID of parent `OrderItem`, if any.
+    ///
+    /// An `OrderItem` can have a parent if, for example, it is a bundled item within a product bundle.
+    ///
+    public let parent: Int64?
+
     /// OrderItem struct initializer.
     ///
     public init(itemID: Int64,
@@ -41,7 +47,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
                 taxes: [OrderItemTax],
                 total: String,
                 totalTax: String,
-                attributes: [OrderItemAttribute]) {
+                attributes: [OrderItemAttribute],
+                parent: Int64?) {
         self.itemID = itemID
         self.name = name
         self.productID = productID
@@ -56,6 +63,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         self.total = total
         self.totalTax = totalTax
         self.attributes = attributes
+        self.parent = parent
     }
 
     /// The public initializer for OrderItem.
@@ -92,6 +100,11 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         let allAttributes = container.failsafeDecodeIfPresent(lossyList: [OrderItemAttribute].self, forKey: .attributes)
         attributes = allAttributes.filter { !$0.name.hasPrefix("_") } // Exclude private items (marked with an underscore)
 
+        // Product Bundle extension properties:
+        // If the order item is part of a product bundle, `bundledBy` is the parent order item (product bundle).
+        // If it's not a bundled item, the API returns an empty string for `bundledBy` and the value will be `nil`.
+        let bundledBy = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundledBy)
+
         // initialize the struct
         self.init(itemID: itemID,
                   name: name,
@@ -106,7 +119,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
                   taxes: taxes,
                   total: total,
                   totalTax: totalTax,
-                  attributes: attributes)
+                  attributes: attributes,
+                  parent: bundledBy)
     }
 
     /// Encodes an order item.
@@ -153,6 +167,7 @@ extension OrderItem {
         case taxes
         case total
         case totalTax       = "total_tax"
+        case bundledBy      = "bundled_by"
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -399,6 +399,21 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(giftCard.code, "SU9F-MGB5-KS5V-EZFT")
         XCTAssertEqual(giftCard.amount, 20)
     }
+
+    func test_order_line_items_parse_bundled_item_parent_correctly() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadOrderWithBundledLineItems())
+
+        // When
+        let lineItems = order.items
+        XCTAssertEqual(lineItems.count, 2)
+
+        // Then
+        let bundleItem = try XCTUnwrap(lineItems.first { $0.itemID == 752 })
+        let bundledItem = try XCTUnwrap(lineItems.first { $0.itemID == 753 })
+        XCTAssertNil(bundleItem.parent)
+        XCTAssertEqual(bundledItem.parent, 752)
+    }
 }
 
 
@@ -487,6 +502,12 @@ private extension OrderMapperTests {
     ///
     func mapLoadOrderWithGiftCards() -> Order? {
         return mapOrder(from: "order-with-gift-cards")
+    }
+
+    /// Returns the Order output upon receiving `order-with-bundled-line-items`
+    ///
+    func mapLoadOrderWithBundledLineItems() -> Order? {
+        return mapOrder(from: "order-with-bundled-line-items")
     }
 
 }

--- a/Networking/NetworkingTests/Responses/order-with-bundled-line-items.json
+++ b/Networking/NetworkingTests/Responses/order-with-bundled-line-items.json
@@ -1,0 +1,252 @@
+{
+    "data": {
+        "id": 357,
+        "parent_id": 0,
+        "status": "processing",
+        "currency": "USD",
+        "version": "7.4.0",
+        "prices_include_tax": false,
+        "date_created": "2023-02-23T13:57:10",
+        "date_modified": "2023-02-23T13:57:25",
+        "discount_total": "0.00",
+        "discount_tax": "0.00",
+        "shipping_total": "0.00",
+        "shipping_tax": "0.00",
+        "cart_tax": "0.00",
+        "total": "120.20",
+        "total_tax": "0.00",
+        "customer_id": 27375286,
+        "order_key": "wc_order_abcd1234",
+        "billing": {
+            "first_name": "Erich",
+            "last_name": "Crist",
+            "company": "",
+            "address_1": "102 Rosalee Orchard",
+            "address_2": "632 O&#8217;Conner Skyway",
+            "city": "Fort Ethelyn",
+            "state": "DF",
+            "postcode": "01089",
+            "country": "MX",
+            "email": "atorresveiga@gmail.com",
+            "phone": "015-993-9088"
+        },
+        "shipping": {
+            "first_name": "Erich",
+            "last_name": "Crist",
+            "company": "",
+            "address_1": "102 Rosalee Orchard",
+            "address_2": "632 O&#8217;Conner Skyway",
+            "city": "Fort Ethelyn",
+            "state": "DF",
+            "postcode": "01089",
+            "country": "MX",
+            "phone": "015-993-9088"
+        },
+        "payment_method": "woocommerce_payments",
+        "payment_method_title": "Visa credit card",
+        "transaction_id": "pi_3MefIVFmpgWy4Lrl1eZCLGrm",
+        "customer_ip_address": "189.216.205.207",
+        "customer_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+        "created_via": "store-api",
+        "customer_note": "",
+        "date_completed": null,
+        "date_paid": "2023-02-23T13:57:25",
+        "cart_hash": "816f3fcdccd585b054222bea8f31272a",
+        "number": "357",
+        "meta_data": [],
+        "line_items": [
+            {
+                "id": 752,
+                "name": "Super Awesome Bundle",
+                "product_id": 190,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "",
+                "subtotal": "59.00",
+                "subtotal_tax": "0.00",
+                "total": "59.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 6658,
+                        "key": "_bundled_items",
+                        "value": [
+                            "5b80e38944256bfe5e9eb074d3bcfff8",
+                            "f8b79dd71d1563311efc117f41121a13",
+                            "36bf426113c0860d2ec75e17c6b8c6d6"
+                        ],
+                        "display_key": "_bundled_items",
+                        "display_value": [
+                            "5b80e38944256bfe5e9eb074d3bcfff8",
+                            "f8b79dd71d1563311efc117f41121a13",
+                            "36bf426113c0860d2ec75e17c6b8c6d6"
+                        ]
+                    },
+                    {
+                        "id": 6659,
+                        "key": "_bundle_group_mode",
+                        "value": "parent",
+                        "display_key": "_bundle_group_mode",
+                        "display_value": "parent"
+                    },
+                    {
+                        "id": 6661,
+                        "key": "_bundle_cart_key",
+                        "value": "1db10061a611971d149015d71d7cb0ff",
+                        "display_key": "_bundle_cart_key",
+                        "display_value": "1db10061a611971d149015d71d7cb0ff"
+                    },
+                    {
+                        "id": 6662,
+                        "key": "_wcsatt_scheme",
+                        "value": "0",
+                        "display_key": "_wcsatt_scheme",
+                        "display_value": "0"
+                    }
+                ],
+                "sku": "",
+                "price": 59,
+                "image": {
+                    "id": "60",
+                    "src": "https://example.com/wp-content/uploads/2023/01/logo-1.jpg"
+                },
+                "parent_name": null,
+                "composite_parent": "",
+                "composite_children": [],
+                "bundled_by": "",
+                "bundled_item_title": "",
+                "bundled_items": [
+                    753
+                ]
+            },
+            {
+                "id": 753,
+                "name": "Beanie with Logo",
+                "product_id": 36,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "clothing-20010",
+                "subtotal": "16.20",
+                "subtotal_tax": "0.00",
+                "total": "16.20",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 6674,
+                        "key": "_bundled_by",
+                        "value": "1db10061a611971d149015d71d7cb0ff",
+                        "display_key": "_bundled_by",
+                        "display_value": "1db10061a611971d149015d71d7cb0ff"
+                    },
+                    {
+                        "id": 6675,
+                        "key": "_bundled_item_id",
+                        "value": "6",
+                        "display_key": "_bundled_item_id",
+                        "display_value": "6"
+                    },
+                    {
+                        "id": 6676,
+                        "key": "_bundled_item_priced_individually",
+                        "value": "yes",
+                        "display_key": "_bundled_item_priced_individually",
+                        "display_value": "yes"
+                    },
+                    {
+                        "id": 6678,
+                        "key": "_bundle_cart_key",
+                        "value": "5b80e38944256bfe5e9eb074d3bcfff8",
+                        "display_key": "_bundle_cart_key",
+                        "display_value": "5b80e38944256bfe5e9eb074d3bcfff8"
+                    },
+                    {
+                        "id": 6679,
+                        "key": "_bundled_item_needs_shipping",
+                        "value": "yes",
+                        "display_key": "_bundled_item_needs_shipping",
+                        "display_value": "yes"
+                    },
+                    {
+                        "id": 6680,
+                        "key": "_wcsatt_scheme",
+                        "value": "0",
+                        "display_key": "_wcsatt_scheme",
+                        "display_value": "0"
+                    },
+                    {
+                        "id": 6729,
+                        "key": "_reduced_stock",
+                        "value": "1",
+                        "display_key": "_reduced_stock",
+                        "display_value": "1"
+                    }
+                ],
+                "sku": "Woo-beanie-logo",
+                "price": 16.2,
+                "image": {
+                    "id": "59",
+                    "src": "https://example.com/wp-content/uploads/2023/01/beanie-with-logo-1.jpg"
+                },
+                "parent_name": null,
+                "composite_parent": "",
+                "composite_children": [],
+                "bundled_by": 752,
+                "bundled_item_title": "Super Awesome Beanie",
+                "bundled_items": []
+            }
+        ],
+        "tax_lines": [],
+        "shipping_lines": [
+            {
+                "id": 757,
+                "method_title": "Free shipping",
+                "method_id": "free_shipping",
+                "instance_id": "9",
+                "total": "0.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 6728,
+                        "key": "Items",
+                        "value": "Hoodie - Blue, Yes &times; 1, Beanie with Logo &times; 1, T-Shirt with Logo &times; 1, Hoodie with Logo &times; 1",
+                        "display_key": "Items",
+                        "display_value": "Hoodie - Blue, Yes &times; 1, Beanie with Logo &times; 1, T-Shirt with Logo &times; 1, Hoodie with Logo &times; 1"
+                    }
+                ]
+            }
+        ],
+        "fee_lines": [],
+        "coupon_lines": [],
+        "refunds": [],
+        "payment_url": "https://example.com/checkout/order-pay/357/?pay_for_order=true&key=wc_order_abcd1234",
+        "is_editable": false,
+        "needs_payment": false,
+        "needs_processing": true,
+        "date_created_gmt": "2023-02-23T13:57:10",
+        "date_modified_gmt": "2023-02-23T13:57:25",
+        "date_completed_gmt": null,
+        "date_paid_gmt": "2023-02-23T13:57:25",
+        "gift_cards": [],
+        "currency_symbol": "$",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders/357"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders"
+                }
+            ],
+            "customer": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/customers/27375286"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -151,6 +151,7 @@ private extension ProductInputTransformer {
                          taxes: [],
                          total: parameters.total,
                          totalTax: "",
-                         attributes: [])
+                         attributes: [],
+                         parent: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -526,7 +526,8 @@ extension ShippingLabelPackagesFormViewModel {
                               taxes: [.init(taxID: 1, subtotal: "2", total: "1.2")],
                               total: "30.00",
                               totalTax: "1.20",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle",
@@ -541,7 +542,8 @@ extension ShippingLabelPackagesFormViewModel {
                               taxes: [.init(taxID: 1, subtotal: "0.4", total: "0")],
                               total: "0.00",
                               totalTax: "0.00",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         return [item1, item2]
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -101,7 +101,8 @@ private extension ShippingLabelSampleData {
                               taxes: [.init(taxID: 1, subtotal: "2", total: "1.2")],
                               total: "30.00",
                               totalTax: "1.20",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle",
@@ -116,7 +117,8 @@ private extension ShippingLabelSampleData {
                               taxes: [.init(taxID: 1, subtotal: "0.4", total: "0")],
                               total: "0.00",
                               totalTax: "0.00",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         return [item1, item2]
     }

--- a/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
@@ -17,7 +17,8 @@ public struct MockOrderItem {
                                   taxes: [OrderItemTax] = [],
                                   total: String = "0",
                                   totalTax: String = "0",
-                                  attributes: [OrderItemAttribute] = []) -> OrderItem {
+                                  attributes: [OrderItemAttribute] = [],
+                                  parent: Int64? = nil) -> OrderItem {
         return OrderItem(itemID: itemID,
                          name: name,
                          productID: productID,
@@ -31,6 +32,7 @@ public struct MockOrderItem {
                          taxes: taxes,
                          total: total,
                          totalTax: totalTax,
-                         attributes: attributes)
+                         attributes: attributes,
+                         parent: nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -645,7 +645,8 @@ private extension OrderDetailsDataSourceTests {
                   taxes: [],
                   total: "1",
                   totalTax: "1",
-                  attributes: [])
+                  attributes: [],
+                  parent: nil)
     }
 
     func makeRefund(refundID: Int64, orderID: Int64, siteID: Int64) -> Refund {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -216,7 +216,8 @@ private extension ProductDetailsCellViewModelTests {
                   taxes: [],
                   total: total,
                   totalTax: "",
-                  attributes: attributes)
+                  attributes: attributes,
+                  parent: nil)
     }
 
     func makeAggregateOrderItem(quantity: Decimal,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
@@ -104,7 +104,8 @@ private extension ProductLoaderViewControllerModelTests {
                   taxes: [],
                   total: "",
                   totalTax: "",
-                  attributes: [])
+                  attributes: [],
+                  parent: nil)
     }
 
     func makeOrderItemRefund(productID: Int64, variationID: Int64) -> OrderItemRefund {

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -215,7 +215,8 @@ extension MockObjectGraph {
             taxes: [],
             total: "\(total)",
             totalTax: "0",
-            attributes: []
+            attributes: [],
+            parent: nil
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -47,6 +47,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
                          taxes: orderItemTaxes,
                          total: total ?? "",
                          totalTax: totalTax ?? "",
-                         attributes: attributes)
+                         attributes: attributes,
+                         parent: nil) // TODO: 8962 - Convert parent property
     }
 }

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -267,7 +267,8 @@ private extension OrdersUpsertUseCaseTests {
                   taxes: taxes,
                   total: "",
                   totalTax: "",
-                  attributes: [])
+                  attributes: [],
+                  parent: nil)
     }
 
     func makeOrder() -> Networking.Order {
@@ -288,6 +289,7 @@ private extension OrdersUpsertUseCaseTests {
               taxes: [],
               total: "-18.00",
               totalTax: "0.00",
-              attributes: attributes)
+              attributes: attributes,
+              parent: nil)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1383,7 +1383,8 @@ private extension OrderStoreTests {
                               taxes: [.init(taxID: 1, subtotal: "2", total: "1.2")],
                               total: "30.00",
                               totalTax: "1.20",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle",
@@ -1398,7 +1399,8 @@ private extension OrderStoreTests {
                               taxes: [.init(taxID: 1, subtotal: "0.4", total: "0")],
                               total: "0.00",
                               totalTax: "0.00",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         return [item1, item2]
     }
@@ -1417,7 +1419,8 @@ private extension OrderStoreTests {
                               taxes: taxes(),
                               total: "64.00",
                               totalTax: "4.00",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle 2",
@@ -1432,7 +1435,8 @@ private extension OrderStoreTests {
                               taxes: taxes(),
                               total: "30.40",
                               totalTax: "0.40",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         let item3 = OrderItem(itemID: 23,
                               name: "Some new product",
@@ -1447,7 +1451,8 @@ private extension OrderStoreTests {
                               taxes: taxes(),
                               total: "140.40",
                               totalTax: "10.40",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         return [item1, item2, item3]
     }
@@ -1466,7 +1471,8 @@ private extension OrderStoreTests {
                               taxes: taxesMutated(),
                               total: "64.00",
                               totalTax: "4.00",
-                              attributes: [])
+                              attributes: [],
+                              parent: nil)
 
         return [item1]
     }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -1093,6 +1093,7 @@ private extension ProductVariationStoreTests {
               taxes: [.init(taxID: 1, subtotal: "2", total: "1.2")],
               total: "30.00",
               totalTax: "1.20",
-              attributes: [])
+              attributes: [],
+              parent: nil)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -527,7 +527,8 @@ private extension ReceiptStoreTests {
                            taxes: [],
                            total: total,
                            totalTax: "",
-                           attributes: [])
+                           attributes: [],
+                           parent: nil)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8962
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Networking layer for displaying a product bundle's hierarchy in order details. It adds a `parent` property to `OrderItem` so we can identify and group all child items of a product bundle in an order, and adjust how they appear.

### Changes

* Adds an initializer to `DotcomSitePlugin` to resolve an error running `rake generate`: `/CodeGeneration/Sourcery/Fakes/Fakes.swifttemplate: SwiftTemplate/main.swift:70: Fatal error: Couldn't find initializer for type: DotcomSitePlugin`. (model added in #9731, FYI @jaclync)
* Adds a `parent` property to the `OrderItem` model. When an order line item is a bundled item, the parent line item ID is provided in the `bundled_by` field and set as the `parent`. (This property will also be able to handle other scenarios where an order item has a parent, e.g. a component in a composite product.)
* Updates generated `fake()` and `copy()` methods, and anywhere `OrderItem` is used.
* Adds a new mock for an order with a product bundle and a unit test in `OrderMapperTests` to confirm the `bundled_by` field is parsed correctly.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass. Build and run the app and confirm the order list loads in the Orders tab, and order details load as expected (no decoding errors).


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
