### PR TITLE
[Store creation] Local notification to remind to subscribe for free trial

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
@@ -2,10 +2,12 @@ import SwiftUI
 
 /// Hosting controller that wraps the `StoreNameForm`.
 final class StoreNameFormHostingController: UIHostingController<StoreNameForm> {
-    init(onContinue: @escaping (String) -> Void,
+    init(prefillStoreName: String? = nil,
+         onContinue: @escaping (String) -> Void,
          onClose: @escaping () -> Void,
          onSupport: @escaping () -> Void) {
-        super.init(rootView: StoreNameForm(onContinue: onContinue,
+        super.init(rootView: StoreNameForm(prefillStoreName: prefillStoreName,
+                                           onContinue: onContinue,
                                            onClose: onClose,
                                            onSupport: onSupport))
     }
@@ -28,7 +30,17 @@ struct StoreNameForm: View {
     let onClose: () -> Void
     let onSupport: () -> Void
 
-    @State private var name: String = ""
+    @State private var name: String
+
+    init(prefillStoreName: String? = nil,
+         onContinue: @escaping (String) -> Void,
+         onClose: @escaping () -> Void,
+         onSupport: @escaping () -> Void) {
+        self.name = prefillStoreName ?? ""
+        self.onContinue = onContinue
+        self.onClose = onClose
+        self.onSupport = onSupport
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -197,6 +197,11 @@ private extension StoreCreationCoordinator {
         }
         navigationController.pushViewController(storeNameForm, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .storeName))
+
+        // Navigate to profiler question screen when store name is prefilled upon launching app from local notification
+        if let prefillStoreName {
+            continueAfterEnteringStoreName(prefillStoreName)
+        }
     }
 
     @MainActor

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -7,6 +7,10 @@ import protocol Storage.StorageManagerType
 
 /// Coordinates navigation for store creation flow, with the assumption that the app is already authenticated with a WPCOM user.
 final class StoreCreationCoordinator: Coordinator {
+    enum LocalNotificationUserInfoKey {
+        static let storeName = "storeName"
+    }
+
     /// Navigation source to store creation.
     enum Source {
         /// Initiated from the logged-out state.

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -52,7 +52,6 @@ final class StoreCreationCoordinator: Coordinator {
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
     private let featureFlagService: FeatureFlagService
     private let localNotificationScheduler: LocalNotificationScheduler
-    private let pushNotesManager: PushNotesManager
     private var jetpackCheckRetryInterval: TimeInterval {
         isFreeTrialCreation ? 10 : 5
     }
@@ -82,7 +81,6 @@ final class StoreCreationCoordinator: Coordinator {
         self.featureFlagService = featureFlagService
         self.isFreeTrialCreation = featureFlagService.isFeatureFlagEnabled(.freeTrial)
         self.localNotificationScheduler = .init(pushNotesManager: pushNotesManager, stores: stores)
-        self.pushNotesManager = pushNotesManager
 
         Task { @MainActor in
             if let purchasesManager {
@@ -197,8 +195,6 @@ private extension StoreCreationCoordinator {
         }
         navigationController.pushViewController(storeNameForm, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .storeName))
-
-        pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false, onCompletion: nil)
 
         // Navigate to profiler question screen when store name is prefilled upon launching app from local notification
         if let prefillStoreName {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -512,6 +512,7 @@ private extension StoreCreationCoordinator {
             let freeTrialResult = await enableFreeTrial(siteID: siteResult.siteID, profilerData: profilerData)
             switch freeTrialResult {
             case .success:
+                cancelLocalNotificationToSubscribeFreeTrial(storeName: storeName)
                 // Wait for jetpack to be installed
                 DDLogInfo("🟢 Free trial enabled on site. Waiting for jetpack to be installed...")
                 waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteResult.siteID, expectedStoreName: siteResult.name)

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -160,7 +160,7 @@ private extension StoreCreationCoordinator {
 
         let isProfilerEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationM3Profiler)
         let isFreeTrialEnabled = featureFlagService.isFeatureFlagEnabled(.freeTrial)
-        let storeNameForm = StoreNameFormHostingController { [weak self] storeName in
+        let continueAfterEnteringStoreName = { [weak self] storeName in
             if isProfilerEnabled {
                 /// `storeCreationM3Profiler` is currently disabled.
                 /// Before enabling it again, make sure the onboarding questions are properly sent on the trial flow around line `343`.
@@ -179,6 +179,9 @@ private extension StoreCreationCoordinator {
                                              planToPurchase: planToPurchase)
                 }
             }
+        }
+        let storeNameForm = StoreNameFormHostingController { storeName in
+            continueAfterEnteringStoreName(storeName)
         } onClose: { [weak self] in
             self?.showDiscardChangesAlert(flow: .native)
         } onSupport: { [weak self] in

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -7,10 +7,6 @@ import protocol Storage.StorageManagerType
 
 /// Coordinates navigation for store creation flow, with the assumption that the app is already authenticated with a WPCOM user.
 final class StoreCreationCoordinator: Coordinator {
-    enum LocalNotificationUserInfoKey {
-        static let storeName = "storeName"
-    }
-
     /// Navigation source to store creation.
     enum Source {
         /// Initiated from the logged-out state.
@@ -926,7 +922,7 @@ private extension StoreCreationCoordinator {
     func scheduleLocalNotificationToSubscribeFreeTrial(storeName: String) {
         guard let notification = LocalNotification(scenario: LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName),
                                                    stores: stores,
-                                                   userInfo: [LocalNotificationUserInfoKey.storeName: storeName]) else {
+                                                   userInfo: [LocalNotification.UserInfoKey.storeName: storeName]) else {
             return
         }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -910,6 +910,27 @@ private extension StoreCreationCoordinator {
     func cancelLocalNotificationWhenStoreIsReady() {
         localNotificationScheduler.cancel(scenario: Constants.LocalNotificationScenario.storeCreationComplete)
     }
+
+    func scheduleLocalNotificationToSubscribeFreeTrial(storeName: String) {
+        guard let notification = LocalNotification(scenario: LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName),
+                                                   stores: stores,
+                                                   userInfo: [LocalNotificationUserInfoKey.storeName: storeName]) else {
+            return
+        }
+
+        cancelLocalNotificationToSubscribeFreeTrial(storeName: storeName)
+        Task {
+            await localNotificationScheduler.schedule(notification: notification,
+                                                      // Notify after 24 hours
+                                                      trigger: UNTimeIntervalNotificationTrigger(timeInterval: 24 * 60 * 60,
+                                                                                                 repeats: false),
+                                                      remoteFeatureFlag: .oneDayAfterStoreCreationNameWithoutFreeTrial)
+        }
+    }
+
+    func cancelLocalNotificationToSubscribeFreeTrial(storeName: String) {
+        localNotificationScheduler.cancel(scenario: LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName))
+    }
 }
 
 private extension StoreCreationCoordinator {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -198,6 +198,8 @@ private extension StoreCreationCoordinator {
         navigationController.pushViewController(storeNameForm, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .storeName))
 
+        pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false, onCompletion: nil)
+
         // Navigate to profiler question screen when store name is prefilled upon launching app from local notification
         if let prefillStoreName {
             continueAfterEnteringStoreName(prefillStoreName)

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -34,7 +34,7 @@ struct LocalNotification {
             case .storeCreationComplete:
                 return "store_creation_complete"
             case .oneDayAfterStoreCreationNameWithoutFreeTrial:
-                return "one_day_after_store_creation_name_without_free_trial"
+                return IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
             case let .oneDayBeforeFreeTrialExpires(siteID, _):
                 return IdentifierPrefix.oneDayBeforeFreeTrialExpires + "\(siteID)"
             case .oneDayAfterFreeTrialExpires(let siteID):
@@ -53,6 +53,7 @@ struct LocalNotification {
         }
 
         enum IdentifierPrefix {
+            static let oneDayAfterStoreCreationNameWithoutFreeTrial = "one_day_after_store_creation_name_without_free_trial"
             static let oneDayBeforeFreeTrialExpires = "one_day_before_free_trial_expires"
             static let oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"
         }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -34,11 +34,11 @@ struct LocalNotification {
             case .storeCreationComplete:
                 return "store_creation_complete"
             case .oneDayAfterStoreCreationNameWithoutFreeTrial:
-                return IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
+                return Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial
             case let .oneDayBeforeFreeTrialExpires(siteID, _):
-                return IdentifierPrefix.oneDayBeforeFreeTrialExpires + "\(siteID)"
+                return Identifier.Prefix.oneDayBeforeFreeTrialExpires + "\(siteID)"
             case .oneDayAfterFreeTrialExpires(let siteID):
-                return IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(siteID)"
+                return Identifier.Prefix.oneDayAfterFreeTrialExpires + "\(siteID)"
             case .loginSiteAddressError:
                 return "site_address_error"
             case .invalidEmailFromSiteAddressLogin:
@@ -52,18 +52,20 @@ struct LocalNotification {
             }
         }
 
-        enum IdentifierPrefix {
+        enum Identifier {
+            enum Prefix {
+                static let oneDayBeforeFreeTrialExpires = "one_day_before_free_trial_expires"
+                static let oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"
+            }
             static let oneDayAfterStoreCreationNameWithoutFreeTrial = "one_day_after_store_creation_name_without_free_trial"
-            static let oneDayBeforeFreeTrialExpires = "one_day_before_free_trial_expires"
-            static let oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"
         }
 
         /// Helper method to remove postfix from notification identifiers if needed.
         static func identifierForAnalytics(_ identifier: String) -> String {
-            if identifier.hasPrefix(IdentifierPrefix.oneDayBeforeFreeTrialExpires) {
-                return IdentifierPrefix.oneDayBeforeFreeTrialExpires
-            } else if identifier.hasPrefix(IdentifierPrefix.oneDayAfterFreeTrialExpires) {
-                return IdentifierPrefix.oneDayAfterFreeTrialExpires
+            if identifier.hasPrefix(Identifier.Prefix.oneDayBeforeFreeTrialExpires) {
+                return Identifier.Prefix.oneDayBeforeFreeTrialExpires
+            } else if identifier.hasPrefix(Identifier.Prefix.oneDayAfterFreeTrialExpires) {
+                return Identifier.Prefix.oneDayAfterFreeTrialExpires
             }
             return identifier
         }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -7,6 +7,7 @@ struct LocalNotification {
     let body: String
     let scenario: Scenario
     let actions: CategoryActions?
+    let userInfo: [AnyHashable: Any]
 
     /// A category of actions in a notification.
     struct CategoryActions {
@@ -78,7 +79,8 @@ extension LocalNotification {
     init?(scenario: Scenario,
           stores: StoresManager = ServiceLocator.stores,
           timeZone: TimeZone = .current,
-          locale: Locale = .current) {
+          locale: Locale = .current,
+          userInfo: [AnyHashable: Any] = [:]) {
         /// Name to display in notifications
         let name: String = {
             let sessionManager = stores.sessionManager
@@ -125,7 +127,8 @@ extension LocalNotification {
         self.init(title: title,
                   body: body,
                   scenario: scenario,
-                  actions: actions)
+                  actions: actions,
+                  userInfo: userInfo)
     }
 }
 

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -74,6 +74,11 @@ struct LocalNotification {
             return ""
         }
     }
+
+    /// Holds `userInfo` dictionary keys
+    enum UserInfoKey {
+        static let storeName = "storeName"
+    }
 }
 
 extension LocalNotification {

--- a/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
@@ -34,7 +34,7 @@ final class LocalNotificationScheduler {
             await pushNotesManager.requestLocalNotificationIfNeeded(notification, trigger: trigger)
         } else {
             await pushNotesManager.requestLocalNotification(notification,
-                                                      trigger: trigger)
+                                                            trigger: trigger)
         }
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -315,6 +315,7 @@ extension PushNotificationsManager {
         let content = UNMutableNotificationContent()
         content.title = notification.title
         content.body = notification.body
+        content.userInfo = notification.userInfo
 
         if let categoryAndActions = notification.actions {
             let categoryIdentifier = categoryAndActions.category.rawValue

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -342,7 +342,7 @@ private extension AppCoordinator {
             }
             openPlansPage(siteID: siteID)
         case let identifier where identifier.hasPrefix(oneDayAfterStoreCreationNameWithoutFreeTrialIdentifier):
-            let storeNameKey = StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName
+            let storeNameKey = LocalNotification.UserInfoKey.storeName
             guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
                   let storeName = response.notification.request.content.userInfo.string(forKey: storeNameKey) else {
                 return

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -324,6 +324,7 @@ private extension AppCoordinator {
     }
 
     func handleLocalNotificationResponse(_ response: UNNotificationResponse) {
+        let oneDayAfterStoreCreationNameWithoutFreeTrialIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
         let oneDayBeforeFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayBeforeFreeTrialExpires
         let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires
 
@@ -340,6 +341,13 @@ private extension AppCoordinator {
                 return
             }
             openPlansPage(siteID: siteID)
+        case let identifier where identifier.hasPrefix(oneDayAfterStoreCreationNameWithoutFreeTrialIdentifier):
+            let storeNameKey = StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName
+            guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+                  let storeName = response.notification.request.content.userInfo.string(forKey: storeNameKey) else {
+                return
+            }
+            startStoreCreationFlow(storeName: storeName)
         default:
             // TODO: 9665 - handle actions on other local notifications
             break

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -395,6 +395,15 @@ private extension AppCoordinator {
             return
         }
 
+        // Do nothing if any one of the store creation screens is being presented already.
+        if navigationController.topViewController is StoreNameFormHostingController ||
+            navigationController.topViewController is StoreCreationCategoryQuestionHostingController ||
+            navigationController.topViewController is StoreCreationSellingStatusQuestionHostingController ||
+            navigationController.topViewController is StoreCreationCountryQuestionHostingController ||
+            navigationController.topViewController is FreeTrialSummaryHostingController {
+            return
+        }
+
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    prefillStoreName: storeName,

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -324,7 +324,6 @@ private extension AppCoordinator {
     }
 
     func handleLocalNotificationResponse(_ response: UNNotificationResponse) {
-        let oneDayAfterStoreCreationNameWithoutFreeTrialIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
         let oneDayBeforeFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayBeforeFreeTrialExpires
         let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires
 
@@ -341,7 +340,7 @@ private extension AppCoordinator {
                 return
             }
             openPlansPage(siteID: siteID)
-        case let identifier where identifier.hasPrefix(oneDayAfterStoreCreationNameWithoutFreeTrialIdentifier):
+        case LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial:
             let storeNameKey = LocalNotification.UserInfoKey.storeName
             guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
                   let storeName = response.notification.request.content.userInfo.string(forKey: storeNameKey) else {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -24,11 +24,13 @@ final class AppCoordinator {
     private let pushNotesManager: PushNotesManager
     private let featureFlagService: FeatureFlagService
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
+    private let purchasesManager: InAppPurchasesForWPComPlansProtocol?
 
     private var storePickerCoordinator: StorePickerCoordinator?
     private var authStatesSubscription: AnyCancellable?
     private var localNotificationResponsesSubscription: AnyCancellable?
     private var isLoggedIn: Bool = false
+    private var storeCreationCoordinator: StoreCreationCoordinator?
 
     /// Checks on whether the Apple ID credential is valid when the app is logged in and becomes active.
     ///
@@ -42,7 +44,8 @@ final class AppCoordinator {
          analytics: Analytics = ServiceLocator.analytics,
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         purchasesManager: InAppPurchasesForWPComPlansProtocol? = nil) {
         self.window = window
         self.tabBarController = {
             let storyboard = UIStoryboard(name: "Main", bundle: nil) // Main is the name of storyboard
@@ -59,6 +62,7 @@ final class AppCoordinator {
         self.loggedOutAppSettings = loggedOutAppSettings
         self.pushNotesManager = pushNotesManager
         self.featureFlagService = featureFlagService
+        self.purchasesManager = purchasesManager
         self.switchStoreUseCase = SwitchStoreUseCase(stores: stores, storageManager: storageManager)
 
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
@@ -350,6 +354,34 @@ private extension AppCoordinator {
             let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .localNotification)
             self?.window.rootViewController?.topmostPresentedViewController.present(controller, animated: true)
         }
+    }
+
+    func startStoreCreationFlow(storeName: String) {
+        // Fetch the navigation controller for store selected or not selected cases
+        guard let navigationController: UINavigationController = {
+            // If logged in with a valid store, tab bar will have a viewcontroller selected.
+            if let navigationController = tabBarController.selectedViewController as? UINavigationController {
+                return navigationController
+            } // If logged in with no valid stores, store picker will be displayed.
+            else if let navigationController = window.rootViewController?.topmostPresentedViewController as? UINavigationController {
+                return navigationController
+            } else {
+                return nil
+            }
+        }() else {
+            return
+        }
+
+        let coordinator = StoreCreationCoordinator(source: .storePicker,
+                                                   navigationController: navigationController,
+                                                   prefillStoreName: storeName,
+                                                   storageManager: storageManager,
+                                                   stores: stores,
+                                                   featureFlagService: featureFlagService,
+                                                   purchasesManager: purchasesManager,
+                                                   pushNotesManager: pushNotesManager)
+        self.storeCreationCoordinator = coordinator
+        coordinator.start()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -364,6 +364,10 @@ private extension AppCoordinator {
     }
 
     func startStoreCreationFlow(storeName: String) {
+        guard stores.isAuthenticated else {
+            return
+        }
+
         // Fetch the navigation controller for store selected or not selected cases
         guard let navigationController: UINavigationController = {
             // If logged in with a valid store, tab bar will have a viewcontroller selected.

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -325,8 +325,8 @@ private extension AppCoordinator {
 
     func handleLocalNotificationResponse(_ response: UNNotificationResponse) {
         let identifier = response.notification.request.identifier
-        let oneDayBeforeFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayBeforeFreeTrialExpires
-        let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires
+        let oneDayBeforeFreeTrialExpiresIdentifier = LocalNotification.Scenario.Identifier.Prefix.oneDayBeforeFreeTrialExpires
+        let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires
 
         guard response.actionIdentifier != UNNotificationDismissActionIdentifier else {
             analytics.track(.localNotificationDismissed, withProperties: [
@@ -352,7 +352,7 @@ private extension AppCoordinator {
                 return
             }
             openPlansPage(siteID: siteID)
-        case LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial:
+        case LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial:
             let storeNameKey = LocalNotification.UserInfoKey.storeName
             guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
                   let storeName = response.notification.request.content.userInfo.string(forKey: storeNameKey) else {

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -398,7 +398,7 @@ final class AppCoordinatorTests: XCTestCase {
         }
     }
 
-    // MARK: - Notification to subscribe to free trail after entering store name
+    // MARK: - Notification to subscribe to free trial after entering store name
     func test_store_creation_flow_starts_upon_tapping_oneDayAfterStoreCreationNameWithoutFreeTrial_notification_when_valid_store_is_selected_already() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -425,7 +425,7 @@ final class AppCoordinatorTests: XCTestCase {
                                           featureFlagService: featureFlagService,
                                           purchasesManager: WebPurchasesForWPComPlans(stores: stores))
 
-        let notificationUserInfo = [StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName: "sampleStoreName"]
+        let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
         let identifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
         let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: UNNotificationDefaultActionIdentifier,
                                                               requestIdentifier: identifier,
@@ -469,7 +469,7 @@ final class AppCoordinatorTests: XCTestCase {
                                           featureFlagService: featureFlagService,
                                           purchasesManager: WebPurchasesForWPComPlans(stores: stores))
 
-        let notificationUserInfo = [StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName: "sampleStoreName"]
+        let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
         let identifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
         let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: UNNotificationDefaultActionIdentifier,
                                                               requestIdentifier: identifier,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -418,7 +418,7 @@ final class AppCoordinatorTests: XCTestCase {
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.localNotificationDismissed.rawValue }))
         let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-        assertEqual(LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
+        assertEqual(LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
     }
 
     func test_local_notification_tap_is_tracked() throws {
@@ -441,7 +441,7 @@ final class AppCoordinatorTests: XCTestCase {
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.localNotificationTapped.rawValue }))
         let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-        assertEqual(LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
+        assertEqual(LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
     }
 
     // MARK: - Notification to subscribe to free trial after entering store name
@@ -472,7 +472,7 @@ final class AppCoordinatorTests: XCTestCase {
                                           purchasesManager: WebPurchasesForWPComPlans(stores: stores))
 
         let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
-        let identifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
+        let identifier = LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial
         let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: UNNotificationDefaultActionIdentifier,
                                                               requestIdentifier: identifier,
                                                               notificationUserInfo: notificationUserInfo))
@@ -516,7 +516,7 @@ final class AppCoordinatorTests: XCTestCase {
                                           purchasesManager: WebPurchasesForWPComPlans(stores: stores))
 
         let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
-        let identifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
+        let identifier = LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial
         let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: UNNotificationDefaultActionIdentifier,
                                                               requestIdentifier: identifier,
                                                               notificationUserInfo: notificationUserInfo))

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -425,10 +425,11 @@ final class AppCoordinatorTests: XCTestCase {
                                           featureFlagService: featureFlagService,
                                           purchasesManager: WebPurchasesForWPComPlans(stores: stores))
 
-        let storeName = "SampleStoreName"
+        let notificationUserInfo = [StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName: "sampleStoreName"]
+        let identifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
         let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: UNNotificationDefaultActionIdentifier,
-                                                              requestIdentifier: LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial,
-                                                              notificationUserInfo: [StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName: storeName]))
+                                                              requestIdentifier: identifier,
+                                                              notificationUserInfo: notificationUserInfo))
 
         stores.whenReceivingAction(ofType: PaymentAction.self) { action in
             if case let .loadPlan(_, completion) = action {
@@ -468,10 +469,11 @@ final class AppCoordinatorTests: XCTestCase {
                                           featureFlagService: featureFlagService,
                                           purchasesManager: WebPurchasesForWPComPlans(stores: stores))
 
-        let storeName = "SampleStoreName"
+        let notificationUserInfo = [StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName: "sampleStoreName"]
+        let identifier = LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial
         let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: UNNotificationDefaultActionIdentifier,
-                                                              requestIdentifier: LocalNotification.Scenario.IdentifierPrefix.oneDayAfterStoreCreationNameWithoutFreeTrial,
-                                                              notificationUserInfo: [StoreCreationCoordinator.LocalNotificationUserInfoKey.storeName: storeName]))
+                                                              requestIdentifier: identifier,
+                                                              notificationUserInfo: notificationUserInfo))
 
         stores.whenReceivingAction(ofType: PaymentAction.self) { action in
             if case let .loadPlan(_, completion) = action {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -10,6 +10,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isStoreCreationMVPEnabled: Bool
     private let isStoreCreationM2Enabled: Bool
     private let isStoreCreationM2WithInAppPurchasesEnabled: Bool
+    private let isStoreCreationM3ProfilerEnabled: Bool
     private let isDomainSettingsEnabled: Bool
     private let isSupportRequestEnabled: Bool
     private let isAddCouponToOrderEnabled: Bool
@@ -34,6 +35,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isStoreCreationMVPEnabled: Bool = true,
          isStoreCreationM2Enabled: Bool = false,
          isStoreCreationM2WithInAppPurchasesEnabled: Bool = false,
+         isStoreCreationM3ProfilerEnabled: Bool = false,
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          isAddCouponToOrderEnabled: Bool = false,
@@ -57,6 +59,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isStoreCreationMVPEnabled = isStoreCreationMVPEnabled
         self.isStoreCreationM2Enabled = isStoreCreationM2Enabled
         self.isStoreCreationM2WithInAppPurchasesEnabled = isStoreCreationM2WithInAppPurchasesEnabled
+        self.isStoreCreationM3ProfilerEnabled = isStoreCreationM3ProfilerEnabled
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isAddCouponToOrderEnabled = isAddCouponToOrderEnabled
@@ -92,6 +95,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isStoreCreationM2Enabled
         case .storeCreationM2WithInAppPurchasesEnabled:
             return isStoreCreationM2WithInAppPurchasesEnabled
+        case .storeCreationM3Profiler:
+            return isStoreCreationM3ProfilerEnabled
         case .domainSettings:
             return isDomainSettingsEnabled
         case .supportRequests:

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -604,7 +604,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let requests = await mockCenter.pendingNotificationRequests()
         assertEqual(1, requests.count)
         let firstRequest = try XCTUnwrap(requests.first)
-        assertEqual(firstRequest.identifier, LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(siteID)")
+        assertEqual(firstRequest.identifier, LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires + "\(siteID)")
     }
 
     func test_requestLocalNotificationIfNeeded_skips_adding_notification_with_the_same_idenfier() async throws {
@@ -628,7 +628,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let requests = await mockCenter.pendingNotificationRequests()
         assertEqual(1, requests.count)
         let firstRequest = try XCTUnwrap(requests.first)
-        assertEqual(firstRequest.identifier, LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(siteID)")
+        assertEqual(firstRequest.identifier, LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires + "\(siteID)")
     }
 
     func test_requestLocalNotification_tracks_local_notification_scheduled() async throws {
@@ -651,7 +651,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.localNotificationScheduled.rawValue }))
         let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-        assertEqual(LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
+        assertEqual(LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
     }
 
     func test_cancelLocalNotification_tracks_local_notification_canceled() throws {
@@ -695,7 +695,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.localNotificationCanceled.rawValue }))
         let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-        assertEqual(LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
+        assertEqual(LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
@@ -111,8 +111,8 @@ final class StorePlanSynchronizerTests: XCTestCase {
         }
         let ids = pushNotesManager.requestedLocalNotificationsIfNeeded.map(\.scenario.identifier)
         let expectedIDs = [
-            LocalNotification.Scenario.IdentifierPrefix.oneDayBeforeFreeTrialExpires + "\(sampleSiteID)",
-            LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(sampleSiteID)",
+            LocalNotification.Scenario.Identifier.Prefix.oneDayBeforeFreeTrialExpires + "\(sampleSiteID)",
+            LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires + "\(sampleSiteID)",
         ]
         assertEqual(expectedIDs, ids)
 
@@ -157,7 +157,7 @@ final class StorePlanSynchronizerTests: XCTestCase {
         }
         let ids = pushNotesManager.requestedLocalNotificationsIfNeeded.map(\.scenario.identifier)
         let expectedIDs = [
-            LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(sampleSiteID)",
+            LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires + "\(sampleSiteID)",
         ]
         assertEqual(expectedIDs, ids)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9732
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Schedules a local notification to remind the user to subscribe for a free trial. The notification is scheduled if the user enters a store name but fails to subscribe for a free trial.

*Changes*
- Adds a way to prefill store name in the `StoreNameForm`
- Ability to add `userInfo` in local notification which can be retrieved for later use
- Schedules local notification if user doesn't finish free trial subscription after entering store name
- Cancels local notification after a successful free trial subscription
- Upon tapping the local notification, launches store creation flow and navigates to profiler questions after prefilling the store name (Gets the name string from `userInfo`)

## Testing instructions
Prerequisites: since the remote feature flags are still not deployed and remain false, some code changes are required to test this PR:
- In `LocalNotificationScheduler.schedule`, remove the whole condition on `isRemoteFeatureFlagEnabled(remoteFeatureFlag)` so that the remote feature flag isn't used
- Change the `timeInterval` in [line](https://github.com/woocommerce/woocommerce-ios/pull/9749/files#diff-62176a23ee8f8679108c1edf59138f7920594824caee60a9bc48895654f982dfR941) and set it as 30 secs to ease the testing process. 
---

**Creating store from sign-up store creation flow**
- Launch the app, skip the prologue, and tap on `Get Started`
- Enter an email and choose a password to create a new WPCOM account
- You will see the "Add you first store" screen. 
- Tap on "Add a Store" -> "Create a new store" to start the store creation flow
- You will be asked for notification permission. Allow it.
- Enter a store name and tap "Continue"
- Kill the app after you land on the profiler question screen (What's your business about?)
- Wait for 30 seconds, and you should get a notification asking you to subscribe for a free trial. The notification will be delivered silently without sound/banner. Check the notification center from the lock screen.
- Tapping on the notification should launch the app and open the store creation flow
- Note that the previously entered store name is prefilled, and you are navigated to the profile screen

**Existing user creating a store from Settings -> Store picker**
- Launch the app, and login into the app with an existing WPCOM account and select a store
- Navigate to "Select Store" screen by tapping on "Menu" -> "Store name section at the top"
- Tap on "+ Add a Store" -> "Create a new store" to start the store creation flow
- You will be asked for notification permission. Allow it.
- Enter a store name and tap "Continue"
- Kill the app after you land on the profiler question screen (What's your business about?)
- Wait for 30 seconds, and you should get a notification asking you to subscribe for a free trial
- Tapping on the notification should launch the app and open the store creation flow
- Note that the previously entered store name is prefilled, and you are navigated to the profile screen

**Users completing the free trial subscription shouldn't get notified**
- As we will be testing by creating a store and subscribing to free trial we shall increase the timeInterval before of this notification
- Increase the `timeInterval` in [line](https://github.com/woocommerce/woocommerce-ios/pull/9749/files#diff-62176a23ee8f8679108c1edf59138f7920594824caee60a9bc48895654f982dfR941) and set it as 3 mins to ease the testing process. 
- Now, launch the app, skip the prologue, and tap on `Get Started`
- Enter an email and choose a password to create a new WPCOM account
- You will see the "Add you first store" screen. 
- Tap on "Add a Store" -> "Create a new store" to start the store creation flow
- You will be asked for notification permission. Allow it.
- Enter a store name and tap "Continue"
- Tap continue until you reach "Free trial subscription screen"
- Tap "Try For Free" and wait for at least 1 min to ensure that the free trial subscription is successful.
- Kill the app and wait for 3 mins
- Ensure that you didn't receive any notification asking you to subscribe to free trial.

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/90345e19-82c0-4463-86f4-24fdfddf8f3f" width="320"/>

https://github.com/woocommerce/woocommerce-ios/assets/524475/a1775b34-f86d-4c49-9086-c0600f318eae


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
