### PR TITLE
[Mobile Payments] Unit tests for Tap to Pay auto reconnection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -7,7 +7,12 @@ import Yosemite
 
 /// Facilitates connecting to a card reader
 ///
-final class BuiltInCardReaderConnectionController {
+
+protocol BuiltInCardReaderConnectionControlling {
+    func searchAndConnect(onCompletion: @escaping (Result<CardReaderConnectionResult, Error>) -> Void)
+}
+
+final class BuiltInCardReaderConnectionController: BuiltInCardReaderConnectionControlling {
     private enum ControllerState {
         /// Initial state of the controller
         ///
@@ -102,7 +107,7 @@ final class BuiltInCardReaderConnectionController {
         }
     }
 
-    var allowTermsOfServiceAcceptance: Bool
+    private var allowTermsOfServiceAcceptance: Bool
 
     init(
         forSiteID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
@@ -1,7 +1,14 @@
 import Foundation
 import Yosemite
 
-class CardReaderSupportDeterminer {
+protocol CardReaderSupportDetermining {
+    func connectedReader() async -> CardReader?
+    func hasPreviousTapToPayUsage() async -> Bool
+    func siteSupportsLocalMobileReader() -> Bool
+    func deviceSupportsLocalMobileReader() async -> Bool
+}
+
+final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
     private let stores: StoresManager
     private let configuration: CardPresentPaymentsConfiguration
     private let siteID: Int64

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -589,6 +589,9 @@
 		03B9E5212A13971F005C77F5 /* TapToPayReconnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B9E5202A13971F005C77F5 /* TapToPayReconnectionController.swift */; };
 		03B9E5272A14EA89005C77F5 /* CardReaderSupportDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B9E5262A14EA89005C77F5 /* CardReaderSupportDeterminer.swift */; };
 		03B9E5292A14F136005C77F5 /* SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B9E5282A14F136005C77F5 /* SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift */; };
+		03B9E52B2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B9E52A2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift */; };
+		03B9E52D2A150D16005C77F5 /* MockBuiltInCardReaderConnectionControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B9E52C2A150D16005C77F5 /* MockBuiltInCardReaderConnectionControllerFactory.swift */; };
+		03B9E52F2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B9E52E2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift */; };
 		03BB9EA5292E2D0C00251E9E /* CardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */; };
 		03BB9EA7292E50B600251E9E /* CardPresentModalSelectSearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
@@ -2873,6 +2876,9 @@
 		03B9E5202A13971F005C77F5 /* TapToPayReconnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayReconnectionController.swift; sourceTree = "<group>"; };
 		03B9E5262A14EA89005C77F5 /* CardReaderSupportDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSupportDeterminer.swift; sourceTree = "<group>"; };
 		03B9E5282A14F136005C77F5 /* SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift; sourceTree = "<group>"; };
+		03B9E52A2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayReconnectionControllerTests.swift; sourceTree = "<group>"; };
+		03B9E52C2A150D16005C77F5 /* MockBuiltInCardReaderConnectionControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBuiltInCardReaderConnectionControllerFactory.swift; sourceTree = "<group>"; };
+		03B9E52E2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardReaderSupportDeterminer.swift; sourceTree = "<group>"; };
 		03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionController.swift; sourceTree = "<group>"; };
 		03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalSelectSearchType.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
@@ -5886,6 +5892,7 @@
 				03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */,
 				03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */,
 				039B7E6629F2855B00E21EF4 /* InPersonPaymentsViewModelTests.swift */,
+				03B9E52A2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -7356,6 +7363,8 @@
 				A650BE852578E76600C655E0 /* MockStorageManager.swift */,
 				A650BE842578E76600C655E0 /* MockStorageManager+Sample.swift */,
 				B56C721321B5BBC000E5E85B /* MockStoresManager.swift */,
+				03B9E52C2A150D16005C77F5 /* MockBuiltInCardReaderConnectionControllerFactory.swift */,
+				03B9E52E2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift */,
 				B53A569A21123E8E000776C9 /* MockTableView.swift */,
 				B555531221B57E8800449E71 /* MockUserNotificationsCenterAdapter.swift */,
 				3198A1E72694DC7200597213 /* MockKnownReadersProvider.swift */,
@@ -12420,6 +12429,7 @@
 				02AB40822784297C00929CF3 /* ProductTableViewCellViewModelTests.swift in Sources */,
 				02829BAA288FA8B300951E1E /* MockUserNotification.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
+				03B9E52D2A150D16005C77F5 /* MockBuiltInCardReaderConnectionControllerFactory.swift in Sources */,
 				3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */,
 				DEC51B04276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift in Sources */,
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
@@ -12442,6 +12452,7 @@
 				682210ED2909666600814E14 /* CustomerSearchUICommandTests.swift in Sources */,
 				4590B652261C8D1E00A6FCE0 /* WeightFormatterTests.swift in Sources */,
 				DE4D23B029B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift in Sources */,
+				03B9E52F2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift in Sources */,
 				D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */,
 				B622BC74289CF19400B10CEC /* WaitingTimeTrackerTests.swift in Sources */,
 				023EC2E224DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift in Sources */,
@@ -12732,6 +12743,7 @@
 				B9B6DEF1283F8EB100901FB7 /* SitePluginsURLTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
 				AEB6903729770B1D00872FE0 /* ProductListViewModelTests.swift in Sources */,
+				03B9E52B2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift in Sources */,
 				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStorageTests.swift in Sources */,
 				262AF38A2713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockBuiltInCardReaderConnectionControllerFactory.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockBuiltInCardReaderConnectionControllerFactory.swift
@@ -1,0 +1,51 @@
+import Foundation
+@testable import WooCommerce
+import Yosemite
+
+class MockBuiltInCardReaderConnectionControllerFactory: BuiltInCardReaderConnectionControllerBuilding {
+    var spyCreateConnectionControllerSiteID: Int64? = nil
+    var spyCreateConnectionControllerAlertsPresenter: CardPresentPaymentAlertsPresenting? = nil
+    var spyCreateConnectionControllerConfiguration: CardPresentPaymentsConfiguration? = nil
+    var spyCreateConnectionControllerAnalyticsTracker: CardReaderConnectionAnalyticsTracker? = nil
+    var spyCreateConnectionControllerAllowTermsOfServiceAcceptance: Bool? = nil
+
+    var onSearchAndConnectCalled: (() -> Void)? = nil
+
+    var mockConnectionController: MockBuiltInCardReaderConnectionController? = nil
+
+    func createConnectionController(forSiteID siteID: Int64,
+                                    alertsPresenter: CardPresentPaymentAlertsPresenting,
+                                    configuration: CardPresentPaymentsConfiguration,
+                                    analyticsTracker: CardReaderConnectionAnalyticsTracker,
+                                    allowTermsOfServiceAcceptance: Bool) -> BuiltInCardReaderConnectionControlling {
+        spyCreateConnectionControllerSiteID = siteID
+        spyCreateConnectionControllerAlertsPresenter = alertsPresenter
+        spyCreateConnectionControllerConfiguration = configuration
+        spyCreateConnectionControllerAnalyticsTracker = analyticsTracker
+        spyCreateConnectionControllerAllowTermsOfServiceAcceptance = allowTermsOfServiceAcceptance
+
+        let mockConnectionController = MockBuiltInCardReaderConnectionController(
+            onSearchAndConnectCalled: onSearchAndConnectCalled)
+        self.mockConnectionController = mockConnectionController
+        connectionControllerCreated()
+        return mockConnectionController
+    }
+
+    var connectionControllerCreated: () -> Void = {}
+}
+
+class MockBuiltInCardReaderConnectionController: BuiltInCardReaderConnectionControlling {
+    let onSearchAndConnectCalled: (() -> Void)?
+
+    init(onSearchAndConnectCalled: (() -> Void)?) {
+        self.onSearchAndConnectCalled = onSearchAndConnectCalled
+    }
+
+    var didCallSearchAndConnect = false
+    var spySearchAndConnectCompletion: ((Result<WooCommerce.CardReaderConnectionResult, Error>) -> Void)? = nil
+    func searchAndConnect(onCompletion: @escaping (Result<WooCommerce.CardReaderConnectionResult, Error>) -> Void) {
+        didCallSearchAndConnect = true
+        spySearchAndConnectCompletion = onCompletion
+        onSearchAndConnectCalled?()
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSupportDeterminer.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSupportDeterminer.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Yosemite
+@testable import WooCommerce
+
+final class MockCardReaderSupportDeterminer: CardReaderSupportDetermining {
+    var shouldReturnConnectedReader: CardReader? = nil
+    func connectedReader() async -> CardReader? {
+        return shouldReturnConnectedReader
+    }
+
+    var shouldReturnHasPreviousTapToPayUsage: Bool = false
+    func hasPreviousTapToPayUsage() async -> Bool {
+        return shouldReturnHasPreviousTapToPayUsage
+    }
+
+    var shouldReturnSiteSupportsLocalMobileReader: Bool = false
+    func siteSupportsLocalMobileReader() -> Bool {
+        return shouldReturnSiteSupportsLocalMobileReader
+    }
+
+    var shouldReturnDeviceSupportsLocalMobileReader: Bool = false
+    func deviceSupportsLocalMobileReader() async -> Bool {
+        return shouldReturnDeviceSupportsLocalMobileReader
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -7,6 +7,7 @@ import Hardware
 final class TapToPayReconnectionControllerTests: XCTestCase {
 
     private var stores: MockStoresManager!
+    private var storageManager: MockStorageManager!
     private var connectionControllerFactory: MockBuiltInCardReaderConnectionControllerFactory!
     private var sut: TapToPayReconnectionController!
     private let sampleSiteID: Int64 = 12891
@@ -19,6 +20,25 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
         connectionControllerFactory = MockBuiltInCardReaderConnectionControllerFactory()
         sut = TapToPayReconnectionController(stores: stores,
                                              connectionControllerFactory: connectionControllerFactory)
+        storageManager = MockStorageManager()
+        setSiteAddressCountry()
+    }
+
+    func setSiteAddressCountry() {
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
+        let setting = SiteSetting.fake()
+            .copy(
+                siteID: sampleSiteID,
+                settingID: "woocommerce_default_country",
+                value: "US:NY",
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        ServiceLocator.selectedSiteSettings.refresh()
+    }
+
+    override func tearDown() {
+        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings())
     }
 
     func test_reconnectIfNeeded_calls_searchAndConnect_if_no_reader_connected_and_site_and_device_meet_requirements() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import Yosemite
+import Hardware
+
+@testable import WooCommerce
+
+final class TapToPayReconnectionControllerTests: XCTestCase {
+
+    private var stores: MockStoresManager!
+    private var connectionControllerFactory: MockBuiltInCardReaderConnectionControllerFactory!
+    private var sut: TapToPayReconnectionController!
+    private let sampleSiteID: Int64 = 12891
+    private let sampleConfiguration: CardPresentPaymentsConfiguration = CardPresentPaymentsConfiguration(country: "US")
+
+    override func setUp() {
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.setStoreId(sampleSiteID)
+        stores = MockStoresManager(sessionManager: sessionManager)
+        connectionControllerFactory = MockBuiltInCardReaderConnectionControllerFactory()
+        sut = TapToPayReconnectionController(stores: stores,
+                                             connectionControllerFactory: connectionControllerFactory)
+    }
+
+    func test_reconnectIfNeeded_calls_searchAndConnect_if_no_reader_connected_and_site_and_device_meet_requirements() throws {
+        // Given
+        let supportDeterminer = MockCardReaderSupportDeterminer()
+        supportDeterminer.shouldReturnConnectedReader = nil
+        supportDeterminer.shouldReturnSiteSupportsLocalMobileReader = true
+        supportDeterminer.shouldReturnDeviceSupportsLocalMobileReader = true
+        supportDeterminer.shouldReturnHasPreviousTapToPayUsage = true
+
+        waitFor { promise in
+            self.connectionControllerFactory.onSearchAndConnectCalled = {
+                promise(())
+            }
+            // When
+            self.sut.reconnectIfNeeded(supportDeterminer: supportDeterminer)
+        }
+
+        // Then
+        let mockConnectionController = try XCTUnwrap(connectionControllerFactory.mockConnectionController)
+        XCTAssert(mockConnectionController.didCallSearchAndConnect)
+    }
+
+    func test_reconnectIfNeeded_creates_a_new_connection_controller_with_expected_parameters() throws {
+        // Given
+        let supportDeterminer = MockCardReaderSupportDeterminer()
+        supportDeterminer.shouldReturnConnectedReader = nil
+        supportDeterminer.shouldReturnSiteSupportsLocalMobileReader = true
+        supportDeterminer.shouldReturnDeviceSupportsLocalMobileReader = true
+        supportDeterminer.shouldReturnHasPreviousTapToPayUsage = true
+
+        waitFor { promise in
+            self.connectionControllerFactory.onSearchAndConnectCalled = {
+                promise(())
+            }
+            // When
+            self.sut.reconnectIfNeeded(supportDeterminer: supportDeterminer)
+        }
+
+        // Then
+        assertEqual(sampleSiteID, connectionControllerFactory.spyCreateConnectionControllerSiteID)
+        assertEqual(false, connectionControllerFactory.spyCreateConnectionControllerAllowTermsOfServiceAcceptance)
+        assertEqual(sampleConfiguration, connectionControllerFactory.spyCreateConnectionControllerConfiguration)
+    }
+
+}

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
@@ -27,7 +27,7 @@ public enum CardPresentPaymentsPlugin: Equatable, CaseIterable {
     }
 }
 
-public struct PaymentPluginVersionSupport {
+public struct PaymentPluginVersionSupport: Equatable {
     public let plugin: CardPresentPaymentsPlugin
     public let minimumVersion: String
 }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WooFoundation
 
-public struct CardPresentPaymentsConfiguration {
+public struct CardPresentPaymentsConfiguration: Equatable {
     public let countryCode: String
     public let paymentMethods: [WCPayPaymentMethodType]
     public let currencies: [CurrencyCode]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9735
Merge after #9750
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds unit tests for the automatic TTP reconnection from #9750

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run unit tests

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
