### PR TITLE
[Privacy Choices] Banner Presentation - Part 2

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -27,7 +27,8 @@ extension Networking.Account {
             displayName: .fake(),
             email: .fake(),
             username: .fake(),
-            gravatarUrl: .fake()
+            gravatarUrl: .fake(),
+            ipCountryCode: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Account.swift
+++ b/Networking/Networking/Model/Account.swift
@@ -25,15 +25,22 @@ public struct Account: Decodable, Equatable, GeneratedFakeable {
     ///
     public let gravatarUrl: String?
 
+    /// Users IP country Code
+    /// This setting is not stored in the Storage layer because we don't want to rely on stale value.
+    /// But there us no problem on add it later if we believe it will be useful.
+    ///
+    public let ipCountryCode: String
+
 
     /// Designated Initializer.
     ///
-    public init(userID: Int64, displayName: String, email: String, username: String, gravatarUrl: String?) {
+    public init(userID: Int64, displayName: String, email: String, username: String, gravatarUrl: String?, ipCountryCode: String) {
         self.userID = userID
         self.displayName = displayName
         self.email = email
         self.username = username
         self.gravatarUrl = gravatarUrl
+        self.ipCountryCode = ipCountryCode
     }
 }
 
@@ -48,5 +55,6 @@ private extension Account {
         case email          = "email"
         case username       = "username"
         case gravatarUrl    = "avatar_URL"
+        case ipCountryCode  = "user_ip_country_code"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
@@ -1,30 +1,90 @@
 import Foundation
 import Yosemite
+import CoreTelephony
 
 /// Type who informs us if the privacy banner should be shown or not.
 ///
-struct PrivacyBannerPresentationUseCase {
-
-    /// Users current location country code.
-    ///
-    private let countryCode: String
+final class PrivacyBannerPresentationUseCase {
 
     /// User Defaults database
     ///
     private let defaults: UserDefaults
 
-    init(countryCode: String, defaults: UserDefaults = UserDefaults.standard) {
-        self.countryCode = countryCode
+    /// Stores to fetch remote information.
+    ///
+    private let stores: StoresManager
+
+    init(defaults: UserDefaults = UserDefaults.standard, stores: StoresManager = ServiceLocator.stores) {
         self.defaults = defaults
+        self.stores = stores
     }
 
     /// Returns `true` if the privacy banner should be shown.
     /// Currently it is shown if the user is in the EU zone & privacy choices have not been saved.
     ///
-    func shouldShowPrivacyBanner() -> Bool {
-        let isCountryInEU = Country.GDPRCountryCodes.contains(countryCode)
-        let hasSavedPrivacySettings = defaults.hasSavedPrivacyBannerSettings
-        return isCountryInEU && !hasSavedPrivacySettings
+    func shouldShowPrivacyBanner() async -> Bool {
+        do {
+            let countryCode = try await fetchUsersCountryCode()
+            let isCountryInEU = Country.GDPRCountryCodes.contains(countryCode)
+            let hasSavedPrivacySettings = defaults.hasSavedPrivacyBannerSettings
+            return isCountryInEU && !hasSavedPrivacySettings
+        } catch {
+            DDLogInfo("⛔️ Could not determine users country code. Error: \(error)")
+            return false
+        }
+    }
+}
+
+// MARK: Private Helpers
+private extension PrivacyBannerPresentationUseCase {
+
+    /// Determines the user country code by the following algorithm.
+    /// - If the user has a WPCOM account:
+    ///   - Use the ip country code.
+    /// - If the user does not has a WPCOM account:
+    ///   - Fetch the active carrier's country code.
+    ///   - If carrier is not available, use the locale country code.
+    ///
+    func fetchUsersCountryCode() async throws -> String {
+        // Use ip country code for WPCom accounts
+        if !stores.isAuthenticatedWithoutWPCom {
+            return try await fetchIPCountryCode()
+        }
+
+        // Use carrier country code for non-WPCom accounts
+        if let carrierCode = fetchCarrierCountryCode() {
+            return carrierCode
+        }
+
+        // Use locale country code as a fallback
+        return fetchLocaleCountryCode()
+    }
+
+    /// Fetches the ip country code using the Account API.
+    ///
+    func fetchIPCountryCode() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = AccountAction.synchronizeAccount { result in
+                let ipCountryCodeResult = result.map { $0.ipCountryCode }
+                continuation.resume(with: ipCountryCodeResult)
+            }
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
+        }
+    }
+
+    /// Fetches the country code from the first registered cellular provider.
+    ///
+    func fetchCarrierCountryCode() -> String? {
+        let networkCarrier = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders?.first?.value
+        return networkCarrier?.isoCountryCode
+    }
+
+    /// Fetches the country code from the current locate.
+    ///
+    func fetchLocaleCountryCode() -> String {
+        Locale.autoupdatingCurrent.identifier
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
@@ -14,9 +14,14 @@ final class PrivacyBannerPresentationUseCase {
     ///
     private let stores: StoresManager
 
-    init(defaults: UserDefaults = UserDefaults.standard, stores: StoresManager = ServiceLocator.stores) {
+    /// Users current locale.
+    ///
+    private let currentLocale: Locale
+
+    init(defaults: UserDefaults = UserDefaults.standard, stores: StoresManager = ServiceLocator.stores, currentLocale: Locale = .autoupdatingCurrent) {
         self.defaults = defaults
         self.stores = stores
+        self.currentLocale = currentLocale
     }
 
     /// Returns `true` if the privacy banner should be shown.
@@ -84,7 +89,7 @@ private extension PrivacyBannerPresentationUseCase {
     /// Fetches the country code from the current locate.
     ///
     func fetchLocaleCountryCode() -> String {
-        Locale.autoupdatingCurrent.identifier
+        currentLocale.regionCode ?? ""
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresentationUseCase.swift
@@ -47,18 +47,12 @@ private extension PrivacyBannerPresentationUseCase {
     /// - If the user has a WPCOM account:
     ///   - Use the ip country code.
     /// - If the user does not has a WPCOM account:
-    ///   - Fetch the active carrier's country code.
-    ///   - If carrier is not available, use the locale country code.
+    ///   - Use the current locale country code.
     ///
     func fetchUsersCountryCode() async throws -> String {
         // Use ip country code for WPCom accounts
         if !stores.isAuthenticatedWithoutWPCom {
             return try await fetchIPCountryCode()
-        }
-
-        // Use carrier country code for non-WPCom accounts
-        if let carrierCode = fetchCarrierCountryCode() {
-            return carrierCode
         }
 
         // Use locale country code as a fallback
@@ -77,13 +71,6 @@ private extension PrivacyBannerPresentationUseCase {
                 stores.dispatch(action)
             }
         }
-    }
-
-    /// Fetches the country code from the first registered cellular provider.
-    ///
-    func fetchCarrierCountryCode() -> String? {
-        let networkCarrier = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders?.first?.value
-        return networkCarrier?.isoCountryCode
     }
 
     /// Fetches the country code from the current locate.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -17,6 +17,12 @@ final class PrivacyBannerPresenter {
     /// Present the banner when the appropriate conditions are met.
     ///
     func presentIfNeeded(from viewController: UIViewController) {
+        // Do not present the privacy banner  when running UI tests.
+        let isUITesting: Bool = CommandLine.arguments.contains("-ui_testing")
+        guard isUITesting == false else {
+            return
+        }
+
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.privacyChoices) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -21,13 +21,17 @@ final class PrivacyBannerPresenter {
             return
         }
 
-        let countryCode = Locale.current.regionCode ?? "" // TODO: Switch for the real user country code.
-        let useCase = PrivacyBannerPresentationUseCase(countryCode: countryCode, defaults: defaults)
-
-        guard useCase.shouldShowPrivacyBanner() else {
-            return
+        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults)
+        Task {
+            if await useCase.shouldShowPrivacyBanner() {
+                await presentPrivacyBanner(from: viewController)
+            }
         }
+    }
 
+    /// Presents the privacy banner using a `BottomSheetViewController`
+    ///
+    @MainActor private func presentPrivacyBanner(from viewController: UIViewController) {
         let privacyBanner = PrivacyBannerViewController(goToSettingsAction: {
             print("Go to settings tapped") // TODO: Navigate to settings
         }, saveAction: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/EUCustomsScenarioValidator.swift
@@ -46,8 +46,8 @@ extension Country {
                                                            "SE", "SWE", // Sweden
                                                            "CH", "CHE"] // Switzerland
 
-    /// GDPR Country Code definitions.
-    /// *Although the UK has departed from the EU as of January 2021, the GDPR was enacted before its withdrawal and is therefore considered a valid UK law.*
+    /// GDPR Country Code definitions. Copied from: https://bit.ly/3Mb101j
+    /// *Although the UK has departed from the EU as of January 2021, the GDPR was enacted before its withdrawal and is therefore considered a valid UK law.* 
     ///
-    static let GDPRCountryCodes = countriesFollowingEUCustoms + ["GB"]
+    static let GDPRCountryCodes = countriesFollowingEUCustoms + ["GB", "IS", "LI"]
 }

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -31,7 +31,12 @@ extension SessionManager {
         manager.setStoreId(nil)
         manager.defaultRoles = defaultRoles
         if let displayName {
-            manager.defaultAccount = Account(userID: 123, displayName: displayName, email: "", username: credentials.username, gravatarUrl: nil)
+            manager.defaultAccount = Account(userID: 123,
+                                             displayName: displayName,
+                                             email: "",
+                                             username: credentials.username,
+                                             gravatarUrl: nil,
+                                             ipCountryCode: "US")
         }
         return manager
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -104,7 +104,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
         let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
 
-        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
+        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil, ipCountryCode: "US")
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case let .loadWPComAccount(_, onCompletion):
@@ -133,7 +133,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
         let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
 
-        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
+        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil, ipCountryCode: "US")
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case let .loadWPComAccount(_, onCompletion):
@@ -162,7 +162,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
         let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
 
-        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
+        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil, ipCountryCode: "US")
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case let .loadWPComAccount(_, onCompletion):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
@@ -33,7 +33,7 @@ final class PrivacyBannerPresentationUseCaseTests: XCTestCase {
         }
     }
 
-    @MainActor func test_show_banner_is_false_when_country_is_outside_of_EU_and_choices_have_not_been_saved() async throws {
+    @MainActor func test_show_banner_is_false_when_WPCOM_user_is_outside_of_EU_and_choices_have_not_been_saved() async throws {
         // Given
         let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
         defaults[.hasSavedPrivacyBannerSettings] = false
@@ -57,7 +57,7 @@ final class PrivacyBannerPresentationUseCaseTests: XCTestCase {
         XCTAssertFalse(shouldShowBanner)
     }
 
-    @MainActor func test_show_banner_is_false_when_country_is_inside_of_EU_and_choices_have_been_saved() async throws {
+    @MainActor func test_show_banner_is_false_when_WPCOM_user_is_inside_of_EU_and_choices_have_been_saved() async throws {
         // Given
         let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
         defaults[.hasSavedPrivacyBannerSettings] = true
@@ -75,6 +75,51 @@ final class PrivacyBannerPresentationUseCaseTests: XCTestCase {
 
         // When
         let useCase = PrivacyBannerPresentationUseCase(defaults: defaults, stores: stores)
+        let shouldShowBanner = await useCase.shouldShowPrivacyBanner()
+
+        // Then
+        XCTAssertFalse(shouldShowBanner)
+    }
+
+    @MainActor func test_show_banner_is_true_when_non_WPCOM_user_has_EU_locale_and_choices_have_not_been_saved() async throws {
+        // Given
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+        defaults[.hasSavedPrivacyBannerSettings] = false
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+
+        // When
+        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults, stores: stores, currentLocale: .init(identifier: "en_GB"))
+        let shouldShowBanner = await useCase.shouldShowPrivacyBanner()
+
+        // Then
+        XCTAssertTrue(shouldShowBanner)
+    }
+
+    @MainActor func test_show_banner_is_false_when_non_WPCOM_user_has_none_EU_locale_and_choices_have_not_been_saved() async throws {
+        // Given
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+        defaults[.hasSavedPrivacyBannerSettings] = false
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+
+        // When
+        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults, stores: stores, currentLocale: .init(identifier: "en_US"))
+        let shouldShowBanner = await useCase.shouldShowPrivacyBanner()
+
+        // Then
+        XCTAssertFalse(shouldShowBanner)
+    }
+
+    @MainActor func test_show_banner_is_false_when_non_WPCOM_user_has_EU_locale_and_choices_have_been_saved() async throws {
+        // Given
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+        defaults[.hasSavedPrivacyBannerSettings] = true
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+
+        // When
+        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults, stores: stores, currentLocale: .init(identifier: "en_GB"))
         let shouldShowBanner = await useCase.shouldShowPrivacyBanner()
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
@@ -6,38 +6,78 @@ import TestKit
 
 final class PrivacyBannerPresentationUseCaseTests: XCTestCase {
 
-    func test_show_banner_is_true_when_conditions_are_met() throws {
-        // Given
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
-
-        // When & Then
-        for euCode in Country.GDPRCountryCodes {
-            let useCase = PrivacyBannerPresentationUseCase(countryCode: euCode, defaults: defaults)
-            XCTAssertTrue(useCase.shouldShowPrivacyBanner())
-        }
-    }
-
-    func test_show_banner_is_false_when_country_is_outside_of_EU_and_choices_have_not_been_saved() throws {
+    @MainActor func test_show_banner_is_true_when_WPCOM_user_is_in_EU_and_choices_havent_been_saved() async throws {
         // Given
         let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
         defaults[.hasSavedPrivacyBannerSettings] = false
 
-        // When
-        let useCase = PrivacyBannerPresentationUseCase(countryCode: "PE", defaults: defaults)
+        // Iterate through all of the country codes
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true))
+        for euCode in Country.GDPRCountryCodes {
+            stores.whenReceivingAction(ofType: AccountAction.self) { action in
+                switch action {
+                case .synchronizeAccount(let onCompletion):
+                    let account = Account(userID: 123, displayName: "", email: "", username: "", gravatarUrl: "", ipCountryCode: euCode)
+                    onCompletion(.success(account))
+                default:
+                    break
+                }
+            }
 
-        // Then
-        XCTAssertFalse(useCase.shouldShowPrivacyBanner())
+            // When
+            let useCase = PrivacyBannerPresentationUseCase(defaults: defaults, stores: stores)
+            let shouldShowBanner = await useCase.shouldShowPrivacyBanner()
+
+            // Then
+            XCTAssertTrue(shouldShowBanner)
+        }
     }
 
-    func test_show_banner_is_false_when_country_is_inside_of_EU_and_choices_have_been_saved() throws {
+    @MainActor func test_show_banner_is_false_when_country_is_outside_of_EU_and_choices_have_not_been_saved() async throws {
+        // Given
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+        defaults[.hasSavedPrivacyBannerSettings] = false
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true))
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .synchronizeAccount(let onCompletion):
+                let account = Account(userID: 123, displayName: "", email: "", username: "", gravatarUrl: "", ipCountryCode: "US")
+                onCompletion(.success(account))
+            default:
+                break
+            }
+        }
+
+        // When
+        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults, stores: stores)
+        let shouldShowBanner = await useCase.shouldShowPrivacyBanner()
+
+        // Then
+        XCTAssertFalse(shouldShowBanner)
+    }
+
+    @MainActor func test_show_banner_is_false_when_country_is_inside_of_EU_and_choices_have_been_saved() async throws {
         // Given
         let defaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
         defaults[.hasSavedPrivacyBannerSettings] = true
 
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true))
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .synchronizeAccount(let onCompletion):
+                let account = Account(userID: 123, displayName: "", email: "", username: "", gravatarUrl: "", ipCountryCode: "GB")
+                onCompletion(.success(account))
+            default:
+                break
+            }
+        }
+
         // When
-        let useCase = PrivacyBannerPresentationUseCase(countryCode: "ES", defaults: defaults)
+        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults, stores: stores)
+        let shouldShowBanner = await useCase.shouldShowPrivacyBanner()
 
         // Then
-        XCTAssertFalse(useCase.shouldShowPrivacyBanner())
+        XCTAssertFalse(shouldShowBanner)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -29,7 +29,8 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         displayName: i18n.DefaultAccount.displayName,
         email: i18n.DefaultAccount.email,
         username: i18n.DefaultAccount.username,
-        gravatarUrl: nil
+        gravatarUrl: nil,
+        ipCountryCode: "USA"
     )
 
     let defaultSite = Site(

--- a/Yosemite/Yosemite/Model/Storage/Account+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Account+ReadOnlyConvertible.swift
@@ -23,6 +23,7 @@ extension Storage.Account: ReadOnlyConvertible {
                        displayName: displayName ?? "",
                        email: email ?? "",
                        username: username ?? "",
-                       gravatarUrl: gravatarUrl)
+                       gravatarUrl: gravatarUrl,
+                       ipCountryCode: "")
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -877,7 +877,8 @@ private extension AccountStoreTests {
                        displayName: "Sample",
                        email: "email@email.com",
                        username: "Username!",
-                       gravatarUrl: "https://automattic.com/superawesomegravatar.png")
+                       gravatarUrl: "https://automattic.com/superawesomegravatar.png",
+                       ipCountryCode: "US")
     }
 
     /// Sample Account: Mark II
@@ -887,7 +888,8 @@ private extension AccountStoreTests {
                        displayName: "Yosemite",
                        email: "yosemite@yosemite.com",
                        username: "YOLO",
-                       gravatarUrl: "https://automattic.com/yosemite.png")
+                       gravatarUrl: "https://automattic.com/yosemite.png",
+                       ipCountryCode: "US")
     }
 
     func sampleAccountSettings() -> Networking.AccountSettings {

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -606,7 +606,8 @@ final class AccountStoreTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(account)
-        XCTAssertEqual(account, sampleAccountPristine())
+        //XCTAssertEqual(account, sampleAccountPristine())
+        assertEqual(account, sampleAccountPristine())
     }
 
     func test_loadAccount_returns_nil_for_unknown_account() {
@@ -878,7 +879,7 @@ private extension AccountStoreTests {
                        email: "email@email.com",
                        username: "Username!",
                        gravatarUrl: "https://automattic.com/superawesomegravatar.png",
-                       ipCountryCode: "US")
+                       ipCountryCode: "")
     }
 
     /// Sample Account: Mark II
@@ -889,7 +890,7 @@ private extension AccountStoreTests {
                        email: "yosemite@yosemite.com",
                        username: "YOLO",
                        gravatarUrl: "https://automattic.com/yosemite.png",
-                       ipCountryCode: "US")
+                       ipCountryCode: "")
     }
 
     func sampleAccountSettings() -> Networking.AccountSettings {


### PR DESCRIPTION
Closes: #9613 

# Why

This PR is a follow-up PR of #9741. It makes sure to fetch the current user country code before presenting the banner.

In particular, it follows the following algorithm:

- If the user is using a WPCom account:
  - Get the country code from the `me` API which is queried on `AccountAction.synchronizeAccount` 
 
- If the user is using a non-WPCom store:
   - Get the country code from the user's locale.

# How

- Update the `Account` entity to deserialize the `ipCountryCode` property.
- Update `PrivacyBannerPresentationUseCase` to implement the country code algorithm.
- Update `GDPRCountryCodes` to add some missing country codes.

# Demo

## EU Located
https://github.com/woocommerce/woocommerce-ios/assets/562080/b15f4d97-a546-4910-b157-680f186104f4

## Non-EU Located
https://github.com/woocommerce/woocommerce-ios/assets/562080/b05a1eda-0da5-4b72-8a1a-964500e7499d

# Testing Steps

- While being in the EU (can use a VPN)
- Launch the app on a WPCom account
- See that the privacy banner is presented.

----

- While not in the EU (can use a VPN)
- Launch the app on a WPCom account
- See that the privacy banner is not presented.

----

- While having an EU Locale
- Launch the app on a **non** WPCom account
- See that the privacy banner is presented presented.

----

- While having a non-EU Locale
- Launch the app on a **non** WPCom account
- See that the privacy banner is not presented.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
