### PR TITLE
Attempt fixing flaky unit test for local notification

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -109,7 +109,7 @@ private extension StorePlanSynchronizer {
         let now = Date().normalizedDate() // with time removed
 
         /// Schedules pre-expiration notification if the plan is not expired in a day.
-        if normalizedDate.timeIntervalSince(now) - Constants.oneDayTimeInterval > 0 {
+        if normalizedDate.timeIntervalSince(now) > Constants.oneDayTimeInterval {
             scheduleBeforeExpirationNotification(siteID: siteID, expiryDate: normalizedDate)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -106,12 +106,13 @@ private extension StorePlanSynchronizer {
         /// Normalizes expiry date to remove timezone difference
         let timeZoneDifference = timeZone.secondsFromGMT()
         let normalizedDate = Date(timeInterval: -Double(timeZoneDifference), since: expiryDate)
+        let now = Date().normalizedDate() // with time removed
 
-        if normalizedDate.timeIntervalSinceNow - Constants.oneDayTimeInterval > 0 {
+        if normalizedDate.timeIntervalSince(now) - Constants.oneDayTimeInterval > 0 {
             scheduleBeforeExpirationNotification(siteID: siteID, expiryDate: normalizedDate)
         }
 
-        if normalizedDate.timeIntervalSinceNow + Constants.oneDayTimeInterval > 0 {
+        if normalizedDate.timeIntervalSince(now) + Constants.oneDayTimeInterval > 0 {
             scheduleAfterExpirationNotification(siteID: siteID, expiryDate: normalizedDate)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -108,11 +108,13 @@ private extension StorePlanSynchronizer {
         let normalizedDate = Date(timeInterval: -Double(timeZoneDifference), since: expiryDate)
         let now = Date().normalizedDate() // with time removed
 
+        /// Schedules pre-expiration notification if the plan is not expired in a day.
         if normalizedDate.timeIntervalSince(now) - Constants.oneDayTimeInterval > 0 {
             scheduleBeforeExpirationNotification(siteID: siteID, expiryDate: normalizedDate)
         }
 
-        if normalizedDate.timeIntervalSince(now) + Constants.oneDayTimeInterval > 0 {
+        /// Schedules post-expiration notification if the plan hasn't expired for a day.
+        if now.timeIntervalSince(normalizedDate) < Constants.oneDayTimeInterval {
             scheduleAfterExpirationNotification(siteID: siteID, expiryDate: normalizedDate)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
@@ -153,8 +153,9 @@ final class StorePlanSynchronizerTests: XCTestCase {
 
         // Then
         waitUntil(timeout: 3) {
-            pushNotesManager.requestedLocalNotificationsIfNeeded.count == 1
+            pushNotesManager.requestedLocalNotificationsIfNeeded.isNotEmpty
         }
+        assertEqual(1, pushNotesManager.requestedLocalNotificationsIfNeeded.count)
         let ids = pushNotesManager.requestedLocalNotificationsIfNeeded.map(\.scenario.identifier)
         let expectedIDs = [
             LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(sampleSiteID)",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
@@ -155,7 +155,6 @@ final class StorePlanSynchronizerTests: XCTestCase {
         waitUntil(timeout: 3) {
             pushNotesManager.requestedLocalNotificationsIfNeeded.isNotEmpty
         }
-        assertEqual(1, pushNotesManager.requestedLocalNotificationsIfNeeded.count)
         let ids = pushNotesManager.requestedLocalNotificationsIfNeeded.map(\.scenario.identifier)
         let expectedIDs = [
             LocalNotification.Scenario.IdentifierPrefix.oneDayAfterFreeTrialExpires + "\(sampleSiteID)",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9665 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the flaky test `StorePlanSynchronizerTests.test_expired_trial_plan_local_notification_is_scheduled_if_the_site_has_trial_plan_being_expired_for_at_most_1_day()`.

The fix is to remove the time from the current date before comparing it with the expiration date. This ensures we only consider the day to avoid test failures in the afternoon UTC.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Testing is tricky because the test is only failing in the afternoon UTC. We can observe to see if test fails again later today.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
