### PR TITLE
[Privacy Choices] Render intial analytics setting state.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -13,7 +13,8 @@ final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
     var bannerIntrinsicHeight: CGFloat = 0
 
     init(goToSettingsAction: @escaping (() -> ()), saveAction: @escaping (() -> ())) {
-        super.init(rootView: PrivacyBanner(goToSettingsAction: goToSettingsAction, saveAction: saveAction))
+        let viewModel = PrivacyBannerViewModel()
+        super.init(rootView: PrivacyBanner(goToSettingsAction: goToSettingsAction, saveAction: saveAction, viewModel: viewModel))
     }
 
     /// Needed for protocol conformance.
@@ -59,6 +60,10 @@ struct PrivacyBanner: View {
     ///
     var shouldScroll: Bool = false
 
+    /// Main View Model.
+    ///
+    @StateObject var viewModel: PrivacyBannerViewModel
+
     var body: some View {
         if shouldScroll {
             ScrollView(showsIndicators: false) {
@@ -79,7 +84,7 @@ struct PrivacyBanner: View {
                 .foregroundColor(Color(.text))
                 .subheadlineStyle()
 
-            Toggle(Localization.analytics, isOn: .constant(true))
+            Toggle(Localization.analytics, isOn: $viewModel.analyticsEnabled)
                 .tint(Color(.primary))
                 .bodyStyle()
                 .padding(.vertical)
@@ -135,7 +140,7 @@ private extension PrivacyBanner {
 
 struct PrivacyBanner_Previews: PreviewProvider {
     static var previews: some View {
-        PrivacyBanner(goToSettingsAction: {}, saveAction: {})
+        PrivacyBanner(goToSettingsAction: {}, saveAction: {}, viewModel: .init())
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Yosemite
+
+/// ViewModel for the privacy banner
+///
+final class PrivacyBannerViewModel: ObservableObject {
+
+    /// Stores the value for the analytics choice.
+    ///
+    @Published var analyticsEnabled: Bool = false
+
+    init(analyticsProvider: Analytics = ServiceLocator.analytics) {
+        self.analyticsEnabled = analyticsProvider.userHasOptedIn
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
@@ -9,7 +9,7 @@ final class PrivacyBannerViewModel: ObservableObject {
     ///
     @Published var analyticsEnabled: Bool = false
 
-    init(analyticsProvider: Analytics = ServiceLocator.analytics) {
-        self.analyticsEnabled = analyticsProvider.userHasOptedIn
+    init(analytics: Analytics = ServiceLocator.analytics) {
+        self.analyticsEnabled = analytics.userHasOptedIn
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -702,6 +702,7 @@
 		263E38462641FF3400260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; };
 		263E38472641FF3400260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		263EAF9A2A15D513008C66CB /* PrivacyBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */; };
+		263EAF9C2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EAF9B2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
 		2647F7B529280A7F00D59FDF /* AnalyticsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */; };
 		2647F7BA292BE2F900D59FDF /* AnalyticsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */; };
@@ -2985,6 +2986,7 @@
 		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
 		263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerViewModel.swift; sourceTree = "<group>"; };
+		263EAF9B2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerViewModelTest.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubView.swift; sourceTree = "<group>"; };
 		2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCard.swift; sourceTree = "<group>"; };
@@ -6012,6 +6014,7 @@
 			isa = PBXGroup;
 			children = (
 				2609797B2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift */,
+				263EAF9B2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -12556,6 +12559,7 @@
 				0212683724C049F000F8A892 /* ProductListMultiSelectorDataSourceTests.swift in Sources */,
 				0252273529A89B0F0074EBFC /* StoreOnboardingCoordinatorTests.swift in Sources */,
 				DE7842EF26F079A60030C792 /* NumberFormatter+LocalizedTests.swift in Sources */,
+				263EAF9C2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift in Sources */,
 				5768315126694ADC00FDFB6C /* AuthenticationManagerTests.swift in Sources */,
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
 				0242CFB829F278B70080F500 /* ProductFormAIEligibilityCheckerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -701,6 +701,7 @@
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		263E38462641FF3400260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; };
 		263E38472641FF3400260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		263EAF9A2A15D513008C66CB /* PrivacyBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
 		2647F7B529280A7F00D59FDF /* AnalyticsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */; };
 		2647F7BA292BE2F900D59FDF /* AnalyticsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */; };
@@ -2983,6 +2984,7 @@
 		2631D4FD29F2141D00F13F20 /* FreeTrialBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerPresenter.swift; sourceTree = "<group>"; };
 		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
+		263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerViewModel.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubView.swift; sourceTree = "<group>"; };
 		2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCard.swift; sourceTree = "<group>"; };
@@ -9079,6 +9081,7 @@
 			children = (
 				CE22E3F62170E23C005A6BEF /* PrivacySettingsViewController.swift */,
 				267F60122A0C24D700CD1E4E /* PrivacyBannerViewController.swift */,
+				263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */,
 				26B233D02A14208800926EAD /* PrivacyBannerPresenter.swift */,
 				260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */,
 			);
@@ -11665,6 +11668,7 @@
 				311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */,
 				0313651128AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift in Sources */,
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
+				263EAF9A2A15D513008C66CB /* PrivacyBannerViewModel.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				B9E4364C287587D300883CFA /* FeatureAnnouncementCardView.swift in Sources */,
 				267F60132A0C24D700CD1E4E /* PrivacyBannerViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
@@ -1,0 +1,32 @@
+import XCTest
+import TestKit
+
+@testable import WooCommerce
+@testable import Yosemite
+
+final class PrivacyBannerViewModelTest: XCTestCase {
+
+    func test_analytics_state_has_correct_initial_value_when_user_has_opt_out() {
+        // Given
+        let analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())
+        analytics.setUserHasOptedOut(true)
+
+        // When
+        let viewModel = PrivacyBannerViewModel(analyticsProvider: analytics)
+
+        // Then
+        XCTAssertFalse(viewModel.analyticsEnabled)
+    }
+
+    func test_analytics_state_has_correct_initial_value_when_user_has_opt_int() {
+        // Given
+        let analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())
+        analytics.setUserHasOptedOut(false)
+
+        // When
+        let viewModel = PrivacyBannerViewModel(analyticsProvider: analytics)
+
+        // Then
+        XCTAssertTrue(viewModel.analyticsEnabled)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
@@ -8,23 +8,23 @@ final class PrivacyBannerViewModelTest: XCTestCase {
 
     func test_analytics_state_has_correct_initial_value_when_user_has_opt_out() {
         // Given
-        let analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())
-        analytics.setUserHasOptedOut(true)
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        analytics.userHasOptedIn = false
 
         // When
-        let viewModel = PrivacyBannerViewModel(analyticsProvider: analytics)
+        let viewModel = PrivacyBannerViewModel(analytics: analytics)
 
         // Then
         XCTAssertFalse(viewModel.analyticsEnabled)
     }
 
-    func test_analytics_state_has_correct_initial_value_when_user_has_opt_int() {
+    func test_analytics_state_has_correct_initial_value_when_user_has_opt_in() {
         // Given
-        let analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())
-        analytics.setUserHasOptedOut(false)
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        analytics.userHasOptedIn = true
 
         // When
-        let viewModel = PrivacyBannerViewModel(analyticsProvider: analytics)
+        let viewModel = PrivacyBannerViewModel(analytics: analytics)
 
         // Then
         XCTAssertTrue(viewModel.analyticsEnabled)


### PR DESCRIPTION
Closes: #9614 

# Why

- This PR makes sure that the analytics toggle in the privacy banner reflects its initial state correctly

# How

- Adds new `PrivacyBannerViewModel ` that will read the analytics value from `ServiceLocator.analytics.userHasOptedIn` and will render it into the screen.

# Testing Steps

- Launch the app
- Go to the privacy settings screen 
- Turn off analytics
- Relaunch the app while being in the EU (can use a VPN)
- See that the privacy banner has the analytic toggle disabled.

---

- Launch the app
- Go to the privacy settings screen 
- Turn on analytics
- Relaunch the app while being in the EU (can use a VPN)
- See that the privacy banner has the analytic toggle enabled.

----

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
