### PR TITLE
Remove deprecated login error notification code

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -320,20 +320,12 @@ private extension AppDelegate {
     /// Push Notifications: Authorization + Registration!
     ///
     func setupPushNotificationsManagerIfPossible() {
-        let loginErrorNotifications: [LocalNotification.Scenario] = [
-            .loginSiteAddressError,
-            .invalidEmailFromSiteAddressLogin,
-            .invalidEmailFromWPComLogin,
-            .invalidPasswordFromWPComLogin,
-            .invalidPasswordFromSiteAddressWPComLogin
-        ]
         let stores = ServiceLocator.stores
         guard stores.isAuthenticated,
               stores.needsDefaultStore == false,
               stores.isAuthenticatedWithoutWPCom == false else {
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.storeCreationNotifications) {
                 ServiceLocator.pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: true, onCompletion: nil)
-                ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: loginErrorNotifications)
             }
             return
         }
@@ -344,7 +336,6 @@ private extension AppDelegate {
             let pushNotesManager = ServiceLocator.pushNotesManager
             pushNotesManager.registerForRemoteNotifications()
             pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false, onCompletion: nil)
-            pushNotesManager.cancelLocalNotification(scenarios: loginErrorNotifications)
         #endif
     }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -903,9 +903,8 @@ private extension StoreCreationCoordinator {
 
 private extension StoreCreationCoordinator {
     func scheduleLocalNotificationWhenStoreIsReady() {
-        guard let notification = LocalNotification(scenario: Constants.LocalNotificationScenario.storeCreationComplete, stores: stores) else {
-            return
-        }
+        let notification = LocalNotification(scenario: Constants.LocalNotificationScenario.storeCreationComplete,
+                                             stores: stores)
         cancelLocalNotificationWhenStoreIsReady()
         Task {
             await localNotificationScheduler.schedule(notification: notification,
@@ -920,11 +919,9 @@ private extension StoreCreationCoordinator {
     }
 
     func scheduleLocalNotificationToSubscribeFreeTrial(storeName: String) {
-        guard let notification = LocalNotification(scenario: LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName),
+        let notification = LocalNotification(scenario: LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName),
                                                    stores: stores,
-                                                   userInfo: [LocalNotification.UserInfoKey.storeName: storeName]) else {
-            return
-        }
+                                                   userInfo: [LocalNotification.UserInfoKey.storeName: storeName])
 
         cancelLocalNotificationToSubscribeFreeTrial(storeName: storeName)
         Task {

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -22,12 +22,6 @@ struct LocalNotification {
         case oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: String)
         case oneDayBeforeFreeTrialExpires(siteID: Int64, expiryDate: Date)
         case oneDayAfterFreeTrialExpires(siteID: Int64)
-        // The following notifications are deprecated and are canceled in the first release.
-        case loginSiteAddressError
-        case invalidEmailFromSiteAddressLogin
-        case invalidEmailFromWPComLogin
-        case invalidPasswordFromSiteAddressWPComLogin
-        case invalidPasswordFromWPComLogin
 
         var identifier: String {
             switch self {
@@ -39,16 +33,6 @@ struct LocalNotification {
                 return Identifier.Prefix.oneDayBeforeFreeTrialExpires + "\(siteID)"
             case .oneDayAfterFreeTrialExpires(let siteID):
                 return Identifier.Prefix.oneDayAfterFreeTrialExpires + "\(siteID)"
-            case .loginSiteAddressError:
-                return "site_address_error"
-            case .invalidEmailFromSiteAddressLogin:
-                return "site_address_email_error"
-            case .invalidEmailFromWPComLogin:
-                return "wpcom_email_error"
-            case .invalidPasswordFromSiteAddressWPComLogin:
-                return "site_address_wpcom_password_error"
-            case .invalidPasswordFromWPComLogin:
-                return "wpcom_password_error"
             }
         }
 

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -78,7 +78,7 @@ struct LocalNotification {
 }
 
 extension LocalNotification {
-    init?(scenario: Scenario,
+    init(scenario: Scenario,
           stores: StoresManager = ServiceLocator.stores,
           timeZone: TimeZone = .current,
           locale: Locale = .current,
@@ -122,8 +122,6 @@ extension LocalNotification {
             title = Localization.OneDayAfterFreeTrialExpires.title
             body = String.localizedStringWithFormat(Localization.OneDayAfterFreeTrialExpires.body, name)
 
-        default:
-            return nil
         }
 
         self.init(title: title,

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -128,9 +128,8 @@ private extension StorePlanSynchronizer {
     }
 
     func scheduleBeforeExpirationNotification(siteID: Int64, expiryDate: Date) {
-        guard let notification = LocalNotification(scenario: .oneDayBeforeFreeTrialExpires(siteID: siteID, expiryDate: expiryDate)) else {
-            return
-        }
+        let notification = LocalNotification(scenario: .oneDayBeforeFreeTrialExpires(siteID: siteID,
+                                                                                     expiryDate: expiryDate))
         /// Scheduled for 1 day before the expiry date
         let triggerDateComponents = expiryDate.addingTimeInterval(-Constants.oneDayTimeInterval).dateAndTimeComponents()
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDateComponents, repeats: false)
@@ -143,9 +142,7 @@ private extension StorePlanSynchronizer {
     }
 
     func scheduleAfterExpirationNotification(siteID: Int64, expiryDate: Date) {
-        guard let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID)) else {
-            return
-        }
+        let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
         /// Scheduled for 1 day after the expiry date
         let triggerDateComponents = expiryDate.addingTimeInterval(Constants.oneDayTimeInterval).dateAndTimeComponents()
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDateComponents, repeats: false)

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -29,7 +29,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         }
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: .storeCreationComplete))
+        let notification = LocalNotification(scenario: .storeCreationComplete)
         await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: .storeCreationCompleteNotification)
 
         // Then
@@ -49,7 +49,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         }
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: .storeCreationComplete))
+        let notification = LocalNotification(scenario: .storeCreationComplete)
         await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: .storeCreationCompleteNotification)
 
         // Then
@@ -62,7 +62,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: .storeCreationComplete))
+        let notification = LocalNotification(scenario: .storeCreationComplete)
         await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: nil)
 
         // Then
@@ -82,7 +82,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         }
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: .storeCreationComplete))
+        let notification = LocalNotification(scenario: .storeCreationComplete)
         await scheduler.schedule(notification: notification,
                                  trigger: nil,
                                  remoteFeatureFlag: .storeCreationCompleteNotification,

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -107,12 +107,7 @@ extension LocalNotification: Equatable {
 extension LocalNotification.Scenario: Equatable {
     public static func ==(lhs: LocalNotification.Scenario, rhs: LocalNotification.Scenario) -> Bool {
         switch (lhs, rhs) {
-        case (.storeCreationComplete, .storeCreationComplete),
-            (.loginSiteAddressError, .loginSiteAddressError),
-            (.invalidEmailFromSiteAddressLogin, .invalidEmailFromSiteAddressLogin),
-            (.invalidEmailFromWPComLogin, .invalidEmailFromWPComLogin),
-            (.invalidPasswordFromSiteAddressWPComLogin, .invalidPasswordFromSiteAddressWPComLogin),
-            (.invalidPasswordFromWPComLogin, .invalidPasswordFromWPComLogin):
+        case (.storeCreationComplete, .storeCreationComplete):
             return true
         case let (.oneDayAfterStoreCreationNameWithoutFreeTrial(lhsStoreName), .oneDayAfterStoreCreationNameWithoutFreeTrial(rhsStoreName)):
             return lhsStoreName == rhsStoreName

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -10,7 +10,7 @@ final class LocalNotificationTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores))
+        let notification = LocalNotification(scenario: scenario, stores: stores)
 
         // Then
         assertEqual(LocalNotification.Localization.StoreCreationComplete.title, notification.title)
@@ -27,7 +27,7 @@ final class LocalNotificationTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores))
+        let notification = LocalNotification(scenario: scenario, stores: stores)
 
         // Then
         assertEqual(LocalNotification.Localization.OneDayAfterStoreCreationNameWithoutFreeTrial.title, notification.title)
@@ -50,7 +50,7 @@ final class LocalNotificationTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores, timeZone: timeZone, locale: locale))
+        let notification = LocalNotification(scenario: scenario, stores: stores, timeZone: timeZone, locale: locale)
 
         // Then
         let expectedTitle = LocalNotification.Localization.OneDayBeforeFreeTrialExpires.title
@@ -67,7 +67,7 @@ final class LocalNotificationTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
 
         // When
-        let notification = try XCTUnwrap(LocalNotification(scenario: scenario, stores: stores))
+        let notification = LocalNotification(scenario: scenario, stores: stores)
 
         // Then
         let expectedTitle = LocalNotification.Localization.OneDayAfterFreeTrialExpires.title

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -594,7 +594,7 @@ final class PushNotificationsManagerTests: XCTestCase {
             userNotificationsCenter: mockCenter
         ))
         let siteID: Int64 = 123
-        let notification = try XCTUnwrap(LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID)))
+        let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Date().timeIntervalSinceNow + 1, repeats: false)
 
         // When
@@ -617,7 +617,7 @@ final class PushNotificationsManagerTests: XCTestCase {
             userNotificationsCenter: mockCenter
         ))
         let siteID: Int64 = 123
-        let notification = try XCTUnwrap(LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID)))
+        let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Date().timeIntervalSinceNow + 1, repeats: false)
 
         // When
@@ -642,7 +642,7 @@ final class PushNotificationsManagerTests: XCTestCase {
             userNotificationsCenter: mockCenter
         ), analytics: WooAnalytics(analyticsProvider: analytics))
         let siteID: Int64 = 123
-        let notification = try XCTUnwrap(LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID)))
+        let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Date().timeIntervalSinceNow + 1, repeats: false)
 
         // When
@@ -685,7 +685,7 @@ final class PushNotificationsManagerTests: XCTestCase {
             userNotificationsCenter: mockCenter
         ), analytics: WooAnalytics(analyticsProvider: analytics))
         let siteID: Int64 = 123
-        let notification = try XCTUnwrap(LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID)))
+        let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Date().timeIntervalSinceNow + 1, repeats: false)
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
Removes deprecated code related to login error notification experiment. 

## Testing instructions
CI passing is sufficient. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
