### PR TITLE
[Mobile Payments] Check onboarding status before TTP auto reconnection

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -9,6 +9,7 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
     private var stores: MockStoresManager!
     private var storageManager: MockStorageManager!
     private var connectionControllerFactory: MockBuiltInCardReaderConnectionControllerFactory!
+    private var onboardingCache: CardPresentPaymentOnboardingStateCache!
     private var sut: TapToPayReconnectionController!
     private let sampleSiteID: Int64 = 12891
     private let sampleConfiguration: CardPresentPaymentsConfiguration = CardPresentPaymentsConfiguration(country: "US")
@@ -18,8 +19,11 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
         sessionManager.setStoreId(sampleSiteID)
         stores = MockStoresManager(sessionManager: sessionManager)
         connectionControllerFactory = MockBuiltInCardReaderConnectionControllerFactory()
+        onboardingCache = CardPresentPaymentOnboardingStateCache()
+        onboardingCache.update(.completed(plugin: .wcPayPreferred))
         sut = TapToPayReconnectionController(stores: stores,
-                                             connectionControllerFactory: connectionControllerFactory)
+                                             connectionControllerFactory: connectionControllerFactory,
+                                             onboardingCache: onboardingCache)
         storageManager = MockStorageManager()
         setSiteAddressCountry()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9735
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We automatically reconnect to the built-in reader when the app is launched or brought into the foreground, subject to eligibility and previous use of TTP.

A connection attempt made when onboarding is not `complete` will fail. By checking the onboarding cache for `complete` status before we reconnect, we reduce the network traffic and number of errors shown for onboarding failures which the user won’t ever see.

Since we can be fairly confident the reconnection will fail when we don’t have `complete` as the cached status, we don’t need to try to reconnect. When they next try to use TTP, a full onboarding check will occur, and any issues shown to the user.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a WCPay store and an iPhone XS or newer, running iOS 16+

### Reconnection still works when onboarding is `.complete`

1. Launch the app and take a payment using Tap to Pay on iPhone
2. Background the app
3. Foreground the app
4. Take another payment using Tap to Pay on iPhone
5. Observe that the built in reader was already connected, and you were taken straight to collecting a payment

### Reconnection is not attempted when onboarding is not `complete`

1. Launch the app and take a payment using Tap to Pay on iPhone (can skip if you've just done the above test)
2. Disable the WCPay plugin on your site's WP-admin
3. Attempt to take a payment using either card reader – observe that you fail onboarding
4. Put a breakpoint on [the `reconnectTapToPayReader` line in the reconnection controller](https://github.com/woocommerce/woocommerce-ios/blob/bd0a8ecd7b47419ebd73dd5b6530f9d000632075/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/TapToPayReconnectionController.swift#L82)
5. Background the app
6. Foreground the app
7. Observe that your breakpoint is not hit
8. Take a payment using Tap to Pay on iPhone
9. Observe that you are shown the onboarding error, and have to resolve it to continue


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/112216dd-83d7-44ea-beda-de86f74359d5


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
