### PR TITLE
[Scan to Pay] Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1002,7 +1002,7 @@ extension WooAnalyticsEvent {
             static let source = "source"
             static let flow = "flow"
             static let cardReaderType = "card_reader_type"
-            static let order_id = "order_id"
+            static let orderID = "order_id"
         }
 
         static func paymentsFlowCompleted(flow: Flow,
@@ -1013,7 +1013,7 @@ extension WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                                                                        Keys.amount: amount,
                                                                        Keys.paymentMethod: method.rawValue,
-                                                                       Keys.order_id: orderID]
+                                                                       Keys.orderID: orderID]
 
             if let cardReaderType = cardReaderType {
                 properties[Keys.cardReaderType] = cardReaderType.rawValue
@@ -1038,7 +1038,7 @@ extension WooAnalyticsEvent {
                                         millisecondsSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                                                                        Keys.paymentMethod: method.rawValue,
-                                                                       Keys.order_id: orderID]
+                                                                       Keys.orderID: orderID]
 
             if let cardReaderType = cardReaderType {
                 properties[Keys.cardReaderType] = cardReaderType.rawValue

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -968,6 +968,7 @@ extension WooAnalyticsEvent {
             case card
             case cash
             case paymentLink = "payment_link"
+            case scanToPay = "scan_to_pay"
         }
 
         /// Possible view sources
@@ -1001,15 +1002,18 @@ extension WooAnalyticsEvent {
             static let source = "source"
             static let flow = "flow"
             static let cardReaderType = "card_reader_type"
+            static let order_id = "order_id"
         }
 
         static func paymentsFlowCompleted(flow: Flow,
                                           amount: String,
                                           method: PaymentMethod,
+                                          orderID: Int64,
                                           cardReaderType: CardReaderType?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                                                                        Keys.amount: amount,
-                                                                       Keys.paymentMethod: method.rawValue]
+                                                                       Keys.paymentMethod: method.rawValue,
+                                                                       Keys.order_id: orderID]
 
             if let cardReaderType = cardReaderType {
                 properties[Keys.cardReaderType] = cardReaderType.rawValue
@@ -1029,10 +1033,12 @@ extension WooAnalyticsEvent {
 
         static func paymentsFlowCollect(flow: Flow,
                                         method: PaymentMethod,
+                                        orderID: Int64,
                                         cardReaderType: CardReaderType?,
                                         millisecondsSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
-                              Keys.paymentMethod: method.rawValue]
+                                                                       Keys.paymentMethod: method.rawValue,
+                                                                       Keys.order_id: orderID]
 
             if let cardReaderType = cardReaderType {
                 properties[Keys.cardReaderType] = cardReaderType.rawValue

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -93,6 +93,7 @@ struct PaymentMethodsView: View {
 
                             MethodRow(icon: .scanToPayIcon, title: Localization.scanToPay, accessibilityID: Accessibility.scanToPayMethod) {
                                 showingScanToPayView = true
+                                viewModel.trackCollectByScanToPay()
                             }
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -374,6 +374,10 @@ final class PaymentMethodsViewModel: ObservableObject {
         trackCollectIntention(method: .paymentLink, cardReaderType: .none)
     }
 
+    func trackCollectByScanToPay() {
+        trackCollectIntention(method: .scanToPay, cardReaderType: .none)
+    }
+
     /// Perform the necesary tasks after a link is shared.
     ///
     func performLinkSharedTasks() {
@@ -383,6 +387,7 @@ final class PaymentMethodsViewModel: ObservableObject {
 
     func performScanToPayFinishedTasks() {
         presentNoticeSubject.send(.created)
+        trackFlowCompleted(method: .scanToPay, cardReaderType: .none)
     }
 
     /// Track the flow cancel scenario.
@@ -463,6 +468,7 @@ private extension PaymentMethodsViewModel {
         analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCompleted(flow: flow,
                                                                                     amount: formattedTotal,
                                                                                     method: method,
+                                                                                    orderID: orderID,
                                                                                     cardReaderType: cardReaderType))
     }
 
@@ -485,6 +491,7 @@ private extension PaymentMethodsViewModel {
 
         analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCollect(flow: flow,
                                                                                   method: method,
+                                                                                  orderID: orderID,
                                                                                   cardReaderType: cardReaderType,
                                                                                   millisecondsSinceOrderAddNew:
                                                                                     try? orderDurationRecorder.millisecondsSinceOrderAddNew()))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9674 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add tracking to the Scan to Pay functionality (collect payment and payment completed), and add the order Id to the collect and complete payment events so we link them with the finished orders after the checkout page.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Simple Payments

Go to the Payments Menu and follow the Collect Payment flow. When the Payment Methods screen is shown, tap on Scan to Pay. See that the event is tracked with the order id:

`🔵 Tracked payments_flow_collect, properties: [AnyHashable("flow"): "simple_payment", AnyHashable("payment_method"): "scan_to_pay", AnyHashable("order_id"): 1428, AnyHashable("blog_id"): 205293073, AnyHashable("is_wpcom_store"): true]`

After the Scan to Pay screen is shown, tap on Done and verify that the `payments_flow_completed` event is tracked:

`🔵 Tracked payments_flow_completed, properties: [AnyHashable("flow"): "simple_payment", AnyHashable("amount"): "$1.00", AnyHashable("payment_method"): "scan_to_pay", AnyHashable("is_wpcom_store"): true, AnyHashable("order_id"): 1428, AnyHashable("blog_id"): 205293073]`

Check that the same events are tracked in the order payment flow:

```
🔵 Tracked payments_flow_collect, properties: [AnyHashable("milliseconds_since_order_add_new"): 587682, AnyHashable("flow"): "order_payment", AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true, AnyHashable("order_id"): 406, AnyHashable("payment_method"): "scan_to_pay"]

🔵 Tracked payments_flow_completed, properties: [AnyHashable("payment_method"): "scan_to_pay", AnyHashable("flow"): "order_payment", AnyHashable("order_id"): 406, AnyHashable("blog_id"): 214354650, AnyHashable("amount"): "$15.00", AnyHashable("is_wpcom_store"): true]
```


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
