### PR TITLE
[Mobile Payments] Tap to Pay reconnection analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1101,6 +1101,7 @@ extension WooAnalyticsEvent {
             static let cancellationSource = "cancellation_source"
             static let millisecondsSinceCardCollectPaymentFlow = "milliseconds_since_card_collect_payment_flow"
             static let siteID = "site_id"
+            static let connectionType = "connection_type"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1185,12 +1186,15 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
         ///
-        static func cardReaderAutomaticDisconnect(cardReaderModel: String?, forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderAutomaticDisconnect(cardReaderModel: String?,
+                                                  forGatewayID: String?, countryCode: String,
+                                                  connectionType: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderAutomaticDisconnect,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.connectionType: connectionType
                               ]
             )
         }
@@ -1205,13 +1209,15 @@ extension WooAnalyticsEvent {
         static func cardReaderDiscoveryFailed(forGatewayID: String?,
                                               error: Error,
                                               countryCode: String,
-                                              siteID: Int64) -> WooAnalyticsEvent {
+                                              siteID: Int64,
+                                              connectionType: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDiscoveryFailed,
                               properties: [
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription,
-                                Keys.siteID: siteID
+                                Keys.siteID: siteID,
+                                Keys.connectionType: connectionType
                               ]
             )
         }
@@ -1227,11 +1233,13 @@ extension WooAnalyticsEvent {
         static func cardReaderConnectionSuccess(forGatewayID: String?,
                                                 batteryLevel: Float?,
                                                 countryCode: String,
-                                                cardReaderModel: String?) -> WooAnalyticsEvent {
+                                                cardReaderModel: String?,
+                                                connectionType: String) -> WooAnalyticsEvent {
             var properties = [
                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                 Keys.countryCode: countryCode,
-                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                Keys.connectionType: connectionType
             ]
 
             if let batteryLevel = batteryLevel {
@@ -1253,14 +1261,16 @@ extension WooAnalyticsEvent {
                                                error: Error,
                                                countryCode: String,
                                                cardReaderModel: String?,
-                                               siteID: Int64) -> WooAnalyticsEvent {
+                                               siteID: Int64,
+                                               connectionType: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderConnectionFailed,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription,
-                                Keys.siteID: siteID
+                                Keys.siteID: siteID,
+                                Keys.connectionType: connectionType
                               ]
             )
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -254,12 +254,7 @@ private extension BuiltInCardReaderConnectionController {
             onError: { [weak self] error in
                 guard let self = self else { return }
 
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
-                                                                                        error: error,
-                                                                                        countryCode: self.configuration.countryCode,
-                                                                                        siteID: self.siteID)
-                )
+                self.analyticsTracker.discoveryFailed(error: error)
                 self.state = .discoveryFailed(error)
             })
 
@@ -375,13 +370,8 @@ private extension BuiltInCardReaderConnectionController {
 
             switch result {
             case .success(let reader):
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments
-                        .cardReaderConnectionSuccess(forGatewayID: self.gatewayID,
-                                                     batteryLevel: reader.batteryLevel,
-                                                     countryCode: self.configuration.countryCode,
-                                                     cardReaderModel: reader.readerType.model)
-                )
+                analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
+                                                   cardReaderModel: reader.readerType.model)
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
@@ -397,13 +387,9 @@ private extension BuiltInCardReaderConnectionController {
                 if case .connection(.appleBuiltInReaderTOSAcceptanceCanceled) = error as? CardReaderServiceError {
                     return self.state = .cancel(.appleTOSAcceptance)
                 } else {
-                    ServiceLocator.analytics.track(
-                        event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
-                                                                                             error: error,
-                                                                                             countryCode: self.configuration.countryCode,
-                                                                                             cardReaderModel: candidateReader.readerType.model,
-                                                                                             siteID: self.siteID)
-                    )
+                    analyticsTracker.connectionFailed(error: error,
+                                                      cardReaderModel: candidateReader.readerType.model)
+
                     self.state = .connectingFailed(error)
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -370,8 +370,8 @@ private extension BuiltInCardReaderConnectionController {
 
             switch result {
             case .success(let reader):
-                analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
-                                                   cardReaderModel: reader.readerType.model)
+                self.analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
+                                                        cardReaderModel: reader.readerType.model)
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
@@ -387,8 +387,8 @@ private extension BuiltInCardReaderConnectionController {
                 if case .connection(.appleBuiltInReaderTOSAcceptanceCanceled) = error as? CardReaderServiceError {
                     return self.state = .cancel(.appleTOSAcceptance)
                 } else {
-                    analyticsTracker.connectionFailed(error: error,
-                                                      cardReaderModel: candidateReader.readerType.model)
+                    self.analyticsTracker.connectionFailed(error: error,
+                                                           cardReaderModel: candidateReader.readerType.model)
 
                     self.state = .connectingFailed(error)
                 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -86,6 +86,7 @@ final class CardPresentPaymentPreflightController {
         self.connectedReader = nil
         self.analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
                                                                      siteID: siteID,
+                                                                     connectionType: .userInitiated,
                                                                      stores: stores,
                                                                      analytics: analytics)
         self.connectionController = CardReaderConnectionController(

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -85,6 +85,7 @@ final class CardPresentPaymentPreflightController {
         self.analytics = analytics
         self.connectedReader = nil
         self.analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
+                                                                     siteID: siteID,
                                                                      stores: stores,
                                                                      analytics: analytics)
         self.connectionController = CardReaderConnectionController(

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -33,10 +33,14 @@ final class CardReaderConnectionAnalyticsTracker {
     private let stores: StoresManager
     private let analytics: Analytics
 
+    private let siteID: Int64
+
     init(configuration: CardPresentPaymentsConfiguration,
+         siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.configuration = configuration
+        self.siteID = siteID
         self.stores = stores
         self.analytics = analytics
 
@@ -47,7 +51,6 @@ final class CardReaderConnectionAnalyticsTracker {
     func setGatewayID(gatewayID: String?) {
         self.gatewayID = gatewayID
     }
-
     func setCandidateReader(_ reader: CardReader?) {
         candidateReader = reader
         if reader != nil {
@@ -105,6 +108,34 @@ final class CardReaderConnectionAnalyticsTracker {
             .cardReaderAutomaticDisconnect(cardReaderModel: cardReaderModel,
                                            forGatewayID: gatewayID,
                                            countryCode: configuration.countryCode))
+    }
+
+    func connectionSuccess(batteryLevel: Float?, cardReaderModel: String?) {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments
+            .cardReaderConnectionSuccess(forGatewayID: gatewayID,
+                                         batteryLevel: batteryLevel,
+                                         countryCode: configuration.countryCode,
+                                         cardReaderModel: cardReaderModel))
+    }
+
+    func connectionFailed(error: Error, cardReaderModel: String?) {
+        analytics.track(
+            event: WooAnalyticsEvent.InPersonPayments
+                .cardReaderConnectionFailed(forGatewayID: gatewayID,
+                                            error: error,
+                                            countryCode: configuration.countryCode,
+                                            cardReaderModel: cardReaderModel,
+                                            siteID: siteID))
+    }
+
+    func discoveryFailed(error: Error) {
+        analytics.track(
+            event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(
+                forGatewayID: gatewayID,
+                error: error,
+                countryCode: configuration.countryCode,
+                siteID: siteID)
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -35,12 +35,16 @@ final class CardReaderConnectionAnalyticsTracker {
 
     private let siteID: Int64
 
+    let connectionType: ConnectionType
+
     init(configuration: CardPresentPaymentsConfiguration,
          siteID: Int64,
+         connectionType: ConnectionType,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.configuration = configuration
         self.siteID = siteID
+        self.connectionType = connectionType
         self.stores = stores
         self.analytics = analytics
 
@@ -107,7 +111,8 @@ final class CardReaderConnectionAnalyticsTracker {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
             .cardReaderAutomaticDisconnect(cardReaderModel: cardReaderModel,
                                            forGatewayID: gatewayID,
-                                           countryCode: configuration.countryCode))
+                                           countryCode: configuration.countryCode,
+                                           connectionType: connectionType.rawValue))
     }
 
     func connectionSuccess(batteryLevel: Float?, cardReaderModel: String?) {
@@ -115,7 +120,8 @@ final class CardReaderConnectionAnalyticsTracker {
             .cardReaderConnectionSuccess(forGatewayID: gatewayID,
                                          batteryLevel: batteryLevel,
                                          countryCode: configuration.countryCode,
-                                         cardReaderModel: cardReaderModel))
+                                         cardReaderModel: cardReaderModel,
+                                         connectionType: connectionType.rawValue))
     }
 
     func connectionFailed(error: Error, cardReaderModel: String?) {
@@ -125,7 +131,8 @@ final class CardReaderConnectionAnalyticsTracker {
                                             error: error,
                                             countryCode: configuration.countryCode,
                                             cardReaderModel: cardReaderModel,
-                                            siteID: siteID))
+                                            siteID: siteID,
+                                            connectionType: connectionType.rawValue))
     }
 
     func discoveryFailed(error: Error) {
@@ -134,8 +141,14 @@ final class CardReaderConnectionAnalyticsTracker {
                 forGatewayID: gatewayID,
                 error: error,
                 countryCode: configuration.countryCode,
-                siteID: siteID)
+                siteID: siteID,
+                connectionType: connectionType.rawValue)
         )
+    }
+
+    enum ConnectionType: String {
+        case automaticReconnection = "automatic_reconnection"
+        case userInitiated = "user_initiated"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -554,8 +554,8 @@ private extension CardReaderConnectionController {
             switch result {
             case .success(let reader):
                 self.knownCardReaderProvider.rememberCardReader(cardReaderID: reader.id)
-                analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
-                                                   cardReaderModel: reader.readerType.model)
+                self.analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
+                                                        cardReaderModel: reader.readerType.model)
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
@@ -566,8 +566,8 @@ private extension CardReaderConnectionController {
                     self.returnSuccess(result: .connected(reader))
                 }
             case .failure(let error):
-                analyticsTracker.connectionFailed(error: error,
-                                                  cardReaderModel: candidateReader.readerType.model)
+                self.analyticsTracker.connectionFailed(error: error,
+                                                       cardReaderModel: candidateReader.readerType.model)
                 self.state = .connectingFailed(error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -376,12 +376,7 @@ private extension CardReaderConnectionController {
             onError: { [weak self] error in
                 guard let self = self else { return }
 
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
-                                                                                        error: error,
-                                                                                        countryCode: self.configuration.countryCode,
-                                                                                        siteID: self.siteID)
-                )
+                self.analyticsTracker.discoveryFailed(error: error)
                 self.state = .discoveryFailed(error)
             })
 
@@ -559,13 +554,8 @@ private extension CardReaderConnectionController {
             switch result {
             case .success(let reader):
                 self.knownCardReaderProvider.rememberCardReader(cardReaderID: reader.id)
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments
-                        .cardReaderConnectionSuccess(forGatewayID: self.gatewayID,
-                                                     batteryLevel: reader.batteryLevel,
-                                                     countryCode: self.configuration.countryCode,
-                                                     cardReaderModel: reader.readerType.model)
-                )
+                analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
+                                                   cardReaderModel: reader.readerType.model)
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
@@ -576,13 +566,8 @@ private extension CardReaderConnectionController {
                     self.returnSuccess(result: .connected(reader))
                 }
             case .failure(let error):
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
-                                                                                         error: error,
-                                                                                         countryCode: self.configuration.countryCode,
-                                                                                         cardReaderModel: candidateReader.readerType.model,
-                                                                                         siteID: self.siteID)
-                )
+                analyticsTracker.connectionFailed(error: error,
+                                                  cardReaderModel: candidateReader.readerType.model)
                 self.state = .connectingFailed(error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
@@ -385,12 +385,7 @@ private extension LegacyCardReaderConnectionController {
             onError: { [weak self] error in
                 guard let self = self else { return }
 
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
-                                                                                        error: error,
-                                                                                        countryCode: self.configuration.countryCode,
-                                                                                        siteID: self.siteID)
-                )
+                analyticsTracker.discoveryFailed(error: error)
                 self.state = .discoveryFailed(error)
             })
 
@@ -587,13 +582,8 @@ private extension LegacyCardReaderConnectionController {
             switch result {
             case .success(let reader):
                 self.knownCardReaderProvider.rememberCardReader(cardReaderID: reader.id)
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments
-                        .cardReaderConnectionSuccess(forGatewayID: self.gatewayID,
-                                                     batteryLevel: reader.batteryLevel,
-                                                     countryCode: self.configuration.countryCode,
-                                                     cardReaderModel: reader.readerType.model)
-                )
+                analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
+                                                   cardReaderModel: reader.readerType.model)
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
@@ -604,13 +594,7 @@ private extension LegacyCardReaderConnectionController {
                     self.returnSuccess(result: .connected)
                 }
             case .failure(let error):
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
-                                                                                         error: error,
-                                                                                         countryCode: self.configuration.countryCode,
-                                                                                         cardReaderModel: candidateReader.readerType.model,
-                                                                                         siteID: self.siteID)
-                )
+                analyticsTracker.connectionFailed(error: error, cardReaderModel: candidateReader.readerType.model)
                 self.state = .connectingFailed(error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
@@ -595,7 +595,7 @@ private extension LegacyCardReaderConnectionController {
                 }
             case .failure(let error):
                 self.analyticsTracker.connectionFailed(error: error,
-                                                       cardReaderModel: self.candidateReader.readerType.model)
+                                                       cardReaderModel: candidateReader.readerType.model)
                 self.state = .connectingFailed(error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
@@ -385,7 +385,7 @@ private extension LegacyCardReaderConnectionController {
             onError: { [weak self] error in
                 guard let self = self else { return }
 
-                analyticsTracker.discoveryFailed(error: error)
+                self.analyticsTracker.discoveryFailed(error: error)
                 self.state = .discoveryFailed(error)
             })
 
@@ -582,8 +582,8 @@ private extension LegacyCardReaderConnectionController {
             switch result {
             case .success(let reader):
                 self.knownCardReaderProvider.rememberCardReader(cardReaderID: reader.id)
-                analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
-                                                   cardReaderModel: reader.readerType.model)
+                self.analyticsTracker.connectionSuccess(batteryLevel: reader.batteryLevel,
+                                                        cardReaderModel: reader.readerType.model)
                 // If we were installing a software update, introduce a small delay so the user can
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
@@ -594,7 +594,8 @@ private extension LegacyCardReaderConnectionController {
                     self.returnSuccess(result: .connected)
                 }
             case .failure(let error):
-                analyticsTracker.connectionFailed(error: error, cardReaderModel: candidateReader.readerType.model)
+                self.analyticsTracker.connectionFailed(error: error,
+                                                       cardReaderModel: self.candidateReader.readerType.model)
                 self.state = .connectingFailed(error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -26,7 +26,8 @@ final class CardReaderSettingsViewModelsOrderedList: PaymentSettingsFlowPrioriti
         knownReaderProvider = CardReaderSettingsKnownReaderStorage()
 
         cardReaderConnectionAnalyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
-                                                                                    siteID: siteID)
+                                                                                    siteID: siteID,
+                                                                                    connectionType: .userInitiated)
 
         /// Instantiate and add each viewmodel related to card reader settings to the
         /// array. Viewmodels will be evaluated for shouldShow starting at the top

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -20,12 +20,13 @@ final class CardReaderSettingsViewModelsOrderedList: PaymentSettingsFlowPrioriti
 
     private let cardReaderConnectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
 
-    init(configuration: CardPresentPaymentsConfiguration) {
+    init(configuration: CardPresentPaymentsConfiguration, siteID: Int64) {
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
         knownReaderProvider = CardReaderSettingsKnownReaderStorage()
 
-        cardReaderConnectionAnalyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration)
+        cardReaderConnectionAnalyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
+                                                                                    siteID: siteID)
 
         /// Instantiate and add each viewmodel related to card reader settings to the
         /// array. Viewmodels will be evaluated for shouldShow starting at the top

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -126,7 +126,7 @@ struct SetUpTapToPayCompleteView_Previews: PreviewProvider {
         let config = CardPresentConfigurationLoader().configuration
         let viewModel = SetUpTapToPayCompleteViewModel(
             didChangeShouldShow: nil,
-            connectionAnalyticsTracker: .init(configuration: config))
+            connectionAnalyticsTracker: .init(configuration: config, siteID: 0))
         SetUpTapToPayCompleteView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -126,7 +126,7 @@ struct SetUpTapToPayCompleteView_Previews: PreviewProvider {
         let config = CardPresentConfigurationLoader().configuration
         let viewModel = SetUpTapToPayCompleteViewModel(
             didChangeShouldShow: nil,
-            connectionAnalyticsTracker: .init(configuration: config, siteID: 0))
+            connectionAnalyticsTracker: .init(configuration: config, siteID: 0, connectionType: .userInitiated))
         SetUpTapToPayCompleteView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -215,7 +215,7 @@ struct SetUpTapToPayInformationView_Previews: PreviewProvider {
             configuration: config,
             didChangeShouldShow: nil,
             onboardingStatePublisher: publisher,
-            connectionAnalyticsTracker: .init(configuration: config))
+            connectionAnalyticsTracker: .init(configuration: config, siteID: 0))
         SetUpTapToPayInformationView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -215,7 +215,7 @@ struct SetUpTapToPayInformationView_Previews: PreviewProvider {
             configuration: config,
             didChangeShouldShow: nil,
             onboardingStatePublisher: publisher,
-            connectionAnalyticsTracker: .init(configuration: config, siteID: 0))
+            connectionAnalyticsTracker: .init(configuration: config, siteID: 0, connectionType: .userInitiated))
         SetUpTapToPayInformationView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -189,7 +189,7 @@ struct SetUpTapToPayPaymentPromptView_Previews: PreviewProvider {
         let viewModel = SetUpTapToPayTryPaymentPromptViewModel(
             didChangeShouldShow: nil,
             connectionAnalyticsTracker: .init(configuration: config,
-                                             siteID: 0))
+                                              siteID: 0, connectionType: .userInitiated))
         SetUpTapToPayPaymentPromptView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -188,7 +188,8 @@ struct SetUpTapToPayPaymentPromptView_Previews: PreviewProvider {
         let config = CardPresentConfigurationLoader().configuration
         let viewModel = SetUpTapToPayTryPaymentPromptViewModel(
             didChangeShouldShow: nil,
-            connectionAnalyticsTracker: .init(configuration: config))
+            connectionAnalyticsTracker: .init(configuration: config,
+                                             siteID: 0))
         SetUpTapToPayPaymentPromptView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -28,7 +28,8 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
          onboardingUseCase: CardPresentPaymentsOnboardingUseCase) {
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
-        cardReaderConnectionAnalyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration)
+        cardReaderConnectionAnalyticsTracker = .init(configuration: configuration,
+                                                     siteID: siteID)
         onboardingUseCase.statePublisher.share().sink { [weak self] onboardingState in
             guard case .completed(let plugin) = onboardingState else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -29,7 +29,8 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
         cardReaderConnectionAnalyticsTracker = .init(configuration: configuration,
-                                                     siteID: siteID)
+                                                     siteID: siteID,
+                                                     connectionType: .userInitiated)
         onboardingUseCase.statePublisher.share().sink { [weak self] onboardingState in
             guard case .completed(let plugin) = onboardingState else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -450,10 +450,15 @@ extension InPersonPaymentsMenuViewController {
         guard enableManageCardReaderCell else {
             return
         }
+        guard let siteID = stores.sessionManager.defaultStoreID else {
+            DDLogError("⛔️ Could not open card reader settings – StoreID could not be determined")
+            return
+        }
 
         ServiceLocator.analytics.track(.paymentsMenuManageCardReadersTapped)
 
-        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList(configuration: viewModel.cardPresentPaymentsConfiguration)
+        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList(configuration: viewModel.cardPresentPaymentsConfiguration,
+                                                                         siteID: siteID)
         let viewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
         show(viewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
@@ -112,7 +112,8 @@ private extension TapToPayReconnectionController {
             forSiteID: siteID,
             alertsPresenter: silencingAlertsPresenter,
             configuration: configuration,
-            analyticsTracker: CardReaderConnectionAnalyticsTracker(configuration: configuration),
+            analyticsTracker: CardReaderConnectionAnalyticsTracker(configuration: configuration,
+                                                                   siteID: siteID),
             allowTermsOfServiceAcceptance: false)
 
         connectionController?.searchAndConnect(onCompletion: { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
@@ -113,7 +113,8 @@ private extension TapToPayReconnectionController {
             alertsPresenter: silencingAlertsPresenter,
             configuration: configuration,
             analyticsTracker: CardReaderConnectionAnalyticsTracker(configuration: configuration,
-                                                                   siteID: siteID),
+                                                                   siteID: siteID,
+                                                                   connectionType: .automaticReconnection),
             allowTermsOfServiceAcceptance: false)
 
         connectionController?.searchAndConnect(onCompletion: { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -94,6 +94,7 @@ final class LegacyCollectOrderPaymentUseCase: NSObject, LegacyCollectOrderPaymen
                                        configuration: configuration,
                                        analyticsTracker: CardReaderConnectionAnalyticsTracker(configuration: configuration,
                                                                                               siteID: siteID,
+                                                                                              connectionType: .userInitiated,
                                                                                               stores: stores,
                                                                                               analytics: analytics))
     }()

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -93,6 +93,7 @@ final class LegacyCollectOrderPaymentUseCase: NSObject, LegacyCollectOrderPaymen
                                        alertsProvider: CardReaderSettingsAlerts(),
                                        configuration: configuration,
                                        analyticsTracker: CardReaderConnectionAnalyticsTracker(configuration: configuration,
+                                                                                              siteID: siteID,
                                                                                               stores: stores,
                                                                                               analytics: analytics))
     }()

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -80,6 +80,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
                                    configuration: cardPresentConfiguration,
                                    analyticsTracker: .init(configuration: cardPresentConfiguration,
                                                            siteID: order.siteID,
+                                                           connectionType: .userInitiated,
                                                            stores: stores,
                                                            analytics: analytics))
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -79,6 +79,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
                                    alertsProvider: cardReaderConnectionAlerts,
                                    configuration: cardPresentConfiguration,
                                    analyticsTracker: .init(configuration: cardPresentConfiguration,
+                                                           siteID: order.siteID,
                                                            stores: stores,
                                                            analytics: analytics))
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionControllerTests.swift
@@ -49,6 +49,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -85,6 +86,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -128,6 +130,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -166,6 +169,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -203,6 +207,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -242,6 +247,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -286,6 +292,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -322,6 +329,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -361,6 +369,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -400,6 +409,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 
@@ -437,6 +447,7 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             alertsProvider: mockAlerts,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager)
         )
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionControllerTests.swift
@@ -50,7 +50,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -87,7 +89,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -103,10 +107,6 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
         XCTAssertEqual(connectionResult, .connected)
 
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderConnectionSuccess.rawValue))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            sampleGatewayID
-        )
     }
 
     func test_finding_an_known_reader_automatically_connects_and_completes_with_success_true() {
@@ -131,7 +131,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -170,7 +172,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -182,10 +186,6 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: Constants.expectationTimeout)
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderDiscoveryFailed.rawValue))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            sampleGatewayID
-        )
     }
 
     func test_finding_multiple_readers_presents_list_to_user_and_cancelling_list_calls_completion_with_success_false() {
@@ -208,7 +208,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -248,7 +250,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -264,10 +268,6 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
         XCTAssertEqual(connectionResult, .canceled)
 
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.cardReaderConnectionFailed.rawValue))
-        XCTAssertEqual(
-            analyticsProvider.receivedProperties.first?[WooAnalyticsEvent.InPersonPayments.Keys.gatewayID] as? String,
-            sampleGatewayID
-        )
     }
 
     func test_user_can_cancel_search_after_connection_error_due_to_low_battery() {
@@ -293,7 +293,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -330,7 +332,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -370,7 +374,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -410,7 +416,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When
@@ -448,7 +456,9 @@ final class LegacyCardReaderConnectionControllerTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
-                                    stores: mockStoresManager)
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics)
         )
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
@@ -26,6 +26,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: Mocks.configuration,
                                                                 siteID: sampleSiteID,
+                                                                connectionType: .userInitiated,
                                                                 stores: mockStoresManager,
                                                                 analytics: analytics)
         analyticsTracker.setCandidateReader(MockCardReader.wisePad3())
@@ -54,6 +55,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -71,6 +73,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -83,6 +86,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "50% Battery")
     }
@@ -100,6 +104,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "Unknown Battery Level")
@@ -111,6 +116,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Version: 1.00.03.34-SZZZ_Generic_v45-300001")
@@ -129,6 +135,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Unknown Software Version")
@@ -179,6 +186,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -483,6 +491,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -504,6 +513,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -527,6 +537,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
                 configuration: Mocks.configuration,
                 analyticsTracker: .init(configuration: Mocks.configuration,
                                         siteID: self.sampleSiteID,
+                                        connectionType: .userInitiated,
                                         stores: self.mockStoresManager),
                 delayToShowUpdateSuccessMessage: .milliseconds(1))
         }
@@ -550,6 +561,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -579,6 +591,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
                                     siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
@@ -10,6 +10,8 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
 
     private var viewModel: BluetoothCardReaderSettingsConnectedViewModel!
 
+    private let sampleSiteID: Int64 = 1234
+
     override func setUpWithError() throws {
         mockStoresManager = MockCardPresentPaymentsStoresManager(
             connectedReaders: [MockCardReader.bbposChipper2XBT()],
@@ -23,6 +25,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
         ServiceLocator.setAnalytics(analytics)
 
         analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: Mocks.configuration,
+                                                                siteID: sampleSiteID,
                                                                 stores: mockStoresManager,
                                                                 analytics: analytics)
         analyticsTracker.setCandidateReader(MockCardReader.wisePad3())
@@ -50,6 +53,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             },
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -66,6 +70,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             },
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -77,6 +82,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "50% Battery")
     }
@@ -93,6 +99,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderBatteryLevel, "Unknown Battery Level")
@@ -103,6 +110,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Version: 1.00.03.34-SZZZ_Generic_v45-300001")
@@ -120,6 +128,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
         XCTAssertEqual(viewModel.connectedReaderSoftwareVersion, "Unknown Software Version")
@@ -169,6 +178,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -472,6 +482,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -492,6 +503,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -514,6 +526,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
                 didChangeShouldShow: { promise($0) },
                 configuration: Mocks.configuration,
                 analyticsTracker: .init(configuration: Mocks.configuration,
+                                        siteID: self.sampleSiteID,
                                         stores: self.mockStoresManager),
                 delayToShowUpdateSuccessMessage: .milliseconds(1))
         }
@@ -536,6 +549,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 
@@ -564,6 +578,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
             didChangeShouldShow: nil,
             configuration: Mocks.configuration,
             analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
                                     stores: mockStoresManager),
             delayToShowUpdateSuccessMessage: .milliseconds(1))
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
@@ -28,6 +28,7 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
             configuration: TestConstants.mockConfiguration,
             cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
                                                         siteID: 0,
+                                                        connectionType: .userInitiated,
                                                         stores: mockStoresManager))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
@@ -53,6 +54,7 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
             configuration: TestConstants.mockConfiguration,
             cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
                                                         siteID: 0,
+                                                        connectionType: .userInitiated,
                                                         stores: mockStoresManager))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
@@ -20,13 +20,15 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
         ServiceLocator.setStores(mockStoresManager)
 
         let expectation = self.expectation(description: #function)
-        let _ = CardReaderSettingsSearchingViewModel(didChangeShouldShow: { shouldShow in
-            XCTAssertTrue(shouldShow == .isTrue)
-            expectation.fulfill()
-        }, knownReaderProvider: mockKnownReaderProvider,
-                                                     configuration: TestConstants.mockConfiguration,
-                                                     cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
-                                                                                                 stores: mockStoresManager))
+        let _ = CardReaderSettingsSearchingViewModel(
+            didChangeShouldShow: { shouldShow in
+                XCTAssertTrue(shouldShow == .isTrue)
+                expectation.fulfill()
+            }, knownReaderProvider: mockKnownReaderProvider,
+            configuration: TestConstants.mockConfiguration,
+            cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
+                                                        siteID: 0,
+                                                        stores: mockStoresManager))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
@@ -43,13 +45,15 @@ final class CardReaderSettingsSearchingViewModelTests: XCTestCase {
 
         let expectation = self.expectation(description: #function)
 
-        let _ = CardReaderSettingsSearchingViewModel(didChangeShouldShow: { shouldShow in
-            XCTAssertTrue(shouldShow == .isFalse)
-            expectation.fulfill()
-        }, knownReaderProvider: mockKnownReaderProvider,
-                                                     configuration: TestConstants.mockConfiguration,
-                                                     cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
-                                                                                                 stores: mockStoresManager))
+        let _ = CardReaderSettingsSearchingViewModel(
+            didChangeShouldShow: { shouldShow in
+                XCTAssertTrue(shouldShow == .isFalse)
+                expectation.fulfill()
+            }, knownReaderProvider: mockKnownReaderProvider,
+            configuration: TestConstants.mockConfiguration,
+            cardReaderConnectionAnalyticsTracker: .init(configuration: TestConstants.mockConfiguration,
+                                                        siteID: 0,
+                                                        stores: mockStoresManager))
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -86,6 +86,8 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
         assertEqual(sampleSiteID, connectionControllerFactory.spyCreateConnectionControllerSiteID)
         assertEqual(false, connectionControllerFactory.spyCreateConnectionControllerAllowTermsOfServiceAcceptance)
         assertEqual(sampleConfiguration, connectionControllerFactory.spyCreateConnectionControllerConfiguration)
+        assertEqual(CardReaderConnectionAnalyticsTracker.ConnectionType.automaticReconnection,
+                    connectionControllerFactory.spyCreateConnectionControllerAnalyticsTracker?.connectionType)
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9735
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've added automatic reconnection to the Tap to Pay reader for eligible stores and devices.

This PR adds a `connection_type` property to relevant card reader connection analytics events, and sets it to `user_initiated` for existing flows, and `automatic_reconnection` for the new reconnection events.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app and take a payment using Tap to Pay on iPhone
2. Background the app
3. Foreground the app
4. Wait a few seconds
5. Observe that the `card_reader_connection_success` event is logged with the `connection_type: automatic_reconnection` property
6. Take a payment using a Bluetooth reader
7. Observe that after connection, the `card_reader_connection_success` event is logged with the `connection_type: user_initiated` property

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="966" alt="`card_reader_connection_success` event console log with the `connection_type: automatic_reconnection` property" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/18b84a56-b1a1-41f1-a3c5-1eed075d3ed6">
<img width="948" alt="`card_reader_connection_success` and `card_reader_automatic_disconnect` event console logs with the `connection_type: user_initiated` property" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/bbe95f70-2017-46e5-8da9-71c6071abbb8">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
