### PR TITLE
[SKU scanner] Persist SKU matches to storage

### DIFF
--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -343,7 +343,9 @@ private extension ProductStore {
                 guard let product = products.first(where: { $0.sku == sku }) else {
                     return onCompletion(.failure(ProductLoadError.notFound))
                 }
-                onCompletion(.success(product))
+                self.upsertStoredProductsInBackground(readOnlyProducts: [product], siteID: siteID, onCompletion: {
+                    onCompletion(.success(product))
+                })
             case .failure:
                 onCompletion(.failure(ProductLoadError.notFound))
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9756 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds additional logic to the `retrieveFirstProductMatchFromSKU` action, by upserting to local storage the product retrieved from the API upon successful SKU search/match.

This is done so we have a more up-to-date local snapshot of the API data, which adds stability later on when calling the action.

## Changes
We call the existing `upsertStoredProductsInBackground()` when handling the `.success` case result from the API call, so if a product is found, this is also inserted or updated into local storage. 

## Testing instructions
Unit Tests should pass