### PR TITLE
[Scan to Pay] Remove feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -97,8 +97,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .sdkLessGoogleSignIn:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .scanToPay:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -207,7 +207,4 @@ public enum FeatureFlag: Int {
     /// Do not use the Google SDK when authenticating through a Google account.
     ///
     case sdkLessGoogleSignIn
-
-    /// Enables Scan to Pay as a payment method.
-    case scanToPay
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,10 +3,11 @@
 13.7
 -----
 - [*] JITMs: Added modal-style Just in Time Message support on the dashboard [https://github.com/woocommerce/woocommerce-ios/pull/9694]
-- [*] Order Creation: Products can be searched by SKU when adding products to an order. [https://github.com/woocommerce/woocommerce-ios/pull/9711]
+- [**] Order Creation: Products can be searched by SKU when adding products to an order. [https://github.com/woocommerce/woocommerce-ios/pull/9711]
 - [*] Orders: Fixes order details so separate order items are not combined just because they are the same product or variation. [https://github.com/woocommerce/woocommerce-ios/pull/9710]
 - [Internal] Store creation: starting May 4, store creation used to time out while waiting for the site to be ready (become a Jetpack/Woo site). A workaround was implemented to wait for the site differently. [https://github.com/woocommerce/woocommerce-ios/pull/9731]
 - [**] Mobile Payments: Tap to Pay is initialised on launch or foreground, to speed up payments [https://github.com/woocommerce/woocommerce-ios/pull/9750]
+- [**] Mobile Payments: Merchants can now collect in-person payments by showing a QR code to their customers. [https://github.com/woocommerce/woocommerce-ios/pull/9762]
 
 13.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -48,7 +48,7 @@ final class PaymentMethodsViewModel: ObservableObject {
     }
 
     var showScanToPayRow: Bool {
-        featureFlagService.isFeatureFlagEnabled(.scanToPay) && paymentLink != nil
+        paymentLink != nil
     }
 
     /// Defines if the Card Reader upsell banner should be shown based on country eligibility and dismissal/reminder preferences

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -25,7 +25,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isReadOnlyGiftCardsEnabled: Bool
     private let isHideStoreOnboardingTaskListFeatureEnabled: Bool
     private let isAddProductToOrderViaSKUScannerEnabled: Bool
-    private let isScanToPayEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -49,8 +48,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
          isHideStoreOnboardingTaskListFeatureEnabled: Bool = false,
-         isAddProductToOrderViaSKUScannerEnabled: Bool = false,
-         isScanToPayEnabled: Bool = false) {
+         isAddProductToOrderViaSKUScannerEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -74,7 +72,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.isHideStoreOnboardingTaskListFeatureEnabled = isHideStoreOnboardingTaskListFeatureEnabled
         self.isAddProductToOrderViaSKUScannerEnabled = isAddProductToOrderViaSKUScannerEnabled
-        self.isScanToPayEnabled = isScanToPayEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -125,8 +122,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isHideStoreOnboardingTaskListFeatureEnabled
         case .addProductToOrderViaSKUScanner:
             return isAddProductToOrderViaSKUScannerEnabled
-        case .scanToPay:
-            return isScanToPayEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -666,29 +666,13 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.paymentLink)
     }
 
-    func test_scanToPayRow_is_hidden_if_feature_flag_is_disabled() {
+    func test_scanToPayRow_is_shown_if_payment_link_is_not_nil() {
         // Given
         let paymentURL = URL(string: "http://www.automattic.com")
-        let dependencies = Dependencies(featureFlagService: MockFeatureFlagService(isScanToPayEnabled: false))
         let viewModel = PaymentMethodsViewModel(paymentLink: paymentURL,
                                                 formattedTotal: "$12.00",
                                                 flow: .simplePayment,
-                                                isTapToPayOnIPhoneEnabled: false,
-                                                dependencies: dependencies)
-
-        // Then
-        XCTAssertFalse(viewModel.showScanToPayRow)
-    }
-
-    func test_scanToPayRow_is_shown_if_feature_flag_is_enabled_and_payment_link_not_nil() {
-        // Given
-        let paymentURL = URL(string: "http://www.automattic.com")
-        let dependencies = Dependencies(featureFlagService: MockFeatureFlagService(isScanToPayEnabled: true))
-        let viewModel = PaymentMethodsViewModel(paymentLink: paymentURL,
-                                                formattedTotal: "$12.00",
-                                                flow: .simplePayment,
-                                                isTapToPayOnIPhoneEnabled: false,
-                                                dependencies: dependencies)
+                                                isTapToPayOnIPhoneEnabled: false)
 
         // Then
         XCTAssertTrue(viewModel.showScanToPayRow)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9699 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we remove the feature flag for Scan to Pay and leave it ready for release.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Check that Scan to Pay is visible in a release Build. You can try that by changing the Build Configuration in the WooCommerce schema:

<img width="923" alt="Screenshot 2023-05-18 at 15 45 54" src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/c0d55d3b-c000-45e2-bbc3-71d9e4972576">


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
