### PR TITLE
[Mobile Payments] Handle site change during TTP auto reconnection

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -454,7 +454,7 @@ extension StripeCardReaderService: CardReaderService {
                 }
 
                 if let reader = reader {
-                    if connectionAttemptInvalidated {
+                    if self.connectionAttemptInvalidated {
                         _ = self.disconnect()
                         promise(.failure(CardReaderServiceError.connection(underlyingError: .connectionAttemptInvalidated)))
                     }
@@ -492,7 +492,7 @@ extension StripeCardReaderService: CardReaderService {
                 }
 
                 if let reader = reader {
-                    if connectionAttemptInvalidated {
+                    if self.connectionAttemptInvalidated {
                         _ = self.disconnect()
                         promise(.failure(CardReaderServiceError.connection(underlyingError: .connectionAttemptInvalidated)))
                     }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -15,6 +15,7 @@ public final class StripeCardReaderService: NSObject {
     private let discoveryStatusSubject = CurrentValueSubject<CardReaderServiceDiscoveryStatus, Never>(.idle)
     private let readerEventsSubject = PassthroughSubject<CardReaderEvent, Never>()
     private let softwareUpdateSubject = CurrentValueSubject<CardReaderSoftwareUpdateState, Never>(.none)
+    private var connectionAttemptInvalidated: Bool = false
 
     /// Volatile, in-memory cache of discovered readers. It has to be cleared after we connect to a reader
     /// see
@@ -287,6 +288,10 @@ extension StripeCardReaderService: CardReaderService {
             return
         }
 
+        if Terminal.shared.connectionStatus == .connecting {
+            connectionAttemptInvalidated = true
+        }
+
         Terminal.shared.clearCachedCredentials()
     }
 
@@ -354,6 +359,7 @@ extension StripeCardReaderService: CardReaderService {
             }.eraseToAnyPublisher()
         }
 
+        connectionAttemptInvalidated = false
         switch stripeReader.deviceType {
         case .appleBuiltIn:
             return getLocalMobileConfiguration(stripeReader, options: options).flatMap { configuration in
@@ -448,6 +454,10 @@ extension StripeCardReaderService: CardReaderService {
                 }
 
                 if let reader = reader {
+                    if connectionAttemptInvalidated {
+                        _ = self.disconnect()
+                        promise(.failure(CardReaderServiceError.connection(underlyingError: .connectionAttemptInvalidated)))
+                    }
                     self.connectedReadersSubject.send([CardReader(reader: reader)])
                     self.switchStatusToIdle()
                     promise(.success(CardReader(reader: reader)))
@@ -482,6 +492,10 @@ extension StripeCardReaderService: CardReaderService {
                 }
 
                 if let reader = reader {
+                    if connectionAttemptInvalidated {
+                        _ = self.disconnect()
+                        promise(.failure(CardReaderServiceError.connection(underlyingError: .connectionAttemptInvalidated)))
+                    }
                     self.connectedReadersSubject.send([CardReader(reader: reader)])
                     self.switchStatusToIdle()
                     promise(.success(CardReader(reader: reader)))

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -149,6 +149,9 @@ public enum UnderlyingError: Error, Equatable {
     /// There was no refund in progress to cancel
     case noRefundInProgress
 
+    /// Connection attempt invalidated while it was in progress – e.g. the store was changed during a connection
+    case connectionAttemptInvalidated
+
     // MARK: - Tap to Pay on iPhone related errors
 
     /// The device must have a passcode in order to use Tap to Pay on iPhone
@@ -408,6 +411,9 @@ extension UnderlyingError: LocalizedError {
             return NSLocalizedString("Sorry, this refund could not be canceled",
                                      comment: "Error message shown when a refund could not be canceled (likely because " +
                                      "it had already completed)")
+        case .connectionAttemptInvalidated:
+            return NSLocalizedString("Sorry, we could not connect to the reader. Please try again.",
+                                     comment: "Error message shown when an in-progress connection is cancelled by the system")
 
             // MARK: - Tap to Pay on iPhone errors
         case .passcodeNotEnabled:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9735
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With the background automatic reconnection to Tap to Pay we recently introduced, it became possible to switch stores while a card reader connection is in progress, for the first time.

The `CardPresentPaymentAction.reset` action is used when we switch stores – it  disconnects from connected readers, then cleans up the config.

However, with Stripe’s SDK it’s not possible to cancel an _in-progress_ connection, so if one was in progress when we switch stores, it would run to completion. Payments against that connection fail, but with Tap to Pay they do show the store name for the wrong store on the Apple-provided payment screen.

With this change, we invalidate any in-progress connection, and immediately disconnect the reader if/when that connection succeeds.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### The reconnection path
**Using two US based WCPay store on iOS 16+ with an iPhone XS or newer**

1. Open the app, and take a Tap to Pay payment with the first store.
2. Go to the store switcher and select the second store, but don't switch to it yet
3. Background the app, then foreground it again
4. Immediately switch to the second store
5. Go and take a Tap to Pay payment
6. Observe that you are _not_ connected to the built in reader, and that when the Apple-provided payment screen is shown, it shows the expected store name

Previously, at step 6 you would have seen that you _were_ connected to the built in reader, _but_ it would show the wrong store name and payments would fail.

See videos for more detail.

### Wider testing
Optional – I've done a lot of this. 

- [ ] When switching while connected to a hardware reader, it gets disconnected as previously on store switch
- [ ] When switching while connected to a tap to pay reader, it gets disconnected
- [ ] When switching while not connected to any reader, subsequent connections work as normal
- [ ] Reconnections on the switched-to site for subsequent background/foreground moves without a store switch work as expected

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before the fix
🔊 Sound on for my commentary!

https://github.com/woocommerce/woocommerce-ios/assets/2472348/daf90d34-9463-44c4-a5de-58e31069c91d


### After: with the fix
🔊 Sound on for my commentary!

https://github.com/woocommerce/woocommerce-ios/assets/2472348/45735fd5-281f-4456-9bd0-bd135681a475



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
