### PR TITLE
[Privacy Choices] Update Tracking and Opt-Outs support document URL

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -98,9 +98,8 @@ extension WooConstants {
         case privacy = "https://automattic.com/privacy/"
 
         /// More Privacy Documentation URL.
-        /// TODO: Replace with the real one once it is built https://github.com/woocommerce/woomobile-private/issues/286
         ///
-        case morePrivacyDocumentation = "https://wordpress.com/support/tracking-opt-outs/"
+        case morePrivacyDocumentation = "https://woocommerce.com/tracking-and-opt-outs/"
 
         /// Documentation about WooCommerce Usage Tracking
         ///


### PR DESCRIPTION
Closes: #9610 

# Why

This PR updates the "morePrivacyDocumentation" URL with the wooCommerce production one.

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/46d1a666-b944-4d2b-bb90-565df1a5ed6d

# Testing 

- Launch the app and navigate to Hub -> Settings -> Privacy Settings
- Tap on the " Web Options" row
- See that the WooCommerce Tracking & Opt-Outs  support document is presented

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
