### PR TITLE
EU-Bound Shipping Notice: Add simple tracks

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2368,15 +2368,15 @@ extension WooAnalyticsEvent {
 extension WooAnalyticsEvent {
     enum EUShippingNotice {
         static func onEUShippingNoticeBannerShown() -> WooAnalyticsEvent {
-            
+            WooAnalyticsEvent(statName: .euShippingNoticeShown, properties: [:])
         }
-        
+
         static func onEUShippingNoticeBannerDismissed() -> WooAnalyticsEvent {
-            
+            WooAnalyticsEvent(statName: .euShippingNoticeDismissed, properties: [:])
         }
-        
+
         static func onEUShippingNoticeLearnMoreTapped() -> WooAnalyticsEvent {
-            
+            WooAnalyticsEvent(statName: .euShippingNoticeLearnMoreTapped, properties: [:])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2362,3 +2362,21 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - EU Shipping Notice Banner
+//
+extension WooAnalyticsEvent {
+    enum EUShippingNotice {
+        static func onEUShippingNoticeBannerShown() -> WooAnalyticsEvent {
+            
+        }
+        
+        static func onEUShippingNoticeBannerDismissed() -> WooAnalyticsEvent {
+            
+        }
+        
+        static func onEUShippingNoticeLearnMoreTapped() -> WooAnalyticsEvent {
+            
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -434,6 +434,9 @@ public enum WooAnalyticsStat: String {
     case shippingLabelPaymentMethodAdded = "shipping_label_payment_method_added"
     case shippingLabelMoveItemTapped = "shipping_label_move_item_tapped"
     case shippingLabelItemMoved = "shipping_label_item_moved"
+    case euShippingNoticeShown = "eu_shipping_notice_shown"
+    case euShippingNoticeDismissed = "eu_shipping_notice_dismissed"
+    case euShippingNoticeLearnMoreTapped = "eu_shipping_notice_learn_more_tapped"
 
     // MARK: Receipt Events
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -591,6 +591,7 @@ private extension ShippingLabelFormViewController {
     /// Present a Top Banner View containing the EU Shipping Notice.
     ///
     func showTopBannerView() {
+        ServiceLocator.analytics.track(.euShippingNoticeShown)
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(self.tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topBannerView)
         headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -591,7 +591,7 @@ private extension ShippingLabelFormViewController {
     /// Present a Top Banner View containing the EU Shipping Notice.
     ///
     func showTopBannerView() {
-        ServiceLocator.analytics.track(.euShippingNoticeShown)
+        ServiceLocator.analytics.track(event: .EUShippingNotice.onEUShippingNoticeBannerShown())
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(self.tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topBannerView)
         headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -6,10 +6,12 @@ final class EUShippingNoticeTopBannerFactory {
                                 onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
         let learnMoreAction = TopBannerViewModel.ActionButton(title: Localization.learnMore) { _ in
             onLearnMorePressed()
+            ServiceLocator.analytics.track(.euShippingNoticeLearnMoreTapped)
         }
 
         let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) { _ in
             onDismissPressed()
+            ServiceLocator.analytics.track(.euShippingNoticeDismissed)
         }
 
         let viewModel = TopBannerViewModel(title: nil,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -6,12 +6,12 @@ final class EUShippingNoticeTopBannerFactory {
                                 onLearnMorePressed: @escaping () -> Void) -> TopBannerView {
         let learnMoreAction = TopBannerViewModel.ActionButton(title: Localization.learnMore) { _ in
             onLearnMorePressed()
-            ServiceLocator.analytics.track(.euShippingNoticeLearnMoreTapped)
+            ServiceLocator.analytics.track(event: .EUShippingNotice.onEUShippingNoticeLearnMoreTapped())
         }
 
         let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) { _ in
             onDismissPressed()
-            ServiceLocator.analytics.track(.euShippingNoticeDismissed)
+            ServiceLocator.analytics.track(event: .EUShippingNotice.onEUShippingNoticeBannerDismissed())
         }
 
         let viewModel = TopBannerViewModel(title: nil,


### PR DESCRIPTION
Summary
==========
Fix issue #9765 by introducing three track events to the EU Shipping Notice flow:

- `euShippingNoticeShown` when the Notice is presented to the user inside the `Create Shipping Label` view
- `euShippingNoticeDismissed` when the user dismiss the banner
- `euShippingNoticeLearnMoreTapped` when the user taps the `Learn More` button

How to Test
==========
1. Open the app using a store with the Shipping Labels plugin activated
2. Open the Order Details of an order with the Processing status
3. Hit the Create Shipping Label button
4. Verify that the Banner only appears when the Origin country is US and the Destination country is one of the EU countries listed above
5. Verify that the `EU_SHIPPING_NOTICE_SHOWN` event is tracked
6. Hit the `Learn More` button and verify that the `EU_SHIPPING_NOTICE_LEARN_MORE_TAPPED` event is tracked
7. Dismiss the banner and verify that the `EU_SHIPPING_NOTICE_DISMISSED` event is tracked

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.