### PR TITLE
Refactor and update how we wait for a created site to be ready

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [*] JITMs: Added modal-style Just in Time Message support on the dashboard [https://github.com/woocommerce/woocommerce-ios/pull/9694]
 - [*] Order Creation: Products can be searched by SKU when adding products to an order. [https://github.com/woocommerce/woocommerce-ios/pull/9711]
 - [*] Orders: Fixes order details so separate order items are not combined just because they are the same product or variation. [https://github.com/woocommerce/woocommerce-ios/pull/9710]
-- [Internal] Store creation: starting May 4, store creation used to time out while waiting for the site to be ready (become a Jetpack/Woo site). A workaround was implemented to wait for the site differently. [https://github.com/woocommerce/woocommerce-ios/pull/9731]
+- [Internal] Store creation: starting May 4, store creation used to time out while waiting for the site to be ready (become a Jetpack/Woo site). A workaround was implemented to wait for the site differently. [https://github.com/woocommerce/woocommerce-ios/pull/9767]
 - [**] Mobile Payments: Tap to Pay is initialised on launch or foreground, to speed up payments [https://github.com/woocommerce/woocommerce-ios/pull/9750]
 
 13.6

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -746,7 +746,9 @@ private extension StoreCreationCoordinator {
             // Retries 10 times with some seconds pause in between to wait for the newly created site to be available as a Jetpack/Woo site.
             .retry(10)
             .sink (receiveCompletion: { [weak self] completion in
-                guard let self else { return }
+                guard let self, case .failure = completion else {
+                    return
+                }
                 self.handleCompletionStatus(site: nil, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
             }, receiveValue: { [weak self] site in
                 guard let self else { return }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -745,13 +745,13 @@ private extension StoreCreationCoordinator {
             })
             // Retries 10 times with some seconds pause in between to wait for the newly created site to be available as a Jetpack/Woo site.
             .retry(10)
-            .sink { [weak self] completion in
+            .sink (receiveCompletion: { [weak self] completion in
                 guard let self else { return }
                 self.handleCompletionStatus(site: nil, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
-            } receiveValue: { [weak self] site in
+            }, receiveValue: { [weak self] site in
                 guard let self else { return }
                 self.handleCompletionStatus(site: site, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
-            }
+            })
     }
 
     @MainActor

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -53,6 +53,7 @@ final class StoreCreationCoordinator: Coordinator {
     }
 
     private weak var storeCreationProgressViewModel: StoreCreationProgressViewModel?
+    private var statusChecker: StoreCreationStatusChecker?
 
     init(source: Source,
          navigationController: UINavigationController,
@@ -507,6 +508,7 @@ private extension StoreCreationCoordinator {
             switch freeTrialResult {
             case .success:
                 cancelLocalNotificationToSubscribeFreeTrial(storeName: storeName)
+                scheduleLocalNotificationWhenStoreIsReady()
                 // Wait for jetpack to be installed
                 DDLogInfo("🟢 Free trial enabled on site. Waiting for jetpack to be installed...")
                 waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteResult.siteID, expectedStoreName: siteResult.name)
@@ -742,92 +744,59 @@ private extension StoreCreationCoordinator {
         ///
         let waitingTimeStart = Date()
 
-        scheduleLocalNotificationWhenStoreIsReady()
-
-        jetpackSiteSubscription = $siteIDFromStoreCreation
-            .compactMap { $0 }
-            .removeDuplicates()
-            .asyncMap { [weak self] siteID -> Site? in
-                guard let self else {
-                    return nil
-                }
-                // Waits some seconds before syncing sites every time.
-                try await Task.sleep(nanoseconds: UInt64(self.jetpackCheckRetryInterval * 1_000_000_000))
-                return try await self.syncSite(siteID: siteID, expectedStoreName: expectedStoreName, haveTrackedOutOfSyncEvent: haveTrackedOutOfSyncEvent)
-            }
-            .receive(on: DispatchQueue.main)
-            .handleEvents(receiveCompletion: { [weak self] output in
+        let statusChecker = StoreCreationStatusChecker(isFreeTrialCreation: isFreeTrialCreation, stores: stores)
+        self.statusChecker = statusChecker
+        jetpackSiteSubscription = statusChecker.waitForSiteToBeReady(siteID: siteID)
+            .sink { [weak self] completion in
                 guard let self else { return }
-                self.storeCreationProgressViewModel?.incrementProgress()
-
-                // Track when a properties out of sync event occur, but only track it once.
-                if self.isPropertiesOutOfSyncError(output) && !haveTrackedOutOfSyncEvent {
-                    self.analytics.track(event: .StoreCreation.siteCreationPropertiesOutOfSync())
-                    haveTrackedOutOfSyncEvent = true
+                switch completion {
+                case .failure:
+                    self.storeCreationProgressViewModel?.incrementProgress()
+                case .finished:
+                    self.handleCompletionStatus(site: nil, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
                 }
-            })
-            // Retries 10 times with some seconds pause in between to wait for the newly created site to be available as a Jetpack site
-            // in the WPCOM `/me/sites` response.
-            .retry(10)
-            .replaceError(with: nil)
-            .sink { [weak self] site in
+            } receiveValue: { [weak self] site in
                 guard let self else { return }
-
-                self.cancelLocalNotificationWhenStoreIsReady()
-
-                guard let site else {
-                    navigationController.dismiss(animated: true) { [weak self] in
-                        guard let self else { return }
-                        self.showJetpackSiteTimeoutAlert(from: self.navigationController)
-                    }
-                    return
-                }
-
-                self.storeCreationProgressViewModel?.markAsComplete()
-                self.trackSiteCreatedEvent(site: site, flow: .native, timeAtStart: waitingTimeStart)
-
-                /// Free trial stores should land directly on the dashboard and not show any success view.
-                ///
-                if self.isFreeTrialCreation {
-                    self.continueWithSelectedSite(site: site)
-                } else {
-                    self.showSuccessView(from: navigationController, site: site)
-                }
+                self.handleCompletionStatus(site: site, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
             }
+    }
+
+    @MainActor
+    func handleCompletionStatus(site: Site?, waitingTimeStart: Date, expectedStoreName: String) {
+        cancelLocalNotificationWhenStoreIsReady()
+        guard let site else {
+            return navigationController.dismiss(animated: true) { [weak self] in
+                guard let self else { return }
+                self.showJetpackSiteTimeoutAlert(from: self.navigationController)
+            }
+        }
+
+        // Sometimes, as soon as the jetpack installation is done some properties like `name` and `isWordPressComStore` are outdated.
+        // Track when a properties out of sync event occur, but only track it once.
+        // https://github.com/woocommerce/woocommerce-ios/pull/9317#issuecomment-1488035433
+        if !(site.isWordPressComStore && site.isWooCommerceActive && site.name == expectedStoreName) {
+            DDLogInfo("🔵 Site available but properties are not yet in sync...")
+            analytics.track(event: .StoreCreation.siteCreationPropertiesOutOfSync())
+        }
+
+        storeCreationProgressViewModel?.markAsComplete()
+        trackSiteCreatedEvent(site: site, flow: .native, timeAtStart: waitingTimeStart)
+
+        /// Free trial stores should land directly on the dashboard and not show any success view.
+        ///
+        if isFreeTrialCreation {
+            continueWithSelectedSite(site: site)
+        } else {
+            showSuccessView(from: navigationController, site: site)
+        }
     }
 
     /// Determines if a given Subscriber.Completion entity contains a `StoreCreationError.newSiteIsNotFullySynced` error.
     ///
     @MainActor
-    func isPropertiesOutOfSyncError(_ output: Subscribers.Completion<Error>) -> Bool {
-        switch output {
-        case .failure(let error):
-            guard let creationError = error as? StoreCreationError else { return false }
-            return creationError == .newSiteIsNotFullySynced
-        case .finished:
-            return false
-        }
-    }
-
-    @MainActor
-    func syncSite(siteID: Int64, expectedStoreName: String, haveTrackedOutOfSyncEvent: Bool) async throws -> Site {
-        let isJetpackActive = try await isJetpackPluginActive(siteID: siteID)
-
-        guard isJetpackActive else {
-            DDLogInfo("🔵 Retrying: Site available but is not a jetpack site yet for siteID \(siteID)...")
-            throw StoreCreationError.newSiteIsNotJetpackSite
-        }
-
-        let site = try await loadSite(siteID: siteID)
-
-        // Sometimes, as soon as the jetpack installation is done some properties like `name` and `isWordPressComStore` are outdated.
-        // In this case, let's keep retrying sites syncing. https://github.com/woocommerce/woocommerce-ios/pull/9317#issuecomment-1488035433
-        guard (site.isWordPressComStore && site.isWooCommerceActive && site.name == expectedStoreName) || haveTrackedOutOfSyncEvent else {
-            DDLogInfo("🔵 Retrying: Site available but properties are not yet in sync...")
-            throw StoreCreationError.newSiteIsNotFullySynced
-        }
-
-        return site
+    func isPropertiesOutOfSyncError(error: Error) -> Bool {
+        guard let creationError = error as? StoreCreationError else { return false }
+        return creationError == .newSiteIsNotFullySynced
     }
 
     @MainActor
@@ -878,26 +847,6 @@ private extension StoreCreationCoordinator {
                                                           flow: flow,
                                                           isFreeTrial: isFreeTrialCreation,
                                                           waitingTime: waitingTime))
-    }
-}
-
-private extension StoreCreationCoordinator {
-    @MainActor
-    func loadSite(siteID: Int64) async throws -> Site {
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(SiteAction.syncSite(siteID: siteID) { result in
-                continuation.resume(with: result)
-            })
-        }
-    }
-
-    @MainActor
-    func isJetpackPluginActive(siteID: Int64) async throws -> Bool {
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(SitePluginAction.isPluginActive(siteID: siteID, plugin: .jetpack) { result in
-                continuation.resume(with: result)
-            })
-        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -37,7 +37,6 @@ final class StoreCreationCoordinator: Coordinator {
         }
     }()
 
-    @Published private var siteIDFromStoreCreation: Int64?
     private var jetpackSiteSubscription: AnyCancellable?
 
     private let stores: StoresManager
@@ -731,10 +730,6 @@ private extension StoreCreationCoordinator {
 
     @MainActor
     func waitForSiteToBecomeJetpackSite(from navigationController: UINavigationController, siteID: Int64, expectedStoreName: String) {
-        /// Free trial sites need more waiting time that regular sites.
-        ///
-        siteIDFromStoreCreation = siteID
-
         /// Timestamp when we start observing times. Needed to track the store creating waiting duration.
         ///
         let waitingTimeStart = Date()
@@ -787,14 +782,6 @@ private extension StoreCreationCoordinator {
         } else {
             showSuccessView(from: navigationController, site: site)
         }
-    }
-
-    /// Determines if a given Subscriber.Completion entity contains a `StoreCreationError.newSiteIsNotFullySynced` error.
-    ///
-    @MainActor
-    func isPropertiesOutOfSyncError(error: Error) -> Bool {
-        guard let creationError = error as? StoreCreationError else { return false }
-        return creationError == .newSiteIsNotFullySynced
     }
 
     @MainActor

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
@@ -40,9 +40,9 @@ final class StoreCreationStatusChecker {
 private extension StoreCreationStatusChecker {
     @MainActor
     func syncSite(siteID: Int64) async throws -> Site {
-        let isJetpackActive = try await isJetpackPluginActive(siteID: siteID)
+        let arePluginsActive = try await areJetpackAndWooPluginsActive(siteID: siteID)
 
-        guard isJetpackActive else {
+        guard arePluginsActive else {
             DDLogInfo("🔵 Retrying: Site available but is not a jetpack site yet for siteID \(siteID)...")
             throw StoreCreationError.newSiteIsNotJetpackSite
         }
@@ -63,7 +63,7 @@ private extension StoreCreationStatusChecker {
     }
 
     @MainActor
-    func isJetpackPluginActive(siteID: Int64) async throws -> Bool {
+    func areJetpackAndWooPluginsActive(siteID: Int64) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(SitePluginAction.arePluginsActive(siteID: siteID, plugins: [.jetpack, .woo]) { result in
                 continuation.resume(with: result)

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
@@ -5,19 +5,16 @@ import protocol Storage.StorageManagerType
 
 final class StoreCreationStatusChecker {
     private let stores: StoresManager
-    private let analytics: Analytics
     private let isFreeTrialCreation: Bool
     private let jetpackCheckRetryInterval: TimeInterval
 
     @Published private var siteIDFromStoreCreation: Int64?
 
     init(isFreeTrialCreation: Bool,
-         stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         stores: StoresManager = ServiceLocator.stores) {
         self.isFreeTrialCreation = isFreeTrialCreation
         self.jetpackCheckRetryInterval = isFreeTrialCreation ? 10 : 5
         self.stores = stores
-        self.analytics = analytics
     }
 
     @MainActor
@@ -39,8 +36,6 @@ final class StoreCreationStatusChecker {
             }
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
-            // Retries 10 times with some seconds pause in between to wait for the newly created site to be available as a Jetpack/Woo site.
-            .retry(10)
             .eraseToAnyPublisher()
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
@@ -68,7 +68,7 @@ private extension StoreCreationStatusChecker {
     @MainActor
     func isJetpackPluginActive(siteID: Int64) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(SitePluginAction.isPluginActive(siteID: siteID, plugin: .jetpack) { result in
+            stores.dispatch(SitePluginAction.arePluginsActive(siteID: siteID, plugins: [.jetpack, .woo]) { result in
                 continuation.resume(with: result)
             })
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
@@ -1,0 +1,81 @@
+import Combine
+import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
+
+final class StoreCreationStatusChecker {
+    private let stores: StoresManager
+    private let analytics: Analytics
+    private let isFreeTrialCreation: Bool
+    private let jetpackCheckRetryInterval: TimeInterval
+
+    @Published private var siteIDFromStoreCreation: Int64?
+
+    init(isFreeTrialCreation: Bool,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.isFreeTrialCreation = isFreeTrialCreation
+        self.jetpackCheckRetryInterval = isFreeTrialCreation ? 10 : 5
+        self.stores = stores
+        self.analytics = analytics
+    }
+
+    @MainActor
+    func waitForSiteToBeReady(siteID: Int64) -> AnyPublisher<Site, Error> {
+        /// Free trial sites need more waiting time that regular sites.
+        ///
+        siteIDFromStoreCreation = siteID
+
+        return $siteIDFromStoreCreation
+            .compactMap { $0 }
+            .removeDuplicates()
+            .asyncMap { [weak self] siteID -> Site? in
+                guard let self else {
+                    return nil
+                }
+                // Waits some seconds before syncing sites every time.
+                try await Task.sleep(nanoseconds: UInt64(self.jetpackCheckRetryInterval * 1_000_000_000))
+                return try await self.syncSite(siteID: siteID)
+            }
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            // Retries 10 times with some seconds pause in between to wait for the newly created site to be available as a Jetpack/Woo site.
+            .retry(10)
+            .eraseToAnyPublisher()
+    }
+}
+
+private extension StoreCreationStatusChecker {
+    @MainActor
+    func syncSite(siteID: Int64) async throws -> Site {
+        let isJetpackActive = try await isJetpackPluginActive(siteID: siteID)
+
+        guard isJetpackActive else {
+            DDLogInfo("🔵 Retrying: Site available but is not a jetpack site yet for siteID \(siteID)...")
+            throw StoreCreationError.newSiteIsNotJetpackSite
+        }
+
+        let site = try await loadSite(siteID: siteID)
+        return site
+    }
+}
+
+private extension StoreCreationStatusChecker {
+    @MainActor
+    func loadSite(siteID: Int64) async throws -> Site {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(SiteAction.syncSite(siteID: siteID) { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+
+    @MainActor
+    func isJetpackPluginActive(siteID: Int64) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(SitePluginAction.isPluginActive(siteID: siteID, plugin: .jetpack) { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationWebViewModel.swift
@@ -40,7 +40,6 @@ enum StoreCreationError: Error {
     case invalidCompletionPath
     case newSiteUnavailable
     case newSiteIsNotJetpackSite
-    case newSiteIsNotFullySynced
 }
 
 private extension StoreCreationWebViewModel {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0273707D24C0047800167204 /* SequenceHelpersTests.swift */; };
 		0273708024C0094500167204 /* ProductListMultiSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0273707F24C0094500167204 /* ProductListMultiSelectorDataSource.swift */; };
+		027385B02A17093C00835889 /* StoreCreationStatusCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027385AF2A17093C00835889 /* StoreCreationStatusCheckerTests.swift */; };
 		02759B9128FFA09600918176 /* StoreCreationWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02759B9028FFA09600918176 /* StoreCreationWebViewModel.swift */; };
 		0277AE9B256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0277AE9A256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift */; };
 		0277AEA5256CAA4200F45C4A /* MockShippingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0277AEA4256CAA4200F45C4A /* MockShippingLabel.swift */; };
@@ -2575,6 +2576,7 @@
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0273707D24C0047800167204 /* SequenceHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceHelpersTests.swift; sourceTree = "<group>"; };
 		0273707F24C0094500167204 /* ProductListMultiSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorDataSource.swift; sourceTree = "<group>"; };
+		027385AF2A17093C00835889 /* StoreCreationStatusCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationStatusCheckerTests.swift; sourceTree = "<group>"; };
 		02759B9028FFA09600918176 /* StoreCreationWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationWebViewModel.swift; sourceTree = "<group>"; };
 		0277AE9A256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedShippingLabelOrderItemsTests.swift; sourceTree = "<group>"; };
 		0277AEA4256CAA4200F45C4A /* MockShippingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabel.swift; sourceTree = "<group>"; };
@@ -4668,6 +4670,7 @@
 				020D0BFE2914F6BA00BB3DCE /* LoggedOutStoreCreationCoordinatorTests.swift */,
 				0203C11B293058CB00EE61BF /* WebPurchasesForWPComPlansTests.swift */,
 				0203C11E2930645B00EE61BF /* WebCheckoutViewModelTests.swift */,
+				027385AF2A17093C00835889 /* StoreCreationStatusCheckerTests.swift */,
 			);
 			path = "Store Creation";
 			sourceTree = "<group>";
@@ -12506,6 +12509,7 @@
 				DEEDA23D298A22180088256B /* SiteCredentialLoginUseCaseTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */,
+				027385B02A17093C00835889 /* StoreCreationStatusCheckerTests.swift in Sources */,
 				EEB4E2D329B2047700371C3C /* StoreOnboardingViewHostingControllerTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
 				267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */; };
 		02DE5CAB279F8754007CBEF3 /* Double+RoundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */; };
 		02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */; };
+		02DF980B2A15FD920009E2EA /* StoreCreationStatusChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF980A2A15FD920009E2EA /* StoreCreationStatusChecker.swift */; };
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9B284743A40010B254 /* ProductImageUploader.swift */; };
 		02E222C829FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E222C729FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift */; };
@@ -2760,6 +2761,7 @@
 		02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Rounding.swift"; sourceTree = "<group>"; };
 		02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+RoundingTests.swift"; sourceTree = "<group>"; };
 		02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingScreen.swift; sourceTree = "<group>"; };
+		02DF980A2A15FD920009E2EA /* StoreCreationStatusChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationStatusChecker.swift; sourceTree = "<group>"; };
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E19B9B284743A40010B254 /* ProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageUploader.swift; sourceTree = "<group>"; };
 		02E222C729FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductFormAI.swift"; sourceTree = "<group>"; };
@@ -5319,6 +5321,7 @@
 				02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */,
 				021940E7291FDBF90090354E /* StoreCreationSummaryView.swift */,
 				02D3B68429657061009BF0BC /* SupportButton.swift */,
+				02DF980A2A15FD920009E2EA /* StoreCreationStatusChecker.swift */,
 			);
 			path = "Store Creation";
 			sourceTree = "<group>";
@@ -11644,6 +11647,7 @@
 				02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */,
 				26ABCE532518EAF300721CB0 /* IssueRefundTableViewCell.swift in Sources */,
 				0304E35E28BDC86D00A80191 /* LearnMoreViewModel.swift in Sources */,
+				02DF980B2A15FD920009E2EA /* StoreCreationStatusChecker.swift in Sources */,
 				02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */,
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				02C27BCE282CB52F0065471A /* CardPresentPaymentReceiptEmailCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationStatusCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationStatusCheckerTests.swift
@@ -1,0 +1,139 @@
+import Combine
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+final class StoreCreationStatusCheckerTests: XCTestCase {
+    private var sut: StoreCreationStatusChecker!
+    private var stores: MockStoresManager!
+    private var siteReadySubscription: AnyCancellable?
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .testingInstance)
+        sut = StoreCreationStatusChecker(jetpackCheckRetryInterval: 0, stores: stores)
+    }
+
+    override func tearDown() {
+        siteReadySubscription = nil
+        sut = nil
+        stores = nil
+        super.tearDown()
+    }
+
+    func test_waitForSiteToBeReady_returns_site_when_plugins_are_active() throws {
+        // Given
+        let site = Site.fake().copy(name: "testing")
+        mockPluginsActive(result: .success(true))
+        mockSyncSite(result: .success(site))
+
+        // When
+        waitFor { promise in
+            self.siteReadySubscription = self.sut.waitForSiteToBeReady(siteID: 122)
+                .sink { completion in
+                    switch completion {
+                    case .finished:
+                        break
+                    case .failure:
+                        XCTFail()
+                    }
+                } receiveValue: { syncedSite in
+                    // Then
+                    XCTAssertEqual(syncedSite, site)
+                    promise(())
+                }
+        }
+    }
+
+    func test_waitForSiteToBeReady_returns_error_when_failing_to_check_plugins() throws {
+        // Given
+        let pluginsError = NSError(domain: "plugins inactive", code: 0)
+        mockPluginsActive(result: .failure(pluginsError))
+        mockSyncSite(result: .success(.fake()))
+
+        // When
+        waitFor { promise in
+            self.siteReadySubscription = self.sut.waitForSiteToBeReady(siteID: 122)
+                .sink { completion in
+                    switch completion {
+                    case .finished:
+                        XCTFail()
+                    case .failure(let error):
+                        // Then
+                        XCTAssertEqual(error as NSError, pluginsError)
+                        promise(())
+                    }
+                } receiveValue: { site in
+                    XCTFail()
+                }
+        }
+    }
+
+    func test_waitForSiteToBeReady_returns_error_when_failing_to_sync_site() throws {
+        // Given
+        let syncSiteError = NSError(domain: "sync site", code: 0)
+        mockPluginsActive(result: .success(true))
+        mockSyncSite(result: .failure(syncSiteError))
+
+        // When
+        waitFor { promise in
+            self.siteReadySubscription = self.sut.waitForSiteToBeReady(siteID: 122)
+                .sink { completion in
+                    switch completion {
+                    case .finished:
+                        XCTFail()
+                    case .failure(let error):
+                        // Then
+                        XCTAssertEqual(error as NSError, syncSiteError)
+                        promise(())
+                    }
+                } receiveValue: { site in
+                    XCTFail()
+                }
+        }
+    }
+
+    func test_waitForSiteToBeReady_returns_error_when_plugins_are_not_active() throws {
+        // Given
+        mockPluginsActive(result: .success(false))
+        mockSyncSite(result: .success(.fake()))
+
+        // When
+        waitFor { promise in
+            self.siteReadySubscription = self.sut.waitForSiteToBeReady(siteID: 122)
+                .sink { completion in
+                    switch completion {
+                    case .finished:
+                        XCTFail()
+                    case .failure(let error):
+                        // Then
+                        XCTAssertEqual(error as? StoreCreationError, .newSiteIsNotJetpackSite)
+                        promise(())
+                    }
+                } receiveValue: { site in
+                    XCTFail()
+                }
+        }
+    }
+}
+
+private extension StoreCreationStatusCheckerTests {
+    func mockSyncSite(result: Result<Site, Error>) {
+        stores.whenReceivingAction(ofType: SiteAction.self) { action in
+            guard case let .syncSite(_, completion) = action else {
+                return
+            }
+            completion(result)
+        }
+    }
+
+    func mockPluginsActive(result: Result<Bool, Error>) {
+        stores.whenReceivingAction(ofType: SitePluginAction.self) { action in
+            guard case let .arePluginsActive(_, _, completion) = action else {
+                return
+            }
+            completion(result)
+        }
+    }
+}

--- a/Yosemite/Yosemite/Actions/SitePluginAction.swift
+++ b/Yosemite/Yosemite/Actions/SitePluginAction.swift
@@ -16,13 +16,14 @@ public enum SitePluginAction: Action {
     /// Get details for the plugin with the specified name for a site given its ID
     case getPluginDetails(siteID: Int64, pluginName: String, onCompletion: (Result<SitePlugin, Error>) -> Void)
 
-    /// Whether the site already has the specified plugin installed and activated.
-    case isPluginActive(siteID: Int64, plugin: Plugin, onCompletion: (Result<Bool, Error>) -> Void)
+    /// Whether the site already has the specified plugins installed and activated.
+    case arePluginsActive(siteID: Int64, plugins: [Plugin], onCompletion: (Result<Bool, Error>) -> Void)
 }
 
 public extension SitePluginAction {
     /// Common plugins of a WooCommerce site.
     enum Plugin {
         case jetpack
+        case woo
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SitePluginStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SitePluginStoreTests.swift
@@ -175,50 +175,69 @@ final class SitePluginStoreTests: XCTestCase {
 
     // MARK: - `isPluginActive`
 
-    func test_isPluginActive_for_jetpack_returns_true_when_site_has_jetpack_plugin() throws {
+    func test_arePluginsActive_for_jetpack_woo_returns_true_when_site_has_both_plugins() throws {
         // Given
-        remote.whenLoadingPluginsFromWPCOM(thenReturn: .success([.init(id: "jetpack/jetpack", isActive: true)]))
+        remote.whenLoadingPluginsFromWPCOM(thenReturn: .success([.init(id: "jetpack/jetpack", isActive: true),
+                                                                 .init(id: "woocommerce/woocommerce", isActive: true)]))
         let store = SitePluginStore(remote: remote, dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
         let result = waitFor { promise in
-            store.onAction(SitePluginAction.isPluginActive(siteID: 122, plugin: .jetpack) { result in
+            store.onAction(SitePluginAction.arePluginsActive(siteID: 122, plugins: [.jetpack, .woo]) { result in
                 promise(result)
             })
         }
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        let isJetpackActive = try XCTUnwrap(result.get())
-        XCTAssertTrue(isJetpackActive)
+        let arePluginsActive = try XCTUnwrap(result.get())
+        XCTAssertTrue(arePluginsActive)
     }
 
-    func test_isPluginActive_for_jetpack_returns_false_when_site_does_not_have_jetpack_plugin() throws {
+    func test_arePluginsActive_for_jetpack_woo_returns_false_when_site_does_not_have_both_plugins() throws {
         // Given
         remote.whenLoadingPluginsFromWPCOM(thenReturn: .success([.init(id: "automatewoo/automatewoo", isActive: true)]))
         let store = SitePluginStore(remote: remote, dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
         let result = waitFor { promise in
-            store.onAction(SitePluginAction.isPluginActive(siteID: 122, plugin: .jetpack) { result in
+            store.onAction(SitePluginAction.arePluginsActive(siteID: 122, plugins: [.jetpack, .woo]) { result in
                 promise(result)
             })
         }
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        let isJetpackActive = try XCTUnwrap(result.get())
-        XCTAssertFalse(isJetpackActive)
+        let arePluginsActive = try XCTUnwrap(result.get())
+        XCTAssertFalse(arePluginsActive)
     }
 
-    func test_isPluginActive_for_jetpack_returns_error_when_loadPluginsFromWPCOM_fails() throws {
+    func test_arePluginsActive_for_jetpack_woo_returns_false_when_site_only_has_one_plugin() throws {
+        // Given
+        remote.whenLoadingPluginsFromWPCOM(thenReturn: .success([.init(id: "jetpack/jetpack", isActive: true)]))
+        let store = SitePluginStore(remote: remote, dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(SitePluginAction.arePluginsActive(siteID: 122, plugins: [.jetpack, .woo]) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let arePluginsActive = try XCTUnwrap(result.get())
+        XCTAssertFalse(arePluginsActive)
+    }
+
+    func test_arePluginsActive_for_jetpack_returns_error_when_loadPluginsFromWPCOM_fails() throws {
         // Given
         remote.whenLoadingPluginsFromWPCOM(thenReturn: .failure(NetworkError.invalidURL))
         let store = SitePluginStore(remote: remote, dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
         let result = waitFor { promise in
-            store.onAction(SitePluginAction.isPluginActive(siteID: 122, plugin: .jetpack) { result in
+            store.onAction(SitePluginAction.arePluginsActive(siteID: 122, plugins: [.jetpack, .woo]) { result in
                 promise(result)
             })
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #9733 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As `StoreCreationCoordinator` already got too huge with many feature flags, it's getting harder to test some of the logic (the coordinator shouldn't be responsible for making API requests anyways). In this PR, the logic that waits for the site to be ready was extracted from `StoreCreationCoordinator` to its own class `StoreCreationStatusChecker` since there are also some updates.

## How

Previously, the sequence of network requests is like:
- `sites/:siteId/plugins` up to 10 times until Jetpack plugin is active
- `sites/:siteId` to fetch the site, and throw an error `newSiteIsNotFullySynced` once when it's missing some properties (it's a known issue on the backend pe5sF9-1vz-p2#comment-2184), and an event is tracked
- `sites/:siteId` to fetch the site again and return success

Now with the latest conclusion in pe5sF9-1vz-p2#comment-2180, the sequence would be:
- `sites/:siteId/plugins` up to 10 times until Jetpack **and Woo** plugins are both active
- `sites/:siteId` to fetch the site and return success
  - at the call site `StoreCreationCoordinator`, it checks if it's missing some properties like before and track the same event

All the other behaviors should stay the same, including local notifications and progress UI.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in with a WPCOM account if needed
- Go to the Menu tab, and tap on the store picker
- At the end of the store list, tap `Add a store`
- Continue the steps to create a free trial site --> the progress UI should be incremented like before. after about 30-60 seconds, the flow should succeed and navigate to the newly created store without a Jetpack upsell banner, with these two events logged `login_woocommerce_site_created` (with a `waiting_time` property) and `site_creation_properties_out_of_sync`

---
- [x] @jaclync tests local notifications work as before

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.