### PR TITLE
[Product Bundles] Add Yosemite support for displaying product bundle hierarchy in order details

### DIFF
--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -26,7 +26,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
         total = orderItem.total
         totalTax = orderItem.totalTax
         variationID = orderItem.variationID
-        parent = orderItem.parent != nil ? NSNumber(value: orderItem.parent!) : nil
+        parent = orderItem.parent.map { NSNumber(value: $0) }
     }
 
     /// Returns a ReadOnly version of the receiver.

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -26,6 +26,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
         total = orderItem.total
         totalTax = orderItem.totalTax
         variationID = orderItem.variationID
+        parent = orderItem.parent != nil ? NSNumber(value: orderItem.parent!) : nil
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -48,6 +49,6 @@ extension Storage.OrderItem: ReadOnlyConvertible {
                          total: total ?? "",
                          totalTax: totalTax ?? "",
                          attributes: attributes,
-                         parent: nil) // TODO: 8962 - Convert parent property
+                         parent: parent?.int64Value)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8962
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for converting the `parent` property on `OrderItem` to/from read-only. It will be used in the UI layer to show the parent/child relationship between product bundles and their bundled products in order details.

This is stored as `NSNumber?` (to support it being optional), so we're converting it here between `NSNumber` and `Int64`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass. (We don't have any unit tests specifically for `ReadOnlyConvertible` extensions, so I haven't added any test coverage here, but we'll have tests that rely on it in the UI layer once we use it there.)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
