### PR TITLE
[Privacy Choices] Handle Privacy Banner Save CTA

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -38,12 +38,22 @@ final class PrivacyBannerPresenter {
     /// Presents the privacy banner using a `BottomSheetViewController`
     ///
     @MainActor private func presentPrivacyBanner(from viewController: UIViewController) {
-        let privacyBanner = PrivacyBannerViewController(goToSettingsAction: {
-            print("Go to settings tapped") // TODO: Navigate to settings
-        }, saveAction: {
-            print("Saved tapped") // TODO: perform network request
+        let privacyBanner = PrivacyBannerViewController(onCompletion: { result in
+            switch result {
+            case .success(let destination):
+                switch destination {
+                case .dismiss:
+                    print("Dismiss banner")
+                case .settings:
+                    print("Dismiss and Go to settings")
+                }
+            case .failure(let error):
+                switch error {
+                case .sync(let analyticsOptOut):
+                    print("Present notice with retry opt-out: \(analyticsOptOut)")
+                }
+            }
         })
-
 
         let bottomSheetViewController = BottomSheetViewController(childViewController: privacyBanner)
         bottomSheetViewController.show(from: viewController)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -12,9 +12,9 @@ final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
     ///
     var bannerIntrinsicHeight: CGFloat = 0
 
-    init(goToSettingsAction: @escaping (() -> ()), saveAction: @escaping (() -> ())) {
-        let viewModel = PrivacyBannerViewModel()
-        super.init(rootView: PrivacyBanner(goToSettingsAction: goToSettingsAction, saveAction: saveAction, viewModel: viewModel))
+    init(onCompletion: @escaping (Result<PrivacyBannerViewModel.Destination, PrivacyBannerViewModel.Error>) -> ()) {
+        let viewModel = PrivacyBannerViewModel(onCompletion: onCompletion)
+        super.init(rootView: PrivacyBanner(viewModel: viewModel))
     }
 
     /// Needed for protocol conformance.
@@ -48,14 +48,6 @@ extension PrivacyBannerViewController: DrawerPresentable {
 /// Banner View for the privacy settings.
 ///
 struct PrivacyBanner: View {
-    /// Closure to be invoked when the go to settings button is pressed.
-    ///
-    let goToSettingsAction: (() -> ())
-
-    /// Closure to be invoked when the save button is pressed.
-    ///
-    let saveAction: (() -> ())
-
     /// Determines in the banner should be scrollable on it's parent container.
     ///
     var shouldScroll: Bool = false
@@ -100,9 +92,11 @@ struct PrivacyBanner: View {
 
 
                 Button(Localization.save) {
-                    print("Tapped Save")
+                    Task {
+                        await viewModel.submitChanges(destination: .dismiss)
+                    }
                 }
-                .buttonStyle(PrimaryButtonStyle())
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
             }
             .padding(.top)
 
@@ -111,6 +105,7 @@ struct PrivacyBanner: View {
             Spacer()
         }
         .padding()
+        .disabled(!viewModel.isViewEnabled)
     }
 }
 
@@ -140,7 +135,7 @@ private extension PrivacyBanner {
 
 struct PrivacyBanner_Previews: PreviewProvider {
     static var previews: some View {
-        PrivacyBanner(goToSettingsAction: {}, saveAction: {}, viewModel: .init())
+        PrivacyBanner(viewModel: .init(onCompletion: { _ in }))
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
@@ -9,7 +9,69 @@ final class PrivacyBannerViewModel: ObservableObject {
     ///
     @Published var analyticsEnabled: Bool = false
 
-    init(analytics: Analytics = ServiceLocator.analytics) {
+    /// Determines if the save button should show a loading state.
+    ///
+    @Published private(set) var isLoading: Bool = false
+
+    /// Determines if the view should be enabled.
+    ///
+    @Published private(set) var isViewEnabled: Bool = true
+
+    /// Completion handler.
+    ///
+    @MainActor private let onCompletion: (Result<Destination, PrivacyBannerViewModel.Error>) -> ()
+
+    /// Stores & Session.
+    ///
+    private let stores: StoresManager
+
+    /// Analytics Manager
+    ///
+    private let analytics: Analytics
+
+    init(analytics: Analytics = ServiceLocator.analytics,
+         stores: StoresManager = ServiceLocator.stores,
+         onCompletion: @escaping (Result<Destination, PrivacyBannerViewModel.Error>) -> ()) {
         self.analyticsEnabled = analytics.userHasOptedIn
+        self.stores = stores
+        self.analytics = analytics
+        self.onCompletion = onCompletion
+    }
+
+    /// Submit changes and notifies via the `completion` block.
+    ///
+    @MainActor func submitChanges(destination: Destination) async {
+        // Set Loading state
+        isLoading = true
+        isViewEnabled = false
+
+        // Perform update
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        do {
+            try await useCase.update(optOut: !analyticsEnabled)
+            onCompletion(.success(destination))
+        } catch {
+            onCompletion(.failure(.sync(analyticsOptOut: !analyticsEnabled)))
+        }
+
+        // Revert Loading state
+        isLoading = false
+        isViewEnabled = true
+    }
+}
+
+// MARK: Definitions
+extension PrivacyBannerViewModel {
+    /// View destination after submitting changes
+    ///
+    enum Destination {
+        case settings
+        case dismiss
+    }
+
+    /// Defined errors.
+    ///
+    enum Error: Swift.Error {
+        case sync(analyticsOptOut: Bool)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Yosemite
+
+/// Use case in charge of updating(remotely and locally) analytics choices.
+///
+final class UpdateAnalyticsSettingUseCase {
+
+    /// Stores dependency
+    ///
+    private let stores: StoresManager
+
+    /// Analytics manager
+    ///
+    private let analytics: Analytics
+
+    init(stores: StoresManager = ServiceLocator.stores, analytics: Analytics = ServiceLocator.analytics) {
+        self.stores = stores
+        self.analytics = analytics
+    }
+
+    /// Async function that updates analytics choices.
+    /// For WPCOM stores: Updates remotely and locally. - The local update only happens after a successful remote update.
+    /// For NON-WPCOM stores: Updates locally.
+    ///
+    func update(optOut: Bool) async throws {
+        // If we can't find an account(non-jp sites), lets commit the change immediately.
+        guard let defaultAccount = stores.sessionManager.defaultAccount else {
+            return analytics.setUserHasOptedOut(optOut)
+        }
+
+        let userID = defaultAccount.userID
+        try await withCheckedThrowingContinuation { continuation in
+            let action = AccountAction.updateAccountSettings(userID: userID, tracksOptOut: optOut) { [weak self] result in
+                switch result {
+                case .success:
+                    self?.analytics.setUserHasOptedOut(optOut)
+                    continuation.resume()
+                case .failure(let error):
+                    DDLogError("⛔️ Error saving the privacy choices: \(error)")
+                    continuation.resume(with: .failure(error))
+                    // TODO: Migrate - self?.collectInfo = !newValue // Revert to the previous value to keep the UI consistent.
+                    // TODO: Migrate - self?.presentErrorUpdatingAccountSettingsNotice(optInValue: newValue)
+                }
+            }
+
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -764,6 +764,8 @@
 		269098B827D68CCD001FEB07 /* FeesInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B727D68CCD001FEB07 /* FeesInputTransformer.swift */; };
 		269098BA27D6922E001FEB07 /* FeesInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B927D6922E001FEB07 /* FeesInputTransformerTests.swift */; };
 		269A2F47295CC683000828A8 /* GenerateVariationsSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */; };
+		269B46622A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46612A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift */; };
+		269B46642A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -3050,6 +3052,8 @@
 		269098B727D68CCD001FEB07 /* FeesInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeesInputTransformer.swift; sourceTree = "<group>"; };
 		269098B927D6922E001FEB07 /* FeesInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeesInputTransformerTests.swift; sourceTree = "<group>"; };
 		269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationsSelectorCommand.swift; sourceTree = "<group>"; };
+		269B46612A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAnalyticsSettingsUseCase.swift; sourceTree = "<group>"; };
+		269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAnalyticsSettingsUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -6021,6 +6025,7 @@
 			children = (
 				2609797B2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift */,
 				263EAF9B2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift */,
+				269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -9093,6 +9098,7 @@
 				263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */,
 				26B233D02A14208800926EAD /* PrivacyBannerPresenter.swift */,
 				260979782A12E20900442249 /* PrivacyBannerPresentationUseCase.swift */,
+				269B46612A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -11202,6 +11208,7 @@
 				022F2FA8295E7A14003A0A46 /* StoreCreationCountryButton.swift in Sources */,
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */,
+				269B46622A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
 				31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */,
 				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
@@ -12831,6 +12838,7 @@
 				B5718D6521B56B400026C9F0 /* PushNotificationsManagerTests.swift in Sources */,
 				EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */,
 				D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */,
+				269B46642A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift in Sources */,
 				AEFF77A829786A2900667F7A /* PriceInputViewControllerTests.swift in Sources */,
 				02C2756F24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift in Sources */,
 				571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -40,6 +40,13 @@ extension SessionManager {
         }
         return manager
     }
+
+    /// Removes the contents of the user defaults testing database.
+    /// Useful to not cause conflicts with other tests that rely on the same database.
+    ///
+    static func removeTestingDatabase() {
+        SessionSettings.defaults.removePersistentDomain(forName: "storesManagerTests")
+    }
 }
 
 // MARK: - SessionManagerProtocol: Testing Methods

--- a/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
@@ -88,6 +88,7 @@ class WaitingTimeTrackerTests: XCTestCase {
         }
 
         func setUserHasOptedOut(_ optedOut: Bool) {
+            userHasOptedIn = !optedOut
         }
 
         var userHasOptedIn: Bool = false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerPresentationUseCaseTests.swift
@@ -125,4 +125,9 @@ final class PrivacyBannerPresentationUseCaseTests: XCTestCase {
         // Then
         XCTAssertFalse(shouldShowBanner)
     }
+
+    override class func tearDown() {
+        super.tearDown()
+        SessionManager.removeTestingDatabase()
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
@@ -4,7 +4,7 @@ import TestKit
 @testable import WooCommerce
 @testable import Yosemite
 
-final class PrivacyBannerViewModelTest: XCTestCase {
+@MainActor final class PrivacyBannerViewModelTest: XCTestCase {
 
     func test_analytics_state_has_correct_initial_value_when_user_has_opt_out() {
         // Given
@@ -12,7 +12,7 @@ final class PrivacyBannerViewModelTest: XCTestCase {
         analytics.userHasOptedIn = false
 
         // When
-        let viewModel = PrivacyBannerViewModel(analytics: analytics)
+        let viewModel = PrivacyBannerViewModel(analytics: analytics, onCompletion: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.analyticsEnabled)
@@ -24,9 +24,89 @@ final class PrivacyBannerViewModelTest: XCTestCase {
         analytics.userHasOptedIn = true
 
         // When
-        let viewModel = PrivacyBannerViewModel(analytics: analytics)
+        let viewModel = PrivacyBannerViewModel(analytics: analytics, onCompletion: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.analyticsEnabled)
+    }
+
+    func test_submit_changes_on_wpcom_account_triggers_network_request_and_updates_loading_state() {
+        // Given
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        analytics.userHasOptedIn = true
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, displayName: "Store"))
+        let (loading, enabled): (Bool, Bool) = waitFor { promise in
+
+            let viewModel = PrivacyBannerViewModel(analytics: analytics, stores: stores, onCompletion: { _ in })
+            stores.whenReceivingAction(ofType: AccountAction.self) { action in
+                switch action {
+                case .updateAccountSettings(_, _, _):
+                    promise((viewModel.isLoading, viewModel.isViewEnabled))
+                default:
+                    break
+                }
+            }
+
+            // When
+            Task {
+                await viewModel.submitChanges(destination: .dismiss)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(loading)
+        XCTAssertFalse(enabled)
+    }
+
+    func test_submit_changes_using_wpcom_account_calls_completion_block() {
+        // Given
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        analytics.userHasOptedIn = true
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, displayName: "Store"))
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .updateAccountSettings(_, _, let onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let completionCalled: Bool = waitFor { promise in
+            let viewModel = PrivacyBannerViewModel(analytics: analytics, stores: stores, onCompletion: { _ in
+                promise(true)
+            })
+
+            // When
+            Task {
+                await viewModel.submitChanges(destination: .dismiss)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(completionCalled)
+    }
+
+    func test_submit_changes_using_non_wpcom_account_calls_completion_block() {
+        // Given
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        analytics.userHasOptedIn = true
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let completionCalled: Bool = waitFor { promise in
+            let viewModel = PrivacyBannerViewModel(analytics: analytics, stores: stores, onCompletion: { _ in
+                promise(true)
+            })
+
+            // When
+            Task {
+                await viewModel.submitChanges(destination: .dismiss)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(completionCalled)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
@@ -109,4 +109,9 @@ import TestKit
         // Then
         XCTAssertTrue(completionCalled)
     }
+
+    override class func tearDown() {
+        super.tearDown()
+        SessionManager.removeTestingDatabase()
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import TestKit
+
+@testable import WooCommerce
+@testable import Yosemite
+
+@MainActor final class UpdateAnalyticsSettingsUseCaseTests: XCTestCase {
+
+    func test_using_a_wpcom_account_opt_in_analytics_updates_analytics_state() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, displayName: "Test Account"))
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .updateAccountSettings(_, _, let onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+
+        // When
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        try await useCase.update(optOut: false)
+
+        // Then
+        XCTAssertTrue(analytics.userHasOptedIn)
+    }
+
+    func test_using_a_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, displayName: "Test Account"))
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .updateAccountSettings(_, _, let onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+
+        // When
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        try await useCase.update(optOut: true)
+
+        // Then
+        XCTAssertFalse(analytics.userHasOptedIn)
+    }
+
+    func test_using_a_non_wpcom_account_opt_in_analytics_updates_analytics_state() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+
+        // When
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        try await useCase.update(optOut: false)
+
+        // Then
+        XCTAssertTrue(analytics.userHasOptedIn)
+    }
+
+    func test_using_a_non_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+
+        // When
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        try await useCase.update(optOut: true)
+
+        // Then
+        XCTAssertFalse(analytics.userHasOptedIn)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
@@ -4,9 +4,9 @@ import TestKit
 @testable import WooCommerce
 @testable import Yosemite
 
-@MainActor final class UpdateAnalyticsSettingsUseCaseTests: XCTestCase {
+final class UpdateAnalyticsSettingsUseCaseTests: XCTestCase {
 
-    func test_using_a_wpcom_account_opt_in_analytics_updates_analytics_state() async throws {
+    @MainActor func test_using_a_wpcom_account_opt_in_analytics_updates_analytics_state() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, displayName: "Test Account"))
         stores.whenReceivingAction(ofType: AccountAction.self) { action in
@@ -29,7 +29,7 @@ import TestKit
         XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 
-    func test_using_a_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
+    @MainActor func test_using_a_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, displayName: "Test Account"))
         stores.whenReceivingAction(ofType: AccountAction.self) { action in
@@ -52,7 +52,7 @@ import TestKit
         XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 
-    func test_using_a_non_wpcom_account_opt_in_analytics_updates_analytics_state() async throws {
+    @MainActor func test_using_a_non_wpcom_account_opt_in_analytics_updates_analytics_state() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let analytics = WaitingTimeTrackerTests.TestAnalytics()
@@ -67,7 +67,7 @@ import TestKit
         XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 
-    func test_using_a_non_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
+    @MainActor func test_using_a_non_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let analytics = WaitingTimeTrackerTests.TestAnalytics()
@@ -80,5 +80,10 @@ import TestKit
         // Then
         XCTAssertFalse(analytics.userHasOptedIn)
         XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
+    }
+
+    override class func tearDown() {
+        super.tearDown()
+        SessionManager.removeTestingDatabase()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
@@ -18,13 +18,15 @@ import TestKit
             }
         }
         let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
 
         // When
-        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics, userDefaults: userDefaults)
         try await useCase.update(optOut: false)
 
         // Then
         XCTAssertTrue(analytics.userHasOptedIn)
+        XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 
     func test_using_a_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
@@ -39,38 +41,44 @@ import TestKit
             }
         }
         let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
 
         // When
-        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics, userDefaults: userDefaults)
         try await useCase.update(optOut: true)
 
         // Then
         XCTAssertFalse(analytics.userHasOptedIn)
+        XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 
     func test_using_a_non_wpcom_account_opt_in_analytics_updates_analytics_state() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
 
         // When
-        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics, userDefaults: userDefaults)
         try await useCase.update(optOut: false)
 
         // Then
         XCTAssertTrue(analytics.userHasOptedIn)
+        XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 
     func test_using_a_non_wpcom_account_opt_out_analytics_updates_analytics_state() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
 
         // When
-        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics)
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics, userDefaults: userDefaults)
         try await useCase.update(optOut: true)
 
         // Then
         XCTAssertFalse(analytics.userHasOptedIn)
+        XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 }


### PR DESCRIPTION
closes #9615

# Why

This PR implements the "Save" CTA of the Privacy Banner. In particular, when tapping the save CTA:

- Shows a loading indicator in the Save button
- Performs the network request to update the analytics setting (Only on WPCOM accounts)
- Shows an error notice with a retry button if the request fails
- Dismiss the Banner
- Marks the banner as presented

# How

- Abstract the request and "mark banner as presented logic" in a new `UpdateAnalyticsSettingUseCase` type.

- Update `PrivacySettingsViewController` to use the new use case mentioned above

- Updates the `PrivacyBannerViewModel` to expose the loading states & call `UpdateAnalyticsSettingUseCase` when tapping save.

- Update the `PrivacyBannerPresenter` to dismiss the banner after the changes are submitted and show the retry notice if an error occurrs.

# Demo

## WPCOM

https://github.com/woocommerce/woocommerce-ios/assets/562080/690dba55-5ad2-46a0-917b-3c21ebee048f

## Non WPCOM

https://github.com/woocommerce/woocommerce-ios/assets/562080/0672e619-4685-46da-a2ed-2135bc74341f

# Error

https://github.com/woocommerce/woocommerce-ios/assets/562080/b7e34bdb-c273-4fd1-ac0d-82e4f65d1d46

# Testing Steps

### WPCom Stores

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented
- Toggle the analytics choice
- Tap save
- See the loading indicator in the save button.
- See that the choices were saved & that the banner gets dismissed

### Non WPCom Stores

- Log out from the app (to clean the user defaults database)
- Log in to a non-WPCom store (make sure your phone has an EU locale)
- See the banner being presented
- Toggle the analytics choice
- Tap save
- See that the choices were saved & that the banner gets dismissed

### Error

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented
- Toggle the analytics choice
- Tap save
- See the banner being dismiss & the error notice with a retry button

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
