### PR TITLE
[Privacy Choices] Use a new localization key instead of the English copy as the key

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -122,10 +122,11 @@ private extension PrivacyBanner {
         static let goToSettings = NSLocalizedString("Go to Settings", comment: "Title for the 'Go To Settings' button in the privacy banner")
         static let save = NSLocalizedString("Save", comment: "Title for the 'Save' button in the privacy banner")
         static let bannerSubtitle = NSLocalizedString(
-            "Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app " +
+            "privacy_banner_subtitle",
+            value: "Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app " +
             "(and your experience) in various ways. Some uses of your data we absolutely need in order to make things work, and others you can " +
             "customize from your Settings.",
-            comment: "Title for the privacy banner"
+            comment: "Subtitle for the privacy banner"
         )
         static let toggleSubtitle = NSLocalizedString(
             "Allow us to optimize performance by collecting information on how users interact with our mobile apps.",


### PR DESCRIPTION
## Description
The `bannerSubtitle` string is 289 characters, but GlotPress has a key limit of 256 characters. The key is truncated at that limit, causing issues with non-English languages trying to reference this key (see [Slack thread](p1684518387552109-slack-C02KLTL3MKM)).

This PR adds a separate key following the instructions added by @AliSoftware in paNNhX-nP-p2.

## Testing instructions 

(Taken from https://github.com/woocommerce/woocommerce-ios/pull/9696) 

1. Add the following code on the `DashboardViewController.viewDidLoad`
```
DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
    let vc = PrivacyBannerViewController(goToSettingsAction: {}, saveAction: {})
    let bottomSheet = BottomSheetViewController(childViewController: vc)
    bottomSheet.show(from: self)
}
```
2. Launch the app (you will also need to be signed into a store within the app for the banner to show up)
3. See the banner appear after 5 seconds with the correct English copy

## Screenshots
The screenshots are the same from before and after this change because the actual string isn't changing, just the localization key for it. 

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.