### PR TITLE
Merge 13.7 code freeze into trunk

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+13.8
+-----
+
+
 13.7
 -----
 - [Internal] Adds guidance for new Customs rule when shipping to some EU countries. [https://github.com/woocommerce/woocommerce-ios/pull/9715]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -122,10 +122,11 @@ private extension PrivacyBanner {
         static let goToSettings = NSLocalizedString("Go to Settings", comment: "Title for the 'Go To Settings' button in the privacy banner")
         static let save = NSLocalizedString("Save", comment: "Title for the 'Save' button in the privacy banner")
         static let bannerSubtitle = NSLocalizedString(
-            "Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app " +
+            "privacy_banner_subtitle",
+            value: "Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app " +
             "(and your experience) in various ways. Some uses of your data we absolutely need in order to make things work, and others you can " +
             "customize from your Settings.",
-            comment: "Title for the privacy banner"
+            comment: "Subtitle for the privacy banner"
         )
         static let toggleSubtitle = NSLocalizedString(
             "Allow us to optimize performance by collecting information on how users interact with our mobile apps.",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/EUShippingNoticeTopBannerFactory.swift
@@ -48,10 +48,11 @@ extension EUShippingNoticeTopBannerFactory {
                                                    "you must provide a clear, specific description of every item. Otherwise, " +
                                                    "shipments may be delayed or interrupted at customs.",
                                                    comment: "The EU notice banner content describing why some countries require special customs description")
-        static let instructionsInfo = NSLocalizedString("Shipping to countries that follow European Union (EU) customs rules now " +
+        static let instructionsInfo = NSLocalizedString("eu_shipping_instructions_info",
+                                                        value: "Shipping to countries that follow European Union (EU) customs rules now " +
                                                         "requires you clearly describe every item. For example, if you are sending " +
                                                         "clothing, you must indicate what type of clothing (e.g., men’s shirts, girl’s vest, boy’s jacket) " +
-                                                        "for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs. ",
+                                                        "for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs.",
                                                         comment: "The EU notice banner content describing how the shipping customs shall be configured")
         static let learnMore = NSLocalizedString("Learn more", comment: "Label for the banner Learn more button")
         static let dismiss = NSLocalizedString("Dismiss", comment: "Label for the banner Dismiss button")

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -57,9 +57,9 @@ msgctxt "app_store_promo_text"
 msgid "Run your store from anywhere"
 msgstr ""
 
-msgctxt "v13.6-whats-new"
+msgctxt "v13.7-whats-new"
 msgid ""
-"This release includes several bug fixes and improvements to your product management experience, including fixing stock statuses for Product Bundles so that backordered bundles and bundle stock quantities are displayed as expected. We've also added the option for you to automatically generate product description based on the a few key words.\n"
+"You’ve asked for it, and now it’s here! You can now search for an order using a SKU when creating an order on the go. We have also made updates to the product selection so it's easier to search variations of a product. Awesome, right?\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -5316,6 +5316,9 @@ This part is the link to the website, and forms part of a longer sentence which 
    Privacy settings screen title */
 "Privacy Settings" = "Privacy Settings";
 
+/* Subtitle for the privacy banner */
+"privacy_banner_subtitle" = "Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app (and your experience) in various ways. Some uses of your data we absolutely need in order to make things work, and others you can customize from your Settings.";
+
 /* One of the possible options in Product Visibility */
 "Private" = "Private";
 
@@ -8747,9 +8750,6 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Dialog message that displays when a configuration update just finished installing */
 "Your phone will be ready to collect payments in a moment..." = "Your phone will be ready to collect payments in a moment...";
-
-/* Title for the privacy banner */
-"Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app (and your experience) in various ways. Some uses of your data we absolutely need in order to make things work, and others you can customize from your Settings." = "Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app (and your experience) in various ways. Some uses of your data we absolutely need in order to make things work, and others you can customize from your Settings.";
 
 /* Label that displays when an optional software update is happening */
 "Your reader will automatically restart and reconnect after the update is complete." = "Your reader will automatically restart and reconnect after the update is complete.";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -2759,6 +2759,9 @@ which should be translated separately and considered part of this sentence. */
 /* Option in the store creation selling platforms question. */
 "Etsy" = "Etsy";
 
+/* The EU notice banner content describing how the shipping customs shall be configured */
+"eu_shipping_instructions_info" = "Shipping to countries that follow European Union (EU) customs rules now requires you clearly describe every item. For example, if you are sending clothing, you must indicate what type of clothing (e.g., men’s shirts, girl’s vest, boy’s jacket) for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs.";
+
 /* The title on the placeholder overlay on the coupon list screen when coupons are disabled for the store.
    The title on the placeholder overlay when there are no coupons on the coupon list screen and creating a coupon is possible. */
 "Everyone loves a deal" = "Everyone loves a deal";
@@ -6266,9 +6269,6 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Title on the refund screen that lists the shipping total cost */
 "Shipping Refund" = "Shipping Refund";
-
-/* The EU notice banner content describing how the shipping customs shall be configured */
-"Shipping to countries that follow European Union (EU) customs rules now requires you clearly describe every item. For example, if you are sending clothing, you must indicate what type of clothing (e.g., men’s shirts, girl’s vest, boy’s jacket) for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs. " = "Shipping to countries that follow European Union (EU) customs rules now requires you clearly describe every item. For example, if you are sending clothing, you must indicate what type of clothing (e.g., men’s shirts, girl’s vest, boy’s jacket) for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs. ";
 
 /* Display label for the product's catalog visibility */
 "Shop and search results" = "Shop and search results";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1154,6 +1154,9 @@ which should be translated separately and considered part of this sentence. */
 /* Country option for a site address. */
 "Cambodia" = "Cambodia";
 
+/* Message of alert that links to settings for camera access. */
+"Camera access is required for barcode scanning. Please enable camera permissions in your device settings" = "Camera access is required for barcode scanning. Please enable camera permissions in your device settings";
+
 /* Message of the action sheet button that links to settings for camera access */
 "Camera access is required for SKU scanning. Please enable camera permissions in your device settings" = "Camera access is required for SKU scanning. Please enable camera permissions in your device settings";
 
@@ -2277,6 +2280,7 @@ which should be translated separately and considered part of this sentence. */
 "Don't show again" = "Don't show again";
 
 /* Action title to select products to add to a grouped product from search results
+   Button title to close the Scan to Pay screen
    Button to dismiss the Order Editing screen
    Button to finish selecting the Coupon expiry date in the Add or Edit Coupon screen
    Button to submit selection on Select Categories screen
@@ -2719,6 +2723,9 @@ which should be translated separately and considered part of this sentence. */
 /* Error message displayed when user information cannot be fetched after authentication. */
 "Error fetching user information." = "Error fetching user information.";
 
+/* Error message in the Scan to Pay screen when the code cannot be generated. */
+"Error generating QR Code. Please try again later" = "Error generating QR Code. Please try again later";
+
 /* Error in finding the address in the Shipping Label Address Validation in Apple Maps */
 "Error in finding the address in Apple Maps" = "Error in finding the address in Apple Maps";
 
@@ -2824,9 +2831,6 @@ which should be translated separately and considered part of this sentence. */
 
 /* Formatted content for coupon expiry date, reads like: Expires August 4, 2022 */
 "Expires %1$@" = "Expires %1$@";
-
-/* Action on the local notification to remind the user of a newly created store. */
-"Explore" = "Explore";
 
 /* The detailed message shown in the Orders → All Orders tab if the list is empty. */
 "Explore how you can increase your store sales" = "Explore how you can increase your store sales";
@@ -4135,6 +4139,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* The maximum limit of spending allowed for a coupon on the Coupon Details screen, reads like: Minimum spend of $20.00 */
 "Maximum spend of %1$@" = "Maximum spend of %1$@";
 
+/* Dismiss button title for modally presented Just in Time Messages */
+"Maybe Later" = "Maybe Later";
+
 /* Country option for a site address. */
 "Mayotte" = "Mayotte";
 
@@ -4989,9 +4996,6 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Title of the in-progress UI while deleting the Product remotely */
 "Placing your product in the trash..." = "Placing your product in the trash...";
 
-/* Message of alert that links to settings for camera access. */
-"Please change your camera permissions in device settings." = "Please change your camera permissions in device settings.";
-
 /* Title of the alert presented when an update fails because the reader is low on battery. */
 "Please charge reader" = "Please charge reader";
 
@@ -5368,6 +5372,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Title of the external URL row on Product main screen for an external/affiliate product */
 "Product link" = "Product link";
+
+/* Error message on the Order list view when the scanner cannot find a matching product and create a new order */
+"Product not found. Failed to create a New Order" = "Product not found. Failed to create a New Order";
 
 /* Title of the alert when a user is publishing a product */
 "Product published" = "Product published";
@@ -5921,6 +5928,12 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Scan Products */
 "Scan products" = "Scan products";
 
+/* Title text on the Scan to Pay screen */
+"Scan QR and follow instructions" = "Scan QR and follow instructions";
+
+/* Scan to Pay method title on the select payment method screen */
+"Scan to Pay" = "Scan to Pay";
+
 /* Label for a cell informing the user that reader scanning is ongoing. */
 "Scanning for readers" = "Scanning for readers";
 
@@ -6251,6 +6264,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Title on the refund screen that lists the shipping total cost */
 "Shipping Refund" = "Shipping Refund";
 
+/* The EU notice banner content describing how the shipping customs shall be configured */
+"Shipping to countries that follow European Union (EU) customs rules now requires you clearly describe every item. For example, if you are sending clothing, you must indicate what type of clothing (e.g., men’s shirts, girl’s vest, boy’s jacket) for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs. " = "Shipping to countries that follow European Union (EU) customs rules now requires you clearly describe every item. For example, if you are sending clothing, you must indicate what type of clothing (e.g., men’s shirts, girl’s vest, boy’s jacket) for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs. ";
+
 /* Display label for the product's catalog visibility */
 "Shop and search results" = "Shop and search results";
 
@@ -6501,6 +6517,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Error message when the app can't create a zendesk identity. */
 "Sorry, we cannot create support requests right now, please try again later." = "Sorry, we cannot create support requests right now, please try again later.";
 
+/* Error message shown when an in-progress connection is cancelled by the system */
+"Sorry, we could not connect to the reader. Please try again." = "Sorry, we could not connect to the reader. Please try again.";
+
 /* Error message when the app can't create a support request. */
 "Sorry, we could not create your support request, please try again later." = "Sorry, we could not create your support request, please try again later.";
 
@@ -6690,9 +6709,6 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Button title to submit a support request. */
 "Submit Support Request" = "Submit Support Request";
-
-/* Action on the local notification to suggest the user to subscribe to the trial plan. */
-"Subscribe" = "Subscribe";
 
 /* Display label for simple subscription product type.
    Title for Subscription row in the product form screen.
@@ -7434,9 +7450,6 @@ This part is the link to the website, and forms part of a longer sentence which 
    Top Performers section title - this year */
 "This Year" = "This Year";
 
-/* Title of the local notification to remind the user of expiring free trial plan.The placeholder is the name of the user. */
-"Time’s almost up, %1$@!" = "Time’s almost up, %1$@!";
-
 /* Country option for a site address. */
 "Timor-Leste" = "Timor-Leste";
 
@@ -8058,8 +8071,8 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Title of the in-progress UI while bulk updating selected products remotely */
 "Updating your products..." = "Updating your products...";
 
-/* Action on the local notification to remind the user of the expiring free trial plan. */
-"Upgrade" = "Upgrade";
+/* Title for the WebView when upgrading a free trial plan */
+"Upgrade Now" = "Upgrade Now";
 
 /* Cell title for Upsells products in Linked Products Settings screen
    Navigation bar title for editing linked products for upsell products */
@@ -8678,6 +8691,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Error message when WooCommerce Payments is not supported because the Stripe account has overdue requirements */
 "You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments." = "You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments.";
 
+/* Error message for a short value in Description row in Customs screen of Shipping Label flow */
+"You must provide a clear, specific description for every item." = "You must provide a clear, specific description for every item.";
+
 /* Alert message to confirm the user wants to discard changes in Product Visibility */
 "You need to add a password to make your product password-protected" = "You need to add a password to make your product password-protected";
 
@@ -8763,12 +8779,6 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Title of the store onboarding launched store screen. */
 "Your store is live!" = "Your store is live!";
 
-/* Title of the local notification about a newly created store */
-"Your store is ready!" = "Your store is ready!";
-
-/* Title of the local notification suggesting a trial plan subscription. */
-"Your store is waiting!" = "Your store is waiting!";
-
 /* Subtitle of the store creation summary screen. */
 "Your store will be created based on the options of your choice!" = "Your store will be created based on the options of your choice!";
 
@@ -8778,8 +8788,7 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Message for the alert after the support request is created. */
 "Your support request has landed safely in our inbox. We will reply via email as quickly as we can." = "Your support request has landed safely in our inbox. We will reply via email as quickly as we can.";
 
-/* Message of the free trial banner when there are no days left
-   Title of the local notification to remind the user of the expired free trial plan. */
+/* Message of the free trial banner when there are no days left */
 "Your trial has ended." = "Your trial has ended.";
 
 /* Error message when WooCommerce Payments is not installed */
@@ -8797,8 +8806,14 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
 "{G} Log in with Google." = "{G} Log in with Google.";
 
+/* Title of the local notification to remind the user of expiring free trial plan. */
+"⏰ Time’s running out on your free trial!" = "⏰ Time’s running out on your free trial!";
+
 /* Badge of the store onboarding task to add the first product when the store is eligible for Jetpack AI. */
 "✨ AI content generator available." = "✨ AI content generator available.";
+
+/* Title of the local notification to remind the user of the expired free trial plan. */
+"🌟 Keep your business going with our plan!" = "🌟 Keep your business going with our plan!";
 
 /* Notice text after completing a simple payment order */
 "🎉 Order completed" = "🎉 Order completed";
@@ -8811,6 +8826,12 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Products successfully refunded";
+
+/* Title of the local notification about a newly created store */
+"🎉 Your store is ready!" = "🎉 Your store is ready!";
+
+/* Title of the local notification suggesting a trial plan subscription. */
+"🛍️ Your store is waiting!" = "🛍️ Your store is waiting!";
 
 
 /* MARK: - InfoPlist.strings */

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,1 +1,9 @@
-This release includes several bug fixes and improvements to your product management experience, including fixing stock statuses for Product Bundles so that backordered bundles and bundle stock quantities are displayed as expected. We've also added the option for you to automatically generate product description based on the a few key words.
+- [Internal] Adds guidance for new Customs rule when shipping to some EU countries. [https://github.com/woocommerce/woocommerce-ios/pull/9715]
+- [*] JITMs: Added modal-style Just in Time Message support on the dashboard [https://github.com/woocommerce/woocommerce-ios/pull/9694]
+- [**] Order Creation: Products can be searched by SKU when adding products to an order. [https://github.com/woocommerce/woocommerce-ios/pull/9711]
+- [*] Orders: Fixes order details so separate order items are not combined just because they are the same product or variation. [https://github.com/woocommerce/woocommerce-ios/pull/9710]
+- [Internal] Store creation: starting May 4, store creation used to time out while waiting for the site to be ready (become a Jetpack/Woo site). A workaround was implemented to wait for the site differently. [https://github.com/woocommerce/woocommerce-ios/pull/9767]
+- [**] Mobile Payments: Tap to Pay is initialised on launch or foreground, to speed up payments [https://github.com/woocommerce/woocommerce-ios/pull/9750]
+- [*] Store Creation: Local notifications are used to support users during the store creation process. [https://github.com/woocommerce/woocommerce-ios/pull/9717, https://github.com/woocommerce/woocommerce-ios/pull/9719, https://github.com/woocommerce/woocommerce-ios/pull/9749]
+- [**] Mobile Payments: Merchants can now collect in-person payments by showing a QR code to their customers. [https://github.com/woocommerce/woocommerce-ios/pull/9762]
+

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,9 +1,1 @@
-- [Internal] Adds guidance for new Customs rule when shipping to some EU countries. [https://github.com/woocommerce/woocommerce-ios/pull/9715]
-- [*] JITMs: Added modal-style Just in Time Message support on the dashboard [https://github.com/woocommerce/woocommerce-ios/pull/9694]
-- [**] Order Creation: Products can be searched by SKU when adding products to an order. [https://github.com/woocommerce/woocommerce-ios/pull/9711]
-- [*] Orders: Fixes order details so separate order items are not combined just because they are the same product or variation. [https://github.com/woocommerce/woocommerce-ios/pull/9710]
-- [Internal] Store creation: starting May 4, store creation used to time out while waiting for the site to be ready (become a Jetpack/Woo site). A workaround was implemented to wait for the site differently. [https://github.com/woocommerce/woocommerce-ios/pull/9767]
-- [**] Mobile Payments: Tap to Pay is initialised on launch or foreground, to speed up payments [https://github.com/woocommerce/woocommerce-ios/pull/9750]
-- [*] Store Creation: Local notifications are used to support users during the store creation process. [https://github.com/woocommerce/woocommerce-ios/pull/9717, https://github.com/woocommerce/woocommerce-ios/pull/9719, https://github.com/woocommerce/woocommerce-ios/pull/9749]
-- [**] Mobile Payments: Merchants can now collect in-person payments by showing a QR code to their customers. [https://github.com/woocommerce/woocommerce-ios/pull/9762]
-
+You’ve asked for it, and now it’s here! You can now search for an order using a SKU when creating an order on the go. We have also made updates to the product selection so it's easier to search variations of a product. Awesome, right?

--- a/config/Version.Public.xcconfig
+++ b/config/Version.Public.xcconfig
@@ -1,7 +1,7 @@
-VERSION_SHORT=13.6
+VERSION_SHORT=13.7
 
 // Public long version example: VERSION_LONG=1.2.0.0
-VERSION_LONG=13.6.0.1
+VERSION_LONG=13.7.0.0
 
 // Re-map our custom version values (used by release-toolkit) to the Xcode ones
 MARKETING_VERSION=$VERSION_SHORT


### PR DESCRIPTION
This PR merges the changes from the 13.7 code freeze into `trunk`. Includes: 
- Localization key fix: https://github.com/woocommerce/woocommerce-ios/pull/9782
- Updated release notes
- Frozen strings for translation
- Version bump
- Similar to #9782, I updated another long string in https://github.com/woocommerce/woocommerce-ios/pull/9783/commits/8f19d4422162fc8139930548a3f8cdbe628f5ec6 to use a non-English copy key for localization so that GlotPress doesn't truncate the key