### PR TITLE
Update scanner button position in Order List view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -314,10 +314,11 @@ private extension OrdersRootViewController {
             createAddOrderItem(),
             createSearchBarButtonItem()
         ]
-        if featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner) {
-            buttons.insert(createAddOrderByProductScanningButtonItem(), at: 1)
-        }
         navigationItem.rightBarButtonItems = buttons
+
+        if featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner) {
+            navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
+        }
     }
 
     func configureFiltersBar() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -305,20 +305,19 @@ private extension OrdersRootViewController {
     }
 
     /// Sets navigation buttons.
-    /// Search: Is always present.
     /// Scan: Present when `.addProductToOrderViaSKUScanner` flag is enabled
+    /// Search: Always present.
     /// Add: Always present.
     ///
     func configureNavigationButtons() {
-        var buttons: [UIBarButtonItem] = [
-            createAddOrderItem(),
-            createSearchBarButtonItem()
-        ]
-        navigationItem.rightBarButtonItems = buttons
-
         if featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner) {
             navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
         }
+
+        navigationItem.rightBarButtonItems = [
+            createAddOrderItem(),
+            createSearchBarButtonItem()
+        ]
     }
 
     func configureFiltersBar() {


### PR DESCRIPTION
Part of: #9742

## Description
As per design feedback, this PR moves the scanner button from appearing between "search" and "add", to be on the left in the navigation row. 

## Testing instructions
No scanning logic has been changed, only the button position. Run the app and confirm the button it's there in debug builds.

## Screenshots
| Before | After |
|--------|--------|
| <img width=450 src="https://user-images.githubusercontent.com/3812076/238540351-c77b02b7-539d-4dce-bee4-00de474fdfe8.png"> | <img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/d15a599b-0ff9-403c-812a-84d552f82328"> | 
