### PR TITLE
Update scanner button in Order Editing view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -282,55 +282,59 @@ private struct ProductsSection: View {
                     Divider()
                 }
 
-                Button(OrderForm.Localization.addProducts) {
-                    showAddProduct.toggle()
-                }
-                .id(addProductButton)
-                .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
-                .buttonStyle(PlusButtonStyle())
-                .sheet(isPresented: $showAddProduct, onDismiss: {
-                    scroll.scrollTo(addProductButton)
-                }, content: {
-                    ProductSelectorNavigationView(
-                        configuration: ProductSelectorView.Configuration.addProductToOrder(),
-                        isPresented: $showAddProduct,
-                        viewModel: viewModel.productSelectorViewModel)
-                    .onDisappear {
-                        viewModel.productSelectorViewModel.clearSearchAndFilters()
-                        navigationButtonID = UUID()
+                HStack {
+                    Button(OrderForm.Localization.addProducts) {
+                        showAddProduct.toggle()
                     }
-                })
-                Button(OrderForm.Localization.addProductViaSKUScanner) {
-                    let capturePermissionStatus = viewModel.capturePermissionStatus
-                    switch capturePermissionStatus {
-                    case .notPermitted:
-                        logPermissionStatus(status: .notPermitted)
-                        self.showPermissionsSheet = true
-                    case .notDetermined:
-                        logPermissionStatus(status: .notDetermined)
-                        viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
-                            if isPermissionGranted {
-                                showAddProductViaSKUScanner = true
-                                logPermissionStatus(status: .permitted)
-                            }
-                        })
-                    case .permitted:
-                        showAddProductViaSKUScanner = true
-                        logPermissionStatus(status: .permitted)
-                    }
-                }
-                .accessibilityIdentifier(OrderForm.Accessibility.addProductViaSKUScannerButtonIdentifier)
-                .buttonStyle(PlusButtonStyle())
-                .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
-                    scroll.scrollTo(addProductViaSKUScannerButton)
-                }, content: {
-                    ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
-                        viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { _ in
-                            showAddProductViaSKUScanner.toggle()
+                    .id(addProductButton)
+                    .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
+                    .buttonStyle(PlusButtonStyle())
+                    .sheet(isPresented: $showAddProduct, onDismiss: {
+                        scroll.scrollTo(addProductButton)
+                    }, content: {
+                        ProductSelectorNavigationView(
+                            configuration: ProductSelectorView.Configuration.addProductToOrder(),
+                            isPresented: $showAddProduct,
+                            viewModel: viewModel.productSelectorViewModel)
+                        .onDisappear {
+                            viewModel.productSelectorViewModel.clearSearchAndFilters()
+                            navigationButtonID = UUID()
+                        }
+                    })
+
+                    Button(action: {
+                        let capturePermissionStatus = viewModel.capturePermissionStatus
+                        switch capturePermissionStatus {
+                        case .notPermitted:
+                            logPermissionStatus(status: .notPermitted)
+                            self.showPermissionsSheet = true
+                        case .notDetermined:
+                            logPermissionStatus(status: .notDetermined)
+                            viewModel.requestCameraAccess(onCompletion: { isPermissionGranted in
+                                if isPermissionGranted {
+                                    showAddProductViaSKUScanner = true
+                                    logPermissionStatus(status: .permitted)
+                                }
+                            })
+                        case .permitted:
+                            showAddProductViaSKUScanner = true
+                            logPermissionStatus(status: .permitted)
+                        }
+                    }, label: {
+                        Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                            .foregroundColor(Color(.brand))
+                    })
+                    .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
+                        scroll.scrollTo(addProductViaSKUScannerButton)
+                    }, content: {
+                        ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
+                            viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { _ in
+                                showAddProductViaSKUScanner.toggle()
+                            })
                         })
                     })
-                })
-                .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
+                    .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
+                }
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()
@@ -368,8 +372,6 @@ private extension OrderForm {
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating or editing an order")
         static let addProducts = NSLocalizedString("Add Products",
                                                    comment: "Title text of the button that allows to add multiple products when creating or editing an order")
-        static let addProductViaSKUScanner = NSLocalizedString("Add Product via SKU scanner",
-                                                                   comment: "Title text of the button to add a single product via SKU scanning")
         static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
                                                                    comment: "Accessibility hint for selecting a product in an order form")
         static let permissionsTitle =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-ios/issues/9742
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
As per design feedback, this PR removes the  "+ Add Products via SKU scanner" row in favor or a unique row, which is used both for adding products via the product selector, as well as the scanner.

## Changes
- We're wrapping both existing buttons in a new `HStack`.
- The scanning button remains wrapped with `.renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)`, so will only display in debug builds.

## Testing instructions
- Go to Order > Tap "+" > See the new "+ Add Products" button. 
- Tap the text to open the product selector
- Tap the icon to open the scanner

## Screenshots
| Before | After |
|--------|--------|
| <img width=450 src="https://user-images.githubusercontent.com/3812076/236798574-41efbfaf-ca38-45f4-b766-1a168db700d9.png"> | <img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/f0123905-5a52-42a9-87e3-56fdd2ec9289"> | 
