### PR TITLE
Show the share CTA in product form navigation bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 13.8
 -----
-
+- [*] Product form: a share action is shown in the navigation bar if the product can be shared and no more than one action is displayed, in addition to the more menu > Share. [https://github.com/woocommerce/woocommerce-ios/pull/9789]
 
 13.7
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductForm.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductForm.swift
@@ -1,0 +1,24 @@
+extension WooAnalyticsEvent {
+    enum ProductForm {
+        /// Event property keys.
+        private enum Key {
+            static let source = "source"
+        }
+
+        /// Tracked when the user taps on the button to share a product.
+        static func productDetailShareButtonTapped(source: ShareProductSource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailShareButtonTapped,
+                              properties: [Key.source: source.rawValue])
+        }
+    }
+}
+
+extension WooAnalyticsEvent.ProductForm {
+    /// Source of the share product action. The raw value is the event property value.
+    enum ShareProductSource: String {
+        /// From product form in the navigation bar.
+        case productForm = "product_form"
+        /// From product form > more menu in the navigation bar.
+        case moreMenu = "more_menu"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -281,8 +281,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
         if viewModel.canShareProduct() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.share) { [weak self] _ in
-                ServiceLocator.analytics.track(.productDetailShareButtonTapped)
-                self?.displayShareProduct()
+                self?.displayShareProduct(source: .moreMenu)
             }
         }
 
@@ -471,8 +470,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     }
 
     @objc private func shareProduct() {
-        ServiceLocator.analytics.track(.productDetailShareButtonTapped)
-        displayShareProduct()
+        displayShareProduct(source: .productForm)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -863,7 +861,9 @@ private extension ProductFormViewController {
         WebviewHelper.launch(url, with: self)
     }
 
-    func displayShareProduct() {
+    func displayShareProduct(source: WooAnalyticsEvent.ProductForm.ShareProductSource) {
+        ServiceLocator.analytics.track(event: .ProductForm.productDetailShareButtonTapped(source: source))
+
         guard let url = URL(string: product.permalink) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -470,6 +470,11 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         }
     }
 
+    @objc private func shareProduct() {
+        ServiceLocator.analytics.track(.productDetailShareButtonTapped)
+        displayShareProduct()
+    }
+
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         let section = tableViewModel.sections[section]
         switch section {
@@ -1003,6 +1008,8 @@ private extension ProductFormViewController {
                 return createSaveBarButtonItem()
             case .more:
                 return createMoreOptionsBarButtonItem()
+            case .share:
+                return createShareBarButtonItem()
             }
         }
 
@@ -1047,6 +1054,12 @@ private extension ProductFormViewController {
         moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "Accessibility label for the Edit Product More Options action sheet")
         moreButton.accessibilityIdentifier = "edit-product-more-options-button"
         return moreButton
+    }
+
+    func createShareBarButtonItem() -> UIBarButtonItem {
+        UIBarButtonItem(barButtonSystemItem: .action,
+                        target: self,
+                        action: #selector(shareProduct))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -168,6 +168,11 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
             buttons.append(.more)
         }
 
+        // Share button if up to one button is visible.
+        if canShareProduct() && buttons.count <= 1 {
+            buttons.insert(.share, at: 0)
+        }
+
         return buttons
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -14,6 +14,7 @@ enum ActionButtonType {
     case publish
     case save
     case more
+    case share
 }
 
 /// The type of save message when saving a product.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		02490D1E284F3226002096EF /* ProductImagesSaverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02490D1D284F3226002096EF /* ProductImagesSaverTests.swift */; };
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
+		024D4E842A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */; };
 		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
 		024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3062372C18D006658FE /* AztecUIConfigurator.swift */; };
 		024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3082372CA00006658FE /* EditorViewProperties.swift */; };
@@ -2481,6 +2482,7 @@
 		02490D1D284F3226002096EF /* ProductImagesSaverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesSaverTests.swift; sourceTree = "<group>"; };
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
+		024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductForm.swift"; sourceTree = "<group>"; };
 		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
 		024DF3062372C18D006658FE /* AztecUIConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecUIConfigurator.swift; sourceTree = "<group>"; };
 		024DF3082372CA00006658FE /* EditorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorViewProperties.swift; sourceTree = "<group>"; };
@@ -7451,6 +7453,7 @@
 				02B21C5629C9EEF900C5623B /* WooAnalyticsEvent+StoreOnboarding.swift */,
 				DE621F6929D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift */,
 				02E222C729FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift */,
+				024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -11178,6 +11181,7 @@
 				03BB9EA5292E2D0C00251E9E /* CardReaderConnectionController.swift in Sources */,
 				B95112DA28BF79CA00D9578D /* PaymentsRoute.swift in Sources */,
 				7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */,
+				024D4E842A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift in Sources */,
 				CC53FB3C2757EC7200C4CA4F /* ProductSelectorViewModel.swift in Sources */,
 				CCA1D5FE293F537400B40560 /* DeltaPercentage.swift in Sources */,
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -357,7 +357,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.more])
+        XCTAssertEqual(actionButtons, [.share, .more])
     }
 
     func test_action_buttons_for_existing_draft_product_and_pending_changes() {
@@ -425,7 +425,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.more])
+        XCTAssertEqual(actionButtons, [.share, .more])
     }
 
     func test_no_preview_button_for_existing_draft_product_on_site_with_no_frame_nonce() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9788 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Right now the share product CTA is buried inside the ellipsis menu. We can show it beside the ellipsis menu in the product form, and then hide it when there is more than one button like when the Save/Update CTA is shown after the merchant makes some changes.

## How

I decided to show the share CTA on the leading edge of the existing CTA in the navigation bar, because the more/ellipsis menu can stay the same while the share CTA changes to Save/Update CTA after some unsaved changes.

The share CTA is added to `ProductFormViewModel.actionButtons` when there is up to 1 existing action and the product can be shared. In `ProductFormViewController`, the share CTA is then shown in the navigation bar that calls the same share function as from the more menu. A new event property `source:product_form|more_menu` was added to `product_detail_share_button_tapped` to see which source is the most effective.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the products tab
- Tap on the + button in the navigation bar to create a product --> in the product form, there should **not** be a share CTA
- Tap `Publish` to publish the product --> after the product is saved remotely, a share CTA should be shown
- Tap on the share CTA --> `product_detail_share_button_tapped` event should be tracked with `source: product_form` and a share sheet should be shown
- Go back to the products tab
- Tap on a product --> a share CTA should be shown
- Tap on the more menu > Share --> `product_detail_share_button_tapped` event should be tracked with `source: more_menu` and a share sheet should be shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Share CTA shown | Share CTA hidden when more than 1 action is shown
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-05-22 at 14 45 14](https://github.com/woocommerce/woocommerce-ios/assets/1945542/72339401-c77f-462a-8ac5-6e7b0d56c06c) | ![Simulator Screen Shot - iPhone 14 - 2023-05-22 at 14 45 25](https://github.com/woocommerce/woocommerce-ios/assets/1945542/780ada15-f3ee-4a50-a9c9-be7438df9f25)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
