### PR TITLE
Add product: Show celebratory view when the first product is created

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 13.8
 -----
+- [*] Add Products: A new view is display to celebrate when the first product is created in a store. [https://github.com/woocommerce/woocommerce-ios/pull/9790]
 
 
 13.7

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "ConfettiSwiftUI",
+        "repositoryURL": "https://github.com/simibac/ConfettiSwiftUI.git",
+        "state": {
+          "branch": null,
+          "revision": "8d3a15d0aa2991e0761749b767ef8d89bca6275a",
+          "version": "1.0.1"
+        }
+      },
+      {
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -715,7 +715,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: First created product events
     case firstCreatedProductShown = "first_created_product_shown"
-    case firstCreatedProductShared = "first_created_product_shared"
+    case firstCreatedProductShareTapped = "first_created_product_share_tapped"
 
     // MARK: Jetpack Tunnel Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -713,6 +713,10 @@ public enum WooAnalyticsStat: String {
     case productDescriptionAIGenerationSuccess = "product_description_ai_generation_success"
     case productDescriptionAIGenerationFailed = "product_description_ai_generation_failed"
 
+    // MARK: First created product events
+    case firstCreatedProductShown = "first_created_product_shown"
+    case firstCreatedProductShared = "first_created_product_shared"
+
     // MARK: Jetpack Tunnel Events
     //
     case jetpackTunnelTimeout = "jetpack_tunnel_timeout"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -471,7 +471,8 @@ private extension DashboardViewController {
         let coordinator = AddProductCoordinator(siteID: siteID,
                                                 source: .productOnboarding,
                                                 sourceView: announcementView,
-                                                sourceNavigationController: navigationController)
+                                                sourceNavigationController: navigationController,
+                                                isFirstProduct: true)
         coordinator.onProductCreated = { [weak self] _ in
             guard let self else { return }
             self.viewModel.announcementViewModel = nil // Remove the products onboarding banner

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -89,7 +89,7 @@ private extension StoreOnboardingCoordinator {
                                                 sourceNavigationController: navigationController,
                                                 isFirstProduct: true)
         self.addProductCoordinator = coordinator
-        coordinator.onProductCreated = { [weak self] product in
+        coordinator.onProductCreated = { [weak self] _ in
             self?.onTaskCompleted(.addFirstProduct)
         }
         coordinator.start()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -86,9 +86,10 @@ private extension StoreOnboardingCoordinator {
         let coordinator = AddProductCoordinator(siteID: site.siteID,
                                                 source: .storeOnboarding,
                                                 sourceView: nil,
-                                                sourceNavigationController: navigationController)
+                                                sourceNavigationController: navigationController,
+                                                isFirstProduct: true)
         self.addProductCoordinator = coordinator
-        coordinator.onProductCreated = { [weak self] _ in
+        coordinator.onProductCreated = { [weak self] product in
             self?.onTaskCompleted(.addFirstProduct)
         }
         coordinator.start()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -1,40 +1,52 @@
+import ConfettiSwiftUI
 import SwiftUI
 
 /// Celebratory screen after creating the first product 🎉
 ///
 struct FirstProductCreatedView: View {
+    @State private var confettiCounter: Int = 0
+
     var body: some View {
-        VStack(spacing: Layout.verticalSpacing) {
-            Spacer()
-            VStack {
+        GeometryReader { proxy in
+            VStack(spacing: Constants.verticalSpacing) {
+                Spacer()
                 Text(Localization.title)
                     .titleStyle()
+                Image(uiImage: .welcomeImage)
                 Text(Localization.message)
                     .secondaryBodyStyle()
+                Button(Localization.shareAction) {
+                    // TODO
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.horizontal)
+                Spacer()
             }
-            Image(uiImage: .welcomeImage)
-            Button(Localization.shareAction) {
-                // TODO
-            }
-            .buttonStyle(PrimaryButtonStyle())
-            Spacer()
+            .padding()
+            .background(Color(uiColor: .systemBackground))
+            .confettiCannon(counter: $confettiCounter,
+                            num: Constants.confettiCount,
+                            rainHeight: proxy.size.height,
+                            radius: proxy.size.width)
         }
-        .padding()
-        .background(Color(uiColor: .systemBackground))
+        .onAppear {
+            confettiCounter += 1
+        }
     }
 }
 
 private extension FirstProductCreatedView {
-    enum Layout {
-        static let verticalSpacing: CGFloat = 32
+    enum Constants {
+        static let verticalSpacing: CGFloat = 48
+        static let confettiCount: Int = 100
     }
     enum Localization {
         static let title = NSLocalizedString(
-            "Congratulations 🎉",
+            "First product created 🎉",
             comment: "Title of the celebratory screen after creating the first product"
         )
         static let message = NSLocalizedString(
-            "Great work on your first product!",
+            "Congratulations! You're one step closer to get the new store ready.",
             comment: "Message on the celebratory screen after creating first product"
         )
         static let shareAction = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -7,6 +7,7 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
         rootView.onSharingProduct = { [weak self] in
             guard let self else { return }
             SharingHelper.shareURL(url: productURL, from: self.view, in: self)
+            ServiceLocator.analytics.track(.firstCreatedProductShared)
         }
     }
 
@@ -19,6 +20,7 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
         super.viewDidLoad()
         configureTransparentNavigationBar()
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
+        ServiceLocator.analytics.track(.firstCreatedProductShown)
     }
 
     @objc
@@ -83,7 +85,7 @@ private extension FirstProductCreatedView {
             comment: "Message on the celebratory screen after creating first product"
         )
         static let shareAction = NSLocalizedString(
-            "Spread the word",
+            "Share Product",
             comment: "Title of the action button to share the first created product"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -7,7 +7,7 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
         rootView.onSharingProduct = { [weak self] in
             guard let self else { return }
             SharingHelper.shareURL(url: productURL, from: self.view, in: self)
-            ServiceLocator.analytics.track(.firstCreatedProductShared)
+            ServiceLocator.analytics.track(.firstCreatedProductShareTapped)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -2,8 +2,12 @@ import ConfettiSwiftUI
 import SwiftUI
 
 final class FirstProductCreatedHostingController: UIHostingController<FirstProductCreatedView> {
-    init(productURL: String) {
-        super.init(rootView: FirstProductCreatedView(productURL: productURL))
+    init(productURL: URL) {
+        super.init(rootView: FirstProductCreatedView())
+        rootView.onSharingProduct = { [weak self] in
+            guard let self else { return }
+            SharingHelper.shareURL(url: productURL, from: self.view, in: self)
+        }
     }
 
     @available(*, unavailable)
@@ -25,14 +29,14 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
 
 private extension FirstProductCreatedHostingController {
     enum Localization {
-        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the site credential login screen")
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the first created product screen")
     }
 }
 
 /// Celebratory screen after creating the first product 🎉
 ///
 struct FirstProductCreatedView: View {
-    let productURL: String
+    var onSharingProduct: () -> Void = {}
     @State private var confettiCounter: Int = 0
 
     var body: some View {
@@ -45,11 +49,10 @@ struct FirstProductCreatedView: View {
                 Text(Localization.message)
                     .secondaryBodyStyle()
                     .multilineTextAlignment(.center)
-                Button(Localization.shareAction) {
-                    // TODO
-                }
-                .buttonStyle(PrimaryButtonStyle())
-                .padding(.horizontal)
+                Button(Localization.shareAction,
+                       action: onSharingProduct)
+                    .buttonStyle(PrimaryButtonStyle())
+                    .padding(.horizontal)
                 Spacer()
             }
             .padding()
@@ -88,10 +91,11 @@ private extension FirstProductCreatedView {
 
 struct FirstProductCreatedView_Previews: PreviewProvider {
     static var previews: some View {
-        FirstProductCreatedView(productURL: "https://example.com")
-            .environment(\.colorScheme, .light)
-        FirstProductCreatedView(productURL: "https://example.com")
-            .environment(\.colorScheme, .dark)
-            .previewInterfaceOrientation(.landscapeLeft)
+        FirstProductCreatedView()
+        .environment(\.colorScheme, .light)
+
+        FirstProductCreatedView()
+        .environment(\.colorScheme, .dark)
+        .previewInterfaceOrientation(.landscapeLeft)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -15,6 +15,7 @@ struct FirstProductCreatedView: View {
                 Image(uiImage: .welcomeImage)
                 Text(Localization.message)
                     .secondaryBodyStyle()
+                    .multilineTextAlignment(.center)
                 Button(Localization.shareAction) {
                     // TODO
                 }
@@ -23,7 +24,7 @@ struct FirstProductCreatedView: View {
                 Spacer()
             }
             .padding()
-            .background(Color(uiColor: .systemBackground))
+            .scrollVerticallyIfNeeded()
             .confettiCannon(counter: $confettiCounter,
                             num: Constants.confettiCount,
                             rainHeight: proxy.size.height,
@@ -32,12 +33,13 @@ struct FirstProductCreatedView: View {
         .onAppear {
             confettiCounter += 1
         }
+        .background(Color(uiColor: .systemBackground))
     }
 }
 
 private extension FirstProductCreatedView {
     enum Constants {
-        static let verticalSpacing: CGFloat = 48
+        static let verticalSpacing: CGFloat = 40
         static let confettiCount: Int = 100
     }
     enum Localization {
@@ -62,5 +64,6 @@ struct FirstProductCreatedView_Previews: PreviewProvider {
             .environment(\.colorScheme, .light)
         FirstProductCreatedView()
             .environment(\.colorScheme, .dark)
+            .previewInterfaceOrientation(.landscapeLeft)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -1,14 +1,43 @@
 import ConfettiSwiftUI
 import SwiftUI
 
+final class FirstProductCreatedHostingController: UIHostingController<FirstProductCreatedView> {
+    init(productURL: String) {
+        super.init(rootView: FirstProductCreatedView(productURL: productURL))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTransparentNavigationBar()
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
+    }
+
+    @objc
+    private func dismissView() {
+        dismiss(animated: true)
+    }
+}
+
+private extension FirstProductCreatedHostingController {
+    enum Localization {
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the site credential login screen")
+    }
+}
+
 /// Celebratory screen after creating the first product 🎉
 ///
 struct FirstProductCreatedView: View {
+    let productURL: String
     @State private var confettiCounter: Int = 0
 
     var body: some View {
         GeometryReader { proxy in
-            VStack(spacing: Constants.verticalSpacing) {
+            ScrollableVStack(spacing: Constants.verticalSpacing) {
                 Spacer()
                 Text(Localization.title)
                     .titleStyle()
@@ -24,7 +53,6 @@ struct FirstProductCreatedView: View {
                 Spacer()
             }
             .padding()
-            .scrollVerticallyIfNeeded()
             .confettiCannon(counter: $confettiCounter,
                             num: Constants.confettiCount,
                             rainHeight: proxy.size.height,
@@ -60,9 +88,9 @@ private extension FirstProductCreatedView {
 
 struct FirstProductCreatedView_Previews: PreviewProvider {
     static var previews: some View {
-        FirstProductCreatedView()
+        FirstProductCreatedView(productURL: "https://example.com")
             .environment(\.colorScheme, .light)
-        FirstProductCreatedView()
+        FirstProductCreatedView(productURL: "https://example.com")
             .environment(\.colorScheme, .dark)
             .previewInterfaceOrientation(.landscapeLeft)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -81,7 +81,7 @@ private extension FirstProductCreatedView {
             comment: "Title of the celebratory screen after creating the first product"
         )
         static let message = NSLocalizedString(
-            "Congratulations! You're one step closer to get the new store ready.",
+            "Congratulations! You're one step closer to getting the new store ready.",
             comment: "Message on the celebratory screen after creating first product"
         )
         static let shareAction = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -31,7 +31,7 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
 
 private extension FirstProductCreatedHostingController {
     enum Localization {
-        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the first created product screen")
+        static let cancel = NSLocalizedString("Dismiss", comment: "Button to dismiss the first created product screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -4,12 +4,51 @@ import SwiftUI
 ///
 struct FirstProductCreatedView: View {
     var body: some View {
-        Text("Hello, World!")
+        VStack(spacing: Layout.verticalSpacing) {
+            Spacer()
+            VStack {
+                Text(Localization.title)
+                    .titleStyle()
+                Text(Localization.message)
+                    .secondaryBodyStyle()
+            }
+            Image(uiImage: .welcomeImage)
+            Button(Localization.shareAction) {
+                // TODO
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            Spacer()
+        }
+        .padding()
+        .background(Color(uiColor: .systemBackground))
+    }
+}
+
+private extension FirstProductCreatedView {
+    enum Layout {
+        static let verticalSpacing: CGFloat = 32
+    }
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Congratulations 🎉",
+            comment: "Title of the celebratory screen after creating the first product"
+        )
+        static let message = NSLocalizedString(
+            "Great work on your first product!",
+            comment: "Message on the celebratory screen after creating first product"
+        )
+        static let shareAction = NSLocalizedString(
+            "Spread the word",
+            comment: "Title of the action button to share the first created product"
+        )
     }
 }
 
 struct FirstProductCreatedView_Previews: PreviewProvider {
     static var previews: some View {
         FirstProductCreatedView()
+            .environment(\.colorScheme, .light)
+        FirstProductCreatedView()
+            .environment(\.colorScheme, .dark)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// Celebratory screen after creating the first product 🎉
+///
+struct FirstProductCreatedView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct FirstProductCreatedView_Previews: PreviewProvider {
+    static var previews: some View {
+        FirstProductCreatedView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -179,6 +179,8 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     private var subscriptions: Set<AnyCancellable> = []
 
+    private var addProductCoordinator: AddProductCoordinator?
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -269,10 +271,12 @@ private extension ProductsViewController {
     }
 
     @objc func addProduct(_ sender: UIBarButtonItem) {
-        addProduct(sourceBarButtonItem: sender)
+        addProduct(sourceBarButtonItem: sender, isFirstProduct: false)
     }
 
-    func addProduct(sourceBarButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
+    func addProduct(sourceBarButtonItem: UIBarButtonItem? = nil,
+                    sourceView: UIView? = nil,
+                    isFirstProduct: Bool) {
         guard let navigationController = navigationController, sourceBarButtonItem != nil || sourceView != nil else {
             return
         }
@@ -283,17 +287,20 @@ private extension ProductsViewController {
             coordinatingController = AddProductCoordinator(siteID: siteID,
                                                            source: source,
                                                            sourceBarButtonItem: sourceBarButtonItem,
-                                                           sourceNavigationController: navigationController)
+                                                           sourceNavigationController: navigationController,
+                                                           isFirstProduct: isFirstProduct)
         } else if let sourceView = sourceView {
             coordinatingController = AddProductCoordinator(siteID: siteID,
                                                            source: source,
                                                            sourceView: sourceView,
-                                                           sourceNavigationController: navigationController)
+                                                           sourceNavigationController: navigationController,
+                                                           isFirstProduct: isFirstProduct)
         } else {
             fatalError("No source view for adding a product")
         }
 
         coordinatingController.start()
+        self.addProductCoordinator = coordinatingController
     }
 }
 
@@ -1022,7 +1029,7 @@ private extension ProductsViewController {
             details: details,
             buttonTitle: buttonTitle,
             onTap: { [weak self] button in
-                self?.addProduct(sourceView: button)
+                self?.addProduct(sourceView: button, isFirstProduct: true)
             },
             onPullToRefresh: { [weak self] refreshControl in
                 self?.pullToRefresh(sender: refreshControl)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2057,6 +2057,7 @@
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */; };
 		DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */; };
+		DE9F2D2C2A1B1F5D004E5957 /* ConfettiSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
 		DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */; };
 		DEC0293A29C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */; };
@@ -4564,6 +4565,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DE9F2D2C2A1B1F5D004E5957 /* ConfettiSwiftUI in Frameworks */,
 				3FFC5EAC2851942F00563C48 /* Charts in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
 				263E37E12641AD8300260D3B /* Codegen in Frameworks */,
@@ -10422,6 +10424,7 @@
 				174CA86927D90A6200126524 /* AutomatticAbout */,
 				3FFC5EAB2851942F00563C48 /* Charts */,
 				4598298028574688003A9AFE /* Inject */,
+				DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -10592,6 +10595,7 @@
 				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
+				DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -13941,6 +13945,14 @@
 				minimumVersion = 1.1.1;
 			};
 		};
+		DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/simibac/ConfettiSwiftUI.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -14025,6 +14037,11 @@
 		57150E0E24F462C200E81611 /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestKit;
+		};
+		DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */;
+			productName = ConfettiSwiftUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2056,6 +2056,7 @@
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */; };
+		DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
 		DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */; };
 		DEC0293A29C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */; };
@@ -4362,6 +4363,7 @@
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddStoreFooterView.swift; sourceTree = "<group>"; };
+		DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstProductCreatedView.swift; sourceTree = "<group>"; };
 		DEA426992875440500265B0C /* PaymentMethodsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsScreen.swift; sourceTree = "<group>"; };
 		DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationWebViewController.swift; sourceTree = "<group>"; };
 		DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationViewModel.swift; sourceTree = "<group>"; };
@@ -5793,6 +5795,7 @@
 			isa = PBXGroup;
 			children = (
 				02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */,
+				DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */,
 				02ECD1E524FFB4E900735BE5 /* ProductFactory.swift */,
 			);
 			path = "Add Product";
@@ -12164,6 +12167,7 @@
 				035DBA45292D0164003E5125 /* CollectOrderPaymentUseCase.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
 				027F83ED29B046D2002688C6 /* DashboardTopPerformersViewModel.swift in Sources */,
+				DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
 				2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */,
 				02D29A9229F7C39200473D6D /* UIImage+Text.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
@@ -44,6 +44,7 @@ private extension AddProductCoordinatorTests {
         return AddProductCoordinator(siteID: 100,
                                      source: .productsTab,
                                      sourceView: view,
-                                     sourceNavigationController: navigationController)
+                                     sourceNavigationController: navigationController,
+                                     isFirstProduct: false)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9785 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new view to celebrate when a product is created for the first time. This view contains a button to share the new product too. To make it more fun, the view also has confetti when first presented - this is handled by a new library.

The `AddProductCoordinator` was updated with a new param `isFirstProduct`, used to decide whether to show the celebratory view after a product is successfully created.

The coordinator is updated in two places to ensure that we celebrate the first product from store onboarding and the empty view of the Products tab. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have access to a store with the checklist for creating the first product not done yet.
- Tap the onboarding item to create the first product for the store and publish the product from the product form.
- After the product is published or saved as draft, you should see that a new view is presented to celebrate the new product. In Xcode console, notice Tracks event: `first_created_product_shown`.
- Tap "Share Product", a  share sheet should be presented with the correct product URL. In Xcode console, notice Tracks event: `first_created_product_share_tapped`.
- Navigate to the Products tab and remove the newly created product. The empty view should then be displayed.
- Tap "Add Product" to create a new product. When the product is published or saved as draft, the celebratory screen should be presented again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/cb4ed6dd-c3e7-48f5-91a7-a0f12f06ed9b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
