### PR TITLE
[IAP Free Trials] Update IAP Debug Screen to handle user site upgrade

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -56,16 +56,14 @@ struct InAppPurchasesDebugView: View {
 
     var body: some View {
         List {
-            Section("Upgrading Site ID Source") {
+             Section("Upgrading Site ID Source") {
                 Picker(selection: $selectedSiteIDSourceType, label: EmptyView()) {
                     ForEach(SiteIDSourceType.allCases, id: \.self) { option in
                         Text(option.title)
-                                }
-                            }
-                            .pickerStyle(.segmented)
-
+                    }
+                }
+                .pickerStyle(.segmented)
             }
-
             Section {
                 Button("Reload products") {
                     Task {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before we only could test IAP by passing the upgrading site id through the Xcode environment variable in the schema. Now that we are going to implement IAP to upgrade free trials sites, it makes sense to upgrade the app user site itself, as would be the case for free trials. With this PR we add a segmented control to choose the source of the store id.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Add a breakpoint to this [line](https://github.com/woocommerce/woocommerce-ios/blob/6ef5832942670abe3d5dbf346545fcb54e7fb2c4/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift#L79) to ensure that we are calling the IAP engine with the right site id depending on the segmented control selection. Stop the execution after the breakpoint is hit and the id is checked, as you don't want to upgrade the site itself.

Test also the error message if we don't see any environment variable (see screenshot).
## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/98ca6957-c47c-43d3-9b88-e523cd415963" width="375">

#### Error when there's no environment variable. It should only appear when the the Environment Variable source is selected in the segmented control:

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/893e6ded-8523-43bc-ba81-cbd23e93189b" width="375">






---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
