### PR TITLE
EU-Bound Shipping Notice: Introduce Banner highlight animation during tooltip tap

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
@@ -1,33 +1,39 @@
 import SwiftUI
 
+/// Casts a blinking border highlight into any view given a Published `state` to control it's visibility
+///
 struct HighlightModifier: ViewModifier {
-    let state: Binding<Bool>
+    let highlighted: Binding<Bool>
     let color: Color
     let repeatCount: Int
     let duration: Double
 
-    private var blinking: Binding<Bool> {
+    private var animationActive: Binding<Bool> {
         Binding<Bool>(get: {
             DispatchQueue.main.asyncAfter(deadline: .now() + self.duration) {
-                self.state.wrappedValue = false
+                self.highlighted.wrappedValue = false
             }
-            return self.state.wrappedValue }, set: {
-            self.state.wrappedValue = $0
+            return self.highlighted.wrappedValue
+        }, set: {
+            self.highlighted.wrappedValue = $0
         })
     }
 
     func body(content: Content) -> some View {
         content
-            .border(self.blinking.wrappedValue ? self.color : Color.clear, width: 3.0)
+            .border(self.animationActive.wrappedValue ? self.color : Color.clear, width: 3.0)
             .animation(Animation.linear(duration: self.duration).repeatCount(self.repeatCount),
-                       value: blinking.wrappedValue)
+                       value: animationActive.wrappedValue)
     }
 }
 
+// MARK: View extension
 extension View {
-    func highlight(on state: Binding<Bool>, color: Color,
+    func highlight(on highlighted: Binding<Bool>, color: Color,
                      repeatCount: Int = 3, duration: Double = 0.5) -> some View {
-        self.modifier(HighlightModifier(state: state, color: color,
-                                             repeatCount: repeatCount, duration: duration))
+        self.modifier(HighlightModifier(highlighted: highlighted,
+                                        color: color,
+                                        repeatCount: repeatCount,
+                                        duration: duration))
     }
 }

--- a/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
@@ -30,7 +30,8 @@ struct HighlightModifier: ViewModifier {
     }
 }
 
-// MARK: View extension
+// MARK: - View extension
+//
 extension View {
     func highlight(on highlighted: Binding<Bool>, color: Color) -> some View {
         self.modifier(HighlightModifier(highlighted: highlighted, color: color))

--- a/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
@@ -24,7 +24,8 @@ struct HighlightModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .border(self.animationActive.wrappedValue ? self.color : Color.clear, width: 3.0)
+            .border(animationActive.wrappedValue ? color : Color.clear,
+                    width: Constants.highlightBorderWidth)
             .animation(animation, value: animationActive.wrappedValue)
     }
 }

--- a/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
@@ -1,0 +1,21 @@
+//
+//  View+HighlightModifier.swift
+//  WooCommerce
+//
+//  Created by Thomaz F B Cortez on 22/05/23.
+//  Copyright © 2023 Automattic. All rights reserved.
+//
+
+import SwiftUI
+
+struct View_HighlightModifier: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct View_HighlightModifier_Previews: PreviewProvider {
+    static var previews: some View {
+        View_HighlightModifier()
+    }
+}

--- a/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
@@ -1,21 +1,33 @@
-//
-//  View+HighlightModifier.swift
-//  WooCommerce
-//
-//  Created by Thomaz F B Cortez on 22/05/23.
-//  Copyright © 2023 Automattic. All rights reserved.
-//
-
 import SwiftUI
 
-struct View_HighlightModifier: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+struct HighlightModifier: ViewModifier {
+    let state: Binding<Bool>
+    let color: Color
+    let repeatCount: Int
+    let duration: Double
+
+    private var blinking: Binding<Bool> {
+        Binding<Bool>(get: {
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.duration) {
+                self.state.wrappedValue = false
+            }
+            return self.state.wrappedValue }, set: {
+            self.state.wrappedValue = $0
+        })
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .border(self.blinking.wrappedValue ? self.color : Color.clear, width: 3.0)
+            .animation(Animation.linear(duration: self.duration).repeatCount(self.repeatCount),
+                       value: blinking.wrappedValue)
     }
 }
 
-struct View_HighlightModifier_Previews: PreviewProvider {
-    static var previews: some View {
-        View_HighlightModifier()
+extension View {
+    func highlight(on state: Binding<Bool>, color: Color,
+                     repeatCount: Int = 3, duration: Double = 0.5) -> some View {
+        self.modifier(HighlightModifier(state: state, color: color,
+                                             repeatCount: repeatCount, duration: duration))
     }
 }

--- a/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+HighlightModifier.swift
@@ -5,12 +5,10 @@ import SwiftUI
 struct HighlightModifier: ViewModifier {
     let highlighted: Binding<Bool>
     let color: Color
-    let repeatCount: Int
-    let duration: Double
 
     private var animationActive: Binding<Bool> {
         Binding<Bool>(get: {
-            DispatchQueue.main.asyncAfter(deadline: .now() + self.duration) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.highlightBlinkDuration) {
                 self.highlighted.wrappedValue = false
             }
             return self.highlighted.wrappedValue
@@ -19,21 +17,29 @@ struct HighlightModifier: ViewModifier {
         })
     }
 
+    private var animation: Animation {
+        Animation.linear(duration: Constants.highlightBlinkDuration)
+            .repeatCount(Constants.highlightBlinkRepetition)
+    }
+
     func body(content: Content) -> some View {
         content
             .border(self.animationActive.wrappedValue ? self.color : Color.clear, width: 3.0)
-            .animation(Animation.linear(duration: self.duration).repeatCount(self.repeatCount),
-                       value: animationActive.wrappedValue)
+            .animation(animation, value: animationActive.wrappedValue)
     }
 }
 
 // MARK: View extension
 extension View {
-    func highlight(on highlighted: Binding<Bool>, color: Color,
-                     repeatCount: Int = 3, duration: Double = 0.5) -> some View {
-        self.modifier(HighlightModifier(highlighted: highlighted,
-                                        color: color,
-                                        repeatCount: repeatCount,
-                                        duration: duration))
+    func highlight(on highlighted: Binding<Bool>, color: Color) -> some View {
+        self.modifier(HighlightModifier(highlighted: highlighted, color: color))
+    }
+}
+
+private extension HighlightModifier {
+    enum Constants {
+        static let highlightBlinkDuration = 0.5
+        static let highlightBlinkRepetition = 3
+        static let highlightBorderWidth = 3.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -37,7 +37,7 @@ struct ShippingLabelCustomsFormList: View {
 
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
     private var shippingNoticeBannerID = UUID()
-    
+
     var onLearnMoreTapped: () -> Void = {}
 
     init(viewModel: ShippingLabelCustomsFormListViewModel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -33,6 +33,8 @@ final class ShippingCustomsFormListHostingController: UIHostingController<Shippi
 struct ShippingLabelCustomsFormList: View {
     @Environment(\.presentationMode) var presentation
     @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel
+    @State private var shippingNoticeBannerID = UUID()
+    
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
 
     var onLearnMoreTapped: () -> Void = {}
@@ -57,6 +59,7 @@ struct ShippingLabelCustomsFormList: View {
                         }
                         .renderedIf(viewModel.isShippingNoticeVisible)
                         .fixedSize(horizontal: false, vertical: true)
+                        .id(shippingNoticeBannerID)
                     
                     ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
                         ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -60,6 +60,7 @@ struct ShippingLabelCustomsFormList: View {
                         }
                         .renderedIf(viewModel.isShippingNoticeVisible)
                         .fixedSize(horizontal: false, vertical: true)
+                        .blinkBorder(on: $isShippingNoticeBannerHighlighted, color: Color.red)
                         .id(shippingNoticeBannerID)
 
                     ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -34,7 +34,7 @@ struct ShippingLabelCustomsFormList: View {
     @Environment(\.presentationMode) var presentation
     @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel
     @State private var shippingNoticeBannerID = UUID()
-    
+
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
 
     var onLearnMoreTapped: () -> Void = {}
@@ -60,7 +60,7 @@ struct ShippingLabelCustomsFormList: View {
                         .renderedIf(viewModel.isShippingNoticeVisible)
                         .fixedSize(horizontal: false, vertical: true)
                         .id(shippingNoticeBannerID)
-                    
+
                     ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
                         ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,
                                                       packageNumber: index + 1,
@@ -68,6 +68,9 @@ struct ShippingLabelCustomsFormList: View {
                                                       viewModel: item,
                                                       infoTooltipTapped: {
                             viewModel.onInfoTooltipTapped()
+                            withAnimation {
+                                scrollProxy.scrollTo(shippingNoticeBannerID, anchor: .top)
+                            }
                         })
                     }
                     .padding(.bottom, insets: geometry.safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -33,11 +33,11 @@ final class ShippingCustomsFormListHostingController: UIHostingController<Shippi
 struct ShippingLabelCustomsFormList: View {
     @Environment(\.presentationMode) var presentation
     @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel
-    @State private var shippingNoticeBannerID = UUID()
     @State private var isShippingNoticeBannerHighlighted = false
 
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
-
+    private var shippingNoticeBannerID = UUID()
+    
     var onLearnMoreTapped: () -> Void = {}
 
     init(viewModel: ShippingLabelCustomsFormListViewModel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -34,6 +34,7 @@ struct ShippingLabelCustomsFormList: View {
     @Environment(\.presentationMode) var presentation
     @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel
     @State private var shippingNoticeBannerID = UUID()
+    @State private var isShippingNoticeBannerHighlighted = false
 
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
 
@@ -70,6 +71,7 @@ struct ShippingLabelCustomsFormList: View {
                             viewModel.onInfoTooltipTapped()
                             withAnimation {
                                 scrollProxy.scrollTo(shippingNoticeBannerID, anchor: .top)
+                                isShippingNoticeBannerHighlighted = true
                             }
                         })
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -46,30 +46,32 @@ struct ShippingLabelCustomsFormList: View {
 
     var body: some View {
         GeometryReader { geometry in
-            ScrollView {
-                EUShippingNoticeBanner(width: geometry.size.width)
-                    .onDismiss {
-                        viewModel.bannerDismissTapped()
+            ScrollViewReader { scrollProxy in
+                ScrollView {
+                    EUShippingNoticeBanner(width: geometry.size.width)
+                        .onDismiss {
+                            viewModel.bannerDismissTapped()
+                        }
+                        .onLearnMore {
+                            onLearnMoreTapped()
+                        }
+                        .renderedIf(viewModel.isShippingNoticeVisible)
+                        .fixedSize(horizontal: false, vertical: true)
+                    
+                    ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
+                        ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,
+                                                      packageNumber: index + 1,
+                                                      safeAreaInsets: geometry.safeAreaInsets,
+                                                      viewModel: item,
+                                                      infoTooltipTapped: {
+                            viewModel.onInfoTooltipTapped()
+                        })
                     }
-                    .onLearnMore {
-                        onLearnMoreTapped()
-                    }
-                    .renderedIf(viewModel.isShippingNoticeVisible)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
-                    ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,
-                                                  packageNumber: index + 1,
-                                                  safeAreaInsets: geometry.safeAreaInsets,
-                                                  viewModel: item,
-                                                  infoTooltipTapped: {
-                        viewModel.onInfoTooltipTapped()
-                    })
+                    .padding(.bottom, insets: geometry.safeAreaInsets)
                 }
-                .padding(.bottom, insets: geometry.safeAreaInsets)
+                .background(Color(.listBackground))
+                .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             }
-            .background(Color(.listBackground))
-            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
         .navigationTitle(Localization.navigationTitle)
         .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -60,7 +60,7 @@ struct ShippingLabelCustomsFormList: View {
                         }
                         .renderedIf(viewModel.isShippingNoticeVisible)
                         .fixedSize(horizontal: false, vertical: true)
-                        .blinkBorder(on: $isShippingNoticeBannerHighlighted, color: Color.red)
+                        .highlight(on: $isShippingNoticeBannerHighlighted, color: Color(.accent))
                         .id(shippingNoticeBannerID)
 
                     ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
@@ -95,39 +95,6 @@ struct ShippingLabelCustomsFormList: View {
             }
         }
         .wooNavigationBarStyle()
-    }
-}
-
-struct BlinkingBorderModifier: ViewModifier {
-    let state: Binding<Bool>
-    let color: Color
-    let repeatCount: Int
-    let duration: Double
-
-    // internal wrapper is needed because there is no didFinish of Animation now
-    private var blinking: Binding<Bool> {
-        Binding<Bool>(get: {
-            DispatchQueue.main.asyncAfter(deadline: .now() + self.duration) {
-                self.state.wrappedValue = false
-            }
-            return self.state.wrappedValue }, set: {
-            self.state.wrappedValue = $0
-        })
-    }
-
-    func body(content: Content) -> some View {
-        content
-            .border(self.blinking.wrappedValue ? self.color : Color.clear, width: 3.0)
-            .animation(Animation.linear(duration: self.duration).repeatCount(self.repeatCount),
-                       value: blinking.wrappedValue)
-    }
-}
-
-extension View {
-    func blinkBorder(on state: Binding<Bool>, color: Color,
-                     repeatCount: Int = 3, duration: Double = 0.5) -> some View {
-        self.modifier(BlinkingBorderModifier(state: state, color: color,
-                                             repeatCount: repeatCount, duration: duration))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -95,6 +95,39 @@ struct ShippingLabelCustomsFormList: View {
     }
 }
 
+struct BlinkingBorderModifier: ViewModifier {
+    let state: Binding<Bool>
+    let color: Color
+    let repeatCount: Int
+    let duration: Double
+
+    // internal wrapper is needed because there is no didFinish of Animation now
+    private var blinking: Binding<Bool> {
+        Binding<Bool>(get: {
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.duration) {
+                self.state.wrappedValue = false
+            }
+            return self.state.wrappedValue }, set: {
+            self.state.wrappedValue = $0
+        })
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .border(self.blinking.wrappedValue ? self.color : Color.clear, width: 3.0)
+            .animation(Animation.linear(duration: self.duration).repeatCount(self.repeatCount),
+                       value: blinking.wrappedValue)
+    }
+}
+
+extension View {
+    func blinkBorder(on state: Binding<Bool>, color: Color,
+                     repeatCount: Int = 3, duration: Double = 0.5) -> some View {
+        self.modifier(BlinkingBorderModifier(state: state, color: color,
+                                             repeatCount: repeatCount, duration: duration))
+    }
+}
+
 private extension ShippingLabelCustomsFormList {
     enum Localization {
         static let navigationTitle = NSLocalizedString("Customs", comment: "Navigation title for Customs screen in Shipping Label flow")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1538,6 +1538,7 @@
 		B63D9009293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63D9008293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift */; };
 		B6440FB6292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */; };
 		B6440FB9292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */; };
+		B649BC7E2A1C295B007AB988 /* View+HighlightModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B649BC7D2A1C295B007AB988 /* View+HighlightModifier.swift */; };
 		B651474527D644FF00C9C4E6 /* CustomerNoteSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */; };
 		B65496342A0B291A003D29E1 /* EUShippingNoticeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65496332A0B291A003D29E1 /* EUShippingNoticeBanner.swift */; };
 		B66D6CEC29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */; };
@@ -3835,6 +3836,7 @@
 		B63D9008293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubQuarterToDateRangeData.swift; sourceTree = "<group>"; };
 		B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeSelection.swift; sourceTree = "<group>"; };
 		B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeSelectionTests.swift; sourceTree = "<group>"; };
+		B649BC7D2A1C295B007AB988 /* View+HighlightModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+HighlightModifier.swift"; sourceTree = "<group>"; };
 		B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerNoteSection.swift; sourceTree = "<group>"; };
 		B65496332A0B291A003D29E1 /* EUShippingNoticeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EUShippingNoticeBanner.swift; sourceTree = "<group>"; };
 		B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeData.swift; sourceTree = "<group>"; };
@@ -6083,6 +6085,7 @@
 				AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */,
 				CC666F2327F329DC0045AF1E /* View+DiscardChanges.swift */,
 				02562ACF296D1FD100980404 /* View+DividerStyle.swift */,
+				B649BC7D2A1C295B007AB988 /* View+HighlightModifier.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -12289,6 +12292,7 @@
 				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
+				B649BC7E2A1C295B007AB988 /* View+HighlightModifier.swift in Sources */,
 				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,
 				31E6F21F26B3577800227E6F /* LegacyCardReaderConnectionController.swift in Sources */,
 				CE13681729FBD94300EBF43C /* QuantityRulesViewModel.swift in Sources */,


### PR DESCRIPTION
Closes #9776 

Why
==========
Inside the Customs form, when the EU Shipping scenario is met, two things will happen:

1. The EU Shipping banner will be visible
2. A info tooltip in the first Custom line will show up

The info tooltip is clickable; if the banner is dismissed, that click will bring it back. But if the banner is already visible, the click will do nothing. 

Instead of doing nothing when the info tooltip is clicked with the banner visible, this PR introduces a behavior where every time the click happens, the view scrolls up to the banner and highlights it to alert the user of what that tooltip is about.

How
==========
Configures a `ScrollViewReader` inside the Customs form to allow scrolling up to the Shipping notice banner alongside a `HighlightModifier` to make it possible to configure any view to activate a blinking border around it. Both solutions will be activated whenever the tooltip tap happens.

Screen Capture
==========
https://github.com/woocommerce/woocommerce-ios/assets/5920403/cbd0f7b0-2352-49fe-afac-007e29422e11

How to Test
==========
1. Open the app with a site containing the Shipping Labels plugin configured
2. Open the order details of an order with the `processing` status
3. Hit the `Create Shipping Label` button
4. Configure the Origin and Destination address that meets the US to EU condition (e. g. US to Austria)
6. Move forward with the Shipping Label creation until you reach the `Customs` section and open the Customs form
7. Verify that hitting the info tooltip on the first Customs line brings the banner to visible, scrolls to the top of it and highlights the whole banner.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.