### PR TITLE
Dashboard: Add button to share store

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,8 @@
 -----
 - [*] Add Products: A new view is display to celebrate when the first product is created in a store. [https://github.com/woocommerce/woocommerce-ios/pull/9790]
 - [*] Product form: a share action is shown in the navigation bar if the product can be shared and no more than one action is displayed, in addition to the more menu > Share. [https://github.com/woocommerce/woocommerce-ios/pull/9789]
-
+- [*] My Store: A new button to share the current store is added on the top right of the screen. [https://github.com/woocommerce/woocommerce-ios/pull/9796]
+ 
 13.7
 -----
 - [Internal] Adds guidance for new Customs rule when shipping to some EU countries. [https://github.com/woocommerce/woocommerce-ios/pull/9715]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -319,8 +319,7 @@ private extension DashboardViewController {
     }
 
     func configureShareButton() {
-        // Only show share button if the site is public.
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite, site.isPublic else {
+        guard viewModel.siteURLToShare != nil else {
             return
         }
         navigationItem.rightBarButtonItem = shareButton
@@ -328,8 +327,7 @@ private extension DashboardViewController {
 
     @objc
     func shareStore() {
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite,
-              let url = URL(string: site.url) else {
+        guard let url = viewModel.siteURLToShare else {
             return
         }
         SharingHelper.shareURL(url: url, from: shareButton, in: self)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -319,6 +319,10 @@ private extension DashboardViewController {
     }
 
     func configureShareButton() {
+        // Only show share button if the site is public.
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite, site.isPublic else {
+            return
+        }
         navigationItem.rightBarButtonItem = shareButton
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -329,6 +329,7 @@ private extension DashboardViewController {
             return
         }
         SharingHelper.shareURL(url: url, from: shareButton, in: self)
+        ServiceLocator.analytics.track(.dashboardShareStoreButtonTapped)
     }
 
     func configureContainerStackView() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -79,6 +79,8 @@ final class DashboardViewController: UIViewController {
         return view
     }()
 
+    private lazy var shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareStore))
+
     /// Stores an animator for showing/hiding the header view while there is an animation in progress
     /// so we can interrupt and reverse if needed
     private var headerAnimator: UIViewPropertyAnimator?
@@ -303,6 +305,7 @@ private extension DashboardViewController {
         configureTitle()
         configureContainerStackView()
         configureHeaderStackView()
+        configureShareButton()
     }
 
     func configureTabBarItem() {
@@ -313,6 +316,19 @@ private extension DashboardViewController {
 
     func configureTitle() {
         navigationItem.title = Localization.title
+    }
+
+    func configureShareButton() {
+        navigationItem.rightBarButtonItem = shareButton
+    }
+
+    @objc
+    func shareStore() {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite,
+              let url = URL(string: site.url) else {
+            return
+        }
+        SharingHelper.shareURL(url: url, from: shareButton, in: self)
     }
 
     func configureContainerStackView() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -32,6 +32,15 @@ final class DashboardViewModel {
     private let analytics: Analytics
     private let justInTimeMessagesManager: JustInTimeMessagesProvider
 
+    var siteURLToShare: URL? {
+        if let site = stores.sessionManager.defaultSite,
+           site.isPublic, // only show share button if the site is public.
+           let url = URL(string: site.url) {
+            return url
+        }
+        return nil
+    }
+
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          featureFlags: FeatureFlagService = ServiceLocator.featureFlagService,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -7,6 +7,7 @@ import enum Yosemite.JustInTimeMessageAction
 import struct Yosemite.JustInTimeMessage
 import struct Yosemite.StoreOnboardingTask
 import enum Yosemite.StoreOnboardingTasksAction
+import struct Yosemite.Site
 @testable import WooCommerce
 
 final class DashboardViewModelTests: XCTestCase {
@@ -465,6 +466,35 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(sut.showOnboarding)
+    }
+
+    func test_siteURLToShare_return_nil_if_site_is_not_public() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: false)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = DashboardViewModel(siteID: 123, stores: stores)
+
+        // When
+        let siteURLToShare = viewModel.siteURLToShare
+
+        // Then
+        XCTAssertNil(siteURLToShare)
+    }
+
+    func test_siteURLToShare_return_url_if_site_is_public() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting()
+        let expectedURL = "https://example.com"
+        sessionManager.defaultSite = Site.fake().copy(url: expectedURL, isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = DashboardViewModel(siteID: 123, stores: stores)
+
+        // When
+        let siteURLToShare = viewModel.siteURLToShare
+
+        // Then
+        assertEqual(expectedURL, siteURLToShare?.absoluteString)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9785 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a button to the top right of the My Store screen to let merchants share their stores.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store, notice that a new button for sharing store is displayed on the top right of the My Store screen.
- Tap the share button the, the share sheet should be displayed. Notice in Xcode console: `🔵 Tracked dashboard_share_your_store_button_tapped`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![IMG_CED2D39830E8-1](https://github.com/woocommerce/woocommerce-ios/assets/5533851/78291cc3-5e8d-4b39-8895-4b5d27d65192)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
