### PR TITLE
Product list: Add share-to-swipe gesture 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.8
 -----
 - [*] Add Products: A new view is display to celebrate when the first product is created in a store. [https://github.com/woocommerce/woocommerce-ios/pull/9790]
+- [*] Product List: Added swipe-to-share gesture on product rows. [https://github.com/woocommerce/woocommerce-ios/pull/9799]
 - [*] Product form: a share action is shown in the navigation bar if the product can be shared and no more than one action is displayed, in addition to the more menu > Share. [https://github.com/woocommerce/woocommerce-ios/pull/9789]
 
 13.7

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -530,6 +530,7 @@ public enum WooAnalyticsStat: String {
     case productListMenuSearchTapped = "product_list_menu_search_tapped"
     case productListAddProductTapped = "product_list_add_product_button_tapped"
     case productListClearFiltersTapped = "product_list_clear_filters_button_tapped"
+    case productListShareButtonTapped = "product_list_share_button_tapped"
 
     // MARK: Product List Bulk Editing Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -939,11 +939,13 @@ extension ProductsViewController: UITableViewDelegate {
     ///
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let product = resultsController.object(at: indexPath)
-        guard let url = URL(string: product.permalink),
+        guard ServiceLocator.stores.sessionManager.defaultSite?.isPublic == true,
+              product.productStatus == .published,
+              let url = URL(string: product.permalink),
             let cell = tableView.cellForRow(at: indexPath) else {
             return nil
         }
-        let shareAction = UIContextualAction(style: .normal, title: Localization.shareAction, handler: { [weak self] _, _, completionHandler in
+        let shareAction = UIContextualAction(style: .normal, title: nil, handler: { [weak self] _, _, completionHandler in
             guard let self else { return }
             SharingHelper.shareURL(url: url, from: cell, in: self)
             ServiceLocator.analytics.track(.productListShareButtonTapped)
@@ -1395,6 +1397,5 @@ private extension ProductsViewController {
                                                            comment: "Title of the notice when a user updated price for selected products")
         static let updateErrorNotice = NSLocalizedString("Cannot update products",
                                                          comment: "Title of the notice when there is an error updating selected products")
-        static let shareAction = NSLocalizedString("Share", comment: "Title for the button to share a selected product.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -946,6 +946,7 @@ extension ProductsViewController: UITableViewDelegate {
         let shareAction = UIContextualAction(style: .normal, title: Localization.shareAction, handler: { [weak self] _, _, completionHandler in
             guard let self else { return }
             SharingHelper.shareURL(url: url, from: cell, in: self)
+            ServiceLocator.analytics.track(.productListShareButtonTapped)
             completionHandler(true) // Tells the table that the action was performed and forces it to go back to its original state (un-swiped)
         })
         shareAction.backgroundColor = .brand

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -181,6 +181,10 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     private var addProductCoordinator: AddProductCoordinator?
 
+    /// Tracks if the swipe actions have been glanced to the user.
+    ///
+    private var swipeActionsGlanced = false
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -699,6 +703,16 @@ private extension ProductsViewController {
 // MARK: - Updates
 //
 private extension ProductsViewController {
+
+    /// Slightly reveal swipe actions of the first visible cell that contains at least one swipe action.
+    /// This action is performed only once, using `swipeActionsGlanced` as a control variable.
+    ///
+    func glanceTrailingActionsIfNeeded() {
+        if !swipeActionsGlanced {
+            swipeActionsGlanced = true
+            tableView.glanceTrailingSwipeActions()
+        }
+    }
 
     /// Displays an error banner if there is an error loading products data.
     ///
@@ -1247,7 +1261,7 @@ private extension ProductsViewController {
                 hideTopBannerView()
             }
         case .results:
-            break
+            glanceTrailingActionsIfNeeded()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -920,6 +920,25 @@ extension ProductsViewController: UITableViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         hiddenScrollView.updateFromScrollViewDidScrollEventForLargeTitleWorkaround(scrollView)
     }
+
+    /// Provide an implementation to show cell swipe actions. Return `nil` to provide no action.
+    ///
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let product = resultsController.object(at: indexPath)
+        guard let url = URL(string: product.permalink),
+            let cell = tableView.cellForRow(at: indexPath) else {
+            return nil
+        }
+        let shareAction = UIContextualAction(style: .normal, title: Localization.shareAction, handler: { [weak self] _, _, completionHandler in
+            guard let self else { return }
+            SharingHelper.shareURL(url: url, from: cell, in: self)
+            completionHandler(true) // Tells the table that the action was performed and forces it to go back to its original state (un-swiped)
+        })
+        shareAction.backgroundColor = .brand
+        shareAction.image = .init(systemName: "square.and.arrow.up")
+
+        return UISwipeActionsConfiguration(actions: [shareAction])
+    }
 }
 
 private extension ProductsViewController {
@@ -1361,5 +1380,6 @@ private extension ProductsViewController {
                                                            comment: "Title of the notice when a user updated price for selected products")
         static let updateErrorNotice = NSLocalizedString("Cannot update products",
                                                          comment: "Title of the notice when there is an error updating selected products")
+        static let shareAction = NSLocalizedString("Share", comment: "Title for the button to share a selected product.")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9785 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a swipe gesture on the product list to enable sharing products from each cell. When the list is first loaded, an animation is run to make the gesture more visible to users.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store with at least 1 product.
- Navigate to the Products tab, notice that there is an animation on the first product cell.
- Swipe and tap Share on any of the product cell. A share sheet should be displayed, and a Tracks event should be logged: `product_list_share_button_tapped`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/3c5e5958-49a0-41d3-a3c0-e25edda8ecc7



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
