### PR TITLE
Product SKU scanner track events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -653,6 +653,18 @@ extension WooAnalyticsEvent {
             ])
         }
 
+        static func orderProductSearchViaSKUFailed(reason: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderProductSearchViaSKUFailure, properties: [
+                "reason": reason
+            ])
+        }
+
+        static func orderProductBarcodeScannerFailed(reason: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderProductBarcodeScanningFailed, properties: [
+                "reason": reason
+            ])
+        }
+
         /// Tracked when the user taps to collect a payment
         ///
         static func collectPaymentTapped() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -466,6 +466,13 @@ extension WooAnalyticsEvent {
             case variation
         }
 
+        /// Possible methods to add items to an Order
+        ///
+        enum EntryMethods: String {
+            case manually
+            case barcode
+        }
+
         enum GlobalKeys {
             static let millisecondsSinceOrderAddNew = "milliseconds_since_order_add_new"
         }
@@ -489,6 +496,7 @@ extension WooAnalyticsEvent {
             static let source = "source"
             static let isFilterActive = "is_filter_active"
             static let searchFilter = "search_filter"
+            static let addedVia = "added_via"
         }
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
@@ -510,10 +518,11 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderProductAdd(flow: Flow, productCount: Int) -> WooAnalyticsEvent {
+        static func orderProductAdd(flow: Flow, productCount: Int, entryMethod: EntryMethods = .manually) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductAdd, properties: [
                 Keys.flow: flow.rawValue,
-                Keys.productCount: Int64(productCount)
+                Keys.productCount: Int64(productCount),
+                Keys.addedVia: entryMethod.rawValue
             ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -405,6 +405,15 @@ public enum WooAnalyticsStat: String {
     //
     case orderListViewFilterOptionsTapped = "order_list_view_filter_options_tapped"
 
+    // MARK: Barcode Scanning events
+    //
+    case orderCreationProductBarcodeScanningTapped = "order_creation_product_barcode_scanning_tapped"
+    case orderListProductBarcodeScanningTapped = "order_list_product_barcode_scanning_tapped"
+    case orderProductBarcodeScanningSuccess = "order_product_barcode_scanning_success"
+    case orderProductBarcodeScanningFailed = "order_product_barcode_scanning_failed"
+    case orderProductSearchViaSKUSuccess = "order_product_search_via_sku_success"
+    case orderProductSearchViaSKUFailure = "order_product_search_via_sku_failure"
+
     // MARK: Shipping Labels Events
     //
     case shippingLabelRefundRequested = "shipping_label_refund_requested"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1299,6 +1299,15 @@ extension EditableOrderViewModel {
         }
     }
 
+    func trackProductSearchViaSKU(with result: Result<Void, Error>, reason: String = "") {
+        switch result {
+        case .success:
+            analytics.track(.orderProductSearchViaSKUSuccess)
+        case .failure:
+            analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUFailed(reason: reason))
+        }
+    }
+
     /// Attempts to add a Product to the current Order by SKU search
     ///
     func addScannedProductToOrder(barcode sku: String?, onCompletion: @escaping (Result<Void, Error>) -> Void) {
@@ -1325,8 +1334,10 @@ extension EditableOrderViewModel {
             switch result {
             case let .success(product):
                 onCompletion(.success(product))
+                self.analytics.track(.orderProductSearchViaSKUSuccess)
             case let .failure(error):
                 onCompletion(.failure(error))
+                self.analytics.track(.orderProductSearchViaSKUFailure)
             }
         })
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1290,6 +1290,15 @@ extension EditableOrderViewModel {
         analytics.track(flow == .list ? .orderListProductBarcodeScanningTapped : .orderCreationProductBarcodeScanningTapped)
     }
 
+    func trackProductBarcodeScanned(with result: Result<Void, Error>, _ reason: String? = nil) {
+        switch result {
+        case .success:
+            analytics.track(.orderProductBarcodeScanningSuccess)
+        case .failure:
+            analytics.track(.orderProductBarcodeScanningFailed)
+        }
+    }
+
     /// Attempts to add a Product to the current Order by SKU search
     ///
     func addScannedProductToOrder(barcode sku: String?, onCompletion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1327,6 +1327,7 @@ extension EditableOrderViewModel {
         } else {
             orderSynchronizer.setProduct.send(.init(product: .product(product), quantity: 1))
         }
+        analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: flow.analyticsFlow, productCount: 1, entryMethod: .barcode))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1286,8 +1286,8 @@ extension EditableOrderViewModel {
         permissionChecker.requestAccess(for: .video, completionHandler: onCompletion)
     }
 
-    func trackProductBarcodeScanningTapped() {
-        analytics.track(.orderCreationProductBarcodeScanningTapped)
+    func trackProductBarcodeScanningTapped(from flow: WooAnalyticsEvent.Orders.Flow) {
+        analytics.track(flow == .list ? .orderListProductBarcodeScanningTapped : .orderCreationProductBarcodeScanningTapped)
     }
 
     /// Attempts to add a Product to the current Order by SKU search

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1286,6 +1286,10 @@ extension EditableOrderViewModel {
         permissionChecker.requestAccess(for: .video, completionHandler: onCompletion)
     }
 
+    func trackProductBarcodeScanningTapped() {
+        analytics.track(.orderCreationProductBarcodeScanningTapped)
+    }
+
     /// Attempts to add a Product to the current Order by SKU search
     ///
     func addScannedProductToOrder(barcode sku: String?, onCompletion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1290,12 +1290,12 @@ extension EditableOrderViewModel {
         analytics.track(flow == .list ? .orderListProductBarcodeScanningTapped : .orderCreationProductBarcodeScanningTapped)
     }
 
-    func trackProductBarcodeScanned(with result: Result<Void, Error>, _ reason: String? = nil) {
+    func trackProductBarcodeScanned(with result: Result<Void, Error>, reason: String = "") {
         switch result {
         case .success:
             analytics.track(.orderProductBarcodeScanningSuccess)
         case .failure:
-            analytics.track(.orderProductBarcodeScanningFailed)
+            analytics.track(event: WooAnalyticsEvent.Orders.orderProductBarcodeScannerFailed(reason: reason))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -329,7 +329,13 @@ private struct ProductsSection: View {
                         scroll.scrollTo(addProductViaSKUScannerButton)
                     }, content: {
                         ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
-                            viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { _ in
+                            viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { result in
+                                switch result {
+                                case .success:
+                                    viewModel.trackProductBarcodeScanned(with: .success(()))
+                                case let .failure(error):
+                                    viewModel.trackProductBarcodeScanned(with: .failure(error))
+                                }
                                 showAddProductViaSKUScanner.toggle()
                             })
                         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -320,6 +320,7 @@ private struct ProductsSection: View {
                             showAddProductViaSKUScanner = true
                             logPermissionStatus(status: .permitted)
                         }
+                        viewModel.trackProductBarcodeScanningTapped()
                     }, label: {
                         Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
                             .foregroundColor(Color(.brand))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -320,7 +320,7 @@ private struct ProductsSection: View {
                             showAddProductViaSKUScanner = true
                             logPermissionStatus(status: .permitted)
                         }
-                        viewModel.trackProductBarcodeScanningTapped()
+                        viewModel.trackProductBarcodeScanningTapped(from: .creation)
                     }, label: {
                         Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
                             .foregroundColor(Color(.brand))

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -164,6 +164,7 @@ final class OrdersRootViewController: UIViewController {
     ///
     private func presentOrderCreationFlowWithScannedProduct(with product: Product) {
         let viewModel = EditableOrderViewModel(siteID: siteID, withInitialProduct: product)
+        viewModel.trackProductBarcodeScanningTapped(from: .creation)
         setupNavigation(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -230,8 +230,10 @@ final class OrdersRootViewController: UIViewController {
             switch result {
             case let .success(matchedProduct):
                 onCompletion(.success(matchedProduct))
+                ServiceLocator.analytics.track(.orderProductSearchViaSKUSuccess)
             case let .failure(error):
                 onCompletion(.failure(error))
+                ServiceLocator.analytics.track(.orderProductSearchViaSKUFailure)
             }
         }
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -164,7 +164,7 @@ final class OrdersRootViewController: UIViewController {
     ///
     private func presentOrderCreationFlowWithScannedProduct(with product: Product) {
         let viewModel = EditableOrderViewModel(siteID: siteID, withInitialProduct: product)
-        viewModel.trackProductBarcodeScanningTapped(from: .creation)
+        viewModel.trackProductBarcodeScanned(with: Result.success(()))
         setupNavigation(viewModel: viewModel)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1867,10 +1867,14 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
-        viewModel.trackProductBarcodeScanned(with: .failure(NSError()))
+        viewModel.trackProductBarcodeScanned(with: .failure(NSError()), reason: "some reason to fail")
 
         // Then
         XCTAssertEqual(analytics.receivedEvents.first, "order_product_barcode_scanning_failed")
+
+        let _ = analytics.receivedProperties.map { property in
+            XCTAssertEqual(property.valueAsString(forKey: "reason"), "some reason to fail")
+        }
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1877,6 +1877,37 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
+    func test_event_when_SKU_is_found_successfully_then_logs_scanning_success_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackProductSearchViaSKU(with: .success(()))
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, "order_product_search_via_sku_success")
+    }
+
+    func test_event_when_SKU_is_not_found_then_logs_scanning_failure_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackProductSearchViaSKU(with: .failure(NSError()), reason: "some reason to fail")
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, "order_product_search_via_sku_failure")
+
+        let _ = analytics.receivedProperties.map { property in
+            XCTAssertEqual(property.valueAsString(forKey: "reason"), "some reason to fail")
+        }
+    }
 }
 
 private extension MockStorageManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1817,7 +1817,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
-    func test_event_when_editable_order_scanner_button_is_tapped_then_logs_correct_event() {
+    func test_event_when_editable_order_scanner_button_is_tapped_then_logs_the_correct_event() {
         // Given
         let analytics = MockAnalyticsProvider()
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
@@ -1831,7 +1831,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(analytics.receivedEvents.first, "order_creation_product_barcode_scanning_tapped")
     }
 
-    func test_event_when_order_list_scanner_button_is_tapped_then_logs_correct_event() {
+    func test_event_when_order_list_scanner_button_is_tapped_then_logs_the_correct_event() {
         // Given
         let analytics = MockAnalyticsProvider()
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
@@ -1844,6 +1844,35 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(analytics.receivedEvents.first, "order_list_product_barcode_scanning_tapped")
     }
+
+    func test_event_when_barcode_is_scanned_successfully_then_logs_scanning_success_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackProductBarcodeScanned(with: .success(()))
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, "order_product_barcode_scanning_success")
+    }
+
+    func test_event_when_barcode_fails_to_scan_then_logs_scanning_failure_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackProductBarcodeScanned(with: .failure(NSError()))
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, "order_product_barcode_scanning_failed")
+    }
+
 }
 
 private extension MockStorageManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1773,7 +1773,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(orderItem.quantity, 1)
     }
 
-    func test_order_creation_when_contains_initial_product_then_added_via_barcode_property_is_tracked() {
+    func test_event_when_order_creation_contains_initial_product_then_added_via_barcode_property_is_tracked() {
         // Given, When
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
@@ -1797,7 +1797,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
-    func test_order_creation_when_does_not_contain_initial_product_then_added_via_barcode_property_is_nil() {
+    func test_event_when_order_creation_does_not_contain_initial_product_then_added_via_barcode_property_is_nil() {
         // Given, When
         let analytics = MockAnalyticsProvider()
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
@@ -1815,6 +1815,20 @@ final class EditableOrderViewModelTests: XCTestCase {
             XCTAssertEqual(property.valueAsString(forKey: "flow"), "creation")
             XCTAssertNil(property.valueAsString(forKey: "added_via"))
         }
+    }
+
+    func test_event_when_order_creation_scanner_button_is_tapped_then_logs_correct_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackProductBarcodeScanningTapped()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, "order_creation_product_barcode_scanning_tapped")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1817,7 +1817,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
-    func test_event_when_order_creation_scanner_button_is_tapped_then_logs_correct_event() {
+    func test_event_when_editable_order_scanner_button_is_tapped_then_logs_correct_event() {
         // Given
         let analytics = MockAnalyticsProvider()
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
@@ -1825,10 +1825,24 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
-        viewModel.trackProductBarcodeScanningTapped()
+        viewModel.trackProductBarcodeScanningTapped(from: WooAnalyticsEvent.Orders.Flow.creation)
 
         // Then
         XCTAssertEqual(analytics.receivedEvents.first, "order_creation_product_barcode_scanning_tapped")
+    }
+
+    func test_event_when_order_list_scanner_button_is_tapped_then_logs_correct_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackProductBarcodeScanningTapped(from: WooAnalyticsEvent.Orders.Flow.list)
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, "order_list_product_barcode_scanning_tapped")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9660 

## Description
This PR adds the following track events:
~~orderCreationProductBarcodeScanningTapped~~
~~orderListProductBarcodeScanningTapped~~
~~orderProductBarcodeScanningSuccess~~
~~orderProductBarcodeScanningFailed~~
~~orderProductSearchViaSKUSuccess~~
~~orderProductSearchViaSKUFailure~~

Update (pdfdoF-2Ql#comment-4137-p2) : These have changed to
```
order_creation_product_barcode_scanning_tapped
order_list_product_barcode_scanning_tapped
barcode_scanning_success – {“source” : “order_creation | order_list”}
barcode_scanning_failure – {"reason" : "", "source" : "order_creation | order_list"}
product_search_via_sku_success – {"source" : "order_creation | order_list"}
product_search_via_sku_failure – {"reason" : "", "source" : "order_creation | order_list", "barcode_format"}
order_product_add – {"added_via" : "Scanning | Manually", “source” : “order_creation | order_list”}
```

We also need to add a barcode_format property when fails to scan, reason: pdfdoF-2Zq-p2
