### PR TITLE
[Privacy Choices] Handle "Settings" CTA

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -46,7 +46,8 @@ final class PrivacyBannerPresenter {
                     viewController.dismiss(animated: true)
 
                 case .settings:
-                    print("Dismiss and Go to settings")
+                    viewController.dismiss(animated: true)
+                    MainTabBarController.navigateToPrivacySettings()
                 }
             case .failure(let error):
                 switch error {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -41,19 +41,22 @@ final class PrivacyBannerPresenter {
         let privacyBanner = PrivacyBannerViewController(onCompletion: { [weak self] result in
             switch result {
             case .success(let destination):
-                switch destination {
-                case .dismiss:
-                    viewController.dismiss(animated: true)
-
-                case .settings:
-                    viewController.dismiss(animated: true)
+                viewController.dismiss(animated: true)
+                if destination == .settings {
                     MainTabBarController.navigateToPrivacySettings()
                 }
+
             case .failure(let error):
                 switch error {
-                case .sync(let analyticsOptOut):
+                case .sync(let analyticsOptOut, let intendedDestination):
                     viewController.dismiss(animated: true)
                     self?.showErrorNotice(optOut: analyticsOptOut)
+
+                    /// Even if we fail, we should redirect the user to settings screen so they can further customize their privacy settings
+                    ///
+                    if intendedDestination == .settings {
+                        MainTabBarController.navigateToPrivacySettings()
+                    }
                 }
             }
         })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -86,7 +86,9 @@ struct PrivacyBanner: View {
 
             HStack {
                 Button(Localization.goToSettings) {
-                    print("Tapped Settings")
+                    Task {
+                        await viewModel.submitChanges(destination: .settings)
+                    }
                 }
                 .buttonStyle(SecondaryButtonStyle())
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
@@ -51,7 +51,7 @@ final class PrivacyBannerViewModel: ObservableObject {
             try await useCase.update(optOut: !analyticsEnabled)
             onCompletion(.success(destination))
         } catch {
-            onCompletion(.failure(.sync(analyticsOptOut: !analyticsEnabled)))
+            onCompletion(.failure(.sync(analyticsOptOut: !analyticsEnabled, intendedDestination: destination)))
         }
 
         // Revert Loading state
@@ -72,6 +72,6 @@ extension PrivacyBannerViewModel {
     /// Defined errors.
     ///
     enum Error: Swift.Error {
-        case sync(analyticsOptOut: Bool)
+        case sync(analyticsOptOut: Bool, intendedDestination: Destination)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
@@ -28,6 +28,11 @@ final class UpdateAnalyticsSettingUseCase {
     /// For NON-WPCOM stores: Updates locally.
     ///
     func update(optOut: Bool) async throws {
+        // There is no need to perform any request if the user hasn't changed the current analytic setting.
+        guard analytics.userHasOptedIn == optOut else {
+            return updateLocally(optOut: optOut)
+        }
+
         // If we can't find an account(non-jp sites), lets commit the change immediately.
         guard let defaultAccount = stores.sessionManager.defaultAccount else {
             return updateLocally(optOut: optOut)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
@@ -27,7 +27,7 @@ final class UpdateAnalyticsSettingUseCase {
     /// For WPCOM stores: Updates remotely and locally. - The local update only happens after a successful remote update.
     /// For NON-WPCOM stores: Updates locally.
     ///
-    func update(optOut: Bool) async throws {
+    @MainActor func update(optOut: Bool) async throws {
         // There is no need to perform any request if the user hasn't changed the current analytic setting.
         guard analytics.userHasOptedIn == optOut else {
             return updateLocally(optOut: optOut)
@@ -59,7 +59,7 @@ final class UpdateAnalyticsSettingUseCase {
 
     /// Updates the local analytics setting
     ///
-    private func updateLocally(optOut: Bool) {
+    @MainActor private func updateLocally(optOut: Bool) {
         analytics.setUserHasOptedOut(optOut)
         userDefaults[.hasSavedPrivacyBannerSettings] = true
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -35,6 +35,20 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         return inPersonPaymentsMenuViewController
     }
 
+    /// Pushes the Settings & Privacy screen onto the navigation stack.
+    ///
+    func showPrivacySettings() {
+        guard let navigationController else {
+            return DDLogError("⛔️ Could not find a navigation controller context.")
+        }
+        guard let privacy = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
+            return DDLogError("⛔️ Could not instantiate PrivacySettingsViewController")
+        }
+
+        let settings = SettingsViewController()
+        navigationController.setViewControllers(navigationController.viewControllers + [settings, privacy], animated: true)
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -448,6 +448,17 @@ extension MainTabBarController {
             viewController?.openSimplePaymentsAmountFlow()
         }
     }
+
+    /// Switches to the hub Menu & Navigates to the Privacy Settings Screen.
+    ///
+    static func navigateToPrivacySettings() {
+        switchToHubMenuTab {
+            guard let hubMenuViewController: HubMenuViewController = childViewController() else {
+                return DDLogError("⛔️ Could not switch to the Hub Menu")
+            }
+            hubMenuViewController.showPrivacySettings()
+        }
+    }
 }
 
 // MARK: - DeeplinkForwarder

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
@@ -49,6 +49,7 @@ import TestKit
             }
 
             // When
+            viewModel.analyticsEnabled = false
             Task {
                 await viewModel.submitChanges(destination: .dismiss)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/UpdateAnalyticsSettingsUseCaseTests.swift
@@ -82,6 +82,31 @@ final class UpdateAnalyticsSettingsUseCaseTests: XCTestCase {
         XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
     }
 
+    @MainActor func test_not_updating_analytic_setting_does_not_fire_a_request() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, displayName: "Test Account"))
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .updateAccountSettings(_, _, let onCompletion):
+                onCompletion(.success(()))
+                XCTFail("Test should not fire a network request")
+            default:
+                break
+            }
+        }
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: "TestingSuite"))
+        analytics.setUserHasOptedOut(true)
+
+        // When
+        let useCase = UpdateAnalyticsSettingUseCase(stores: stores, analytics: analytics, userDefaults: userDefaults)
+        try await useCase.update(optOut: true)
+
+        // Then
+        XCTAssertFalse(analytics.userHasOptedIn)
+        XCTAssertEqual(userDefaults[.hasSavedPrivacyBannerSettings], true)
+    }
+
     override class func tearDown() {
         super.tearDown()
         SessionManager.removeTestingDatabase()


### PR DESCRIPTION
closes #9616 

# Why

This PR handles the actions to be performed when the "Go To Settings" button on the privacy banner is tapped. In particular it:

- Prevents the update network request from being fired if there is no change to the analytics setting.
- Updates the analytics setting after tapping the "Go To Setting" button.
- Navigate to the "Privacy Settings" screen after tapping the "Go To Setting" button.
- Show an error notice when failing to update the analytic setting. (Only WPCom stores)

# Demo

## WPCom Update Settings

https://github.com/woocommerce/woocommerce-ios/assets/562080/fa68857d-70b7-44b7-a437-a6182bc0b511

## WPCom Dont Update Settings

https://github.com/woocommerce/woocommerce-ios/assets/562080/49294af6-4706-4aaa-9797-b7b754583836

## WPCom Error

https://github.com/woocommerce/woocommerce-ios/assets/562080/86b64257-b612-423d-b1ac-e8d2dc9a1871

## Non WPCom Update Settings
https://github.com/woocommerce/woocommerce-ios/assets/562080/a68ab8ea-9990-432d-a0f2-45c7ac8d828e

# Testing Steps

### WPCom Stores

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented
- Toggle the analytics choice
- Tap "Go To Settings"
- See the loading indicator in the save button.
- See that you are navigated to the "Privacy Settings" screen

### WPCom Stores

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented
- **DO NOT** toggle the analytics choice
- Tap "Go To Settings"
- See that you are navigated to the "Privacy Settings" screen
- Notice that there are no loading indicators.

### Non WPCom Stores

- Log out from the app (to clean the user defaults database)
- Log in to a non-WPCom store (make sure your phone has an EU locale)
- See the banner being presented
- Toggle the analytics choice
- Tap save
- See that you are navigated to the "Privacy Settings" screen

### Error

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented
- Toggle the analytics choice
- Tap "Go to Settings"
- See that you are navigated to the "Privacy Settings" screen
- See the error notice with a retry button

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
