### PR TITLE
Update quantity when scanning products already in order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1327,7 +1327,7 @@ extension EditableOrderViewModel {
     func updateOrderWithProductID(_ productID: Int64) {
         guard currentOrderItems.contains(where: { $0.productOrVariationID == productID }) else {
             // If it's not part of the current order, send the correct productType to the synchronizer
-            if let productVariation = allProductVariations.first(where: { $0.productVariationID == productID }) {
+            if let productVariation = retrieveVariation(for: productID) {
                 orderSynchronizer.setProduct.send(.init(product: .variation(productVariation), quantity: 1))
             } else if let product = allProducts.first(where: { $0.productID == productID }) {
                 orderSynchronizer.setProduct.send(.init(product: .product(product), quantity: 1))
@@ -1398,6 +1398,14 @@ private extension EditableOrderViewModel {
     func retrieveVariation(for item: OrderItem) -> ProductVariation? {
         guard let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) else {
             let product = allProducts.first(where: { $0.productID == item.variationID })
+            return product?.toProductVariation()
+        }
+        return variation
+    }
+
+    func retrieveVariation(for id: Int64) -> ProductVariation? {
+        guard let variation = allProductVariations.first(where: { $0.productVariationID == id }) else {
+            let product = allProducts.first(where: { $0.productID == id })
             return product?.toProductVariation()
         }
         return variation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1302,7 +1302,7 @@ extension EditableOrderViewModel {
             guard let self = self else { return }
             switch result {
             case let .success(productID):
-                self.orderSynchronizer.setProduct.send(.init(product: .productID(productID), quantity: 1))
+                self.updateOrderWithProductID(productID: productID)
                 onCompletion(.success(()))
             case .failure:
                 onCompletion(.failure(ScannerError.productNotFound))
@@ -1322,6 +1322,17 @@ extension EditableOrderViewModel {
             }
         })
         stores.dispatch(action)
+    }
+
+    /// Updates the Order with the given product and quantity
+    ///
+    private func updateOrderWithProductID(productID: Int64) {
+        if orderSynchronizer.order.items.contains(where: { $0.productID == productID }) {
+            let match = productRows.first(where: { $0.productOrVariationID == productID })
+            match?.incrementQuantity()
+        } else {
+            orderSynchronizer.setProduct.send(.init(product: .productID(productID), quantity: 1))
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1302,7 +1302,7 @@ extension EditableOrderViewModel {
             guard let self = self else { return }
             switch result {
             case let .success(productID):
-                self.updateOrderWithProductID(productID: productID)
+                self.updateOrderWithProduct(productID: productID)
                 onCompletion(.success(()))
             case .failure:
                 onCompletion(.failure(ScannerError.productNotFound))
@@ -1324,10 +1324,10 @@ extension EditableOrderViewModel {
         stores.dispatch(action)
     }
 
-    /// Updates the Order with the given product and quantity
+    /// Updates the Order with the given product
     ///
-    private func updateOrderWithProductID(productID: Int64) {
-        if orderSynchronizer.order.items.contains(where: { $0.productID == productID }) {
+    func updateOrderWithProduct(productID: Int64) {
+        if currentOrderItems.contains(where: { $0.productOrVariationID == productID }) {
             let match = productRows.first(where: { $0.productOrVariationID == productID })
             match?.incrementQuantity()
         } else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1739,6 +1739,44 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)
     }
+
+    func test_order_with_no_products_when_updateOrderWithProduct_is_invoked_then_product_is_added() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // Confidence check
+        let orderItem = viewModel.currentOrderItems.first
+        XCTAssertNil(orderItem)
+
+        // When
+        viewModel.updateOrderWithProduct(productID: sampleProductID)
+
+        // Then
+        XCTAssertEqual(viewModel.currentOrderItems.count, 1)
+        XCTAssertEqual(viewModel.currentOrderItems.first?.quantity, 1)
+        XCTAssertEqual(viewModel.productRows[safe: 0]?.quantity, 1)
+    }
+
+    func test_order_with_products_when_updateOrderWithProduct_is_invoked_then_product_quantity_is_updated() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, withInitialProductID: sampleProductID)
+
+        // Confidence check
+        let orderItem = viewModel.currentOrderItems.first
+        XCTAssertEqual(orderItem?.quantity, 1)
+
+        // When
+        viewModel.updateOrderWithProduct(productID: sampleProductID)
+
+        // Then
+        XCTAssertEqual(viewModel.currentOrderItems.count, 1)
+        XCTAssertEqual(viewModel.currentOrderItems.first?.quantity, 2)
+        XCTAssertEqual(viewModel.productRows[safe: 0]?.quantity, 2)
+    }
 }
 
 private extension MockStorageManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1782,7 +1782,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertNil(orderItem)
 
         // When
-        viewModel.updateOrderWithProduct(productID: sampleProductID)
+        viewModel.updateOrderWithProductID(sampleProductID)
 
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)
@@ -1794,14 +1794,14 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, withInitialProductID: sampleProductID)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProductID: sampleProductID)
 
         // Confidence check
         let orderItem = viewModel.currentOrderItems.first
         XCTAssertEqual(orderItem?.quantity, 1)
 
         // When
-        viewModel.updateOrderWithProduct(productID: sampleProductID)
+        viewModel.updateOrderWithProductID(sampleProductID)
 
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)


### PR DESCRIPTION
Closes: #9784

## Description
Before this PR, scanning the same barcode multiple times would add multiple product rows to the order. With this change we will update the product's quantity, rather than adding an additional row, if a product already exists in the current Order.

## Changes

Rather than sending the product directly to the remote sync, we perform a check to see if this already exists within the order, if that's the case, we use the pre-existing `incrementQuantity()` method to increase it. Otherwise, we'll send it to the order as before.

## Testing instructions
On a physical device: 
- Go to `Order` > `+` > Tap the scan button > scan a barcode for a product (not a variation) > See how is added to the current order
- Tap the scan button again > scan the same barcode > See how the quantity is increased

## Screenshots

<img width="450" alt="Screenshot 2023-05-24 at 09 38 04" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/66469148-3b68-4dd9-949e-b675e2dd23cf">