### PR TITLE
Increase screen brightness when showing the QR code

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Orders: Fixes a bug where the Orders list would not load if an order had a non-integer gift card amount applied to the order (with the Gift Cards extension). [https://github.com/woocommerce/woocommerce-ios/pull/9795]
 
 - [*] My Store: A new button to share the current store is added on the top right of the screen. [https://github.com/woocommerce/woocommerce-ios/pull/9796]
+- [*] Mobile Payments: The screen brightness is increased when showing the Scan to Pay view so the QR code can be scanned more easily [https://github.com/woocommerce/woocommerce-ios/pull/9807]
  
 13.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ScanToPayView: View {
     let viewModel: ScanToPayViewModel
     let onSuccess: (() -> Void)
+    let previousBrightness = UIScreen.main.brightness
 
     @Environment(\.dismiss) var dismiss
 
@@ -42,6 +43,12 @@ struct ScanToPayView: View {
             }
             .padding(Layout.scanToPayBoxOutterPadding)
             .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .onAppear {
+            UIScreen.main.brightness = 1.0
+        }
+        .onDisappear {
+            UIScreen.main.brightness = previousBrightness
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ScanToPayView: View {
     let viewModel: ScanToPayViewModel
     let onSuccess: (() -> Void)
+    /// We keep this value to reset the screen brightness after increasing it for better QR readability. Only works on phsycal device.
+    /// 
     let screenBrightnessAtViewCreation = UIScreen.main.brightness
 
     @Environment(\.dismiss) var dismiss

--- a/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ScanToPayView: View {
     let viewModel: ScanToPayViewModel
     let onSuccess: (() -> Void)
-    let previousBrightness = UIScreen.main.brightness
+    let screenBrightnessAtViewCreation = UIScreen.main.brightness
 
     @Environment(\.dismiss) var dismiss
 
@@ -48,7 +48,7 @@ struct ScanToPayView: View {
             UIScreen.main.brightness = 1.0
         }
         .onDisappear {
-            UIScreen.main.brightness = previousBrightness
+            UIScreen.main.brightness = screenBrightnessAtViewCreation
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9806 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we increase the screen brightness when the Scan to Pay screen is shown, so the QR code can be scanned in an easier way. Once that screen disappears, we reset the value to the previous one, which was captured when the view is created.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Set your device brightness to a medium value, so the brightness increase is more easily noticeable

1. Run the app
2. Go to menu
3. Go to Payments
4. Tap on Collect Payment and follow the flow
5. On the Payment Methods screen tap on Scan to Pay
6. Notice that the screen brightness is increased
7. Tap on done
8. Notice that the screen brightness goes back to the previous value

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/031589f3-77e9-48ca-bd88-6f5cd8230163" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
