### PR TITLE
Enable performance monitoring in production

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -49,8 +49,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
                 .performanceMonitoringNetworking,
                 .performanceMonitoringViewController,
                 .performanceMonitoringUserInteraction:
-            // Disabled by default to avoid costs spikes, unless in internal testing builds.
-            return buildConfig == .alpha
+            // Disabled for development builds.
+            return buildConfig == .alpha || buildConfig == .appStore
         case .tapToPayOnIPhone:
             // It is not possible to get the TTPoI entitlement for an enterprise certificate,
             // so we should not enable this for alpha builds.

--- a/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
+++ b/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
@@ -146,7 +146,7 @@ class WCCrashLoggingDataProvider: CrashLoggingDataProvider {
         return .enabled(
             .init(
                 // FIXME: Is there a way to control this via feature flags?
-                sampler: { 0.1 },
+                sampler: { 0.01 },
                 trackCoreData: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringCoreData),
                 trackFileIO: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringFileIO),
                 trackNetwork: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringNetworking),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This enables performance monitoring in production, sampling 1% of transactions. We're enabling this to record baseline measurements for future performance improvements.

Related (internal ref): pdnsEh-1a1-p2

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
You can confirm the monitoring is working by installing the alpha build from this PR (which also has performance monitoring enabled), navigating the app, and checking Sentry > Performance for transactions.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.