### PR TITLE
[Privacy Choices] Add Analytics to privacy banner

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2380,3 +2380,22 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+
+// MARK: - Privacy Choices Banner
+//
+extension WooAnalyticsEvent {
+    enum PrivacyChoicesBanner {
+        static func bannerPresented() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .privacyChoicesBannerPresented, properties: [:])
+        }
+
+        static func settingsButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .privacyChoicesSettingsButtonTapped, properties: [:])
+        }
+
+        static func saveButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .privacyChoicesSaveButtonTapped, properties: [:])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -920,6 +920,11 @@ public enum WooAnalyticsStat: String {
     case jetpackSetupFlow = "jetpack_setup_flow"
     case jetpackSetupCompleted = "jetpack_setup_completed"
     case jetpackSetupSynchronizationCompleted = "jetpack_setup_synchronization_completed"
+
+    // MARK: Privacy Banner
+    case privacyChoicesBannerPresented = "privacy_choices_banner_presented"
+    case privacyChoicesSettingsButtonTapped = "privacy_choices_banner_settings_button_tapped"
+    case privacyChoicesSaveButtonTapped = "privacy_choices_banner_save_button_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -10,8 +10,13 @@ final class PrivacyBannerPresenter {
     ///
     private let defaults: UserDefaults
 
-    init(defaults: UserDefaults = UserDefaults.standard) {
+    /// Analytics manager.
+    ///
+    private let analytics: Analytics
+
+    init(defaults: UserDefaults = UserDefaults.standard, analytics: Analytics = ServiceLocator.analytics) {
         self.defaults = defaults
+        self.analytics = analytics
     }
 
     /// Present the banner when the appropriate conditions are met.
@@ -63,6 +68,8 @@ final class PrivacyBannerPresenter {
 
         let bottomSheetViewController = BottomSheetViewController(childViewController: privacyBanner)
         bottomSheetViewController.show(from: viewController)
+
+        analytics.track(event: .PrivacyChoicesBanner.bannerPresented())
     }
 
     /// Presents an error notice and provide a retry action to update the analytics setting.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
@@ -57,6 +57,22 @@ final class PrivacyBannerViewModel: ObservableObject {
         // Revert Loading state
         isLoading = false
         isViewEnabled = true
+
+        // Analytics
+        trackAnalyticsFrom(destination: destination)
+    }
+
+    /// Track analytics based on the destination provided by the view.
+    /// Dismiss ----> Save
+    /// Settings ----> Settings
+    ///
+    private func trackAnalyticsFrom(destination: Destination) {
+        switch destination {
+        case .dismiss:
+            analytics.track(event: .PrivacyChoicesBanner.saveButtonTapped())
+        case .settings:
+            analytics.track(event: .PrivacyChoicesBanner.settingsButtonTapped())
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
@@ -59,14 +59,14 @@ final class PrivacyBannerViewModel: ObservableObject {
         isViewEnabled = true
 
         // Analytics
-        trackAnalyticsFrom(destination: destination)
+        trackAnalytics(from: destination)
     }
 
     /// Track analytics based on the destination provided by the view.
     /// Dismiss ----> Save
     /// Settings ----> Settings
     ///
-    private func trackAnalyticsFrom(destination: Destination) {
+    private func trackAnalytics(from destination: Destination) {
         switch destination {
         case .dismiss:
             analytics.track(event: .PrivacyChoicesBanner.saveButtonTapped())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/Privacy/PrivacyBannerViewModelTest.swift
@@ -111,6 +111,32 @@ import TestKit
         XCTAssertTrue(completionCalled)
     }
 
+    @MainActor func test_tapping_go_to_settings_tracks_analytic_event() async {
+        // Given
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let viewModel = PrivacyBannerViewModel(analytics: analytics, stores: stores, onCompletion: { _ in })
+
+        // When
+        await viewModel.submitChanges(destination: .settings)
+
+        // Then
+        XCTAssertEqual(analytics.lastReceivedStat, WooAnalyticsStat.privacyChoicesSettingsButtonTapped)
+    }
+
+    @MainActor func test_tapping_go_to_save_tracks_analytic_event() async {
+        // Given
+        let analytics = WaitingTimeTrackerTests.TestAnalytics()
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let viewModel = PrivacyBannerViewModel(analytics: analytics, stores: stores, onCompletion: { _ in })
+
+        // When
+        await viewModel.submitChanges(destination: .dismiss)
+
+        // Then
+        XCTAssertEqual(analytics.lastReceivedStat, WooAnalyticsStat.privacyChoicesSaveButtonTapped)
+    }
+
     override class func tearDown() {
         super.tearDown()
         SessionManager.removeTestingDatabase()


### PR DESCRIPTION
Closes: #9647 

# Why

This PR adds the following analytic events to the privacy choices banner.

- https://github.com/Automattic/tracks-events-registration/pull/1615
- https://github.com/Automattic/tracks-events-registration/pull/1616
- https://github.com/Automattic/tracks-events-registration/pull/1617


# Testing Steps

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented & the `presented` event being tracked
- Make sure the analytic settings remains enabled
- Tap the "Go so Settings" | "Save" save button.
- See the appropriate event being tracked.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
