### PR TITLE
[Privacy Choices] Prevent banner from being dismissed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -92,3 +92,15 @@ extension PrivacyBannerPresenter {
         static let retry = NSLocalizedString("Retry", comment: "Retry title on the notice action button")
     }
 }
+
+extension BottomSheetViewController {
+    /// Temporary hack to prevent the `PrivacyBannerViewController` to be dismissed.
+    /// This should be changed once https://github.com/wordpress-mobile/WordPressUI-iOS/pull/126 is merged.
+    ///
+    public override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        if children.first is PrivacyBannerViewController {
+            return
+        }
+        super.dismiss(animated: flag, completion: completion)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -62,6 +62,7 @@ final class PrivacyBannerPresenter {
         })
 
         let bottomSheetViewController = BottomSheetViewController(childViewController: privacyBanner)
+        bottomSheetViewController.isModalInPresentation = true
         bottomSheetViewController.show(from: viewController)
     }
 


### PR DESCRIPTION
Closes: #9811

# Why

This PR makes sure the privacy banner is not dismissable via a tap or a drag gesture.

The current bottom sheet implementation does not allow for that, This PR  adds not ideal temporary solution while we update `BottomSheetViewController` to allow for this behavior natively.

- https://github.com/wordpress-mobile/WordPressUI-iOS/pull/126

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/1ddebd5c-d217-4335-a65a-cf3e134b8a2d


# Testing Steps

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented
- See that the banner can't be dismissed by tapping outside of it or by dragging it down.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
