### PR TITLE
Enable "Share Product" only for public site

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -309,7 +309,8 @@ private extension AddProductCoordinator {
     /// Presents the celebratory view for the first created product.
     ///
     func showFirstProductCreatedView(productURL: URL) {
-        let viewController = FirstProductCreatedHostingController(productURL: productURL)
+        let viewController = FirstProductCreatedHostingController(productURL: productURL,
+                                                                  showShareProductButton: stores.sessionManager.defaultSite?.isPublic ?? false)
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -29,7 +29,6 @@ final class AddProductCoordinator: Coordinator {
     private let sourceView: UIView?
     private let productImageUploader: ProductImageUploaderProtocol
     private let storage: StorageManagerType
-    private let stores: StoresManager
     private let isFirstProduct: Bool
 
     /// ResultController to to track the current product count.
@@ -50,7 +49,6 @@ final class AddProductCoordinator: Coordinator {
          sourceBarButtonItem: UIBarButtonItem,
          sourceNavigationController: UINavigationController,
          storage: StorageManagerType = ServiceLocator.storageManager,
-         stores: StoresManager = ServiceLocator.stores,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          isFirstProduct: Bool) {
         self.siteID = siteID
@@ -60,7 +58,6 @@ final class AddProductCoordinator: Coordinator {
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
         self.storage = storage
-        self.stores = stores
         self.isFirstProduct = isFirstProduct
     }
 
@@ -69,7 +66,6 @@ final class AddProductCoordinator: Coordinator {
          sourceView: UIView?,
          sourceNavigationController: UINavigationController,
          storage: StorageManagerType = ServiceLocator.storageManager,
-         stores: StoresManager = ServiceLocator.stores,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          isFirstProduct: Bool) {
         self.siteID = siteID
@@ -79,7 +75,6 @@ final class AddProductCoordinator: Coordinator {
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
         self.storage = storage
-        self.stores = stores
         self.isFirstProduct = isFirstProduct
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -29,6 +29,7 @@ final class AddProductCoordinator: Coordinator {
     private let sourceView: UIView?
     private let productImageUploader: ProductImageUploaderProtocol
     private let storage: StorageManagerType
+    private let stores: StoresManager
     private let isFirstProduct: Bool
 
     /// ResultController to to track the current product count.
@@ -49,6 +50,7 @@ final class AddProductCoordinator: Coordinator {
          sourceBarButtonItem: UIBarButtonItem,
          sourceNavigationController: UINavigationController,
          storage: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          isFirstProduct: Bool) {
         self.siteID = siteID
@@ -58,6 +60,7 @@ final class AddProductCoordinator: Coordinator {
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
         self.storage = storage
+        self.stores = stores
         self.isFirstProduct = isFirstProduct
     }
 
@@ -66,6 +69,7 @@ final class AddProductCoordinator: Coordinator {
          sourceView: UIView?,
          sourceNavigationController: UINavigationController,
          storage: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          isFirstProduct: Bool) {
         self.siteID = siteID
@@ -75,6 +79,7 @@ final class AddProductCoordinator: Coordinator {
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
         self.storage = storage
+        self.stores = stores
         self.isFirstProduct = isFirstProduct
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -249,7 +249,8 @@ private extension AddProductCoordinator {
             guard let self else { return }
             self.onProductCreated(product)
             if self.isFirstProduct, let url = URL(string: product.permalink) {
-                self.showFirstProductCreatedView(productURL: url)
+                self.showFirstProductCreatedView(productURL: url,
+                                                 showShareProductButton: viewModel.canShareProduct())
             }
         }
         let viewController = ProductFormViewController(viewModel: viewModel,
@@ -308,9 +309,9 @@ private extension AddProductCoordinator {
 
     /// Presents the celebratory view for the first created product.
     ///
-    func showFirstProductCreatedView(productURL: URL) {
+    func showFirstProductCreatedView(productURL: URL, showShareProductButton: Bool) {
         let viewController = FirstProductCreatedHostingController(productURL: productURL,
-                                                                  showShareProductButton: stores.sessionManager.defaultSite?.isPublic ?? false)
+                                                                  showShareProductButton: showShareProductButton)
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -2,8 +2,9 @@ import ConfettiSwiftUI
 import SwiftUI
 
 final class FirstProductCreatedHostingController: UIHostingController<FirstProductCreatedView> {
-    init(productURL: URL) {
-        super.init(rootView: FirstProductCreatedView())
+    init(productURL: URL,
+         showShareProductButton: Bool) {
+        super.init(rootView: FirstProductCreatedView(showShareProductButton: showShareProductButton))
         rootView.onSharingProduct = { [weak self] in
             guard let self else { return }
             SharingHelper.shareURL(url: productURL, from: self.view, in: self)
@@ -38,6 +39,7 @@ private extension FirstProductCreatedHostingController {
 /// Celebratory screen after creating the first product 🎉
 ///
 struct FirstProductCreatedView: View {
+    let showShareProductButton: Bool
     var onSharingProduct: () -> Void = {}
     @State private var confettiCounter: Int = 0
 
@@ -51,10 +53,14 @@ struct FirstProductCreatedView: View {
                 Text(Localization.message)
                     .secondaryBodyStyle()
                     .multilineTextAlignment(.center)
-                Button(Localization.shareAction,
-                       action: onSharingProduct)
+
+                if showShareProductButton {
+                    Button(Localization.shareAction,
+                           action: onSharingProduct)
                     .buttonStyle(PrimaryButtonStyle())
                     .padding(.horizontal)
+                }
+
                 Spacer()
             }
             .padding()
@@ -93,11 +99,14 @@ private extension FirstProductCreatedView {
 
 struct FirstProductCreatedView_Previews: PreviewProvider {
     static var previews: some View {
-        FirstProductCreatedView()
-        .environment(\.colorScheme, .light)
+        FirstProductCreatedView(showShareProductButton: true)
+            .environment(\.colorScheme, .light)
 
-        FirstProductCreatedView()
-        .environment(\.colorScheme, .dark)
-        .previewInterfaceOrientation(.landscapeLeft)
+        FirstProductCreatedView(showShareProductButton: false)
+            .environment(\.colorScheme, .light)
+
+        FirstProductCreatedView(showShareProductButton: false)
+            .environment(\.colorScheme, .dark)
+            .previewInterfaceOrientation(.landscapeLeft)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -54,12 +54,11 @@ struct FirstProductCreatedView: View {
                     .secondaryBodyStyle()
                     .multilineTextAlignment(.center)
 
-                if showShareProductButton {
-                    Button(Localization.shareAction,
-                           action: onSharingProduct)
-                    .buttonStyle(PrimaryButtonStyle())
-                    .padding(.horizontal)
-                }
+                Button(Localization.shareAction,
+                       action: onSharingProduct)
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.horizontal)
+                .renderedIf(showShareProductButton)
 
                 Spacer()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -261,7 +261,7 @@ extension ProductFormViewModel {
     }
 
     func canShareProduct() -> Bool {
-        formType != .add
+        stores.sessionManager.defaultSite?.isPublic == true && formType != .add
     }
 
     func canDeleteProduct() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -167,7 +167,7 @@ extension ProductVariationFormViewModel {
     }
 
     func canShareProduct() -> Bool {
-        formType != .add
+        storesManager.sessionManager.defaultSite?.isPublic == true && formType != .add
     }
 
     func canDeleteProduct() -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -91,6 +91,21 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertTrue(canShareProduct)
     }
 
+    func test_edit_product_form_with_non_public_site_cannot_share_product() {
+        // Given
+        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: false)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertFalse(canShareProduct)
+    }
+
     func test_add_product_form_with_published_status_cannot_share_product() {
         // Arrange
         let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
@@ -349,7 +364,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_existing_published_product_and_no_pending_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123", isPublic: true)
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
@@ -416,7 +431,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_any_product_in_read_only_mode() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123", isPublic: true)
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product, formType: .readonly, stores: stores)
         viewModel.updateName("new name")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -82,28 +82,16 @@ final class ProductFormViewModelTests: XCTestCase {
     func test_edit_product_form_with_published_status_can_share_product() {
         // Arrange
         let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // Action
         let canShareProduct = viewModel.canShareProduct()
 
         // Assert
         XCTAssertTrue(canShareProduct)
-    }
-
-    func test_edit_product_form_with_non_public_site_cannot_share_product() {
-        // Given
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
-        let sessionManager = SessionManager.makeForTesting()
-        sessionManager.defaultSite = Site.fake().copy(isPublic: false)
-        let stores = MockStoresManager(sessionManager: sessionManager)
-        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
-
-        // When
-        let canShareProduct = viewModel.canShareProduct()
-
-        // Then
-        XCTAssertFalse(canShareProduct)
     }
 
     func test_add_product_form_with_published_status_cannot_share_product() {
@@ -121,7 +109,10 @@ final class ProductFormViewModelTests: XCTestCase {
     func test_edit_product_form_with_non_published_status_can_share_product() {
         // Arrange
         let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.pending.rawValue)
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // Action
         let canShareProduct = viewModel.canShareProduct()
@@ -139,6 +130,21 @@ final class ProductFormViewModelTests: XCTestCase {
         let canShareProduct = viewModel.canShareProduct()
 
         // Assert
+        XCTAssertFalse(canShareProduct)
+    }
+
+    func test_edit_product_form_with_non_public_site_cannot_share_product() {
+        // Given
+        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: false)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
         XCTAssertFalse(canShareProduct)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -60,20 +60,8 @@ final class ProductVariationFormViewModelTests: XCTestCase {
     func test_edit_product_variation_form_with_published_status_can_share_product() {
         // Given
         let product = ProductVariation.fake().copy(status: ProductStatus.published)
-        let viewModel = createViewModel(product: product, formType: .edit)
-
-        // When
-        let canShareProduct = viewModel.canShareProduct()
-
-        // Then
-        XCTAssertTrue(canShareProduct)
-    }
-
-    func test_edit_product_form_with_non_public_site_cannot_share_product() {
-        // Given
-        let product = ProductVariation.fake().copy(status: ProductStatus.published)
         let sessionManager = SessionManager.makeForTesting()
-        sessionManager.defaultSite = Site.fake().copy(isPublic: false)
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
         let stores = MockStoresManager(sessionManager: sessionManager)
         let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
@@ -81,7 +69,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         let canShareProduct = viewModel.canShareProduct()
 
         // Then
-        XCTAssertFalse(canShareProduct)
+        XCTAssertTrue(canShareProduct)
     }
 
     func test_add_product_variation_form_with_published_status_cannot_share_product() {
@@ -99,7 +87,10 @@ final class ProductVariationFormViewModelTests: XCTestCase {
     func test_edit_product_variation_form_with_non_published_status_can_share_product() {
         // Given
         let product = ProductVariation.fake().copy(status: ProductStatus.pending)
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // When
         let canShareProduct = viewModel.canShareProduct()
@@ -112,6 +103,21 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         // Given
         let product = ProductVariation.fake().copy(status: ProductStatus.pending)
         let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertFalse(canShareProduct)
+    }
+
+    func test_edit_product_form_with_non_public_site_cannot_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.published)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: false)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // When
         let canShareProduct = viewModel.canShareProduct()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -69,6 +69,21 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         XCTAssertTrue(canShareProduct)
     }
 
+    func test_edit_product_form_with_non_public_site_cannot_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(status: ProductStatus.published)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: false)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertFalse(canShareProduct)
+    }
+
     func test_add_product_variation_form_with_published_status_cannot_share_product() {
         // Given
         let product = ProductVariation.fake().copy(status: ProductStatus.published)
@@ -104,7 +119,6 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(canShareProduct)
     }
-
 }
 
 private extension ProductVariationFormViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9817 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
As the product URLs cannot be viewed publicly until a free trial site is published, we decided to show the "Share Product" button only if the site is public.

This PR checks `isPublic` value of the `defaultSite` before showing the "Share product" feature.

## Testing instructions

Free trial site (Not launched)
- Create a free trial store https://wordpress.com/setup/wooexpress/
- Login into the app using the free trial store
- From the dashboard, tap on "Add your first product" onboarding task
- Add a product and notice that you are presented with a confetti celebration screen at the end
- Validate that you don't see a "Share product" button (as the store is not launched yet)
- Navigate to the "Products" tab and open the newly added product
- Validate that you don't see the "Share" navigation bar button (as the store is not launched yet)

Public site
- Launch the free trial store by adding credits to your account https://wordpress.com/me/purchases
- Login into the app using the publicly available store
- From the dashboard, tap on "Add your first product" onboarding task
- Add a product and notice that you are presented with a confetti celebration screen at the end
- Validate that you can see a "Share product" button
- Navigate to the "Products" tab and open the newly added product
- Validate that you can see the "Share" navigation bar button

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Screen | Free trial (Not launched) | Public site |
|--------|--------|--------|
| First product created | ![Simulator Screen Shot - iPhone 14 - 2023-05-25 at 12 10 30](https://github.com/woocommerce/woocommerce-ios/assets/524475/5390e794-c997-4f9b-a19d-54df7885a65e) | ![Simulator Screen Shot - iPhone 14 - 2023-05-25 at 11 56 41](https://github.com/woocommerce/woocommerce-ios/assets/524475/5576dc88-36fd-47c8-84b3-91d27b10cfb6) | 
| Product detail screen | ![Simulator Screen Shot - iPhone 14 - 2023-05-25 at 12 10 42](https://github.com/woocommerce/woocommerce-ios/assets/524475/ec8be554-d779-4515-ac85-a26735f87f48) | ![Simulator Screen Shot - iPhone 14 - 2023-05-25 at 11 54 33](https://github.com/woocommerce/woocommerce-ios/assets/524475/5ad630cf-fc37-446d-aa30-ac464bba6868) |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
