### PR TITLE
[Mobile Payments] Track when Learn More is tapped on Set up Tap to Pay and Manage Card Reader screens

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1893,6 +1893,7 @@ extension WooAnalyticsEvent {
         enum LearnMoreLinkSource {
             case paymentsMenu
             case paymentMethods
+            case tapToPaySummary
 
             var trackingValue: String {
                 switch self {
@@ -1900,6 +1901,8 @@ extension WooAnalyticsEvent {
                     return "payments_menu"
                 case .paymentMethods:
                     return "payment_methods"
+                case .tapToPaySummary:
+                    return "tap_to_pay_summary"
                 }
             }
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1894,6 +1894,7 @@ extension WooAnalyticsEvent {
             case paymentsMenu
             case paymentMethods
             case tapToPaySummary
+            case manageCardReader
 
             var trackingValue: String {
                 switch self {
@@ -1903,6 +1904,8 @@ extension WooAnalyticsEvent {
                     return "payment_methods"
                 case .tapToPaySummary:
                     return "tap_to_pay_summary"
+                case .manageCardReader:
+                    return "manage_card_reader"
                 }
             }
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -277,6 +277,7 @@ public enum WooAnalyticsStat: String {
     case cardReaderDisconnectTapped = "card_reader_disconnect_tapped"
     case manageCardReadersBuiltInReaderAutoDisconnect = "manage_card_readers_automatic_disconnect_built_in_reader"
     case cardReaderAutomaticDisconnect = "card_reader_automatic_disconnect"
+    case manageCardReaderLearnMoreTapped = "card_present_connection_learn_more_tapped"
 
     // MARK: Card Reader Software Update Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -277,7 +277,6 @@ public enum WooAnalyticsStat: String {
     case cardReaderDisconnectTapped = "card_reader_disconnect_tapped"
     case manageCardReadersBuiltInReaderAutoDisconnect = "manage_card_readers_automatic_disconnect_built_in_reader"
     case cardReaderAutomaticDisconnect = "card_reader_automatic_disconnect"
-    case manageCardReaderLearnMoreTapped = "card_present_connection_learn_more_tapped"
 
     // MARK: Card Reader Software Update Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -147,28 +147,29 @@ struct CardReaderSettingsSearchingView: View {
                 .buttonStyle(PrimaryButtonStyle())
                 .padding(.bottom, 8)
 
-            InPersonPaymentsLearnMore()
-                .customOpenURL(action: { url in
-                    switch url {
-                    case LearnMoreViewModel.learnMoreURL:
-                        if let url = learnMoreUrl {
-                            showURL?(url)
-                        }
-                    default:
+            InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(
+                tappedAnalyticEvent: WooAnalyticsEvent(statName: .manageCardReaderLearnMoreTapped, properties: [:])))
+            .customOpenURL(action: { url in
+                switch url {
+                case LearnMoreViewModel.learnMoreURL:
+                    if let url = learnMoreUrl {
                         showURL?(url)
                     }
-                })
-        }
-            .frame(
-                maxWidth: .infinity,
-                maxHeight: .infinity
-            )
-            .padding()
-            .if(isCompact || isSizeCategoryLargeThanExtraLarge) {content in
-                ScrollView(.vertical) {
-                    content
+                default:
+                    showURL?(url)
                 }
+            })
+        }
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity
+        )
+        .padding()
+        .if(isCompact || isSizeCategoryLargeThanExtraLarge) {content in
+            ScrollView(.vertical) {
+                content
             }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -148,7 +148,7 @@ struct CardReaderSettingsSearchingView: View {
                 .padding(.bottom, 8)
 
             InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(
-                tappedAnalyticEvent: WooAnalyticsEvent(statName: .manageCardReaderLearnMoreTapped, properties: [:])))
+                tappedAnalyticEvent: WooAnalyticsEvent.InPersonPayments.learnMoreTapped(source: .manageCardReader)))
             .customOpenURL(action: { url in
                 switch url {
                 case LearnMoreViewModel.learnMoreURL:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -120,7 +120,9 @@ struct SetUpTapToPayInformationView: View {
                 .disabled(!viewModel.enableSetup)
 
                 InPersonPaymentsLearnMore(
-                    viewModel: LearnMoreViewModel(formatText: Localization.learnMore))
+                    viewModel: LearnMoreViewModel(
+                        formatText: Localization.learnMore,
+                        tappedAnalyticEvent: WooAnalyticsEvent.InPersonPayments.learnMoreTapped(source: .tapToPaySummary)))
                 .customOpenURL(action: { url in
                     switch url {
                     case LearnMoreViewModel.learnMoreURL:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have a Learn More link in each of the card reader related screens from the Payment menu:
- Set up Tap to Pay on iPhone
- Manage Card Reader

These screens are functionally equivalent – when there's no reader connected, they show and the user can learn more about getting started with IPP/TTP

Taps on these screens were not tracked, unlike other learn more links across the system.

From both screens, we now log the existing `in_person_payments_learn_more_tapped` event.

From the Set up Tap to Pay on iPhone screen, we use the `source: tap_to_pay_summary` – this is agreed to match and be suitable for both iOS and Android pdfdoF-2WK-p2

From the Manage Card Reader screen, we use the `source: manage_card_reader`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Launch the app
Navigate to `Menu > Payments > Set up Tap to Pay on iPhone`
Tap `Learn More`
Observe that the `in_person_payments_learn_more_tapped` event is logged with the `source: tap_to_pay_summary`
Tap back
Tap `Manage card reader`
Tap `Learn More`
Observe that the `in_person_payments_learn_more_tapped` event is logged with the `source: manage_card_reader`


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="909" alt="Console log showing the in_person_payments_learn_more_tapped event with source tap_to_pay_summary" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/d09bfae1-84e8-4e59-a061-5301b67d6a47">

<img width="911" alt="Console log showing the in_person_payments_learn_more_tapped event with source manage_card_reader" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/0d5401cc-bb18-4fc0-8aa2-4d702895911a">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
