### PR TITLE
Fix hidden settings menu on iPad

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -486,6 +486,11 @@ private extension SettingsViewController {
         hiddenSettingsMenu.addAction(crashDebugMenuCrashAction)
         hiddenSettingsMenu.addAction(crashDebugMenuCancelAction)
 
+        if let popoverController = hiddenSettingsMenu.popoverPresentationController {
+            popoverController.sourceView = sender?.view
+            popoverController.sourceRect = sender?.view?.bounds ?? .zero
+        }
+
         present(hiddenSettingsMenu, animated: true, completion: nil)
     }
 


### PR DESCRIPTION

# Why

During the review of #9816 it was uncovered that the hidden settings menu crashed on iPad due to the lack of a a source view. This PR fixes that.

# Screenshots

iPad | Iphone
---- | ----
<img width="712" alt="Screenshot 2023-05-25 at 8 52 46 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/21e2d4b7-fd29-4067-a645-b1d38f03b172"> | <img width="440" alt="Screenshot 2023-05-25 at 8 54 11 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/01b30621-dcb4-47a8-ac19-24b3955698c2">

# Testing steps

- Launch the app on an iPad
- Navigate to the settings menu
- Tap rapidly 4 times the heart icon at the bottom of the screen.
- See the settings menu appear.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
