### PR TITLE
[Privacy Choices] Toggle Descriptions Alignments

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -83,6 +83,7 @@ struct PrivacyBanner: View {
 
             Text(Localization.toggleSubtitle)
                 .subheadlineStyle()
+                .padding(.trailing, Layout.toggleDescriptionMargin)
 
             HStack {
                 Button(Localization.goToSettings) {
@@ -133,6 +134,7 @@ private extension PrivacyBanner {
 
     enum Layout {
         static let mainVerticalSpacing = CGFloat(8)
+        static let toggleDescriptionMargin = CGFloat(40)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -345,6 +345,7 @@ private extension PrivacySettingsViewController {
         if isPrivacyChoicesEnabled {
             cell.textLabel?.applySubheadlineStyle()
             cell.textLabel?.textColor = .textSubtle
+            cell.contentView.directionalLayoutMargins = .init(top: 0, leading: 0, bottom: 0, trailing: Constants.toggleDescriptionMargin)
         }
     }
 
@@ -596,6 +597,7 @@ private struct Constants {
     static let headerTitleInsets = UIEdgeInsets(top: 16, left: 14, bottom: 32, right: 14)
     static let footerInsets = UIEdgeInsets(top: 8, left: 16, bottom: 16, right: 16)
     static let footerPadding = CGFloat(44)
+    static let toggleDescriptionMargin = CGFloat(40)
 }
 
 private struct Section {


### PR DESCRIPTION
# Why 

This PR adjusts the content below the toggles to have some trailing padding as per designs.

# Screenshots

Banner | Privacy Screen 
---- | ----
<img width="434" alt="banner" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/adc0b5fa-5389-491b-b061-2d45c84be342"> | <img width="435" alt="privacy" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/5ffa7706-eb11-4219-9cc1-3bfefb2aed2e">

# Testing Steps

- Log out from the app (to clean the user defaults database)
- Log in to a WPCom store in the EU region (Can use a VPN)
- See the banner being presented
- See that the text below the toggle does not enter the toggle vertical area.

----

- Go to Settings ->  Privacy Settings
- See that the text below the toggles does not enter the toggle vertical area.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
