### PR TITLE
[Privacy Choices] Release Privacy Choices

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -92,7 +92,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .readOnlyMinMaxQuantities:
             return true
         case .privacyChoices:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .storeCreationNotifications:
             return true
         case .euShippingNotification:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 
 - [*] My Store: A new button to share the current store is added on the top right of the screen. [https://github.com/woocommerce/woocommerce-ios/pull/9796]
 - [*] Mobile Payments: The screen brightness is increased when showing the Scan to Pay view so the QR code can be scanned more easily [https://github.com/woocommerce/woocommerce-ios/pull/9807]
+- [*] Allow EU merchants to have better control of their privacy choices. A privacy choices banner will be shown the next time they open the app.
  
 13.7
 -----


### PR DESCRIPTION
# Why

Now that the test plan has been run pe5pgL-2Tq-p2, this PR sets the feature flag to `true` so the feature it's ready for release.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
