### PR TITLE
Make privacy banner not dismissable via WordPress UI tooling

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -90,7 +90,7 @@ target 'WooCommerce' do
 
   wordpress_shared
 
-  pod 'WordPressUI', '~> 1.12.5'
+  pod 'WordPressUI', '~> 1.13-beta'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
 
   aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
     - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.1.0)
-  - WordPressUI (1.12.5)
+  - WordPressUI (1.13.0)
   - Wormholy (1.6.6)
   - WPMediaPicker (1.8.1)
   - wpxmlrpc (0.10.0)
@@ -85,7 +85,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.1)
-  - WordPressUI (~> 1.12.5)
+  - WordPressUI (~> 1.13-beta)
   - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8.1)
   - ZendeskSupportSDK (~> 6.0)
@@ -161,7 +161,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 8a27a3c61ca0d740df66f260902aa2ca8528c61b
   WordPressKit: b65a51863982d8166897bea8b753f1fc51732aad
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
-  WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
+  WordPressUI: 9951bdade87c8c64b50535aaed2a53a11d0c52ee
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -173,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 7ef16ee777d45b27a6ea41073fce0a707bda17a7
+PODFILE CHECKSUM: 08c354d1c2b7fcbef3508c1931f343661f463f8e
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -100,15 +100,3 @@ extension PrivacyBannerPresenter {
         static let retry = NSLocalizedString("Retry", comment: "Retry title on the notice action button")
     }
 }
-
-extension BottomSheetViewController {
-    /// Temporary hack to prevent the `PrivacyBannerViewController` to be dismissed.
-    /// This should be changed once https://github.com/wordpress-mobile/WordPressUI-iOS/pull/126 is merged.
-    ///
-    public override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        if children.first is PrivacyBannerViewController {
-            return
-        }
-        super.dismiss(animated: flag, completion: completion)
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -7,12 +7,6 @@ import WordPressUI
 ///
 final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
 
-    // These are part of the `DrawerPresentable` protocol.
-    // We define them here instead than in the existing extension that defines the protocol conformance so that we can make the stored constants.
-    // Otherwise, since extensions don't allow for stored properties, they would have had to be computed vars.
-    let allowsTapToDismiss = false
-    let allowsDragToDismiss = false
-
     /// Tracks the banner view intrinsic height.
     /// Needed to enable it's scrolling when it grows bigger than the screen.
     ///
@@ -49,6 +43,11 @@ extension PrivacyBannerViewController: DrawerPresentable {
     var expandedHeight: DrawerHeight {
         return .contentHeight(bannerIntrinsicHeight)
     }
+
+    // We want the user to dimiss this only by completing the flow, not by tapping, dragging, or collapsing.
+    var allowsDragToDismiss: Bool { false }
+    var allowsTapToDismiss: Bool { false }
+    var allowsUserTransition: Bool { false }
 }
 
 /// Banner View for the privacy settings.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -7,6 +7,12 @@ import WordPressUI
 ///
 final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
 
+    // These are part of the `DrawerPresentable` protocol.
+    // We define them here instead than in the existing extension that defines the protocol conformance so that we can make the stored constants.
+    // Otherwise, since extensions don't allow for stored properties, they would have had to be computed vars.
+    let allowsTapToDismiss = false
+    let allowsDragToDismiss = false
+
     /// Tracks the banner view intrinsic height.
     /// Needed to enable it's scrolling when it grows bigger than the screen.
     ///


### PR DESCRIPTION
## Description
Removes the workaround that was required while waiting for the changes in https://github.com/wordpress-mobile/WordPressUI-iOS/pull/126/ to be published

## Testing instructions
I tested this by forcing the app to present the banner and by both tapping out of it and trying to drag it (in the Simulator) to verify it staid on screen. I'm not familiar with how the component should behave, _and we don't have a demo for it in WordPress-UI_, so I might have missed something.

I recorded myself during the process, but QuickTime crashed when I tried to crop the video...

For reference, here's the diff I used to force the display:

<details>
<summary>Diff</summary>

```diff
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerPresenter.swift
@@ -27,16 +27,16 @@ final class PrivacyBannerPresenter {
         guard isUITesting == false else {
             return
         }
+
+//        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.privacyChoices) else {
+//            return
+//        }
 
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.privacyChoices) else {
-            return
-        }
-
-        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults)
+//        let useCase = PrivacyBannerPresentationUseCase(defaults: defaults)
         Task {
-            if await useCase.shouldShowPrivacyBanner() {
+//            if await useCase.shouldShowPrivacyBanner() {
                 await presentPrivacyBanner(from: viewController)
-            }
+//            }
         }
     }
 

```

</details>




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
