### PR TITLE
[Reliability] Add fallbacks for known Product decoding errors

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -357,7 +357,12 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
 
         let fullDescription = try container.decodeIfPresent(String.self, forKey: .fullDescription)
         let shortDescription = try container.decodeIfPresent(String.self, forKey: .shortDescription)
-        let sku = try container.decodeIfPresent(String.self, forKey: .sku)
+
+        // Even though a plain install of WooCommerce Core provides String values,
+        // some plugins alter the field value from String to Int or Decimal.
+        let sku = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                    forKey: .sku,
+                                                    alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
 
         // Even though a plain install of WooCommerce Core provides string values,
         // some plugins alter the field value from String to Int or Decimal.

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -429,7 +429,12 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let backordered = try container.decode(Bool.self, forKey: .backordered)
 
         let soldIndividually = try container.decodeIfPresent(Bool.self, forKey: .soldIndividually) ?? false
-        let weight = try container.decodeIfPresent(String.self, forKey: .weight)
+
+        // Even though a plain install of WooCommerce Core provides String values,
+        // some plugins alter the field value from String to Int or Decimal.
+        let weight = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                       forKey: .weight,
+                                                       alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
         let dimensions = try container.decode(ProductDimensions.self, forKey: .dimensions)
 
         let shippingRequired = try container.decode(Bool.self, forKey: .shippingRequired)

--- a/Networking/Networking/Model/Product/ProductDimensions.swift
+++ b/Networking/Networking/Model/Product/ProductDimensions.swift
@@ -17,6 +17,24 @@ public struct ProductDimensions: Codable, Equatable, GeneratedFakeable {
         self.width = width
         self.height = height
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Even though a plain install of WooCommerce Core provides String dimension values,
+        // some plugins may alter the field values from String to Int or Decimal.
+        let length = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                       forKey: .length,
+                                                       alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? ""
+        let width = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                      forKey: .width,
+                                                      alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? ""
+        let height = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                       forKey: .height,
+                                                       alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? ""
+
+        self.init(length: length, width: width, height: height)
+    }
 }
 
 /// Defines all of the Dimensions CodingKeys

--- a/Networking/Networking/Model/Product/ProductDownload.swift
+++ b/Networking/Networking/Model/Product/ProductDownload.swift
@@ -23,7 +23,11 @@ public struct ProductDownload: Codable, Equatable, GeneratedFakeable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let downloadID = try container.decode(String.self, forKey: .downloadID)
+        // Even though a plain install of WooCommerce Core provides String values,
+        // some plugins alter the field value from String to Int or Decimal.
+        let downloadID = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                           forKey: .downloadID,
+                                                           alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? "0"
         let name = try container.decodeIfPresent(String.self, forKey: .name)
         let fileURL = try container.decodeIfPresent(String.self, forKey: .fileURL)
 

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -119,6 +119,9 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(product.permalink, "")
         XCTAssertEqual(product.sku, "123")
         XCTAssertEqual(product.weight, "213")
+        XCTAssertEqual(product.dimensions.length, "12")
+        XCTAssertEqual(product.dimensions.width, "33")
+        XCTAssertEqual(product.dimensions.height, "54")
     }
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -118,6 +118,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertTrue(product.purchasable)
         XCTAssertEqual(product.permalink, "")
         XCTAssertEqual(product.sku, "123")
+        XCTAssertEqual(product.weight, "213")
     }
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -122,6 +122,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(product.dimensions.length, "12")
         XCTAssertEqual(product.dimensions.width, "33")
         XCTAssertEqual(product.dimensions.height, "54")
+        XCTAssertEqual(product.downloads.first?.downloadID, "12345")
     }
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -117,6 +117,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertFalse(product.soldIndividually)
         XCTAssertTrue(product.purchasable)
         XCTAssertEqual(product.permalink, "")
+        XCTAssertEqual(product.sku, "123")
     }
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string

--- a/Networking/NetworkingTests/Responses/product-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-alternative-types.json
@@ -44,9 +44,9 @@
             "sold_individually": null,
             "weight": 213,
             "dimensions": {
-                "length": "12",
-                "width": "33",
-                "height": "54"
+                "length": 12,
+                "width": 33,
+                "height": 54
             },
             "shipping_required": false,
             "shipping_taxable": false,

--- a/Networking/NetworkingTests/Responses/product-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-alternative-types.json
@@ -28,7 +28,11 @@
             "total_sales": 0,
             "virtual": true,
             "downloadable": false,
-            "downloads": [],
+            "downloads": [{
+                "id" : 12345,
+                "name" : "Song #1",
+                "file" : "https://example.com/woo-single-1.ogg"
+              }],
             "download_limit": -1,
             "download_expiry": -1,
             "external_url": "http://somewhere.com",

--- a/Networking/NetworkingTests/Responses/product-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-alternative-types.json
@@ -14,7 +14,7 @@
             "catalog_visibility": "visible",
             "description": "<p>This is the party room!</p>\n",
             "short_description": "[contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests for $100.</p>\n",
-            "sku": "",
+            "sku": 123,
             "price": 17,
             "regular_price": 12.89,
             "sale_price": 26.73,

--- a/Networking/NetworkingTests/Responses/product-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-alternative-types.json
@@ -42,7 +42,7 @@
             "backorders_allowed": false,
             "backordered": false,
             "sold_individually": null,
-            "weight": "213",
+            "weight": 213,
             "dimensions": {
                 "length": "12",
                 "width": "33",

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.9
 -----
 - [*] Payments: Location permissions request is not shown to TTP users who grant "Allow once" permission on first foregrounding the app any more [https://github.com/woocommerce/woocommerce-ios/pull/9821]
+- [*] Products: Allow alternative types for the `sku` and `weight` in `Product`, the dimensions in `ProductDimensions`, and the `downloadID` in `ProductDownload`, as some third-party plugins alter the types in the API. This helps with the product list not loading due to product decoding errors. [https://github.com/woocommerce/woocommerce-ios/pull/9846]
 
 13.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9837
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR increases the app's resilience when `Product` fields have unexpected types:

* When a product's SKU is a number instead of a `String`.
* When a product's weight is a number instead of a `String`.
* When a product dimensions (length, width, height) are a number instead of a `String`.
* When a product download's ID is a number instead of a `String`.

It uses failsafe decoding to handle those alternative types, and adds to the unit test for parsing alternative types in a `Product`. (These are known decoding errors that users have experienced.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
We don't know the exact plugins that can cause this behavior, but you can test using a tool like Charles Proxy or Proxyman to intercept and modify the response:

1. Set a breakpoint in your tool of choice for requests to the `/wc/v3/products` endpoint.
2. Build and run the app.
3. Open the Products tab.
4. Modify the response in one or more of the following ways:
   * A product's SKU is a number (e.g. `"sku": 123` or see the `product-alternative-types.json` mock for an example).
   * A product's weight is a number (e.g. `"weight": 213`).
   * A product's dimensions is a number (e.g. `"dimensions": { "length": 12, "width": 33, "height": 54 }`).
   * A product's download ID is a number (e.g. `"downloads": [{ "id" : 12345, "name" : "Song #1", "file" : "https://example.com/woo-single-1.ogg" }]`).
9. Execute the response and confirm the app loads the product list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-05-30 at 16 09 25](https://github.com/woocommerce/woocommerce-ios/assets/8658164/00fe2976-f49a-4989-bc04-ea7d42ac9ed6)|![Simulator Screen Shot - iPhone 14 Pro - 2023-05-30 at 16 12 43](https://github.com/woocommerce/woocommerce-ios/assets/8658164/cfc4f4dd-6862-4904-837a-7f34e336cb18)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
