### PR TITLE
[Reliability] Add fallbacks for known product variation decoding errors

### DIFF
--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -206,7 +206,12 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
         let statusKey = try container.decode(String.self, forKey: .statusKey)
         let status = ProductStatus(rawValue: statusKey)
         let description = try container.decodeIfPresent(String.self, forKey: .description)
-        let sku = try container.decodeIfPresent(String.self, forKey: .sku)
+
+        // Even though a plain install of WooCommerce Core provides String values,
+        // some plugins alter the field value from String to Int or Decimal.
+        let sku = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                    forKey: .sku,
+                                                    alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
 
         // Even though a plain install of WooCommerce Core provides string values,
         // some plugins alter the field value from String to Int or Decimal.

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -275,7 +275,12 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
         let backordersKey = try container.decode(String.self, forKey: .backordersKey)
         let backordersAllowed = try container.decode(Bool.self, forKey: .backordersAllowed)
         let backordered = try container.decode(Bool.self, forKey: .backordered)
-        let weight = try container.decodeIfPresent(String.self, forKey: .weight)
+
+        // Even though a plain install of WooCommerce Core provides String values,
+        // some plugins alter the field value from String to Int or Decimal.
+        let weight = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                       forKey: .weight,
+                                                       alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
         let dimensions = try container.decode(ProductDimensions.self, forKey: .dimensions)
         let shippingClass = try container.decodeIfPresent(String.self, forKey: .shippingClass)
         let shippingClassID = try container.decode(Int64.self, forKey: .shippingClassID)

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -41,6 +41,7 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertTrue(productVariation.purchasable)
         XCTAssertEqual(productVariation.permalink, "")
         XCTAssertEqual(productVariation.sku, "12345")
+        XCTAssertEqual(productVariation.weight, "2.5")
     }
 
     /// Test that the fields for variations of a subscription product are properly parsed.

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -40,6 +40,7 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertFalse(productVariation.manageStock)
         XCTAssertTrue(productVariation.purchasable)
         XCTAssertEqual(productVariation.permalink, "")
+        XCTAssertEqual(productVariation.sku, "12345")
     }
 
     /// Test that the fields for variations of a subscription product are properly parsed.

--- a/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
@@ -8,7 +8,7 @@
             "date_modified_gmt": "2019-11-14T13:06:42",
             "description": "<p>Nutty chocolate marble, 99% and organic.</p>\n",
             "permalink": 0,
-            "sku": "99%-nuts-marble",
+            "sku": 12345,
             "price": 13.99,
             "regular_price": 16,
             "sale_price": 9.99,

--- a/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
@@ -32,7 +32,7 @@
             "backorders": "notify",
             "backorders_allowed": true,
             "backordered": false,
-            "weight": "2.5",
+            "weight": 2.5,
             "dimensions": {
                 "length": "10",
                 "width": "2.5",

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.9
 -----
 - [*] Payments: Location permissions request is not shown to TTP users who grant "Allow once" permission on first foregrounding the app any more [https://github.com/woocommerce/woocommerce-ios/pull/9821]
+- [*] Products: Allow alternative types for the `sku` and `weight` in `ProductVariation`, as some third-party plugins alter the types in the API. This helps with the product variation list not loading due to product variation decoding errors. [https://github.com/woocommerce/woocommerce-ios/pull/9847]
 
 13.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9838
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR increases the app's resilience when `ProductVariation` fields have unexpected types:

* When a variation's SKU is a number instead of a `String`.
* When a variation's weight is a number instead of a `String`.

It uses failsafe decoding to handle those alternative types, and adds to the unit test for parsing alternative types in a `ProductVariation`. (These are known decoding errors that users have experienced.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Set a breakpoint in your tool of choice for requests to the `/wc/v3/products` endpoint.
2. Build and run the app.
3. Open the Products tab.
4. Select a variable product.
5. Select the Variations section in product details.
6. Modify the response in one or both of the following ways:
   * A variation's SKU is a number (e.g. `"sku": 123` or see the `product-variation-alternative-types.json` mock for an example).
   * A variation's weight is a number (e.g. `"weight": 213`).
9. Execute the response and confirm the app loads the variation list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-05-30 at 16 53 42](https://github.com/woocommerce/woocommerce-ios/assets/8658164/87905b05-aeb8-48a4-94d2-de4e161800d8)|![Simulator Screen Shot - iPhone 14 Pro - 2023-05-30 at 16 54 43](https://github.com/woocommerce/woocommerce-ios/assets/8658164/19025d5c-4853-475d-a5e9-66c755cd64f9)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
