### PR TITLE
[Reliability] Introduce local vs store timezone difference tracks

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -1,3 +1,4 @@
+import Foundation
 import enum Yosemite.StatsTimeRangeV4
 
 extension WooAnalyticsEvent {
@@ -29,6 +30,13 @@ extension WooAnalyticsEvent {
         /// - Parameter timeRange: the range of store stats (e.g. Today, This Week, This Month, This Year).
         static func dashboardTopPerformersDate(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardTopPerformersDate, properties: [Keys.range: timeRange.analyticsValue])
+        }
+        
+        /// Tracked when the dashboard is accessed with a device timezone different from the store timezone.
+        /// - Parameter localTimezone: The current timezone of the device running the app.
+        /// - Parameter storeTimezone: The store timezone defined by the API.
+        static func dashboardTimezonesDiffers(localTimezone: TimeZone, storeTimezone: TimeZone) {
+            
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -37,12 +37,10 @@ extension WooAnalyticsEvent {
         /// Tracked when the dashboard is accessed with a device timezone different from the store timezone.
         /// - Parameter localTimezone: The current timezone of the device running the app.
         /// - Parameter storeTimezone: The store timezone defined by the API.
-        static func dashboardTimezonesDiffers(localTimezone: TimeZone, storeTimezone: TimeZone) -> WooAnalyticsEvent {
-            let localGMTOffset = String(localTimezone.secondsFromGMT())
-            let storeGMTOffset = String(storeTimezone.secondsFromGMT())
+        static func dashboardTimezonesDiffers(localTimezone: String, storeTimezone: String) -> WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .dashboardStoreTimezoneDifferFromDevice,
-                                     properties: [Keys.storeTimezone: storeGMTOffset,
-                                                  Keys.localTimezone: localGMTOffset])
+                                     properties: [Keys.storeTimezone: storeTimezone,
+                                                  Keys.localTimezone: localTimezone])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -6,6 +6,8 @@ extension WooAnalyticsEvent {
         /// Common event keys.
         private enum Keys {
             static let range = "range"
+            static let localTimezone = "local_timezone"
+            static let storeTimezone = "store_timezone"
         }
 
         /// Tracked when the store stats are loaded with fresh data either via first load, event driven refresh, or manual refresh.
@@ -36,7 +38,6 @@ extension WooAnalyticsEvent {
         /// - Parameter localTimezone: The current timezone of the device running the app.
         /// - Parameter storeTimezone: The store timezone defined by the API.
         static func dashboardTimezonesDiffers(localTimezone: TimeZone, storeTimezone: TimeZone) {
-            
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -33,11 +33,16 @@ extension WooAnalyticsEvent {
         static func dashboardTopPerformersDate(timeRange: StatsTimeRangeV4) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dashboardTopPerformersDate, properties: [Keys.range: timeRange.analyticsValue])
         }
-        
+
         /// Tracked when the dashboard is accessed with a device timezone different from the store timezone.
         /// - Parameter localTimezone: The current timezone of the device running the app.
         /// - Parameter storeTimezone: The store timezone defined by the API.
-        static func dashboardTimezonesDiffers(localTimezone: TimeZone, storeTimezone: TimeZone) {
+        static func dashboardTimezonesDiffers(localTimezone: TimeZone, storeTimezone: TimeZone) -> WooAnalyticsEvent {
+            let localGMTOffset = String(localTimezone.secondsFromGMT())
+            let storeGMTOffset = String(storeTimezone.secondsFromGMT())
+            return WooAnalyticsEvent(statName: .dashboardStoreTimezoneDifferFromDevice,
+                                     properties: [Keys.storeTimezone: storeGMTOffset,
+                                                  Keys.localTimezone: localGMTOffset])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -35,8 +35,8 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when the dashboard is accessed with a device timezone different from the store timezone.
-        /// - Parameter localTimezone: The current timezone of the device running the app.
-        /// - Parameter storeTimezone: The store timezone defined by the API.
+        /// - Parameter localTimezone: The current timezone offset in hours of the device running the app.
+        /// - Parameter storeTimezone: The store timezone offset in hours defined by the API.
         static func dashboardTimezonesDiffers(localTimezone: Double, storeTimezone: Double) -> WooAnalyticsEvent {
             let localTimezoneText = String(format: "%g", localTimezone)
             let storeTimezoneText = String(format: "%g", storeTimezone)

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -37,10 +37,10 @@ extension WooAnalyticsEvent {
         /// Tracked when the dashboard is accessed with a device timezone different from the store timezone.
         /// - Parameter localTimezone: The current timezone of the device running the app.
         /// - Parameter storeTimezone: The store timezone defined by the API.
-        static func dashboardTimezonesDiffers(localTimezone: String, storeTimezone: String) -> WooAnalyticsEvent {
+        static func dashboardTimezonesDiffers(localTimezone: Double, storeTimezone: Double) -> WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .dashboardStoreTimezoneDifferFromDevice,
-                                     properties: [Keys.storeTimezone: storeTimezone,
-                                                  Keys.localTimezone: localTimezone])
+                                     properties: [Keys.storeTimezone: String(storeTimezone),
+                                                  Keys.localTimezone: String(localTimezone)])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -38,9 +38,11 @@ extension WooAnalyticsEvent {
         /// - Parameter localTimezone: The current timezone of the device running the app.
         /// - Parameter storeTimezone: The store timezone defined by the API.
         static func dashboardTimezonesDiffers(localTimezone: Double, storeTimezone: Double) -> WooAnalyticsEvent {
+            let localTimezoneText = String(format: "%g", localTimezone)
+            let storeTimezoneText = String(format: "%g", storeTimezone)
             return WooAnalyticsEvent(statName: .dashboardStoreTimezoneDifferFromDevice,
-                                     properties: [Keys.storeTimezone: String(storeTimezone),
-                                                  Keys.localTimezone: String(localTimezone)])
+                                     properties: [Keys.storeTimezone: storeTimezoneText,
+                                                  Keys.localTimezone: localTimezoneText])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -151,6 +151,7 @@ public enum WooAnalyticsStat: String {
     case dashboardUnfulfilledOrdersLoaded = "dashboard_unfulfilled_orders_loaded"
     case dashboardMainStatsWaitingTimeLoaded = "dashboard_main_stats_waiting_time_loaded"
     case dashboardTopPerformersWaitingTimeLoaded = "dashboard_top_performers_waiting_time_loaded"
+    case dashboardStoreTimezoneDifferFromDevice = "dashboard_store_timezone_differ_from_device"
 
     // MARK: Dashboard Stats v3/v4 Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -822,6 +822,7 @@ private extension DashboardViewController {
                 return
             }
             self.updateUI(site: site)
+            self.trackDeviceTimezoneDifferenceWithStore()
             Task { @MainActor [weak self] in
                 await self?.reloadData(forced: true)
             }
@@ -869,6 +870,10 @@ private extension DashboardViewController {
     func stopObservingNavigationBarHeightForHeaderVisibility() {
         navbarObserverSubscription?.cancel()
         navbarObserverSubscription = nil
+    }
+    
+    func trackDeviceTimezoneDifferenceWithStore() {
+        viewModel.trackStatsTimezone(localTimezone: TimeZone.current, siteTimezone: TimeZone.siteTimezone)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -822,7 +822,7 @@ private extension DashboardViewController {
                 return
             }
             self.updateUI(site: site)
-            self.trackDeviceTimezoneDifferenceWithStore()
+            self.trackDeviceTimezoneDifferenceWithStore(siteGMTOffset: site.gmtOffset)
             Task { @MainActor [weak self] in
                 await self?.reloadData(forced: true)
             }
@@ -871,9 +871,9 @@ private extension DashboardViewController {
         navbarObserverSubscription?.cancel()
         navbarObserverSubscription = nil
     }
-    
-    func trackDeviceTimezoneDifferenceWithStore() {
-        viewModel.trackStatsTimezone(localTimezone: TimeZone.current, siteTimezone: TimeZone.siteTimezone)
+
+    func trackDeviceTimezoneDifferenceWithStore(siteGMTOffset: Double) {
+        viewModel.trackStatsTimezone(localTimezone: TimeZone.current, siteGMTOffset: siteGMTOffset)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -59,14 +59,6 @@ final class DashboardViewModel {
     func reloadStoreOnboardingTasks() async {
         await storeOnboardingViewModel.reloadTasks()
     }
-    
-    func trackStatsTimezone(localTimeZone: TimeZone, siteTimezone: TimeZone) {
-        guard localTimeZone.secondsFromGMT() != siteTimezone.secondsFromGMT() else {
-            return
-        }
-        
-        //analytics.track(<#T##stat: WooAnalyticsStat##WooAnalyticsStat#>)
-    }
 
     /// Syncs store stats for dashboard UI.
     func syncStats(for siteID: Int64,
@@ -186,6 +178,16 @@ final class DashboardViewModel {
         } catch {
             await syncJustInTimeMessages(for: siteID)
         }
+    }
+
+    /// Triggers the `.dashboardTimezonesDiffer` track event whenever the device local timezone and the current site timezone are different from each other
+    /// 
+    func trackStatsTimezone(localTimeZone: TimeZone, siteTimezone: TimeZone) {
+        guard localTimeZone.secondsFromGMT() != siteTimezone.secondsFromGMT() else {
+            return
+        }
+        
+        analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localTimeZone, storeTimezone: siteTimezone))
     }
 
     /// Checks if a store is eligible for products onboarding -returning error otherwise- and prepares the onboarding announcement if needed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -187,9 +187,9 @@ final class DashboardViewModel {
             return
         }
 
-        let localGMTOffset = String(localTimezone.secondsFromGMT())
-        let siteGMTOffset = String(siteTimezone.secondsFromGMT())
-        analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localGMTOffset, storeTimezone: siteGMTOffset))
+        let localGMTOffsetInHours = String(localTimezone.secondsFromGMT() / 3600)
+        let siteGMTOffsetInHours = String(siteTimezone.secondsFromGMT() / 3600)
+        analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localGMTOffsetInHours, storeTimezone: siteGMTOffsetInHours))
     }
 
     /// Checks if a store is eligible for products onboarding -returning error otherwise- and prepares the onboarding announcement if needed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -182,12 +182,14 @@ final class DashboardViewModel {
 
     /// Triggers the `.dashboardTimezonesDiffer` track event whenever the device local timezone and the current site timezone are different from each other
     /// 
-    func trackStatsTimezone(localTimeZone: TimeZone, siteTimezone: TimeZone) {
-        guard localTimeZone.secondsFromGMT() != siteTimezone.secondsFromGMT() else {
+    func trackStatsTimezone(localTimezone: TimeZone, siteTimezone: TimeZone) {
+        guard localTimezone.secondsFromGMT() != siteTimezone.secondsFromGMT() else {
             return
         }
-        
-        analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localTimeZone, storeTimezone: siteTimezone))
+
+        let localGMTOffset = String(localTimezone.secondsFromGMT())
+        let siteGMTOffset = String(siteTimezone.secondsFromGMT())
+        analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localGMTOffset, storeTimezone: siteGMTOffset))
     }
 
     /// Checks if a store is eligible for products onboarding -returning error otherwise- and prepares the onboarding announcement if needed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -59,6 +59,14 @@ final class DashboardViewModel {
     func reloadStoreOnboardingTasks() async {
         await storeOnboardingViewModel.reloadTasks()
     }
+    
+    func trackStatsTimezone(localTimeZone: TimeZone, siteTimezone: TimeZone) {
+        guard localTimeZone.secondsFromGMT() != siteTimezone.secondsFromGMT() else {
+            return
+        }
+        
+        //analytics.track(<#T##stat: WooAnalyticsStat##WooAnalyticsStat#>)
+    }
 
     /// Syncs store stats for dashboard UI.
     func syncStats(for siteID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -187,8 +187,8 @@ final class DashboardViewModel {
             return
         }
 
-        let localGMTOffsetInHours = String(localTimezone.secondsFromGMT() / 3600)
-        let siteGMTOffsetInHours = String(siteTimezone.secondsFromGMT() / 3600)
+        let localGMTOffsetInHours = Double(localTimezone.secondsFromGMT()) / 3600
+        let siteGMTOffsetInHours = Double(siteTimezone.secondsFromGMT()) / 3600
         analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localGMTOffsetInHours, storeTimezone: siteGMTOffsetInHours))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -182,14 +182,13 @@ final class DashboardViewModel {
 
     /// Triggers the `.dashboardTimezonesDiffer` track event whenever the device local timezone and the current site timezone are different from each other
     /// 
-    func trackStatsTimezone(localTimezone: TimeZone, siteTimezone: TimeZone) {
-        guard localTimezone.secondsFromGMT() != siteTimezone.secondsFromGMT() else {
+    func trackStatsTimezone(localTimezone: TimeZone, siteGMTOffset: Double) {
+        let localGMTOffsetInHours = Double(localTimezone.secondsFromGMT()) / 3600
+        guard localGMTOffsetInHours != siteGMTOffset else {
             return
         }
 
-        let localGMTOffsetInHours = Double(localTimezone.secondsFromGMT()) / 3600
-        let siteGMTOffsetInHours = Double(siteTimezone.secondsFromGMT()) / 3600
-        analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localGMTOffsetInHours, storeTimezone: siteGMTOffsetInHours))
+        analytics.track(event: .Dashboard.dashboardTimezonesDiffers(localTimezone: localGMTOffsetInHours, storeTimezone: siteGMTOffset))
     }
 
     /// Checks if a store is eligible for products onboarding -returning error otherwise- and prepares the onboarding announcement if needed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -101,6 +101,7 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
             selection = selectedTabIndex
             observeSelectedTimeRangeIndex()
         }
+        dashboardViewModel.trackStatsTimezone(localTimeZone: TimeZone.current, siteTimezone: TimeZone.siteTimezone)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -101,7 +101,8 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
             selection = selectedTabIndex
             observeSelectedTimeRangeIndex()
         }
-        dashboardViewModel.trackStatsTimezone(localTimeZone: TimeZone.current, siteTimezone: TimeZone.siteTimezone)
+
+        dashboardViewModel.trackStatsTimezone(localTimezone: TimeZone.current, siteTimezone: TimeZone.siteTimezone)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -101,8 +101,6 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
             selection = selectedTabIndex
             observeSelectedTimeRangeIndex()
         }
-
-        dashboardViewModel.trackStatsTimezone(localTimezone: TimeZone.current, siteTimezone: TimeZone.siteTimezone)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -248,6 +248,26 @@ final class DashboardViewModelTests: XCTestCase {
         assertEqual(2, properties["count"] as? Int64)
     }
 
+    func test_track_stats_timezone_correctly_configure_parameters() {
+        // Given
+        let localTimezone = TimeZone(secondsFromGMT: -3600)
+        let storeTimezone = TimeZone(secondsFromGMT: 0)
+        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+
+        // When
+        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteTimezone: storeTimezone!)
+
+        // Then
+        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "dashboard_store_timezone_differ_from_device"),
+              let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
+        else {
+            return XCTFail("Expected event was not logged")
+        }
+
+        assertEqual("-1", properties["local_timezone"] as? String)
+        assertEqual("0", properties["store_timezone"] as? String)
+    }
+
     func test_when_two_messages_are_received_only_the_first_is_displayed() async {
         // Given
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "Higher priority JITM")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -500,11 +500,11 @@ final class DashboardViewModelTests: XCTestCase {
     func test_different_timezones_correctly_trigger_tracks_with_parameters() {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -3600)
-        let storeTimezone = TimeZone(secondsFromGMT: 0)
+        let siteGMTOffset = 0.0
         let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
 
         // When
-        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteTimezone: storeTimezone!)
+        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
 
         // Then
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "dashboard_store_timezone_differ_from_device"),
@@ -520,11 +520,11 @@ final class DashboardViewModelTests: XCTestCase {
     func test_different_decimal_timezones_correctly_trigger_tracks_with_parameters() {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -5400)
-        let storeTimezone = TimeZone(secondsFromGMT: 9000)
+        let siteGMTOffset = 2.50000
         let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
 
         // When
-        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteTimezone: storeTimezone!)
+        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
 
         // Then
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "dashboard_store_timezone_differ_from_device"),
@@ -540,11 +540,11 @@ final class DashboardViewModelTests: XCTestCase {
     func test_same_local_and_store_timezone_do_not_trigger_tracks() {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -7200)
-        let storeTimezone = TimeZone(secondsFromGMT: -7200)
+        let siteGMTOffset = -2.0
         let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
 
         // When
-        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteTimezone: storeTimezone!)
+        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
 
         // Then
         XCTAssertNil(analyticsProvider.receivedEvents.firstIndex(of: "dashboard_store_timezone_differ_from_device"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -517,6 +517,26 @@ final class DashboardViewModelTests: XCTestCase {
         assertEqual("0", properties["store_timezone"] as? String)
     }
 
+    func test_different_decimal_timezones_correctly_trigger_tracks_with_parameters() {
+        // Given
+        let localTimezone = TimeZone(secondsFromGMT: -5400)
+        let storeTimezone = TimeZone(secondsFromGMT: 9000)
+        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+
+        // When
+        viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteTimezone: storeTimezone!)
+
+        // Then
+        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "dashboard_store_timezone_differ_from_device"),
+              let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
+        else {
+            return XCTFail("Expected event was not logged")
+        }
+
+        assertEqual("-1.5", properties["local_timezone"] as? String)
+        assertEqual("2.5", properties["store_timezone"] as? String)
+    }
+
     func test_same_local_and_store_timezone_do_not_trigger_tracks() {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -7200)


### PR DESCRIPTION
Closes: #9835

Why
==========
We want to verify how often our user base uses a different device timezone from the one configured in the store. To achieve this a new track event called `DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE` must be introduced. The relevance of such data is that since the app can adopt the local device timezone to fetch stats, whenever the store is configured with a different timezone, the analytics values and numbers between the wp-admin and app stats can significantly differ.

How
==========
 This PR introduces a track event triggered whenever we start the app Dashboard and the device's local timezone configuration differs from the store timezone configuration. The GMT offset will be compared in seconds, but the tracks will log it in hours for better analytics data navigation.


How to Test
==========
### Scenario 1
1. Open the app with a store configured in a different timezone from the device you're testing
2. Verify that the `DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE` event is triggered as soon as the `My Store` section is loaded
3. Verify that the same event contains the `store_timezone` and `local_timezone` carrying the expected values from each
4. Now, without reopening the app, go to the App More menu and switch the store to another one with a different timezone from the local
5. Verify that again the `DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE` event is triggered, containing the same `local_timezone` as before, and that `store_timezone` follows the value of the new selected store

### Scenario 2
1. Open the app with a store configured with the same timezone from the device you're testing
2. Verify that the `DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE` is NOT triggered


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.