### PR TITLE
[Reliability] Add failsafe decoding for Bool when string/data is received

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -420,7 +420,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
 
         let backordersKey = try container.decode(String.self, forKey: .backordersKey)
-        let backordersAllowed = try container.decode(Bool.self, forKey: .backordersAllowed)
+
+        // Even though WooCommerce Core returns Bool values,
+        // some plugins alter the field value from Bool to String.
+        let backordersAllowed = container.failsafeDecodeIfPresent(targetType: Bool.self,
+                                                                  forKey: .backordersAllowed,
+                                                                  alternativeTypes: [ .string(transform: { NSString(string: $0).boolValue })]) ?? false
+
         let backordered = try container.decode(Bool.self, forKey: .backordered)
 
         let soldIndividually = try container.decodeIfPresent(Bool.self, forKey: .soldIndividually) ?? false

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -370,7 +370,11 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                                                              alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
             ?? ""
 
-        let onSale = try container.decode(Bool.self, forKey: .onSale)
+        // Even though WooCommerce Core returns Bool values,
+        // some plugins alter the field value from Bool to String.
+        let onSale = container.failsafeDecodeIfPresent(targetType: Bool.self,
+                                                       forKey: .onSale,
+                                                       alternativeTypes: [ .string(transform: { NSString(string: $0).boolValue })]) ?? false
 
         // Even though a plain install of WooCommerce Core provides string values,
         // some plugins alter the field value from String to Int or Decimal.

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -268,7 +268,13 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
         let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
         let stockStatus = ProductStockStatus(rawValue: stockStatusKey)
         let backordersKey = try container.decode(String.self, forKey: .backordersKey)
-        let backordersAllowed = try container.decode(Bool.self, forKey: .backordersAllowed)
+
+        // Even though WooCommerce Core returns Bool values,
+        // some plugins alter the field value from Bool to String.
+        let backordersAllowed = container.failsafeDecodeIfPresent(targetType: Bool.self,
+                                                                  forKey: .backordersAllowed,
+                                                                  alternativeTypes: [ .string(transform: { NSString(string: $0).boolValue })]) ?? false
+
         let backordered = try container.decode(Bool.self, forKey: .backordered)
         let weight = try container.decodeIfPresent(String.self, forKey: .weight)
         let dimensions = try container.decode(ProductDimensions.self, forKey: .dimensions)

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -219,7 +219,12 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                                                              forKey: .regularPrice,
                                                              alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
             ?? ""
-        let onSale = try container.decode(Bool.self, forKey: .onSale)
+
+        // Even though WooCommerce Core returns Bool values,
+        // some plugins alter the field value from Bool to String.
+        let onSale = container.failsafeDecodeIfPresent(targetType: Bool.self,
+                                                       forKey: .onSale,
+                                                       alternativeTypes: [ .string(transform: { NSString(string: $0).boolValue })]) ?? false
 
         // Even though a plain install of WooCommerce Core provides string values,
         // some plugins alter the field value from String to Int or Decimal.

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -117,6 +117,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertFalse(product.soldIndividually)
         XCTAssertTrue(product.purchasable)
         XCTAssertEqual(product.permalink, "")
+        XCTAssertEqual(product.backordersAllowed, true)
     }
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -118,6 +118,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertTrue(product.purchasable)
         XCTAssertEqual(product.permalink, "")
         XCTAssertEqual(product.backordersAllowed, true)
+        XCTAssertEqual(product.onSale, false)
     }
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -40,6 +40,7 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertFalse(productVariation.manageStock)
         XCTAssertTrue(productVariation.purchasable)
         XCTAssertEqual(productVariation.permalink, "")
+        XCTAssertEqual(productVariation.backordersAllowed, true)
     }
 
     /// Test that the fields for variations of a subscription product are properly parsed.

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -41,6 +41,7 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertTrue(productVariation.purchasable)
         XCTAssertEqual(productVariation.permalink, "")
         XCTAssertEqual(productVariation.backordersAllowed, true)
+        XCTAssertEqual(productVariation.onSale, false)
     }
 
     /// Test that the fields for variations of a subscription product are properly parsed.

--- a/Networking/NetworkingTests/Responses/product-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-alternative-types.json
@@ -39,7 +39,7 @@
             "stock_quantity": null,
             "stock_status": "instock",
             "backorders": "no",
-            "backorders_allowed": false,
+            "backorders_allowed": "1",
             "backordered": false,
             "sold_individually": null,
             "weight": "213",

--- a/Networking/NetworkingTests/Responses/product-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-alternative-types.json
@@ -23,7 +23,7 @@
             "date_on_sale_to": null,
             "date_on_sale_to_gmt": "2019-10-27T21:29:59",
             "price_html": "Free",
-            "on_sale": false,
+            "on_sale": "",
             "purchasable": 1,
             "total_sales": 0,
             "virtual": true,

--- a/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
@@ -30,7 +30,7 @@
             "stock_quantity": 16,
             "stock_status": "instock",
             "backorders": "notify",
-            "backorders_allowed": true,
+            "backorders_allowed": "1",
             "backordered": false,
             "weight": "2.5",
             "dimensions": {

--- a/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-variation-alternative-types.json
@@ -16,7 +16,7 @@
             "date_on_sale_from_gmt": "2019-10-15T21:30:00",
             "date_on_sale_to": "2019-10-27T23:59:59",
             "date_on_sale_to_gmt": "2019-10-27T21:29:59",
-            "on_sale": false,
+            "on_sale": "0",
             "status": "publish",
             "purchasable": 1,
             "virtual": false,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.9
 -----
 - [*] Payments: Location permissions request is not shown to TTP users who grant "Allow once" permission on first foregrounding the app any more [https://github.com/woocommerce/woocommerce-ios/pull/9821]
+- [*] Products: Allow alternative types for the `backordersAllowed` and `onSale` in `Product` and `ProductVariation`, as some third-party plugins alter the types in the API. This helps with the product list not loading due to product decoding errors. [https://github.com/woocommerce/woocommerce-ios/pull/9849]
 
 13.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9839
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR increases the app's resilience when `Product` or `ProductVariation` fields that expect a `Bool` receive a `String` instead:

* `backordersAllowed`
* `onSale`

It uses failsafe decoding to handle those alternative types, and adds to the unit tests for parsing alternative types. (These are known decoding errors that users have experienced for these fields.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
We don't know the exact plugins that can cause this behavior, but you can test using a tool like Charles Proxy or Proxyman to intercept and modify the response:

1. Set a breakpoint in your tool of choice for requests to the `/wc/v3/products` endpoint.
2. Build and run the app.
3. Open the Products tab.
4. Modify the response in one or more of the following ways:
   * A product's `backorders_allowed` field returns a string representing a boolean value (e.g. `"backorders_allowed": "1"`).
   * A product's `on_sale` field returns a string representing a boolean value (e.g. `"on_sale": "0"`).
5. Execute the response and confirm the app loads the product list.

You can repeat the same steps with the variations list for a variable product, modifying the same fields in the response for a variation.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
