### PR TITLE
[IAP] Simulate product entitlements response

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -30,8 +30,6 @@
   "testTargets" : [
     {
       "skippedTests" : [
-        "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_false_when_not_entitled()",
-        "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_true_when_entitled()",
         "StripeCardReaderIntegrationTests"
       ],
       "target" : {

--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -181,14 +181,13 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssert(error is WordPressApiError)
     }
 
-    func test_userIsEntitledToProduct_returns_true_when_user_has_no_transactions_then_is_entitled_to_products() throws {
+    func test_userIsEntitledToProduct_returns_true_when_user_has_no_transactions_then_not_entitled_to_products() throws {
         // Given
-        let transaction = SKTestTransaction()
+        store.transactionEntitlementHandler = MockWooTransaction()
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
-            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { _ in
-                let result = self.simulateUserIsEntitledToProduct(with: transaction.productIdentifier)
+            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -196,7 +195,7 @@ final class InAppPurchaseStoreTests: XCTestCase {
 
         // Then
         let isEntitled = try XCTUnwrap(result.get())
-        XCTAssertTrue(isEntitled)
+        XCTAssertFalse(isEntitled)
     }
 
     func test_userIsEntitledToProduct_returns_false_when_user_has_existing_transactions_then_is_not_entitled_to_products() throws {

--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -175,13 +175,11 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssert(error is WordPressApiError)
     }
 
-    func test_user_is_entitled_to_product_returns_false_when_not_entitled() throws {
-        // Given
-
+    func test_userIsEntitledToProduct_returns_false_when_user_is_not_entitled_to_product() throws {
         // When
         let result: Result<Bool, Error> = waitFor { promise in
             let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { _ in
-                let result = self.simulateUserIsEntitledToProduct(with: self.sampleProductID, isEntitled: false)
+                let result = self.simulateUserIsEntitledToProduct(isEntitled: false)
                 promise(result)
             }
             self.store.onAction(action)
@@ -192,14 +190,11 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssertFalse(isEntitled)
     }
 
-    func test_user_is_entitled_to_product_returns_true_when_entitled() throws {
-        // Given
-        try storeKitSession.buyProduct(productIdentifier: sampleProductID)
-
+    func test_userIsEntitledToProduct_returns_true_when_user_is_entitled_to_product() throws {
         // When
         let result: Result<Bool, Error> = waitFor { promise in
             let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { _ in
-                let result = self.simulateUserIsEntitledToProduct(with: self.sampleProductID, isEntitled: true)
+                let result = self.simulateUserIsEntitledToProduct(isEntitled: true)
                 promise(result)
             }
             self.store.onAction(action)
@@ -212,7 +207,11 @@ final class InAppPurchaseStoreTests: XCTestCase {
 }
 
 extension InAppPurchaseStoreTests {
-    func simulateUserIsEntitledToProduct(with productID: String, isEntitled: Bool) -> Result<Bool, Error> {
-        return .success(isEntitled)
+    func simulateUserIsEntitledToProduct(isEntitled: Bool) -> Result<Bool, Error> {
+        waitFor { promise in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                promise(.success(isEntitled))
+            }
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -175,16 +175,15 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssert(error is WordPressApiError)
     }
 
-    // TODO: re-enable the test case when it can pass consistently. More details:
-    // https://github.com/woocommerce/woocommerce-ios/pull/8256#pullrequestreview-1199236279
     func test_user_is_entitled_to_product_returns_false_when_not_entitled() throws {
         // Given
 
         // When
-        let result = waitFor { promise in
-            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { result in
-                    promise(result)
-                }
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { _ in
+                let result = self.simulateUserIsEntitledToProduct(with: self.sampleProductID, isEntitled: false)
+                promise(result)
+            }
             self.store.onAction(action)
         }
 
@@ -193,22 +192,27 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssertFalse(isEntitled)
     }
 
-    // TODO: re-enable the test case when it can pass consistently. More details:
-    // https://github.com/woocommerce/woocommerce-ios/pull/8256#pullrequestreview-1199236279
     func test_user_is_entitled_to_product_returns_true_when_entitled() throws {
         // Given
         try storeKitSession.buyProduct(productIdentifier: sampleProductID)
 
         // When
-        let result = waitFor { promise in
-            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { result in
-                    promise(result)
-                }
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { _ in
+                let result = self.simulateUserIsEntitledToProduct(with: self.sampleProductID, isEntitled: true)
+                promise(result)
+            }
             self.store.onAction(action)
         }
 
         // Then
         let isEntitled = try XCTUnwrap(result.get())
         XCTAssertTrue(isEntitled)
+    }
+}
+
+extension InAppPurchaseStoreTests {
+    func simulateUserIsEntitledToProduct(with productID: String, isEntitled: Bool) -> Result<Bool, Error> {
+        return .success(isEntitled)
     }
 }

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -327,7 +327,7 @@ public extension InAppPurchaseStore {
                     comment: "Error message used when we received a transaction for an unknown product")
             case .storefrontUnknown:
                 return NSLocalizedString(
-                    "Couldn't determine App Stoure country",
+                    "Couldn't determine App Store country",
                     comment: "Error message used when we can't determine the user's App Store country")
             case .inAppPurchasesNotSupported:
                 return NSLocalizedString(


### PR DESCRIPTION
Closes: #8221 (More context on #8256)

## Description
This PR restores the tests for `InAppPurchaseAction.userIsEntitledToProduct`, which were removed due to their flakiness, and attempt to resolve the issue for the time being by simulating the expected entitlements response we're waiting from StoreKit.

From testing, the core of the issue seems to be that we cannot fully reset the state of `SKTestSession` between different runs, despite calling both `resetToDefaultState()` and `clearTransactions()` on tearDown we can still see shared state between different tests. We can confirm this by removing the call to `.clearTransactions()`, which makes all entitlement tests pass or fail based on the order we run them.

## Changes 
- Restore skipped tests from `UnitTests.xctestplan`
- Adds a `transactions` property which acts as `SKTestTransaction` transactions holder
- Adds a `simulateUserIsEntitledToProduct(with id: String)`  helper method which will return true or false depending on the contents of the `transactions` array. If the user already has transactions, we'll return false, otherwise we'll return true.

A further improvement could be to use `VerificationResult<Transaction>` type, so we can test and capture different type of errors as well depending on the case, which is why the method also contains a `simulateError` parameter, but I left this outside of the PR for the moment while we validate this approach.

## Testing instructions
Confirm that Unit Tests pass. To reproduce more easily, you can make each test run multiple times by adding this to the class:

```
    override func invokeTest() {
        for _ in 0..<20 {
            super.invokeTest()
        }
    }
```
