### PR TITLE
Send Slack notification for UI/Unit test failures

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#2.17.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -47,6 +47,11 @@ else
   echo "The UI Tests, which ran inside the '🧪 Testing' section above in the logs, have failed."
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🧪 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
-annotate_test_failures "fastlane/test_output/WooCommerce.xml"
+
+if [ "$BUILDKITE_BRANCH" = "trunk" ]; then
+    annotate_test_failures "fastlane/test_output/WooCommerce.xml" --slack "build-and-ship"
+else
+    annotate_test_failures "fastlane/test_output/WooCommerce.xml"
+fi
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -48,7 +48,7 @@ else
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🧪 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
 
-if [ "$BUILDKITE_BRANCH" = "trunk" ]; then
+if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
     annotate_test_failures "fastlane/test_output/WooCommerce.xml" --slack "build-and-ship"
 else
     annotate_test_failures "fastlane/test_output/WooCommerce.xml"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -37,7 +37,7 @@ else
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🧪 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
 
-if [ "$BUILDKITE_BRANCH" = "trunk" ]; then
+if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
     annotate_test_failures "fastlane/test_output/WooCommerce.xml" --slack "build-and-ship"
 else
     annotate_test_failures "fastlane/test_output/WooCommerce.xml"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -36,6 +36,11 @@ else
   echo "The Unit Tests, which ran inside the '🧪 Testing' section above in the logs, have failed."
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🧪 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
-annotate_test_failures "fastlane/test_output/WooCommerce.xml"
+
+if [ "$BUILDKITE_BRANCH" = "trunk" ]; then
+    annotate_test_failures "fastlane/test_output/WooCommerce.xml" --slack "build-and-ship"
+else
+    annotate_test_failures "fastlane/test_output/WooCommerce.xml"
+fi
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.16.0
+    - automattic/a8c-ci-toolkit#2.17.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#2.17.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization


### PR DESCRIPTION
## Description
This PR updates the version of `a8c-ci-toolkit` plugin to the latest v2.17.0 to get the [recent change where a Slack notification will be sent when there's a test failure.](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/60) This change will be for both Unit and UI test failures. 

I updated the 3 .yml files under `.buildkite` to point to the latest version. I'm not sure if that's the right way but please me know if this shouldn't be the case.

## Testing instructions
This was previously tested using [this draft PR](https://github.com/woocommerce/woocommerce-ios/pull/9798), when there's a failing test, a notification is sent to the channel set in `annotate_test_failures`. When there are no test failures, the notification is not sent.
