### PR TITLE
[Reliability] Track all JSON decoding errors

### DIFF
--- a/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
+++ b/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
@@ -38,7 +38,13 @@ private extension TrackEventRequestNotificationHandler {
             self?.trackApplicationPasswordsGenerationFailed(note: note)
         }
 
-        trackingObservers = [newPasswordCreatedObserver, passwordGenerationFailedObserver]
+        let jsonParsingFailedObserver = notificationCenter.addObserver(forName: .RemoteDidReceiveJSONParsingError,
+                                                                   object: nil,
+                                                                   queue: .main) { [weak self] note in
+            self?.trackJSONParsingFailed(note: note)
+        }
+
+        trackingObservers = [newPasswordCreatedObserver, passwordGenerationFailedObserver, jsonParsingFailedObserver]
     }
 
     /// Tracks an event when an application password is created
@@ -54,5 +60,14 @@ private extension TrackEventRequestNotificationHandler {
             return
         }
         analytics.track(event: .ApplicationPassword.applicationPasswordGenerationFailed(scenario: .regeneration, error: error))
+    }
+
+    /// Tracks an event when JSON parsing fails
+    ///
+    func trackJSONParsingFailed(note: Notification) {
+        guard let error = note.object as? DecodingError else {
+            return
+        }
+        analytics.track(event: .RemoteRequest.jsonParsingError(error))
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2405,3 +2405,13 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Remote Requests
+//
+extension WooAnalyticsEvent {
+    enum RemoteRequest {
+        static func jsonParsingError(_ error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .apiJSONParsingError, properties: [:], error: error)
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -719,9 +719,10 @@ public enum WooAnalyticsStat: String {
     case firstCreatedProductShown = "first_created_product_shown"
     case firstCreatedProductShareTapped = "first_created_product_share_tapped"
 
-    // MARK: Jetpack Tunnel Events
+    // MARK: Remote Request Events
     //
     case jetpackTunnelTimeout = "jetpack_tunnel_timeout"
+    case apiJSONParsingError = "api_json_parsing_error"
 
     // MARK: In-app Feedback and Survey Events
     //

--- a/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
@@ -123,6 +123,28 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         assertEqual("regeneration", actualProperties["scenario"] as? String)
         assertEqual("other", actualProperties["cause"] as? String)
     }
+
+    func test_json_parsing_failed_event_is_tracked_upon_decoding_error() {
+        // When
+        let error = mockDecodingError()
+        mockNotificationCenter.post(name: .RemoteDidReceiveJSONParsingError, object: error, userInfo: nil)
+
+        // Then
+        let expectedEvent = WooAnalyticsEvent.RemoteRequest.jsonParsingError(error)
+
+        XCTAssert(analyticsProvider.receivedEvents.contains(where: { $0 == expectedEvent.statName.rawValue }))
+    }
+}
+
+private extension TrackEventRequestNotificationHandlerTests {
+    func mockDecodingError() -> Error {
+        do {
+            _ = try JSONDecoder().decode(String.self, from: Data())
+            return MockError.mockError
+        } catch {
+            return error
+        }
+    }
 }
 
 private class MockNotificationCenter: NotificationCenter { }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9085
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a new analytics event to track all JSON decoding errors:

* `api_json_parsing_error` (Event registration: 1645-gh-tracks-events-registration)

This new event will help with monitoring and prioritizing errors, and getting a full picture of the scope of decoding issues (in areas we aren't already tracking).

### Changes

* The new event is added to `WooAnalyticsStat` and `WooAnalyticsEvent`, and it includes the decoding error in the tracked event.
* In `Remote`, we now handle any `Swift.DecodingError` by publishing a notification to `NotificationCenter`.
* In `TrackEventRequestNotificationHandler`, we add an observer for that notification and use it to trigger the related analytics event.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
To test, you can install and activate a plugin that causes a known decoding/parsing error, or use a tool like Charles Proxy or Proxyman to intercept and modify a response:

1. Set a breakpoint in your tool of choice for requests to an endpoint used in the app.
2. Build and run the app.
3. Trigger a request to the endpoint you chose, and modify the response to include a field with an unexpected value (e.g. the wrong type or an unexpected `null` value).
4. Execute the response and confirm the event `api_json_parsing_error` is triggered and includes custom props with the decoding error details (`error_code`, `error_description`, and `error_domain`).

Example:
```
🔵 Tracked api_json_parsing_error, properties: [AnyHashable("error_code"): "4865", AnyHashable("blog_id"): 186855689, AnyHashable("is_wpcom_store"): false, AnyHashable("error_description"): "Swift.DecodingError.valueNotFound(Swift.Int, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: \"data\", intValue: nil), CodingKeys(stringValue: \"totals\", intValue: nil), CodingKeys(stringValue: \"orders_count\", intValue: nil)], debugDescription: \"Expected Int value but found null instead.\", underlyingError: nil))", AnyHashable("error_domain"): "NSCocoaErrorDomain"]
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
