### PR TITLE
Merge 13.9 updated release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
 ## 13.9
-No new bells and whistles, just incremental improvements to bring you a faster, more stable app. All that glitters is not gold — sometimes it's code!
+In this update, we've made several improvements to enhance compatibility with third-party plugins, ensuring a smoother experience when loading order lists, product lists, and product variations. All that glitters is not gold — sometimes it's code!
 
 ## 13.8
 Lots of updates this week! We've added a new privacy screen for merchants in the EU to better control their privacy choices. We made it easy for you to share your products and store directly from the app. We also focused on fixing a few bugs and enhancements around product and order management. Keep your feedback coming!

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -59,7 +59,7 @@ msgstr ""
 
 msgctxt "v13.9-whats-new"
 msgid ""
-"No new bells and whistles, just incremental improvements to bring you a faster, more stable app. All that glitters is not gold — sometimes it's code!\n"
+"In this update, we've made several improvements to enhance compatibility with third-party plugins, ensuring a smoother experience when loading order lists, product lists, and product variations. All that glitters is not gold — sometimes it's code!\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.


### PR DESCRIPTION
This PR merges the updated 13.9 release notes into `trunk`. There were some editorialized release notes added late Friday: p1685739377208739-slack-C6H8C3G23