### PR TITLE
Add `freeTrialInAppPurchasesUpgradeM1` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -73,6 +73,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .freeTrial:
             return true
+        case .freeTrialInAppPurchasesUpgradeM1:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
         case .compositeProducts:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -160,6 +160,10 @@ public enum FeatureFlag: Int {
     ///
     case freeTrial
 
+    /// Enables free trial store upgrades via In-App Purchases
+    ///
+    case freeTrialInAppPurchasesUpgradeM1
+
     /// Enables manual error handling for site credential login.
     ///
     case manualErrorHandlingForSiteCredentialLogin

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -30,10 +30,14 @@ final class FreeTrialBannerPresenter {
     ///
     private var subscriptions: Set<AnyCancellable> = []
 
+    /// Flag that indicates if a site can be upgraded via In-App Purchases
+    ///
+    private var inAppPurchasesUpgradeEnabled: Bool
+
     /// String for the banner action button text
     ///
     private var bannerActionText: String {
-        return Localization.learnMore
+        inAppPurchasesUpgradeEnabled ? Localization.upgradeNow : Localization.learnMore
     }
 
     /// - Parameters:
@@ -48,6 +52,7 @@ final class FreeTrialBannerPresenter {
         self.containerView = containerView
         self.siteID = siteID
         self.onLayoutUpdated = onLayoutUpdated
+        self.inAppPurchasesUpgradeEnabled = featureFlagService.isFeatureFlagEnabled(.freeTrialInAppPurchasesUpgradeM1)
         observeStorePlan()
         observeConnectivity()
     }
@@ -154,5 +159,6 @@ private extension FreeTrialBannerPresenter {
 private extension FreeTrialBannerPresenter {
     enum Localization {
         static let learnMore = NSLocalizedString("Learn more", comment: "Title on the button to learn more about the free trial plan.")
+        static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")
     }
 }


### PR DESCRIPTION
## Description
This PR adds a `freeTrialInAppPurchasesUpgradeM1` feature flag for pdfdoF-33C-p2

## Testing instructions
* With a Woo Express Free Trial store, run the app with a `Build Configuration: Debug`
  * In My Store, see a `Upgrade Now` link in the CTA banner.
* With a Woo Express Free Trial store, run the app with a `Build Configuration: Release`
  * In My Store, see a `Learn More` link in the CTA banner.

There's a known issue when creating new Free Trial sites, which may not get the correct Jetpack state, if that's the case, you can follow the reconnection steps here: p1685941630369959-slack-C025A8VV728

| Debug config | Release config |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-05 at 12 24 04](https://github.com/woocommerce/woocommerce-ios/assets/3812076/c6186557-34b4-40ce-b689-4c80a3c459ae) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-05 at 11 55 48](https://github.com/woocommerce/woocommerce-ios/assets/3812076/eeed1939-67e6-49fe-bbbf-5e665b86a5fd) | 