### PR TITLE
Apply `tintColor` to `icon-comment-content`

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -220,7 +220,7 @@ extension UIImage {
     ///
     static var commentContent: UIImage {
         let tintColor = UIColor(light: .black, dark: .white)
-        return UIImage(named: "icon-comment-content")?.withTintColor(tintColor) ?? UIImage.gridicon(.comment)
+        return UIImage(named: "icon-comment-content")?.withTintColor(tintColor) ?? .commentImage.withTintColor(tintColor)
     }
 
     /// Credit Card Icon

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -219,7 +219,8 @@ extension UIImage {
     /// Comment Content Icon
     ///
     static var commentContent: UIImage {
-        return UIImage(named: "icon-comment-content") ?? UIImage.gridicon(.comment)
+        let tintColor = UIColor(light: .black, dark: .white)
+        return UIImage(named: "icon-comment-content")?.withTintColor(tintColor) ?? UIImage.gridicon(.comment)
     }
 
     /// Credit Card Icon


### PR DESCRIPTION
Found while using the app.

## Description
This PR addresses applying the correct tint color to the IPP Feedback banner icon when we use the app in light/dark mode.

## Changes
Added `withTintColor()` both to the primary and fallback icons, since there are no `ColorStudio` variants that fit the design I went ahead directly using white and black. 

Preferably I'd say we could use `withRenderingMode(.alwaysTemplate)`  instead, but that would make the icon sort of grey for both light and dark modes.

## Testing instructions
As the banner will only appear on eligible IPP stores that have not dismissed the banner, the easiest way to test it is to change the current implementation of `syncIPPBannerVisibility()` method in `OrderListViewController` for the following one:

```
private func syncIPPBannerVisibility() {
  let action = AppSettingsAction.loadFeedbackVisibility(type: .inPersonPayments) { [weak self] _ in
    self?.hideIPPFeedbackBanner = false
  }
  self.stores.dispatch(action)
}
```

## Screenshots
| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-05 at 18 36 19](https://github.com/woocommerce/woocommerce-ios/assets/3812076/3a2b28ba-e17e-4183-8131-2c26ccfc4656) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-05 at 19 03 33](https://github.com/woocommerce/woocommerce-ios/assets/3812076/4bab99c2-4c35-4aa6-b435-581200f516e9) |