### PR TITLE
Blaze: navigate to webview from entry points

### DIFF
--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -2,21 +2,22 @@ import Foundation
 import WebKit
 import Yosemite
 
+/// Blaze entry points.
 enum BlazeSource {
+    /// From the Menu tab.
     case menu
+    /// From the product more menu.
     case productMoreMenu
 }
 
-final class BlazeWebViewModel: AuthenticatedWebViewModel {
+/// View model for Blaze webview.
+final class BlazeWebViewModel {
     let title = Localization.title
-
-    // MARK: Private Variables
+    let initialURL: URL?
 
     private let source: BlazeSource
     private let site: Site
     private let productID: Int64?
-
-    // MARK: Initializer
 
     init(source: BlazeSource,
          site: Site,
@@ -24,29 +25,21 @@ final class BlazeWebViewModel: AuthenticatedWebViewModel {
         self.source = source
         self.site = site
         self.productID = productID
-    }
-
-    // MARK: Computed Variables
-
-    var initialURL: URL? {
-        let siteURL = site.url.trimHTTPScheme()
-        let urlString: String = {
-            if let productID {
-                return String(format: Constants.blazePostURLFormat, siteURL, productID, source.analyticsValue)
-            } else {
-                return String(format: Constants.blazeSiteURLFormat, siteURL, source.analyticsValue)
-            }
+        self.initialURL = {
+            let siteURL = site.url.trimHTTPScheme()
+            let urlString: String = {
+                if let productID {
+                    return String(format: Constants.blazePostURLFormat, siteURL, productID, source.analyticsValue)
+                } else {
+                    return String(format: Constants.blazeSiteURLFormat, siteURL, source.analyticsValue)
+                }
+            }()
+            return URL(string: urlString)
         }()
-        return URL(string: urlString)
     }
+}
 
-    private var baseURLString: String {
-        let siteURL = site.url.trimHTTPScheme()
-        return String(format: Constants.baseURLFormat, siteURL)
-    }
-
-    // MARK: `AuthenticatedWebViewModel` conformance
-
+extension BlazeWebViewModel: AuthenticatedWebViewModel {
     func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
         .allow
     }

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -64,7 +64,6 @@ private extension BlazeSource {
 
 private extension BlazeWebViewModel {
     enum Constants {
-        static let baseURLFormat = "https://wordpress.com/advertising/%@"
         static let blazeSiteURLFormat = "https://wordpress.com/advertising/%@?source=%@"
         static let blazePostURLFormat = "https://wordpress.com/advertising/%@?blazepress-widget=post-%d&source=%@"
     }

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -1,0 +1,84 @@
+import Foundation
+import WebKit
+import Yosemite
+
+enum BlazeSource {
+    case menu
+    case productMoreMenu
+}
+
+final class BlazeWebViewModel: AuthenticatedWebViewModel {
+    let title = Localization.title
+
+    // MARK: Private Variables
+
+    private let source: BlazeSource
+    private let site: Site
+    private let productID: Int64?
+
+    // MARK: Initializer
+
+    init(source: BlazeSource,
+         site: Site,
+         productID: Int64?) {
+        self.source = source
+        self.site = site
+        self.productID = productID
+    }
+
+    // MARK: Computed Variables
+
+    var initialURL: URL? {
+        let siteURL = site.url.trimHTTPScheme()
+        let urlString: String = {
+            if let productID {
+                return String(format: Constants.blazePostURLFormat, siteURL, productID, source.analyticsValue)
+            } else {
+                return String(format: Constants.blazeSiteURLFormat, siteURL, source.analyticsValue)
+            }
+        }()
+        return URL(string: urlString)
+    }
+
+    private var baseURLString: String {
+        let siteURL = site.url.trimHTTPScheme()
+        return String(format: Constants.baseURLFormat, siteURL)
+    }
+
+    // MARK: `AuthenticatedWebViewModel` conformance
+
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
+        .allow
+    }
+
+    func handleDismissal() {
+
+    }
+
+    func handleRedirect(for url: URL?) {
+
+    }
+}
+
+private extension BlazeSource {
+    var analyticsValue: String {
+        switch self {
+        case .menu:
+            return "menu"
+        case .productMoreMenu:
+            return "product_more_menu"
+        }
+    }
+}
+
+private extension BlazeWebViewModel {
+    enum Constants {
+        static let baseURLFormat = "https://wordpress.com/advertising/%@"
+        static let blazeSiteURLFormat = "https://wordpress.com/advertising/%@?source=%@"
+        static let blazePostURLFormat = "https://wordpress.com/advertising/%@?blazepress-widget=post-%d&source=%@"
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString("Blaze", comment: "Title of the Blaze view.")
+    }
+}

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 import WebKit
-import Yosemite
+import struct Yosemite.Site
 
 /// Blaze entry points.
 enum BlazeSource {
@@ -45,11 +45,9 @@ extension BlazeWebViewModel: AuthenticatedWebViewModel {
     }
 
     func handleDismissal() {
-
     }
 
     func handleRedirect(for url: URL?) {
-
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -182,7 +182,12 @@ final class HubMenuViewModel: ObservableObject {
     /// Navigates to show the Blaze view from the view model's navigation controller property.
     ///
     func showBlaze() {
-        // TODO: 9866 - show Blaze view
+        guard let site = stores.sessionManager.defaultSite else {
+            return
+        }
+        let viewModel = BlazeWebViewModel(source: .menu, site: site, productID: nil)
+        let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
+        navigationController?.show(webViewController, sender: self)
     }
 
     private func observeSiteForUIUpdates() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -290,8 +290,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         }
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.blaze) {
-            actionSheet.addDefaultActionWithTitle(ActionSheetStrings.promoteWithBlaze) { _ in
-                // TODO: 9866 - show Blaze view
+            actionSheet.addDefaultActionWithTitle(ActionSheetStrings.promoteWithBlaze) { [weak self] _ in
+                self?.displayBlaze()
             }
         }
 
@@ -963,6 +963,15 @@ private extension ProductFormViewController {
             self?.viewModel.resetPassword(originalPassword)
         })
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func displayBlaze() {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+            return
+        }
+        let viewModel = BlazeWebViewModel(source: .menu, site: site, productID: product.productID)
+        let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
+        navigationController?.show(webViewController, sender: self)
     }
 
     func trackVariationRemoveButtonTapped() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		024D4E842A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */; };
+		024D4E942A2E1E240090E0E6 /* BlazeWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */; };
 		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
 		024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3062372C18D006658FE /* AztecUIConfigurator.swift */; };
 		024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3082372CA00006658FE /* EditorViewProperties.swift */; };
@@ -2492,6 +2493,7 @@
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductForm.swift"; sourceTree = "<group>"; };
+		024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeWebViewModel.swift; sourceTree = "<group>"; };
 		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
 		024DF3062372C18D006658FE /* AztecUIConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecUIConfigurator.swift; sourceTree = "<group>"; };
 		024DF3082372CA00006658FE /* EditorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorViewProperties.swift; sourceTree = "<group>"; };
@@ -5104,6 +5106,14 @@
 				024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */,
 			);
 			path = Developer;
+			sourceTree = "<group>";
+		};
+		024D4E922A2E1E190090E0E6 /* Blaze */ = {
+			isa = PBXGroup;
+			children = (
+				024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */,
+			);
+			path = Blaze;
 			sourceTree = "<group>";
 		};
 		024DF30C237429CF006658FE /* FormatBar */ = {
@@ -8062,6 +8072,7 @@
 			isa = PBXGroup;
 			children = (
 				B9F3DAAB29BB714900DDD545 /* App Intents */,
+				024D4E922A2E1E190090E0E6 /* Blaze */,
 				B946880A29B6268D000646B0 /* Spotlight */,
 				B912603F2940B2C400CACD4B /* JustInTimeMessages */,
 				B958A7C528B3D42000823EEF /* Universal Links */,
@@ -12425,6 +12436,7 @@
 				02C8876D24501FAC00E4470F /* FilterListViewController.swift in Sources */,
 				02B2828E27C35061004A332A /* RefreshableInfiniteScrollList.swift in Sources */,
 				021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */,
+				024D4E942A2E1E240090E0E6 /* BlazeWebViewModel.swift in Sources */,
 				456C7EEB25EE71F10016CBC6 /* ShippingLabelSuggestedAddressViewController.swift in Sources */,
 				D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */,
 				DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		024D4E842A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */; };
 		024D4E942A2E1E240090E0E6 /* BlazeWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */; };
+		024D4E972A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */; };
 		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
 		024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3062372C18D006658FE /* AztecUIConfigurator.swift */; };
 		024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3082372CA00006658FE /* EditorViewProperties.swift */; };
@@ -2494,6 +2495,7 @@
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductForm.swift"; sourceTree = "<group>"; };
 		024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeWebViewModel.swift; sourceTree = "<group>"; };
+		024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeWebViewModelTests.swift; sourceTree = "<group>"; };
 		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
 		024DF3062372C18D006658FE /* AztecUIConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecUIConfigurator.swift; sourceTree = "<group>"; };
 		024DF3082372CA00006658FE /* EditorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorViewProperties.swift; sourceTree = "<group>"; };
@@ -5112,6 +5114,14 @@
 			isa = PBXGroup;
 			children = (
 				024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */,
+			);
+			path = Blaze;
+			sourceTree = "<group>";
+		};
+		024D4E952A2EC6790090E0E6 /* Blaze */ = {
+			isa = PBXGroup;
+			children = (
+				024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -9618,6 +9628,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				024D4E952A2EC6790090E0E6 /* Blaze */,
 				02CA3C9829F8EB580079E2FF /* BottomSheet */,
 				DEF8CF0B29A76F6200800A60 /* JetpackSetup */,
 				02645D8027BA20950065DC68 /* Inbox */,
@@ -12711,6 +12722,7 @@
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
 				DEF8CF1129A8933E00800A60 /* JetpackBenefitsViewModelTests.swift in Sources */,
 				31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */,
+				024D4E972A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift in Sources */,
 				CC3B35DF28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift in Sources */,
 				DE4D23A029B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift in Sources */,
 				02F5F80E246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeWebViewModelTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class BlazeWebViewModelTests: XCTestCase {
+    // MARK: - `initialURL`
+
+    func test_initialURL_includes_source_and_siteURL_and_productID_when_product_is_available() {
+        // Given
+        let source: BlazeSource = .menu
+        let site = Site.fake().copy(url: "https://example.com")
+        let productID: Int64? = 134
+        let viewModel = BlazeWebViewModel(source: source, site: site, productID: productID)
+
+        // Then
+        XCTAssertEqual(viewModel.initialURL, URL(string: "https://wordpress.com/advertising/example.com?blazepress-widget=post-134&source=menu"))
+    }
+
+    func test_initialURL_includes_source_and_siteURL_when_product_is_unavailable() {
+        // Given
+        let source: BlazeSource = .productMoreMenu
+        let site = Site.fake().copy(url: "https://example.com")
+        let viewModel = BlazeWebViewModel(source: source, site: site, productID: nil)
+
+        // Then
+        XCTAssertEqual(viewModel.initialURL, URL(string: "https://wordpress.com/advertising/example.com?source=product_more_menu"))
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9866 
⚠️ Please make sure https://github.com/woocommerce/woocommerce-ios/pull/9868 is approved before reviewing this PR
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After the entry points are added in https://github.com/woocommerce/woocommerce-ios/pull/9868, this PR focuses on navigating to the Blaze webview. `BlazeWebViewModel` was created for the authenticated webview. I was hoping to limit the URLs in `decidePolicy(for:)` so that the flow stays in the WPCOM ads pages, but it didn't work because there were a bunch of URLs like `https://wordpress.com/wp-login.php` among other calls not directly related to Blaze before reaching the main page.

🗒️ Please note that the webview looks a bit different from JPiOS because JP mobile worked on customizations for WP mobile user agents. I asked in pe5sF9-1yI-p2#comment-2226 to clarify with product if we want the same customized webview flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites: the site is hosted on WPCOM and is public (not staging - you can publicize a store by tapping on the onboarding task). the site also has at least one product that is public and not password protected.

### Menu tab

- Log in to a store as in the prerequisites
- Go to the Menu tab
- Tap on `Blaze` row --> it should navigate to a webview to promote products/posts/pages on Blaze
- Promote a product and go through the flow (testing tips pe5sF9-1yI-p2#testing-tips)

### Product menu

- Go to the Products tab
- Tap on a product that is public and not password protected
- Tap on the ellipsis menu in the navigation bar 
- Tap `Promote with Blaze` --> it should navigate to a webview to promote products/posts/pages on Blaze
- Feel free to play around the flow again, like checking the existing campaigns

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Menu tab:

https://github.com/woocommerce/woocommerce-ios/assets/1945542/6353d7f9-a8a4-44e4-a954-b3e4b476e41f

Product more menu:


https://github.com/woocommerce/woocommerce-ios/assets/1945542/af40cfbc-a7cd-4001-8ed7-a6ee06def243



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.