### PR TITLE
Product sharing: Update Yosemite to generate sharing messages for products

### DIFF
--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -115,4 +115,8 @@ public enum ProductAction: Action {
     /// Generates a product description with Jetpack AI given the name, features, and language code.
     ///
     case generateProductDescription(siteID: Int64, name: String, features: String, languageCode: String, completion: (Result<String, Error>) -> Void)
+
+    /// Generates a product sharing message with Jetpack AI given the URL and language code.
+    ///
+    case generateProductSharingMessage(siteID: Int64, url: String, languageCode: String, completion: (Result<String, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -120,6 +120,8 @@ public class ProductStore: Store {
             createTemplateProduct(siteID: siteID, template: template, onCompletion: onCompletion)
         case let .generateProductDescription(siteID, name, features, languageCode, completion):
             generateProductDescription(siteID: siteID, name: name, features: features, languageCode: languageCode, completion: completion)
+        case let .generateProductSharingMessage(siteID, url, languageCode, completion):
+            generateProductSharingMessage(siteID: siteID, url: url, languageCode: languageCode, completion: completion)
         }
     }
 }
@@ -526,6 +528,25 @@ private extension ProductStore {
             "- The length should be up to 50-60 words in English, or equivalent length in other languages",
             "- Try to make shorter sentences, using less difficult words to improve readability\n",
             "```Product name: \(name)\nProduct features: \(features)```"
+        ].joined(separator: "\n")
+        Task {
+            let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt) }
+            await MainActor.run {
+                completion(result)
+            }
+        }
+    }
+
+    func generateProductSharingMessage(siteID: Int64,
+                                       url: String,
+                                       languageCode: String,
+                                       completion: @escaping (Result<String, Error>) -> Void) {
+        let prompt = [
+            "Your task is to help a merchant create a message to share with their customers a product in the provided URL: \(url)",
+            "Some requirements for the message are:",
+            "- In language \(languageCode)",
+            "- The length should be up to 3 sentences",
+            "- Try to make shorter sentences, using less difficult words to improve readability"
         ].joined(separator: "\n")
         Task {
             let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt) }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -546,7 +546,8 @@ private extension ProductStore {
             "Some requirements for the message are:",
             "- In language \(languageCode)",
             "- The length should be up to 3 sentences",
-            "- Try to make shorter sentences, using less difficult words to improve readability"
+            "- Try to make shorter sentences, using less difficult words to improve readability",
+            "- Add related hashtags at the end of the message."
         ].joined(separator: "\n")
         Task {
             let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt) }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the `ProductStore` and `ProductAction` to add an option to use AI to generate efficient sharing messages for products given an URL and the language for the message.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just unit test passing is sufficient since the feature hasn't been integrated yet.
You can also test the prompt with ChatGPT, please feel free to share any suggestion for better generated messages.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
