### PR TITLE
[IAP] Basic UI flow to allow upgrades purchase

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -8,14 +8,13 @@ import SwiftUI
 final class UpgradesViewModel: ObservableObject {
 
     private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansManager
-    var siteID: Int64 {
-        ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
-    }
+    private let siteID: Int64
 
     @Published var products: [WPComPlanProduct]
     @Published var entitledProductIDs: Set<String>
 
-    init() {
+    init(siteID: Int64) {
+        self.siteID = siteID
         // TODO: Inject dependencies
         // https://github.com/woocommerce/woocommerce-ios/issues/9884
         inAppPurchasesPlanManager = InAppPurchasesForWPComPlansManager()
@@ -36,6 +35,7 @@ final class UpgradesViewModel: ObservableObject {
             }
         } catch {
             // TODO: Handle errors
+            // https://github.com/woocommerce/woocommerce-ios/issues/9886
             DDLogError("loadEntitlements \(error)")
         }
     }
@@ -53,6 +53,7 @@ final class UpgradesViewModel: ObservableObject {
             await loadUserEntitlements()
         } catch {
             // TODO: Handle errors
+            // https://github.com/woocommerce/woocommerce-ios/issues/9886
             DDLogError("loadProducts \(error)")
         }
     }
@@ -63,6 +64,7 @@ final class UpgradesViewModel: ObservableObject {
     func purchaseProduct(with productID: String) async {
         do {
             // TODO: Deal with purchase result
+            // https://github.com/woocommerce/woocommerce-ios/issues/9886
             let _ = try await inAppPurchasesPlanManager.purchaseProduct(with: productID, for: siteID)
         } catch {
             // TODO: Handle errors

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -71,4 +71,20 @@ final class UpgradesViewModel: ObservableObject {
             DDLogError("purchaseProduct \(error)")
         }
     }
+
+    /// Retrieves a specific In-App Purchase WPCOM plan from the available products
+    ///
+    func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans ) -> WPComPlanProduct? {
+        let match = type.rawValue
+        guard let wpcomPlanProduct = products.first(where: { $0.id == match }) else {
+            return nil
+        }
+        return wpcomPlanProduct
+    }
+}
+
+extension UpgradesViewModel {
+    enum AvailableInAppPurchasesWPComPlans: String {
+        case essentialMonthly = "debug.woocommerce.express.essential.monthly"
+    }
 }

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -65,7 +65,7 @@ final class UpgradesViewModel: ObservableObject {
         do {
             // TODO: Deal with purchase result
             // https://github.com/woocommerce/woocommerce-ios/issues/9886
-            let _ = try await inAppPurchasesPlanManager.purchaseProduct(with: productID, for: siteID)
+            let _ = try await inAppPurchasesPlanManager.purchaseProduct(with: productID, for: self.siteID)
         } catch {
             // TODO: Handle errors
             DDLogError("purchaseProduct \(error)")

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -43,6 +43,11 @@ final class UpgradesViewModel: ObservableObject {
     ///
     func loadProducts() async {
         do {
+            guard await inAppPurchasesPlanManager.inAppPurchasesAreSupported() else {
+                DDLogError("IAP not supported")
+                return
+            }
+
             self.products = try await inAppPurchasesPlanManager.fetchProducts()
             await loadUserEntitlements()
         } catch {

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+
+///
+///
+///
+@MainActor
+final class UpgradesViewModel: ObservableObject {
+
+    private let inAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansManager
+    @Published var products: [WPComPlanProduct]
+    @Published var entitledProductIDs: Set<String>
+
+    init() {
+        inAppPurchasesForWPComPlansManager = InAppPurchasesForWPComPlansManager()
+        products = []
+        entitledProductIDs = []
+    }
+
+    ///
+    ///
+    func loadUserEntitlements() async {
+        do {
+            for product in self.products {
+                if try await inAppPurchasesForWPComPlansManager.userIsEntitledToProduct(with: product.id) {
+                    self.entitledProductIDs.insert(product.id)
+                } else {
+                    self.entitledProductIDs.remove(product.id)
+                }
+            }
+        } catch {
+            DDLogError("loadEntitlements \(error)")
+        }
+    }
+
+    ///
+    ///
+    func loadProducts() async {
+        do {
+            self.products = try await inAppPurchasesForWPComPlansManager.fetchProducts()
+            await loadUserEntitlements()
+        } catch {
+            DDLogError("loadProducts \(error)")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -1,13 +1,13 @@
 import Foundation
 import SwiftUI
 
-///
-///
+/// ViewModel for the Upgrades View
+/// Drives the site's available In-App Purchases plan upgrades
 ///
 @MainActor
 final class UpgradesViewModel: ObservableObject {
 
-    private let inAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansManager
+    private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansManager
     var siteID: Int64 {
         ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
     }
@@ -17,7 +17,7 @@ final class UpgradesViewModel: ObservableObject {
 
     init() {
         // TODO: Inject dependencies
-        inAppPurchasesForWPComPlansManager = InAppPurchasesForWPComPlansManager()
+        inAppPurchasesPlanManager = InAppPurchasesForWPComPlansManager()
         products = []
         entitledProductIDs = []
     }
@@ -27,7 +27,7 @@ final class UpgradesViewModel: ObservableObject {
     func loadUserEntitlements() async {
         do {
             for product in self.products {
-                if try await inAppPurchasesForWPComPlansManager.userIsEntitledToProduct(with: product.id) {
+                if try await inAppPurchasesPlanManager.userIsEntitledToProduct(with: product.id) {
                     self.entitledProductIDs.insert(product.id)
                 } else {
                     self.entitledProductIDs.remove(product.id)
@@ -43,7 +43,7 @@ final class UpgradesViewModel: ObservableObject {
     ///
     func loadProducts() async {
         do {
-            self.products = try await inAppPurchasesForWPComPlansManager.fetchProducts()
+            self.products = try await inAppPurchasesPlanManager.fetchProducts()
             await loadUserEntitlements()
         } catch {
             // TODO: Handle errors
@@ -57,7 +57,7 @@ final class UpgradesViewModel: ObservableObject {
     func purchaseProduct(with productID: String) async {
         do {
             // TODO: Deal with purchase result
-            let _ = try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: productID, for: siteID)
+            let _ = try await inAppPurchasesPlanManager.purchaseProduct(with: productID, for: siteID)
         } catch {
             // TODO: Handle errors
             DDLogError("purchaseProduct \(error)")

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -17,6 +17,7 @@ final class UpgradesViewModel: ObservableObject {
 
     init() {
         // TODO: Inject dependencies
+        // https://github.com/woocommerce/woocommerce-ios/issues/9884
         inAppPurchasesPlanManager = InAppPurchasesForWPComPlansManager()
         products = []
         entitledProductIDs = []

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -8,16 +8,21 @@ import SwiftUI
 final class UpgradesViewModel: ObservableObject {
 
     private let inAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansManager
+    var siteID: Int64 {
+        ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
+    }
+
     @Published var products: [WPComPlanProduct]
     @Published var entitledProductIDs: Set<String>
 
     init() {
+        // TODO: Inject dependencies
         inAppPurchasesForWPComPlansManager = InAppPurchasesForWPComPlansManager()
         products = []
         entitledProductIDs = []
     }
 
-    ///
+    /// Iterates through all available products (In-App Purchases WPCom plans) and checks whether the merchant is entitled
     ///
     func loadUserEntitlements() async {
         do {
@@ -29,18 +34,33 @@ final class UpgradesViewModel: ObservableObject {
                 }
             }
         } catch {
+            // TODO: Handle errors
             DDLogError("loadEntitlements \(error)")
         }
     }
 
-    ///
+    /// Retrieves all products (In-App Purchases WPCom plans)
     ///
     func loadProducts() async {
         do {
             self.products = try await inAppPurchasesForWPComPlansManager.fetchProducts()
             await loadUserEntitlements()
         } catch {
+            // TODO: Handle errors
             DDLogError("loadProducts \(error)")
+        }
+    }
+
+    /// Triggers the purchase of the specified In-App Purchases WPCom plans by the passed product ID
+    /// linked to the current site ID
+    ///
+    func purchaseProduct(with productID: String) async {
+        do {
+            // TODO: Deal with purchase result
+            let _ = try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: productID, for: siteID)
+        } catch {
+            // TODO: Handle errors
+            DDLogError("purchaseProduct \(error)")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -152,8 +152,13 @@ private extension FreeTrialBannerPresenter {
     func showUpgradesView() {
         guard let viewController else { return }
         Task { @MainActor in
-            let upgradesController = UpgradesHostingController(siteID: siteID)
-            viewController.show(upgradesController, sender: self)
+            if inAppPurchasesUpgradeEnabled {
+                let upgradesController = UpgradesHostingController(siteID: siteID)
+                viewController.show(upgradesController, sender: self)
+            } else {
+                let subscriptionsController = SubscriptionsHostingController(siteID: siteID)
+                viewController.show(subscriptionsController, sender: self)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -151,8 +151,10 @@ private extension FreeTrialBannerPresenter {
     ///
     func showUpgradesView() {
         guard let viewController else { return }
-        let upgradeController = SubscriptionsHostingController(siteID: siteID)
-        viewController.show(upgradeController, sender: self)
+        Task { @MainActor in
+            let upgradesController = UpgradesHostingController(siteID: siteID)
+            viewController.show(upgradesController, sender: self)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -147,11 +147,11 @@ private extension FreeTrialBannerPresenter {
         self.freeTrialBanner = nil
     }
 
-    /// Shows a web view for the merchant to update their site plan.
+    /// Shows a view for the merchant to upgrade their site's plan.
     ///
     func showUpgradesView() {
         guard let viewController else { return }
-        let upgradeController = UpgradesHostingController(siteID: siteID)
+        let upgradeController = SubscriptionsHostingController(siteID: siteID)
         viewController.show(upgradeController, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -151,7 +151,7 @@ private extension StoreOnboardingCoordinator {
     /// Navigates the user to the plan subscription details view.
     ///
     func showPlanView() {
-        let upgradeController = SubscriptionsHostingController(siteID: site.siteID)
-        navigationController.show(upgradeController, sender: self)
+        let subscriptionController = SubscriptionsHostingController(siteID: site.siteID)
+        navigationController.show(subscriptionController, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -148,10 +148,10 @@ private extension StoreOnboardingCoordinator {
 }
 
 private extension StoreOnboardingCoordinator {
-    /// Navigates the user to the plan detail view.
+    /// Navigates the user to the plan subscription details view.
     ///
     func showPlanView() {
-        let upgradeController = UpgradesHostingController(siteID: site.siteID)
+        let upgradeController = SubscriptionsHostingController(siteID: site.siteID)
         navigationController.show(upgradeController, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -154,7 +154,7 @@ final class HubMenuViewModel: ObservableObject {
     /// Presents the `Subscriptions` view from the view model's navigation controller property.
     ///
     func presentSubscriptions() {
-        let upgradesViewController = UpgradesHostingController(siteID: siteID)
+        let upgradesViewController = SubscriptionsHostingController(siteID: siteID)
         navigationController?.show(upgradesViewController, sender: self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -154,8 +154,8 @@ final class HubMenuViewModel: ObservableObject {
     /// Presents the `Subscriptions` view from the view model's navigation controller property.
     ///
     func presentSubscriptions() {
-        let upgradesViewController = SubscriptionsHostingController(siteID: siteID)
-        navigationController?.show(upgradesViewController, sender: self)
+        let subscriptionController = SubscriptionsHostingController(siteID: siteID)
+        navigationController?.show(subscriptionController, sender: self)
     }
 
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 final class SubscriptionsHostingController: UIHostingController<SubscriptionsView> {
 
     init(siteID: Int64) {
-        let viewModel = UpgradesViewModel()
+        let viewModel = SubscriptionsViewModel()
         super.init(rootView: .init(viewModel: viewModel))
 
         rootView.onReportIssueTapped = { [weak self] in
@@ -30,7 +30,7 @@ struct SubscriptionsView: View {
 
     /// Drives the view.
     ///
-    @StateObject var viewModel: UpgradesViewModel
+    @StateObject var viewModel: SubscriptionsViewModel
 
     /// Closure to be invoked when the "Report Issue" button is tapped.
     ///

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -1,12 +1,9 @@
 import Foundation
 import SwiftUI
 
-/// Main view for the plan settings.
+/// Main view for the plan subscription settings.
 ///
-/// We might want to consider renaming this group of types to follow the `Subscriptions`
-/// wording since we're deactivating the `Upgrades` structure from the app.
-///
-final class UpgradesHostingController: UIHostingController<UpgradesView> {
+final class SubscriptionsHostingController: UIHostingController<SubscriptionsView> {
 
     init(siteID: Int64) {
         let viewModel = UpgradesViewModel()
@@ -29,7 +26,7 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
 
 /// Main view for the plan settings.
 ///
-struct UpgradesView: View {
+struct SubscriptionsView: View {
 
     /// Drives the view.
     ///
@@ -96,7 +93,7 @@ struct UpgradesView: View {
 }
 
 // Definitions
-private extension UpgradesView {
+private extension SubscriptionsView {
     enum Localization {
         static let title = NSLocalizedString("Subscriptions", comment: "Title for the Subscriptions / Upgrades view")
         static let subscriptionStatus = NSLocalizedString("SUBSCRIPTION STATUS", comment: "Title for the plan section on the subscriptions view. Uppercased")
@@ -118,7 +115,7 @@ private extension UpgradesView {
 struct UpgradesPreviews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            UpgradesView(viewModel: .init())
+            SubscriptionsView(viewModel: .init())
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -14,7 +14,7 @@ final class SubscriptionsHostingController: UIHostingController<SubscriptionsVie
         }
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -20,6 +20,10 @@ final class SubscriptionsViewModel: ObservableObject {
     ///
     private(set) var planInfo = ""
 
+    /// Current store plan details information.
+    ///
+    private(set) var planDaysLeft = ""
+
     /// Defines if the view should show the Full Plan features..
     ///
     private(set) var shouldShowFreeTrialFeatures = false
@@ -97,6 +101,7 @@ private extension SubscriptionsViewModel {
     func updateViewProperties(from plan: WPComSitePlan) {
         planName = Self.getPlanName(from: plan)
         planInfo = Self.getPlanInfo(from: plan)
+        planDaysLeft = Self.daysLeft(for: plan).formatted()
         errorNotice = nil
         showLoadingIndicator = false
         shouldShowFreeTrialFeatures = plan.isFreeTrial

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -3,7 +3,8 @@ import Yosemite
 import Combine
 import protocol Experiments.FeatureFlagService
 
-/// ViewModel for the Upgrades View
+/// ViewModel for the Subscriptions View
+/// Drives the site's plan subscription
 ///
 final class SubscriptionsViewModel: ObservableObject {
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -5,7 +5,7 @@ import protocol Experiments.FeatureFlagService
 
 /// ViewModel for the Upgrades View
 ///
-final class UpgradesViewModel: ObservableObject {
+final class SubscriptionsViewModel: ObservableObject {
 
     /// Indicates if the view should show an error notice.
     ///
@@ -74,7 +74,7 @@ final class UpgradesViewModel: ObservableObject {
 }
 
 // MARK: Helpers
-private extension UpgradesViewModel {
+private extension SubscriptionsViewModel {
     /// Observes and reacts to plan changes
     ///
     func observePlan() {
@@ -197,7 +197,7 @@ private extension UpgradesViewModel {
 }
 
 // MARK: Definitions
-private extension UpgradesViewModel {
+private extension SubscriptionsViewModel {
     enum Localization {
         static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
         static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. " +

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftUI
+
+/// Hosting controller for `UpgradesView`
+/// To be used to display available plan Upgrades and the CTA to upgrade them
+///
+@MainActor
+final class UpgradesHostingController: UIHostingController<UpgradesView> {
+    init(siteID: Int64) {
+        super.init(rootView: UpgradesView())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("Not implemented")
+    }
+}
+
+struct UpgradesView: View {
+    var body: some View {
+        VStack {
+            Text("Upgrades view")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -2,13 +2,17 @@ import Foundation
 import SwiftUI
 
 /// Hosting controller for `UpgradesView`
-/// To be used to display available plan Upgrades and the CTA to upgrade them
+/// To be used to display available current plan Subscriptions, available plan Upgrades,
+/// and the CTA to upgrade
 ///
 @MainActor
 final class UpgradesHostingController: UIHostingController<UpgradesView> {
     init(siteID: Int64) {
         let upgradesViewModel = UpgradesViewModel()
-        super.init(rootView: UpgradesView(viewModel: upgradesViewModel))
+        let subscriptionsViewModel = SubscriptionsViewModel()
+
+        super.init(rootView: UpgradesView(viewModel: upgradesViewModel,
+                                          subscriptionsViewModel: subscriptionsViewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -19,21 +23,24 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
 struct UpgradesView: View {
 
     @ObservedObject var viewModel: UpgradesViewModel
+    @ObservedObject var subscriptionsViewModel: SubscriptionsViewModel
 
     @State var isLoading = false
     @State var isPurchasing = false
 
-    init(viewModel: UpgradesViewModel) {
+    init(viewModel: UpgradesViewModel, subscriptionsViewModel: SubscriptionsViewModel) {
         self.viewModel = viewModel
+        self.subscriptionsViewModel = subscriptionsViewModel
     }
 
     var body: some View {
         List {
             Section {
-                Text("Upgrades view")
+                Text("Plans")
             }
             Section {
-                Text("Plan details")
+                Text("Your Plan: \(subscriptionsViewModel.planName)")
+                Text("Days left in trial: \(String(subscriptionsViewModel.planDaysLeft))")
             }
             Section {
                 if viewModel.products.isEmpty {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -15,7 +15,7 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
                                           subscriptionsViewModel: subscriptionsViewModel))
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("Not implemented")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -7,7 +7,8 @@ import SwiftUI
 @MainActor
 final class UpgradesHostingController: UIHostingController<UpgradesView> {
     init(siteID: Int64) {
-        super.init(rootView: UpgradesView())
+        let upgradesViewModel = UpgradesViewModel()
+        super.init(rootView: UpgradesView(viewModel: upgradesViewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -16,9 +17,39 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
 }
 
 struct UpgradesView: View {
+
+    @ObservedObject var viewModel: UpgradesViewModel
+
+    @State var isLoading = false
+    @State var isPurchasing = false
+
+    init(viewModel: UpgradesViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
-        VStack {
-            Text("Upgrades view")
+        List {
+            Section {
+                Text("Upgrades view")
+            }
+            Section {
+                Text("Plan details")
+            }
+            Section {
+                ForEach(viewModel.products, id: \.id) { product in
+                    Button("\(product.displayName)") {
+                        // ...
+                    }
+                }
+            }
+            Section {
+                Button("Purchase") {
+                    // ...
+                }
+            }
+        }
+        .task {
+            await viewModel.loadProducts()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -8,10 +8,10 @@ import SwiftUI
 @MainActor
 final class UpgradesHostingController: UIHostingController<UpgradesView> {
     init(siteID: Int64) {
-        let upgradesViewModel = UpgradesViewModel()
+        let upgradesViewModel = UpgradesViewModel(siteID: siteID)
         let subscriptionsViewModel = SubscriptionsViewModel()
 
-        super.init(rootView: UpgradesView(viewModel: upgradesViewModel,
+        super.init(rootView: UpgradesView(upgradesViewModel: upgradesViewModel,
                                           subscriptionsViewModel: subscriptionsViewModel))
     }
 
@@ -21,14 +21,13 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
 }
 
 struct UpgradesView: View {
-
-    @ObservedObject var viewModel: UpgradesViewModel
+    @ObservedObject var upgradesViewModel: UpgradesViewModel
     @ObservedObject var subscriptionsViewModel: SubscriptionsViewModel
 
     @State var isPurchasing = false
 
-    init(viewModel: UpgradesViewModel, subscriptionsViewModel: SubscriptionsViewModel) {
-        self.viewModel = viewModel
+    init(upgradesViewModel: UpgradesViewModel, subscriptionsViewModel: SubscriptionsViewModel) {
+        self.upgradesViewModel = upgradesViewModel
         self.subscriptionsViewModel = subscriptionsViewModel
     }
 
@@ -42,7 +41,7 @@ struct UpgradesView: View {
                 VStack {
                     Image(uiImage: .emptyOrdersImage)
                     // TODO: Move logic to viewmodel
-                    if let availableProduct = viewModel.products.first(where: { $0.id == "debug.woocommerce.express.essential.monthly" }) {
+                    if let availableProduct = upgradesViewModel.products.first(where: { $0.id == "debug.woocommerce.express.essential.monthly"}) {
                         Text("\(availableProduct.displayName)")
                             .font(.title)
                         Text("Everything you need to launch an online store")
@@ -53,17 +52,17 @@ struct UpgradesView: View {
                 }
             }
             Section {
-                if viewModel.products.isEmpty || isPurchasing {
+                if upgradesViewModel.products.isEmpty || isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
-                    ForEach(viewModel.products, id: \.id) { product in
+                    ForEach(upgradesViewModel.products, id: \.id) { product in
                         // TODO: Move logic to viewmodel
                         if product.id == "debug.woocommerce.express.essential.monthly" {
                             Button("Purchase \(product.displayName)") {
                                 // TODO: Add product entitlement check
                                 Task {
                                     isPurchasing = true
-                                    await viewModel.purchaseProduct(with: product.id)
+                                    await upgradesViewModel.purchaseProduct(with: product.id)
                                     isPurchasing = false
                                 }
                             }
@@ -73,7 +72,7 @@ struct UpgradesView: View {
             }
         }
         .task {
-            await viewModel.loadProducts()
+            await upgradesViewModel.loadProducts()
         }
         .navigationBarTitle("Plans")
         .navigationBarTitleDisplayMode(.large)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -26,6 +26,13 @@ struct UpgradesView: View {
 
     @State var isPurchasing = false
 
+    private var planText: String {
+        String.localizedStringWithFormat(Constants.planName, subscriptionsViewModel.planName)
+    }
+    private var daysLeftText: String {
+        String.localizedStringWithFormat(Constants.daysLeftInTrial, subscriptionsViewModel.planDaysLeft)
+    }
+
     init(upgradesViewModel: UpgradesViewModel, subscriptionsViewModel: SubscriptionsViewModel) {
         self.upgradesViewModel = upgradesViewModel
         self.subscriptionsViewModel = subscriptionsViewModel
@@ -34,8 +41,8 @@ struct UpgradesView: View {
     var body: some View {
         List {
             Section {
-                Text("\(Constants.planName)\(subscriptionsViewModel.planName)")
-                Text("\(Constants.daysLeftInTrial)\(String(subscriptionsViewModel.planDaysLeft))")
+                Text(planText)
+                Text(daysLeftText)
             }
             Section {
                 VStack {
@@ -55,7 +62,8 @@ struct UpgradesView: View {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
                     ForEach(upgradesViewModel.products, id: \.id) { product in
-                        Button("Purchase \(product.displayName)") {
+                        let buttonText = String.localizedStringWithFormat(Constants.purchaseCTAButtonText, product.displayName)
+                        Button(buttonText) {
                             // TODO: Add product entitlement check
                             Task {
                                 isPurchasing = true
@@ -70,16 +78,21 @@ struct UpgradesView: View {
         .task {
             await upgradesViewModel.loadProducts()
         }
-        .navigationBarTitle("Plans")
+        .navigationBarTitle(Constants.navigationTitle)
         .navigationBarTitleDisplayMode(.large)
     }
 }
 
 private extension UpgradesView {
     struct Constants {
-        static let planName = NSLocalizedString("Your Plan: ", comment: "")
-        static let daysLeftInTrial = NSLocalizedString("Days left in trial: ", comment: "")
+        static let navigationTitle = NSLocalizedString("Plans", comment: "Navigation title for the Upgrades screen")
+        static let purchaseCTAButtonText = NSLocalizedString("Purchase %1$@", comment: "The title of the button to purchase a Plan." +
+                                                             "Reads as 'Purchase Essential Monthly'")
+        static let planName = NSLocalizedString("Your Plan: %1$@", comment: "Message describing which Plan the merchant is currently subscribed to." +
+                                                "Reads as 'Your Plan: Free Trial'")
+        static let daysLeftInTrial = NSLocalizedString("Days left in trial: %1$@", comment: "Message describing days left on a Plan to expire." +
+                                                       "Reads as 'Days left in trial: 15'")
         static let upgradeSubtitle = NSLocalizedString("Everything you need to launch an online store",
-                                                       comment: "")
+                                                       comment: "Subtitle that can be read under the Plan upgrade name")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -25,7 +25,6 @@ struct UpgradesView: View {
     @ObservedObject var viewModel: UpgradesViewModel
     @ObservedObject var subscriptionsViewModel: SubscriptionsViewModel
 
-    @State var isLoading = false
     @State var isPurchasing = false
 
     init(viewModel: UpgradesViewModel, subscriptionsViewModel: SubscriptionsViewModel) {
@@ -36,30 +35,36 @@ struct UpgradesView: View {
     var body: some View {
         List {
             Section {
-                Text("Your Plan: \(subscriptionsViewModel.planName)")
-                Text("Days left in trial: \(String(subscriptionsViewModel.planDaysLeft))")
+                Text("\(Constants.planName)\(subscriptionsViewModel.planName)")
+                Text("\(Constants.daysLeftInTrial)\(String(subscriptionsViewModel.planDaysLeft))")
             }
             Section {
                 VStack {
                     Image(uiImage: .emptyOrdersImage)
-                    Text("Essential")
-                        .font(.title)
-                    Text("Everything you need to launch an online store")
-                        .font(.body)
-                    Text("$39")
-                        .font(.title)
+                    // TODO: Move logic to viewmodel
+                    if let availableProduct = viewModel.products.first(where: { $0.id == "debug.woocommerce.express.essential.monthly" }) {
+                        Text("\(availableProduct.displayName)")
+                            .font(.title)
+                        Text("Everything you need to launch an online store")
+                            .font(.body)
+                        Text("\(availableProduct.displayPrice)")
+                            .font(.title)
+                    }
                 }
             }
             Section {
-                if viewModel.products.isEmpty {
+                if viewModel.products.isEmpty || isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
                     ForEach(viewModel.products, id: \.id) { product in
-                        if product.id == "debug.woocommerce.ecommerce.monthly" {
+                        // TODO: Move logic to viewmodel
+                        if product.id == "debug.woocommerce.express.essential.monthly" {
                             Button("Purchase \(product.displayName)") {
                                 // TODO: Add product entitlement check
                                 Task {
+                                    isPurchasing = true
                                     await viewModel.purchaseProduct(with: product.id)
+                                    isPurchasing = false
                                 }
                             }
                         }
@@ -72,5 +77,12 @@ struct UpgradesView: View {
         }
         .navigationBarTitle("Plans")
         .navigationBarTitleDisplayMode(.large)
+    }
+}
+
+private extension UpgradesView {
+    struct Constants {
+        static let planName = NSLocalizedString("Your Plan: ", comment: "")
+        static let daysLeftInTrial = NSLocalizedString("Days left in trial: ", comment: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -55,15 +55,12 @@ struct UpgradesView: View {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
                     ForEach(upgradesViewModel.products, id: \.id) { product in
-                        // TODO: Move logic to viewmodel
-                        if product.id == "debug.woocommerce.express.essential.monthly" {
-                            Button("Purchase \(product.displayName)") {
-                                // TODO: Add product entitlement check
-                                Task {
-                                    isPurchasing = true
-                                    await upgradesViewModel.purchaseProduct(with: product.id)
-                                    isPurchasing = false
-                                }
+                        Button("Purchase \(product.displayName)") {
+                            // TODO: Add product entitlement check
+                            Task {
+                                isPurchasing = true
+                                await upgradesViewModel.purchaseProduct(with: product.id)
+                                isPurchasing = false
                             }
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -40,13 +40,12 @@ struct UpgradesView: View {
             Section {
                 VStack {
                     Image(uiImage: .emptyOrdersImage)
-                    // TODO: Move logic to viewmodel
-                    if let availableProduct = upgradesViewModel.products.first(where: { $0.id == "debug.woocommerce.express.essential.monthly"}) {
-                        Text("\(availableProduct.displayName)")
+                    if let availableProduct = upgradesViewModel.retrievePlanDetailsIfAvailable(.essentialMonthly) {
+                        Text(availableProduct.displayName)
                             .font(.title)
-                        Text("Everything you need to launch an online store")
+                        Text(Constants.upgradeSubtitle)
                             .font(.body)
-                        Text("\(availableProduct.displayPrice)")
+                        Text(availableProduct.displayPrice)
                             .font(.title)
                     }
                 }
@@ -83,5 +82,7 @@ private extension UpgradesView {
     struct Constants {
         static let planName = NSLocalizedString("Your Plan: ", comment: "")
         static let daysLeftInTrial = NSLocalizedString("Days left in trial: ", comment: "")
+        static let upgradeSubtitle = NSLocalizedString("Everything you need to launch an online store",
+                                                       comment: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -36,15 +36,19 @@ struct UpgradesView: View {
                 Text("Plan details")
             }
             Section {
-                ForEach(viewModel.products, id: \.id) { product in
-                    Button("\(product.displayName)") {
-                        // ...
+                if viewModel.products.isEmpty {
+                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                } else {
+                    ForEach(viewModel.products, id: \.id) { product in
+                        if product.id == "debug.woocommerce.ecommerce.monthly" {
+                            Button("Purchase \(product.displayName)") {
+                                // TODO: Add product entitlement check
+                                Task {
+                                    await viewModel.purchaseProduct(with: product.id)
+                                }                                
+                            }
+                        }
                     }
-                }
-            }
-            Section {
-                Button("Purchase") {
-                    // ...
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -36,11 +36,19 @@ struct UpgradesView: View {
     var body: some View {
         List {
             Section {
-                Text("Plans")
-            }
-            Section {
                 Text("Your Plan: \(subscriptionsViewModel.planName)")
                 Text("Days left in trial: \(String(subscriptionsViewModel.planDaysLeft))")
+            }
+            Section {
+                VStack {
+                    Image(uiImage: .emptyOrdersImage)
+                    Text("Essential")
+                        .font(.title)
+                    Text("Everything you need to launch an online store")
+                        .font(.body)
+                    Text("$39")
+                        .font(.title)
+                }
             }
             Section {
                 if viewModel.products.isEmpty {
@@ -52,7 +60,7 @@ struct UpgradesView: View {
                                 // TODO: Add product entitlement check
                                 Task {
                                     await viewModel.purchaseProduct(with: product.id)
-                                }                                
+                                }
                             }
                         }
                     }
@@ -62,5 +70,7 @@ struct UpgradesView: View {
         .task {
             await viewModel.loadProducts()
         }
+        .navigationBarTitle("Plans")
+        .navigationBarTitleDisplayMode(.large)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -682,8 +682,8 @@
 		261AA30C2753119E009530FE /* PaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */; };
 		261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */; };
 		261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */; };
-		261E91A029C961EE00A5C118 /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */; };
-		261E91A329C9882600A5C118 /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */; };
+		261E91A029C961EE00A5C118 /* SubscriptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E919F29C961EE00A5C118 /* SubscriptionsViewModel.swift */; };
+		261E91A329C9882600A5C118 /* SubscriptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E91A229C9882600A5C118 /* SubscriptionsViewModelTests.swift */; };
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
@@ -2982,8 +2982,8 @@
 		261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormMetadataProvider.swift; sourceTree = "<group>"; };
-		261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
-		261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
+		261E919F29C961EE00A5C118 /* SubscriptionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsViewModel.swift; sourceTree = "<group>"; };
+		261E91A229C9882600A5C118 /* SubscriptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsViewModelTests.swift; sourceTree = "<group>"; };
 		261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModel.swift; sourceTree = "<group>"; };
 		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
@@ -6077,7 +6077,7 @@
 		261E91A129C9880C00A5C118 /* Upgrades */ = {
 			isa = PBXGroup;
 			children = (
-				261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */,
+				261E91A229C9882600A5C118 /* SubscriptionsViewModelTests.swift */,
 				267C01D029E9B18E00FCC97B /* StorePlanSynchronizerTests.swift */,
 			);
 			path = Upgrades;
@@ -6172,7 +6172,7 @@
 			isa = PBXGroup;
 			children = (
 				264957A229C520860095AA4C /* SubscriptionsView.swift */,
-				261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */,
+				261E919F29C961EE00A5C118 /* SubscriptionsViewModel.swift */,
 				267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */,
 				DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */,
 			);
@@ -12092,7 +12092,7 @@
 				CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */,
 				26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */,
 				DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */,
-				261E91A029C961EE00A5C118 /* UpgradesViewModel.swift in Sources */,
+				261E91A029C961EE00A5C118 /* SubscriptionsViewModel.swift in Sources */,
 				4574745D24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift in Sources */,
 				26578C4126277AFF00A15097 /* OrderAddOnsListViewController.swift in Sources */,
 				02F67FEE25805F9C00C3BAD2 /* ShippingLabelTrackingURLGenerator.swift in Sources */,
@@ -12956,7 +12956,7 @@
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
 				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */,
-				261E91A329C9882600A5C118 /* UpgradesViewModelTests.swift in Sources */,
+				261E91A329C9882600A5C118 /* SubscriptionsViewModelTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,
 				4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */,
 				26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1211,6 +1211,7 @@
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
 		68709D3D2A2ED94900A7FA6C /* UpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */; };
+		68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
 		68D1BEDB28FFEDC20074A29E /* OrderCustomerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */; };
 		68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */; };
@@ -3489,6 +3490,7 @@
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
 		68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesView.swift; sourceTree = "<group>"; };
+		68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
 		68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerListView.swift; sourceTree = "<group>"; };
 		68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommand.swift; sourceTree = "<group>"; };
@@ -7348,6 +7350,14 @@
 			path = Testing;
 			sourceTree = "<group>";
 		};
+		68709D3E2A2EE2C000A7FA6C /* InAppPurchases */ = {
+			isa = PBXGroup;
+			children = (
+				68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */,
+			);
+			path = InAppPurchases;
+			sourceTree = "<group>";
+		};
 		74036CBE211B87FD00E462C2 /* MyStore */ = {
 			isa = PBXGroup;
 			children = (
@@ -9295,6 +9305,7 @@
 		CE85535B209B5B6A00938BDC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				68709D3E2A2EE2C000A7FA6C /* InAppPurchases */,
 				02E3B62B290631A5007E0F13 /* Authentication */,
 				D41C9F2A26D9A04A00993558 /* WhatsNew */,
 				D8815AE526383FC200EDAD62 /* CardPresentPayments */,
@@ -11627,6 +11638,7 @@
 				0227958D237A51F300787C63 /* OptionsTableViewController+Styles.swift in Sources */,
 				02863F6F2925FC29006A06AA /* MockInAppPurchases.swift in Sources */,
 				B541B226218A412C008FE7C1 /* UIFont+Woo.swift in Sources */,
+				68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */,
 				4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */,
 				DE4B3B5626A68DD000EEF2D8 /* View+InsetPaddings.swift in Sources */,
 				B59D1EEC2190B08B009D1978 /* Age.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1201,6 +1201,7 @@
 		6827140F28A3988300E6E3F6 /* DismissableNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */; };
 		6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */; };
 		6832C7CC26DA5FDF00BA4088 /* LabeledTextViewTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6832C7CB26DA5FDE00BA4088 /* LabeledTextViewTableViewCell.xib */; };
+		683AA9D62A303CB70099F7BA /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */; };
 		684AB83A2870677F003DFDD1 /* CardReaderManualsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */; };
 		684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */; };
 		6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */; };
@@ -3480,6 +3481,7 @@
 		6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableNoticeView.swift; sourceTree = "<group>"; };
 		6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledTextViewTableViewCell.swift; sourceTree = "<group>"; };
 		6832C7CB26DA5FDE00BA4088 /* LabeledTextViewTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabeledTextViewTableViewCell.xib; sourceTree = "<group>"; };
+		683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
 		684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsView.swift; sourceTree = "<group>"; };
 		684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModel.swift; sourceTree = "<group>"; };
 		6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProvider.swift; sourceTree = "<group>"; };
@@ -6083,6 +6085,7 @@
 			children = (
 				261E91A229C9882600A5C118 /* SubscriptionsViewModelTests.swift */,
 				267C01D029E9B18E00FCC97B /* StorePlanSynchronizerTests.swift */,
+				683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */,
 			);
 			path = Upgrades;
 			sourceTree = "<group>";
@@ -12537,6 +12540,7 @@
 				B555531321B57E8800449E71 /* MockUserNotificationsCenterAdapter.swift in Sources */,
 				682210ED2909666600814E14 /* CustomerSearchUICommandTests.swift in Sources */,
 				4590B652261C8D1E00A6FCE0 /* WeightFormatterTests.swift in Sources */,
+				683AA9D62A303CB70099F7BA /* UpgradesViewModelTests.swift in Sources */,
 				DE4D23B029B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift in Sources */,
 				03B9E52F2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift in Sources */,
 				D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1210,6 +1210,7 @@
 		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
+		68709D3D2A2ED94900A7FA6C /* UpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
 		68D1BEDB28FFEDC20074A29E /* OrderCustomerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */; };
 		68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */; };
@@ -3487,6 +3488,7 @@
 		6856D66A1963092C34D20674 /* Calendar+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Calendar+Extensions.swift"; sourceTree = "<group>"; };
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
+		68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesView.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
 		68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerListView.swift; sourceTree = "<group>"; };
 		68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommand.swift; sourceTree = "<group>"; };
@@ -6175,6 +6177,7 @@
 				261E919F29C961EE00A5C118 /* SubscriptionsViewModel.swift */,
 				267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */,
 				DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */,
+				68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */,
 			);
 			name = Upgrades;
 			path = Classes/ViewRelated/Upgrades;
@@ -11692,6 +11695,7 @@
 				02C27BCE282CB52F0065471A /* CardPresentPaymentReceiptEmailCoordinator.swift in Sources */,
 				2647F7BA292BE2F900D59FDF /* AnalyticsReportCard.swift in Sources */,
 				451526392577D89E0076B03C /* AddAttributeViewModel.swift in Sources */,
+				68709D3D2A2ED94900A7FA6C /* UpgradesView.swift in Sources */,
 				DE0A2EAF281BA278007A8015 /* ProductCategorySelectorViewModel.swift in Sources */,
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,
 				E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -713,7 +713,7 @@
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
 		2647F7B529280A7F00D59FDF /* AnalyticsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */; };
 		2647F7BA292BE2F900D59FDF /* AnalyticsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */; };
-		264957A329C520860095AA4C /* UpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264957A229C520860095AA4C /* UpgradesView.swift */; };
+		264957A329C520860095AA4C /* SubscriptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264957A229C520860095AA4C /* SubscriptionsView.swift */; };
 		265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */; };
 		265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */; };
 		2655905B27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2655905A27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift */; };
@@ -3009,7 +3009,7 @@
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubView.swift; sourceTree = "<group>"; };
 		2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCard.swift; sourceTree = "<group>"; };
-		264957A229C520860095AA4C /* UpgradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesView.swift; sourceTree = "<group>"; };
+		264957A229C520860095AA4C /* SubscriptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsView.swift; sourceTree = "<group>"; };
 		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
 		265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceTests.swift; sourceTree = "<group>"; };
 		2655905A27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
@@ -6171,7 +6171,7 @@
 		264957A129C5206B0095AA4C /* Upgrades */ = {
 			isa = PBXGroup;
 			children = (
-				264957A229C520860095AA4C /* UpgradesView.swift */,
+				264957A229C520860095AA4C /* SubscriptionsView.swift */,
 				261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */,
 				267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */,
 				DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */,
@@ -11890,7 +11890,7 @@
 				579CDEFF274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
 				314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */,
-				264957A329C520860095AA4C /* UpgradesView.swift in Sources */,
+				264957A329C520860095AA4C /* SubscriptionsView.swift in Sources */,
 				02DE39D92968647100BB31D4 /* DomainSettingsViewModel.swift in Sources */,
 				576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */,
 				2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/SubscriptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/SubscriptionsViewModelTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
-final class UpgradesViewModelTests: XCTestCase {
+final class SubscriptionsViewModelTests: XCTestCase {
 
     let freeTrialID = "1052"
     let sampleSite = Site.fake().copy(siteID: 123, isWordPressComStore: true)
@@ -30,7 +30,7 @@ final class UpgradesViewModelTests: XCTestCase {
 
         // When
         let synchronizer = StorePlanSynchronizer(stores: stores)
-        let viewModel = UpgradesViewModel(stores: stores, storePlanSynchronizer: synchronizer, featureFlagService: featureFlags)
+        let viewModel = SubscriptionsViewModel(stores: stores, storePlanSynchronizer: synchronizer, featureFlagService: featureFlags)
         viewModel.loadPlan()
 
         // Then
@@ -61,7 +61,7 @@ final class UpgradesViewModelTests: XCTestCase {
         }
         let synchronizer = StorePlanSynchronizer(stores: stores)
         let featureFlags = MockFeatureFlagService()
-        let viewModel = UpgradesViewModel(stores: stores, storePlanSynchronizer: synchronizer, featureFlagService: featureFlags)
+        let viewModel = SubscriptionsViewModel(stores: stores, storePlanSynchronizer: synchronizer, featureFlagService: featureFlags)
 
         // When
         viewModel.loadPlan()
@@ -94,7 +94,7 @@ final class UpgradesViewModelTests: XCTestCase {
             }
         }
         let synchronizer = StorePlanSynchronizer(stores: stores)
-        let viewModel = UpgradesViewModel(stores: stores, storePlanSynchronizer: synchronizer)
+        let viewModel = SubscriptionsViewModel(stores: stores, storePlanSynchronizer: synchronizer)
 
         // When
         viewModel.loadPlan()
@@ -127,7 +127,7 @@ final class UpgradesViewModelTests: XCTestCase {
             }
         }
         let synchronizer = StorePlanSynchronizer(stores: stores)
-        let viewModel = UpgradesViewModel(stores: stores, storePlanSynchronizer: synchronizer)
+        let viewModel = SubscriptionsViewModel(stores: stores, storePlanSynchronizer: synchronizer)
 
         // When
         viewModel.loadPlan()
@@ -151,7 +151,7 @@ final class UpgradesViewModelTests: XCTestCase {
             }
         }
         let synchronizer = StorePlanSynchronizer(stores: stores)
-        let viewModel = UpgradesViewModel(stores: stores, storePlanSynchronizer: synchronizer)
+        let viewModel = SubscriptionsViewModel(stores: stores, storePlanSynchronizer: synchronizer)
 
         // When
         viewModel.loadPlan()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import WooCommerce
+
+final class UpgradesViewModelTests: XCTestCase {
+
+    func test_initial_UpgradesViewModel_initializes_with_correct_empty_values() {
+
+        let expectation = XCTestExpectation(description: "Waiting for main queue")
+
+        Task {
+            // Given
+            let sut = await UpgradesViewModel()
+
+            let initialProducts = await sut.products
+            let initialEntitledProducts = await sut.entitledProductIDs
+
+            // When/Then
+            DispatchQueue.main.async {
+                XCTAssertTrue(initialProducts.isEmpty)
+                XCTAssertTrue(initialEntitledProducts.isEmpty)
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_inAppPurchasesPlanManager() {
+        /**
+         TODO: https://github.com/woocommerce/woocommerce-ios/issues/9884
+         In order to pass a `MockInAppPurchases` and test the view model behavior,
+         we need to inject it into the initializer via `InAppPurchasesForWPComPlansProtocol`.
+         This cannot be done at the moment due to the concrete `InAppPurchasesForWPComPlansManager` concrete implementation using `@MainActor` on class-level.
+         */
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -3,13 +3,15 @@ import XCTest
 
 final class UpgradesViewModelTests: XCTestCase {
 
+    private let sampleSiteID: Int64 = 12345
+
     func test_initial_UpgradesViewModel_initializes_with_correct_empty_values() {
 
         let expectation = XCTestExpectation(description: "Waiting for main queue")
 
         Task {
             // Given
-            let sut = await UpgradesViewModel()
+            let sut = await UpgradesViewModel(siteID: sampleSiteID)
 
             let initialProducts = await sut.products
             let initialEntitledProducts = await sut.entitledProductIDs


### PR DESCRIPTION
Almost half of the 500+ lines is due to renaming. `SubscriptionsView`, and `SubscriptionsViewModelTests` is existing code.

## Description:
This PR tackles creating an initial UI flow to allow merchants to upgrade their plan via an Upgrades View. We do so by splitting the existing responsibility between Upgrades (what plan upgrades a merchant might be entitled to upgrade to) and Subscriptions (what plan the merchant's site currently has).

Along with this, we create a new Upgrades View that will appear when we tap on the "Upgrade Now" CTA banner for Free Trial sites. This Upgrades View will currently show all the available debug plans, as well as the details of Essential Monthly, as is the first plan we intend to use with M1.

<img width="320" alt="Screenshot 2023-06-07 at 14 39 20" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/194ff192-d178-493a-8039-cd3aae494843">


## Changes:
- Renamed existing `UpgradesView` and `UpgradesViewModel` to `SubscriptionsView` and `SubscriptionsViewModel`, to reflect the actual usage of this view as the existing subscriptions management view.
- Created a new `UpgradesView` and `UpgradesViewModel` which deals with upgrading and purchasing a new plan. This view is driven by two view models, as we need information from the current site subscription details, and the potential available upgrades.

## Testing instructions
* With a Free Trial site (can be created via https://woocommerce.com/express/ )
* On a physical device, go to My Store > Tap on "Upgrade Now" banner > See the Upgrades View
* See the Plans view with dynamically loaded information
* The button loading indicator will spin until we can fetch the available products, then we can see "Purchase Debug Monthly"
* Once `Purchase Debug Monthly` button appears, tap on purchase and perform the purchase with your sandbox credentials and wait until the "All is set message" appears.

At this point the upgrade is given, but there's a known issue where we won't see these unless we relaunch the app. By relaunching the app you will see the site is under the "Essential" plan upgrade, and  going to Menu > Subscriptions > you can see the subscription details of 1 month of Essential plan.

## Screenshots

| Purchase flow 1 | Purchase flow 2 | Purchase flow 3 | 
|--------|--------|--------|
| <img width="443" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/75e2fefe-8234-4abe-91a4-9c32fa4cf45e"> | <img width="443" alt="Screenshot 2023-06-06 at 17 06 47" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/89370d84-16e2-4922-abd8-328ac9532887"> | <img width="432" alt="Screenshot 2023-06-06 at 17 07 04" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/97956342-c54a-4412-b9bb-adc25d07c930"> | 


After restarting the app:

| Menu | Subscriptions |
|--------|--------|
![IMG_0076](https://github.com/woocommerce/woocommerce-ios/assets/3812076/42f98c15-4602-45b2-8b7b-4388e2283740) | ![IMG_0077](https://github.com/woocommerce/woocommerce-ios/assets/3812076/3fa4e1fb-5325-45ca-947e-b55770700ac8) | 










