### PR TITLE
Add coordinator for sharing product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -243,8 +243,8 @@ private extension AddProductCoordinator {
         viewModel.onProductCreated = { [weak self] product in
             guard let self else { return }
             self.onProductCreated(product)
-            if self.isFirstProduct, let url = URL(string: product.permalink) {
-                self.showFirstProductCreatedView(productURL: url,
+            if self.isFirstProduct {
+                self.showFirstProductCreatedView(product: product,
                                                  showShareProductButton: viewModel.canShareProduct())
             }
         }
@@ -304,8 +304,8 @@ private extension AddProductCoordinator {
 
     /// Presents the celebratory view for the first created product.
     ///
-    func showFirstProductCreatedView(productURL: URL, showShareProductButton: Bool) {
-        let viewController = FirstProductCreatedHostingController(productURL: productURL,
+    func showFirstProductCreatedView(product: Product, showShareProductButton: Bool) {
+        let viewController = FirstProductCreatedHostingController(product: product,
                                                                   showShareProductButton: showShareProductButton)
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -8,11 +8,17 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
         super.init(rootView: FirstProductCreatedView(showShareProductButton: showShareProductButton))
         rootView.onSharingProduct = { [weak self] in
             guard let self,
+                  let navigationController = self.navigationController,
                   let productURL = URL(string: product.permalink) else {
                 return
             }
 
-            SharingHelper.shareURL(url: productURL, from: self.view, in: self)
+            let shareProductCoordinator = ShareProductCoordinator(productURL: productURL,
+                                                                  productName: product.name,
+                                                                  shareSheetAnchorView: self.view,
+                                                                  viewControllerToPresentShareSheet: self,
+                                                                  navigationController: navigationController)
+            shareProductCoordinator.start()
             ServiceLocator.analytics.track(.firstCreatedProductShareTapped)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -1,12 +1,17 @@
 import ConfettiSwiftUI
 import SwiftUI
+import struct Yosemite.Product
 
 final class FirstProductCreatedHostingController: UIHostingController<FirstProductCreatedView> {
-    init(productURL: URL,
+    init(product: Product,
          showShareProductButton: Bool) {
         super.init(rootView: FirstProductCreatedView(showShareProductButton: showShareProductButton))
         rootView.onSharingProduct = { [weak self] in
-            guard let self else { return }
+            guard let self,
+                  let productURL = URL(string: product.permalink) else {
+                return
+            }
+
             SharingHelper.shareURL(url: productURL, from: self.view, in: self)
             ServiceLocator.analytics.track(.firstCreatedProductShareTapped)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreatedView.swift
@@ -16,7 +16,6 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
             let shareProductCoordinator = ShareProductCoordinator(productURL: productURL,
                                                                   productName: product.name,
                                                                   shareSheetAnchorView: self.view,
-                                                                  viewControllerToPresentShareSheet: self,
                                                                   navigationController: navigationController)
             shareProductCoordinator.start()
             ServiceLocator.analytics.track(.firstCreatedProductShareTapped)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -876,7 +876,6 @@ private extension ProductFormViewController {
         let shareProductCoordinator = ShareProductCoordinator(productURL: url,
                                                               productName: product.name,
                                                               shareSheetAnchorItem: sourceView,
-                                                              viewControllerToPresentShareSheet: self,
                                                               navigationController: navigationController)
         shareProductCoordinator.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -868,11 +868,17 @@ private extension ProductFormViewController {
     func displayShareProduct(from sourceView: UIBarButtonItem, analyticSource: WooAnalyticsEvent.ProductForm.ShareProductSource) {
         ServiceLocator.analytics.track(event: .ProductForm.productDetailShareButtonTapped(source: analyticSource))
 
-        guard let url = URL(string: product.permalink) else {
+        guard let url = URL(string: product.permalink),
+              let navigationController = self.navigationController else {
             return
         }
 
-        SharingHelper.shareURL(url: url, title: product.name, from: sourceView, in: self)
+        let shareProductCoordinator = ShareProductCoordinator(productURL: url,
+                                                              productName: product.name,
+                                                              shareSheetAnchorItem: sourceView,
+                                                              viewControllerToPresentShareSheet: self,
+                                                              navigationController: navigationController)
+        shareProductCoordinator.start()
     }
 
     func duplicateProduct() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -261,7 +261,9 @@ extension ProductFormViewModel {
     }
 
     func canShareProduct() -> Bool {
-        stores.sessionManager.defaultSite?.isPublic == true && formType != .add
+        let isSitePublic = stores.sessionManager.defaultSite?.isPublic == true
+        let productHasLinkToShare = URL(string: product.permalink) != nil
+        return isSitePublic && formType != .add && productHasLinkToShare
     }
 
     func canDeleteProduct() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -167,7 +167,9 @@ extension ProductVariationFormViewModel {
     }
 
     func canShareProduct() -> Bool {
-        storesManager.sessionManager.defaultSite?.isPublic == true && formType != .add
+        let isSitePublic = storesManager.sessionManager.defaultSite?.isPublic == true
+        let productHasLinkToShare = URL(string: originalProductVariation.permalink) != nil
+        return isSitePublic && formType != .add && productHasLinkToShare
     }
 
     func canDeleteProduct() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -946,8 +946,16 @@ extension ProductsViewController: UITableViewDelegate {
             return nil
         }
         let shareAction = UIContextualAction(style: .normal, title: nil, handler: { [weak self] _, _, completionHandler in
-            guard let self else { return }
-            SharingHelper.shareURL(url: url, from: cell, in: self)
+            guard let self,
+                  let navigationController = self.navigationController else {
+                return
+            }
+            let shareProductCoordinator = ShareProductCoordinator(productURL: url,
+                                                                  productName: product.name,
+                                                                  shareSheetAnchorView: cell,
+                                                                  viewControllerToPresentShareSheet: self,
+                                                                  navigationController: navigationController)
+            shareProductCoordinator.start()
             ServiceLocator.analytics.track(.productListShareButtonTapped)
             completionHandler(true) // Tells the table that the action was performed and forces it to go back to its original state (un-swiped)
         })

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -953,7 +953,6 @@ extension ProductsViewController: UITableViewDelegate {
             let shareProductCoordinator = ShareProductCoordinator(productURL: url,
                                                                   productName: product.name,
                                                                   shareSheetAnchorView: cell,
-                                                                  viewControllerToPresentShareSheet: self,
                                                                   navigationController: navigationController)
             shareProductCoordinator.start()
             ServiceLocator.analytics.track(.productListShareButtonTapped)

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -1,0 +1,102 @@
+import UIKit
+import struct Yosemite.Site
+import protocol Experiments.FeatureFlagService
+
+/// Coordinates navigation for product sharing
+final class ShareProductCoordinator: Coordinator {
+    let navigationController: UINavigationController
+
+    private let site: Site?
+    private let productURL: URL
+    private let productName: String
+    private let shareSheetAnchorView: UIView?
+    private let shareSheetAnchorItem: UIBarButtonItem?
+    private let viewControllerToPresentShareSheet: UIViewController
+    private let featureFlagService: FeatureFlagService
+
+    private var shouldEnableShareProductUsingAI: Bool {
+        site?.isWordPressComStore == true && featureFlagService.isFeatureFlagEnabled(.shareProductAI)
+    }
+
+    private init(site: Site?,
+                 productURL: URL,
+                 productName: String,
+                 shareSheetAnchorView: UIView?,
+                 shareSheetAnchorItem: UIBarButtonItem?,
+                 viewControllerToPresentShareSheet: UIViewController,
+                 featureFlagService: FeatureFlagService,
+                 navigationController: UINavigationController) {
+        self.site = site
+        self.productURL = productURL
+        self.productName = productName
+        self.shareSheetAnchorView = shareSheetAnchorView
+        self.shareSheetAnchorItem = shareSheetAnchorItem
+        self.viewControllerToPresentShareSheet = viewControllerToPresentShareSheet
+        self.featureFlagService = featureFlagService
+        self.navigationController = navigationController
+    }
+
+    convenience init(site: Site? = ServiceLocator.stores.sessionManager.defaultSite,
+                     productURL: URL,
+                     productName: String,
+                     shareSheetAnchorView: UIView,
+                     viewControllerToPresentShareSheet: UIViewController,
+                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+                     navigationController: UINavigationController) {
+        self.init(site: site,
+                  productURL: productURL,
+                  productName: productName,
+                  shareSheetAnchorView: shareSheetAnchorView,
+                  shareSheetAnchorItem: nil,
+                  viewControllerToPresentShareSheet: viewControllerToPresentShareSheet,
+                  featureFlagService: featureFlagService,
+                  navigationController: navigationController)
+    }
+
+    convenience init(site: Site? = ServiceLocator.stores.sessionManager.defaultSite,
+                     productURL: URL,
+                     productName: String,
+                     shareSheetAnchorItem: UIBarButtonItem,
+                     viewControllerToPresentShareSheet: UIViewController,
+                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+                     navigationController: UINavigationController) {
+        self.init(site: site,
+                  productURL: productURL,
+                  productName: productName,
+                  shareSheetAnchorView: nil,
+                  shareSheetAnchorItem: shareSheetAnchorItem,
+                  viewControllerToPresentShareSheet: viewControllerToPresentShareSheet,
+                  featureFlagService: featureFlagService,
+                  navigationController: navigationController)
+    }
+
+    func start() {
+        if shouldEnableShareProductUsingAI {
+            presentShareProductAIGeneration()
+        } else {
+            presentShareSheet()
+        }
+    }
+}
+
+// MARK: Navigation
+private extension ShareProductCoordinator {
+    func presentShareSheet() {
+        if let shareSheetAnchorView {
+            SharingHelper.shareURL(url: productURL,
+                                   title: productName,
+                                   from: shareSheetAnchorView,
+                                   in: viewControllerToPresentShareSheet)
+        } else if let shareSheetAnchorItem {
+            SharingHelper.shareURL(url: productURL,
+                                   title: productName,
+                                   from: shareSheetAnchorItem,
+                                   in: viewControllerToPresentShareSheet)
+        }
+    }
+
+    // TODO: 9867 UI to show product sharing message AI generation for eligible sites
+    func presentShareProductAIGeneration() {
+
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -11,7 +11,6 @@ final class ShareProductCoordinator: Coordinator {
     private let productName: String
     private let shareSheetAnchorView: UIView?
     private let shareSheetAnchorItem: UIBarButtonItem?
-    private let viewControllerToPresentShareSheet: UIViewController
     private let featureFlagService: FeatureFlagService
 
     private var shouldEnableShareProductUsingAI: Bool {
@@ -23,7 +22,6 @@ final class ShareProductCoordinator: Coordinator {
                  productName: String,
                  shareSheetAnchorView: UIView?,
                  shareSheetAnchorItem: UIBarButtonItem?,
-                 viewControllerToPresentShareSheet: UIViewController,
                  featureFlagService: FeatureFlagService,
                  navigationController: UINavigationController) {
         self.site = site
@@ -31,7 +29,6 @@ final class ShareProductCoordinator: Coordinator {
         self.productName = productName
         self.shareSheetAnchorView = shareSheetAnchorView
         self.shareSheetAnchorItem = shareSheetAnchorItem
-        self.viewControllerToPresentShareSheet = viewControllerToPresentShareSheet
         self.featureFlagService = featureFlagService
         self.navigationController = navigationController
     }
@@ -40,7 +37,6 @@ final class ShareProductCoordinator: Coordinator {
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorView: UIView,
-                     viewControllerToPresentShareSheet: UIViewController,
                      featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
                      navigationController: UINavigationController) {
         self.init(site: site,
@@ -48,7 +44,6 @@ final class ShareProductCoordinator: Coordinator {
                   productName: productName,
                   shareSheetAnchorView: shareSheetAnchorView,
                   shareSheetAnchorItem: nil,
-                  viewControllerToPresentShareSheet: viewControllerToPresentShareSheet,
                   featureFlagService: featureFlagService,
                   navigationController: navigationController)
     }
@@ -57,7 +52,6 @@ final class ShareProductCoordinator: Coordinator {
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorItem: UIBarButtonItem,
-                     viewControllerToPresentShareSheet: UIViewController,
                      featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
                      navigationController: UINavigationController) {
         self.init(site: site,

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -65,7 +65,6 @@ final class ShareProductCoordinator: Coordinator {
                   productName: productName,
                   shareSheetAnchorView: nil,
                   shareSheetAnchorItem: shareSheetAnchorItem,
-                  viewControllerToPresentShareSheet: viewControllerToPresentShareSheet,
                   featureFlagService: featureFlagService,
                   navigationController: navigationController)
     }
@@ -86,12 +85,12 @@ private extension ShareProductCoordinator {
             SharingHelper.shareURL(url: productURL,
                                    title: productName,
                                    from: shareSheetAnchorView,
-                                   in: viewControllerToPresentShareSheet)
+                                   in: navigationController.topmostPresentedViewController)
         } else if let shareSheetAnchorItem {
             SharingHelper.shareURL(url: productURL,
                                    title: productName,
                                    from: shareSheetAnchorItem,
-                                   in: viewControllerToPresentShareSheet)
+                                   in: navigationController.topmostPresentedViewController)
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2195,6 +2195,7 @@
 		EEB4E2DA29B5F8FC00371C3C /* CouponLineDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */; };
 		EEB4E2DC29B600B800371C3C /* CouponLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */; };
 		EEB4E2DE29B61AAD00371C3C /* CouponInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */; };
+		EEBDF7DA2A2EF69B00EFEF47 /* ShareProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */; };
 		EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */; };
 		EEC2D281292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */; };
 		EEC5E01129A70CC300416CAC /* StoreSetupProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */; };
@@ -4509,6 +4510,7 @@
 		EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetailsViewModel.swift; sourceTree = "<group>"; };
 		EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetails.swift; sourceTree = "<group>"; };
 		EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponInputTransformer.swift; sourceTree = "<group>"; };
+		EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductCoordinator.swift; sourceTree = "<group>"; };
 		EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupHostingControllerTests.swift; sourceTree = "<group>"; };
 		EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginHostingViewControllerTests.swift; sourceTree = "<group>"; };
 		EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSetupProgressView.swift; sourceTree = "<group>"; };
@@ -7491,6 +7493,7 @@
 		74EC34A3225FE1F3004BBC2E /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				EEBDF7D62A2EF65D00EFEF47 /* ShareProduct */,
 				02EAF5BC29FA04660058071C /* AI */,
 				DE4FB771280E758D003D20D6 /* ProductSelector */,
 				0279F0DD252DC1060098D7DE /* Product Loader */,
@@ -10246,6 +10249,14 @@
 			path = ShippingValueLocalizer;
 			sourceTree = "<group>";
 		};
+		EEBDF7D62A2EF65D00EFEF47 /* ShareProduct */ = {
+			isa = PBXGroup;
+			children = (
+				EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */,
+			);
+			path = ShareProduct;
+			sourceTree = "<group>";
+		};
 		F4B77A83B2A3D94EA331691B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -11233,6 +11244,7 @@
 				FEDD70AF26A7223500194C3A /* StorageEligibilityErrorInfo+Woo.swift in Sources */,
 				AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
+				EEBDF7DA2A2EF69B00EFEF47 /* ShareProductCoordinator.swift in Sources */,
 				DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */,
 				022F2FA8295E7A14003A0A46 /* StoreCreationCountryButton.swift in Sources */,
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -148,6 +148,36 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertFalse(canShareProduct)
     }
 
+    func test_edit_product_form_with_invalid_permalink_cannot_share_product() {
+        // Given
+        let product = Product.fake().copy(name: "Test", permalink: "", statusKey: ProductStatus.published.rawValue)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertFalse(canShareProduct)
+    }
+
+    func test_edit_product_form_with_valid_permalink_can_share_product() {
+        // Given
+        let product = Product.fake().copy(name: "Test", permalink: "https://example.com/product", statusKey: ProductStatus.published.rawValue)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertTrue(canShareProduct)
+    }
+
     // MARK: `canDeleteProduct`
 
     func test_edit_product_form_with_published_status_can_delete_product() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -81,7 +81,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_edit_product_form_with_published_status_can_share_product() {
         // Arrange
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
+        let product = Product.fake().copy(name: "Test", permalink: "https://example.com/product", statusKey: ProductStatus.published.rawValue)
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(isPublic: true)
         let stores = MockStoresManager(sessionManager: sessionManager)
@@ -96,7 +96,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_add_product_form_with_published_status_cannot_share_product() {
         // Arrange
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
+        let product = Product.fake().copy(name: "Test", permalink: "https://example.com/product", statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product, formType: .add)
 
         // Action
@@ -108,7 +108,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_edit_product_form_with_non_published_status_can_share_product() {
         // Arrange
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.pending.rawValue)
+        let product = Product.fake().copy(name: "Test", permalink: "https://example.com/product", statusKey: ProductStatus.pending.rawValue)
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(isPublic: true)
         let stores = MockStoresManager(sessionManager: sessionManager)
@@ -123,7 +123,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_add_product_form_with_non_published_status_cannot_share_product() {
         // Arrange
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.pending.rawValue)
+        let product = Product.fake().copy(name: "Test", permalink: "https://example.com/product", statusKey: ProductStatus.pending.rawValue)
         let viewModel = createViewModel(product: product, formType: .add)
 
         // Action
@@ -135,7 +135,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_edit_product_form_with_non_public_site_cannot_share_product() {
         // Given
-        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
+        let product = Product.fake().copy(name: "Test", permalink: "https://example.com/product", statusKey: ProductStatus.published.rawValue)
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(isPublic: false)
         let stores = MockStoresManager(sessionManager: sessionManager)
@@ -371,7 +371,9 @@ final class ProductFormViewModelTests: XCTestCase {
     func test_action_buttons_for_existing_published_product_and_no_pending_changes() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123", isPublic: true)
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
+        let product = Product.fake().copy(productID: 123,
+                                          permalink: "https://example.com/product",
+                                          statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // When
@@ -438,7 +440,9 @@ final class ProductFormViewModelTests: XCTestCase {
     func test_action_buttons_for_any_product_in_read_only_mode() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123", isPublic: true)
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
+        let product = Product.fake().copy(productID: 123,
+                                          permalink: "https://example.com/product",
+                                          statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product, formType: .readonly, stores: stores)
         viewModel.updateName("new name")
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -141,7 +141,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         XCTAssertFalse(canShareProduct)
     }
 
-    func test_edit_product_variation_form_with_valid_permalink_cannot_share_product() {
+    func test_edit_product_variation_form_with_valid_permalink_can_share_product() {
         // Given
         let product = ProductVariation.fake().copy(permalink: "https://example.com/product", status: ProductStatus.published)
         let sessionManager = SessionManager.makeForTesting()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -59,7 +59,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
 
     func test_edit_product_variation_form_with_published_status_can_share_product() {
         // Given
-        let product = ProductVariation.fake().copy(status: ProductStatus.published)
+        let product = ProductVariation.fake().copy(permalink: "https://example.com/product", status: ProductStatus.published)
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(isPublic: true)
         let stores = MockStoresManager(sessionManager: sessionManager)
@@ -74,7 +74,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
 
     func test_add_product_variation_form_with_published_status_cannot_share_product() {
         // Given
-        let product = ProductVariation.fake().copy(status: ProductStatus.published)
+        let product = ProductVariation.fake().copy(permalink: "https://example.com/product", status: ProductStatus.published)
         let viewModel = createViewModel(product: product, formType: .add)
 
         // When
@@ -86,7 +86,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
 
     func test_edit_product_variation_form_with_non_published_status_can_share_product() {
         // Given
-        let product = ProductVariation.fake().copy(status: ProductStatus.pending)
+        let product = ProductVariation.fake().copy(permalink: "https://example.com/product", status: ProductStatus.pending)
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(isPublic: true)
         let stores = MockStoresManager(sessionManager: sessionManager)
@@ -101,7 +101,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
 
     func test_add_product_form_with_non_published_status_cannot_share_product() {
         // Given
-        let product = ProductVariation.fake().copy(status: ProductStatus.pending)
+        let product = ProductVariation.fake().copy(permalink: "https://example.com/product", status: ProductStatus.pending)
         let viewModel = createViewModel(product: product, formType: .add)
 
         // When
@@ -113,7 +113,7 @@ final class ProductVariationFormViewModelTests: XCTestCase {
 
     func test_edit_product_form_with_non_public_site_cannot_share_product() {
         // Given
-        let product = ProductVariation.fake().copy(status: ProductStatus.published)
+        let product = ProductVariation.fake().copy(permalink: "https://example.com/product", status: ProductStatus.published)
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(isPublic: false)
         let stores = MockStoresManager(sessionManager: sessionManager)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -125,6 +125,36 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(canShareProduct)
     }
+
+    func test_edit_product_variation_form_with_invalid_permalink_cannot_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(permalink: "", status: ProductStatus.published)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertFalse(canShareProduct)
+    }
+
+    func test_edit_product_variation_form_with_valid_permalink_cannot_share_product() {
+        // Given
+        let product = ProductVariation.fake().copy(permalink: "https://example.com/product", status: ProductStatus.published)
+        let sessionManager = SessionManager.makeForTesting()
+        sessionManager.defaultSite = Site.fake().copy(isPublic: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
+
+        // When
+        let canShareProduct = viewModel.canShareProduct()
+
+        // Then
+        XCTAssertTrue(canShareProduct)
+    }
 }
 
 private extension ProductVariationFormViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9867
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Introduces a coordinator to check for site eligibility before presenting a share sheet for product sharing. 

- [x] I will look into adding a few unit tests for `ShareProductCoordinator` in a future PR. https://github.com/woocommerce/woocommerce-ios/pull/9880

## Testing instructions

1. Turn off `shareProductAI` feature flag
1. Create a JN site

**First product created**
1. Open the site from the mobile app
1. Create a first product by tapping on "Add your first product" onboarding task
1. You will be presented with a confetti screen after you finish creating and publishing a product
1. Tap on "Share product" and validate that a share sheet is presented.

**Swipe to share**
1. Launch app and navigate to Products tab
2. Swipe on a product and try to "Share" a product
3. Validate that a share sheet is presented.

**Product detail screen**
1. Open a product and tap on the "Share" bar button item
2. Validate that a share sheet is presented.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Screen | Image |
|--------|--------|
| First product created | ![Simulator Screen Recording - iPhone 14 - 2023-06-06 at 13 46 35](https://github.com/woocommerce/woocommerce-ios/assets/524475/3619769b-2db6-470f-892b-461cf439f97a) |
| Swipe to share | ![Simulator Screen Recording - iPhone 14 - 2023-06-06 at 13 47 12](https://github.com/woocommerce/woocommerce-ios/assets/524475/de7e1e0a-0f34-4c60-b36c-87599a75d3b0) |
| Product detail screen | ![Simulator Screen Recording - iPhone 14 - 2023-06-06 at 13 47 57](https://github.com/woocommerce/woocommerce-ios/assets/524475/f6475038-2cff-47bb-9d7a-f16562375146) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
