### PR TITLE
[SKU Scan] Show Error Notice with Retry Button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -178,7 +178,8 @@ struct OrderForm: View {
             }
         }
         .wooNavigationBarStyle()
-        .notice($viewModel.notice, autoDismiss: false)
+        .notice($viewModel.autodismissableNotice)
+        .notice($viewModel.fixedNotice, autoDismiss: false)
     }
 }
 
@@ -330,6 +331,8 @@ private struct ProductsSection: View {
                         ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
                             viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { _ in
                                 showAddProductViaSKUScanner.toggle()
+                            }, onRetryRequested: {
+                                showAddProductViaSKUScanner = true
                             })
                         })
                     })

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -330,8 +330,7 @@ extension OrderListViewController {
         }
     }
 
-    func showErrorNotice(with message: String, in viewController: UIViewController) {
-        let notice = Notice(title: message, feedbackType: .error)
+    func showErrorNotice(_ notice: Notice, in viewController: UIViewController) {
         noticePresenter.presentingViewController = viewController
         noticePresenter.enqueue(notice: notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -514,7 +514,7 @@ private extension OrdersRootViewController {
                                                           comment: "Error message on the Order list view when the scanner cannot find a matching product " +
                                                           "and create a new order")
         static let scannedProductErrorNoticeRetryActionTitle = NSLocalizedString("Retry",
-                                                          comment: "Retry button title on the Order list view when the scanner cannot find a matching product " +
-                                                          "and create a new order")
+                                                          comment: "Retry button title on the Order list view when the scanner cannot find" +
+                                                          "a matching product and create a new order")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -211,7 +211,7 @@ final class OrdersRootViewController: UIViewController {
                 case let .success(product):
                     self.presentOrderCreationFlowWithScannedProduct(with: product.productID)
                 case .failure:
-                    self.displayErrorNotice()
+                    self.displayScannedProductErrorNotice()
                 }
             }
         })
@@ -238,9 +238,14 @@ final class OrdersRootViewController: UIViewController {
 
     /// Presents an Error notice
     ///
-    private func displayErrorNotice() {
-        let message = Localization.errorNoticeMessage
-        ordersViewController.showErrorNotice(with: message, in: self)
+    private func displayScannedProductErrorNotice() {
+        let notice = Notice(title: Localization.scannedProductErrorNoticeMessage,
+                            feedbackType: .error,
+                            actionTitle: Localization.scannedProductErrorNoticeRetryActionTitle) { [weak self] in
+            self?.presentOrderCreationFlowByProductScanning()
+        }
+
+        ordersViewController.showErrorNotice(notice, in: self)
     }
 
     /// Present `FilterListViewController`
@@ -505,8 +510,11 @@ private extension OrdersRootViewController {
         )
         static let emptyOrderDetails = NSLocalizedString("No order selected",
                                                          comment: "Message on the detail view of the Orders tab before any order is selected")
-        static let errorNoticeMessage = NSLocalizedString("Product not found. Failed to create a New Order",
+        static let scannedProductErrorNoticeMessage = NSLocalizedString("Product not found. Failed to create a New Order",
                                                           comment: "Error message on the Order list view when the scanner cannot find a matching product " +
+                                                          "and create a new order")
+        static let scannedProductErrorNoticeRetryActionTitle = NSLocalizedString("Retry",
+                                                          comment: "Retry button title on the Order list view when the scanner cannot find a matching product " +
                                                           "and create a new order")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -160,7 +160,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.createOrder()
 
         // Then
-        XCTAssertEqual(viewModel.notice, EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake()))
+        XCTAssertEqual(viewModel.fixedNotice, EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake()))
     }
 
     func test_view_model_fires_error_notice_when_order_sync_fails() {
@@ -186,21 +186,21 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(viewModel.notice, EditableOrderViewModel.NoticeFactory.syncOrderErrorNotice(error, flow: .creation, with: synchronizer))
+        XCTAssertEqual(viewModel.fixedNotice, EditableOrderViewModel.NoticeFactory.syncOrderErrorNotice(error, flow: .creation, with: synchronizer))
     }
 
     func test_view_model_clears_error_notice_when_order_is_syncing() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
         let error = NSError(domain: "Error", code: 0)
-        viewModel.notice = EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake())
+        viewModel.fixedNotice = EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake())
 
         // When
         let notice: Notice? = waitFor { promise in
             self.stores.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {
                 case .createOrder:
-                    promise(viewModel.notice)
+                    promise(viewModel.fixedNotice)
                 default:
                     XCTFail("Received unsupported action: \(action)")
                 }
@@ -1614,7 +1614,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             default:
                 XCTFail("Expected failure, got success")
             }
-        })
+        }, onRetryRequested: {})
 
         // Then
         XCTAssertEqual(capturedErrors, [.nilSKU])
@@ -1640,7 +1640,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 default:
                     XCTFail("Expected failure, got success")
                 }
-            })
+            }, onRetryRequested: {})
         }
 
         // Then
@@ -1668,7 +1668,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 default:
                     XCTFail("Expected success, got failure")
                 }
-            })
+            }, onRetryRequested: {})
         }
 
         // Then
@@ -1706,7 +1706,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 default:
                     XCTFail("Expected success, got failure")
                 }
-            })
+            }, onRetryRequested: {})
         }
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProductID: initialProductID)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9819
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before this PR we used to show a Notice after an error finding a product with the given SKU in the order **only** in the Order list, but **without** a Retry button. With this PR we add a Notice also in the second entry point for scanning a SKU, the order creation details, and add a Retry button in both notices.
Furthermore, we add some logic to show both a fixed notice -as we had before- and an auto dismissable one -as we need now-.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

1. Go to both of the SKU scanning entry points as shown in the videos below (Order list, Order creation details)
2. Tap on the Barcode scan button
3. Scan a code with an SKU that doesn't belong to any product of your store
4. The Scan camera screen should dismiss and a notice shown at the bottom with the right title.
5. Tap on Retry.
6. The Scan camera screen should show again.

###Order Details

https://github.com/woocommerce/woocommerce-ios/assets/1864060/74c77e0b-5c1f-4bdb-bc0f-7e6cf50f72d4

### Order List

https://github.com/woocommerce/woocommerce-ios/assets/1864060/b404e5d7-bbed-4a92-8e82-e71282eb72bc

## Known Issues

As the Notice presenter logic avoids adding a Notice if It's already presented or enqueued, repeating the flow very fast might end up not presenting a new Notice as the previous one is not dismissed yet. This is however an edge case, not worth the effort to refactor the Notice presentation logic. Of course, if we get feedback from our users about this being confusing we'll fix it.

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
