### PR TITLE
[UI Test] - Add External Product Test

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -64,11 +64,12 @@ public final class SingleProductScreen: ScreenObject {
     }
 
     public func verifyProductTypeScreenLoaded(productType: String) throws -> Self {
-        let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)\(productType == "external" ? "/Affiliate" : "")'")
+        let productTypeLabel = productType + (productType == "external" ? "/Affiliate" : "")
+        let productTypeLabelPredicate = NSPredicate(format: "label ==[c] '\(productTypeLabel)'")
 
         // the common fields on add product screen
         XCTAssertTrue(app.cells["product-review-cell"].exists)
-        XCTAssertTrue(app.staticTexts.containing(productTypeLabel).firstMatch.exists)
+        XCTAssertTrue(app.staticTexts.containing(productTypeLabelPredicate).firstMatch.exists)
 
         // different product types display different fields on add product screen
         // this is to validate that the correct screens are displayed

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -56,13 +56,15 @@ public final class SingleProductScreen: ScreenObject {
             XCTAssertTrue(app.staticTexts["Add variations"].exists)
         case "grouped":
             XCTAssertTrue(app.staticTexts["Grouped products"].exists)
+        case "external":
+            XCTAssertTrue(app.staticTexts["Add product link"].exists)
         default:
             XCTFail("Product Type \(productType) doesn't exist!")
         }
     }
 
     public func verifyProductTypeScreenLoaded(productType: String) throws -> Self {
-        let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)'")
+        let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)\(productType == "external" ? "/Affiliate" : "")'")
 
         // the common fields on add product screen
         XCTAssertTrue(app.cells["product-review-cell"].exists)
@@ -79,6 +81,10 @@ public final class SingleProductScreen: ScreenObject {
             XCTAssertTrue(app.staticTexts["Inventory"].exists)
         case "grouped":
             XCTAssertTrue(app.staticTexts["Add products to the group"].exists)
+            XCTAssertFalse(app.staticTexts["Inventory"].exists)
+        case "external":
+            XCTAssertTrue(app.staticTexts["Add product link"].exists)
+            XCTAssertTrue(app.staticTexts["Add Price"].exists)
             XCTAssertFalse(app.staticTexts["Inventory"].exists)
         default:
             XCTFail("Product Type \(productType) doesn't exist!")

--- a/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
@@ -22,7 +22,8 @@ class GetMocks {
         "physical": "products_add_new_physical_2129",
         "virtual": "products_add_new_virtual_2123",
         "variable": "products_add_new_variable_2131",
-        "grouped": "products_add_new_grouped_2130"
+        "grouped": "products_add_new_grouped_2130",
+        "external": "products_add_new_external_2132"
     ]
 
     static func getMockData(test: AnyClass, filename file: String) -> Data {

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -47,7 +47,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [x] Add new product - Simple virtual product
     - [x] Add new product - Variable product
     - [x] Add new product - Grouped product
-    - [ ] Add new product - External product
+    - [x] Add new product - External product
     - [x] Search product
     - [x] Filter product
     - [ ] Edit product

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -40,6 +40,10 @@ final class ProductsTests: XCTestCase {
         try ProductFlow.addAndVerifyNewProduct(productType: "grouped")
     }
 
+    func test_add_external_product() throws {
+        try ProductFlow.addAndVerifyNewProduct(productType: "external")
+    }
+
     func test_search_product() throws {
         let products = try GetMocks.readProductsData()
 


### PR DESCRIPTION
## Description
This PR adds the last Add Product test in the test suite: `test_add_external_product`. The test follows the format of all the other Product tests and validates that the expected rows are displayed for the External Product Type. The mock for adding external product was added previously in [a separate PR](https://github.com/woocommerce/woocommerce-ios/pull/9441/files#diff-7d6c953619988b41ff2bab58cbaa6f96a875250e829d9f0d4fc401203fd8fd15).

## Testing instructions
New test `test_add_external_product` should work as expected locally and CI should be green.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
