### PR TITLE
Site Blaze status - Networking & Yosemite layer changes

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		023930632918FF5400B2632F /* DomainRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023930622918FF5400B2632F /* DomainRemote.swift */; };
 		0239306B291A96F800B2632F /* DomainRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0239306A291A96F800B2632F /* DomainRemoteTests.swift */; };
 		0239306D291A973F00B2632F /* domain-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = 0239306C291A973F00B2632F /* domain-suggestions.json */; };
+		0259B0822A304E8D0050D7D7 /* blaze-status-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 0259B0802A304E8D0050D7D7 /* blaze-status-failure.json */; };
+		0259B0832A304E8D0050D7D7 /* blaze-status-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 0259B0812A304E8D0050D7D7 /* blaze-status-success.json */; };
 		025CA2C0238EB8CB00B05C81 /* ProductShippingClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2BF238EB8CB00B05C81 /* ProductShippingClass.swift */; };
 		025CA2C2238EBBAA00B05C81 /* ProductShippingClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2C1238EBBAA00B05C81 /* ProductShippingClassListMapper.swift */; };
 		025CA2C4238EBC4300B05C81 /* ProductShippingClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */; };
@@ -972,6 +974,8 @@
 		023930622918FF5400B2632F /* DomainRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRemote.swift; sourceTree = "<group>"; };
 		0239306A291A96F800B2632F /* DomainRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRemoteTests.swift; sourceTree = "<group>"; };
 		0239306C291A973F00B2632F /* domain-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "domain-suggestions.json"; sourceTree = "<group>"; };
+		0259B0802A304E8D0050D7D7 /* blaze-status-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-status-failure.json"; sourceTree = "<group>"; };
+		0259B0812A304E8D0050D7D7 /* blaze-status-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-status-success.json"; sourceTree = "<group>"; };
 		025CA2BF238EB8CB00B05C81 /* ProductShippingClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClass.swift; sourceTree = "<group>"; };
 		025CA2C1238EBBAA00B05C81 /* ProductShippingClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassListMapper.swift; sourceTree = "<group>"; };
 		025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassRemote.swift; sourceTree = "<group>"; };
@@ -2412,6 +2416,8 @@
 			isa = PBXGroup;
 			children = (
 				DE4D23BD29B6E10F003A4B5D /* announcements.json */,
+				0259B0802A304E8D0050D7D7 /* blaze-status-failure.json */,
+				0259B0812A304E8D0050D7D7 /* blaze-status-success.json */,
 				021D741B2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json */,
 				DEC2B092297AA60D003923FB /* category-without-data.json */,
 				DEC2B090297AA5A6003923FB /* categories-all-without-data.json */,
@@ -3506,6 +3512,7 @@
 				DEF13C5E296686AB0024A02B /* orders-load-all-without-data.json in Resources */,
 				4515282B257A8C010076B03C /* product-attribute-delete.json in Resources */,
 				020C907B24C6E108001E2BEB /* product-variation-update.json in Resources */,
+				0259B0822A304E8D0050D7D7 /* blaze-status-failure.json in Resources */,
 				D8FBFF1822D4DDB9006E3336 /* order-stats-v4-hour.json in Resources */,
 				CCA1D6082943804C00B40560 /* site-summary-stats.json in Resources */,
 				B554FA8D2180B59700C54DFF /* notifications-load-hashes.json in Resources */,
@@ -3531,6 +3538,7 @@
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,
 				DEC51AED2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json in Resources */,
+				0259B0832A304E8D0050D7D7 /* blaze-status-success.json in Resources */,
 				0286A1B62A0CBAC50099EF94 /* feature-flags-load-all-with-missing-values.json in Resources */,
 				DE66C5552976662700DAA978 /* just-in-time-message-list-without-data.json in Resources */,
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -21,6 +21,11 @@ public protocol SiteRemoteProtocol {
     /// - Parameter siteID: Remote ID of the site to load.
     /// - Returns: The site that matches the site ID.
     func loadSite(siteID: Int64) async throws -> Site
+
+    /// Loads the Blaze status of a site.
+    /// - Parameter siteID: Remote ID of the site to load the Blaze status.
+    /// - Returns: A boolean that indicates whether Blaze is approved for the site.
+    func loadBlazeStatus(siteID: Int64) async throws -> Bool
 }
 
 /// Site: Remote Endpoints
@@ -109,6 +114,13 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)
         return try await enqueue(request)
+    }
+
+    public func loadBlazeStatus(siteID: Int64) async throws -> Bool {
+        let path = Path.loadBlazeStatus(siteID: siteID)
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: path)
+        let response: BlazeStatusResponse = try await enqueue(request)
+        return response.isApproved
     }
 }
 
@@ -221,6 +233,15 @@ public struct SiteProfilerData {
     }
 }
 
+/// Site Blaze status response.
+private struct BlazeStatusResponse: Decodable {
+    public let isApproved: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case isApproved = "approved"
+    }
+}
+
 extension SiteRemote {
     enum SiteParameter {
         enum Fields {
@@ -252,6 +273,10 @@ private extension SiteRemote {
 
         static func loadSite(siteID: Int64) -> String {
             "sites/\(siteID)"
+        }
+
+        static func loadBlazeStatus(siteID: Int64) -> String {
+            "sites/\(siteID)/blaze/status"
         }
     }
 }

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -235,7 +235,7 @@ public struct SiteProfilerData {
 
 /// Site Blaze status response.
 private struct BlazeStatusResponse: Decodable {
-    public let isApproved: Bool
+    let isApproved: Bool
 
     private enum CodingKeys: String, CodingKey {
         case isApproved = "approved"

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -193,4 +193,41 @@ final class SiteRemoteTests: XCTestCase {
                                                 message: "You cannot add WordPress.com eCommerce Trial when you already have paid upgrades")
         })
     }
+
+    // MARK: - `loadBlazeStatus`
+
+    func test_loadBlazeStatus_returns_true_on_success() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "blaze/status", filename: "blaze-status-success")
+
+        // When
+        let isApproved = try await remote.loadBlazeStatus(siteID: 134)
+
+        // Then
+        XCTAssertTrue(isApproved)
+    }
+
+    func test_loadBlazeStatus_returns_false_on_failure() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "blaze/status", filename: "blaze-status-failure")
+
+        // When
+        let isApproved = try await remote.loadBlazeStatus(siteID: 134)
+
+        // Then
+        XCTAssertFalse(isApproved)
+    }
+
+    func test_loadBlazeStatus_throws_decoding_error_on_generic_error() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "blaze/status", filename: "generic_error")
+
+        await assertThrowsError({
+            // When
+            let isApproved = try await remote.loadBlazeStatus(siteID: 134)
+        }, errorAssert: { error in
+            // Unexpected response format.
+            error is DecodingError
+        })
+    }
 }

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -224,7 +224,7 @@ final class SiteRemoteTests: XCTestCase {
 
         await assertThrowsError({
             // When
-            let isApproved = try await remote.loadBlazeStatus(siteID: 134)
+            _ = try await remote.loadBlazeStatus(siteID: 134)
         }, errorAssert: { error in
             // Unexpected response format.
             error is DecodingError

--- a/Networking/NetworkingTests/Responses/blaze-status-failure.json
+++ b/Networking/NetworkingTests/Responses/blaze-status-failure.json
@@ -1,0 +1,3 @@
+{
+    "approved": false
+}

--- a/Networking/NetworkingTests/Responses/blaze-status-success.json
+++ b/Networking/NetworkingTests/Responses/blaze-status-success.json
@@ -1,0 +1,3 @@
+{
+    "approved": true
+}

--- a/Yosemite/Yosemite/Actions/SiteAction.swift
+++ b/Yosemite/Yosemite/Actions/SiteAction.swift
@@ -28,6 +28,12 @@ public enum SiteAction: Action {
     ///   - siteID: ID of the site to load.
     ///   - completion: Called when the result of the synced site is available.
     case syncSite(siteID: Int64, completion: (Result<Site, Error>) -> Void)
+
+    /// Loads the Blaze status of a site.
+    /// - Parameter:
+    ///   - siteID: ID of the site to load.
+    ///   - completion: Called when the result of the Blaze status is available.
+    case loadBlazeStatus(siteID: Int64, completion: (Result<Bool, Error>) -> Void)
 }
 
 /// The result of site creation including necessary site information.

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -54,8 +54,10 @@ public final class SiteStore: Store {
             launchSite(siteID: siteID, completion: completion)
         case let .enableFreeTrial(siteID, profilerData, completion):
             enableFreeTrial(siteID: siteID, profilerData: profilerData, completion: completion)
-        case let.syncSite(siteID, completion):
+        case let .syncSite(siteID, completion):
             syncSite(siteID: siteID, completion: completion)
+        case let .loadBlazeStatus(siteID, completion):
+            loadBlazeStatus(siteID: siteID, completion: completion)
         }
     }
 }
@@ -115,6 +117,17 @@ private extension SiteStore {
                     return completion(.failure(SynchronizeSiteError.unknownSite))
                 }
                 completion(.success(syncedSite))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func loadBlazeStatus(siteID: Int64, completion: @escaping (Result<Bool, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let isApproved = try await remote.loadBlazeStatus(siteID: siteID)
+                completion(.success(isApproved))
             } catch {
                 completion(.failure(error))
             }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -16,6 +16,9 @@ final class MockSiteRemote {
     /// The results to return in `loadSite`.
     private var loadSiteResult: Result<Site, Error>?
 
+    /// The results to return in `loadBlazeStatus`.
+    private var loadBlazeStatusResult: Result<Bool, Error>?
+
     /// Returns the value when `createSite` is called.
     func whenCreatingSite(thenReturn result: Result<SiteCreationResponse, Error>) {
         createSiteResult = result
@@ -34,6 +37,11 @@ final class MockSiteRemote {
     /// Returns the value when `loadSite` is called.
     func whenLoadingSite(thenReturn result: Result<Site, Error>) {
         loadSiteResult = result
+    }
+
+    /// Returns the value when `loadBlazeStatus` is called.
+    func whenLoadingBlazeStatus(thenReturn result: Result<Bool, Error>) {
+        loadBlazeStatusResult = result
     }
 }
 
@@ -71,6 +79,14 @@ extension MockSiteRemote: SiteRemoteProtocol {
             throw NetworkError.notFound
         }
 
+        return try result.get()
+    }
+
+    func loadBlazeStatus(siteID: Int64) async throws -> Bool {
+        guard let result = loadBlazeStatusResult else {
+            XCTFail("Could not find result for loading a site's Blaze status.")
+            throw NetworkError.notFound
+        }
         return try result.get()
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
@@ -239,4 +239,56 @@ final class SiteStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? DotcomError, .unknown(code: "error", message: nil))
     }
+
+    // MARK: - `loadBlazeStatus`
+
+    func test_loadBlazeStatus_returns_true_on_success_with_approved_status() throws {
+        // Given
+        remote.whenLoadingBlazeStatus(thenReturn: .success(true))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(SiteAction.loadBlazeStatus(siteID: 134) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let isApproved = try XCTUnwrap(result.get())
+        XCTAssertTrue(isApproved)
+    }
+
+    func test_loadBlazeStatus_returns_false_on_success_without_approved_status() throws {
+        // Given
+        remote.whenLoadingBlazeStatus(thenReturn: .success(false))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(SiteAction.loadBlazeStatus(siteID: 134) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let isApproved = try XCTUnwrap(result.get())
+        XCTAssertFalse(isApproved)
+    }
+
+    func test_loadBlazeStatus_returns_error_on_failure() throws {
+        // Given
+        remote.whenLoadingBlazeStatus(thenReturn: .failure(DotcomError.unknown(code: "error", message: nil)))
+
+        // When
+        let result = waitFor { promise inx
+            self.store.onAction(SiteAction.loadBlazeStatus(siteID: 134) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? DotcomError, .unknown(code: "error", message: nil))
+    }
 }

--- a/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
@@ -281,7 +281,7 @@ final class SiteStoreTests: XCTestCase {
         remote.whenLoadingBlazeStatus(thenReturn: .failure(DotcomError.unknown(code: "error", message: nil)))
 
         // When
-        let result = waitFor { promise inx
+        let result = waitFor { promise in
             self.store.onAction(SiteAction.loadBlazeStatus(siteID: 134) { result in
                 promise(result)
             })


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9866
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The eligibility check for Blaze includes an API request to fetch the site's Blaze status, with more details in pe5sF9-1yI-p2#eligibility-ref. The endpoint is `/wpcom/v2/sites/{siteID}/blaze/status`. I decided to PR just the Networking & Yosemite layer changes first, since the overall changes for the Blaze eligibility check are spread out in lots of files. 

## How

- Networking changes: added `SiteRemote.loadBlazeStatus`
- Yosemite changes: added `SiteAction.loadBlazeStatus`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient since the new action isn't used yet.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.