### PR TITLE
[UI Test] - Remove redundant return value

### DIFF
--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -25,11 +25,10 @@ class LoginFlow {
 
     @discardableResult
     static func logInWithSiteAddress() throws -> MyStoreScreen {
-        try PrologueScreen()
+        return try PrologueScreen()
             .tapLogIn()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .enterValidPassword()
-        return try MyStoreScreen()
     }
 }


### PR DESCRIPTION
## Description
While working on a different test, I noticed that on `logInWithSiteAddress` we do `return try MyStoreScreen()` at the end even though `.enterValidPassword()` already does `return try MyStoreScreen()` - we are duplicating the check twice. Moved the `return` to the start of the function to remove the extra check. 

#### Before change:
(See that "Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.MyStoreScreen" logged twice)
```
    t =    22.89s         Checking `Expect predicate `exists == 1` for object "Save Password" Button`
    t =    22.89s             Checking existence of `"Save Password" Button`
    t =    22.95s             Capturing element debug description
    t =    23.57s     Checking existence of `"Save Password" Button`
    t =    23.64s     Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.MyStoreScreen
    t =    24.67s         Checking `Expect predicate `isHittable == 1` for object "Your WooCommerce Store" StaticText`
    t =    24.67s             Find the "Your WooCommerce Store" StaticText
    t =    24.79s     Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.MyStoreScreen
    t =    25.82s         Checking `Expect predicate `isHittable == 1` for object "Your WooCommerce Store" StaticText`
    t =    25.82s             Find the "Your WooCommerce Store" StaticText
    t =    25.94s Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.TabNavComponent
    t =    26.97s     Checking `Expect predicate `isHittable == 1` for object "tab-bar-my-store-item" Button`
    t =    26.97s         Find the "tab-bar-my-store-item" Button
    t =    27.05s Tap "tab-bar-products-item" Button
    t =    27.05s     Wait for com.automattic.woocommerce to idle
    t =    27.09s     Find the "tab-bar-products-item" Button
    t =    27.11s     Check for interrupting elements affecting "tab-bar-products-item" Button
    t =    27.16s     Synthesize event
```

#### After change:
(See that "Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.MyStoreScreen" logged once)
```
    t =    22.98s         Checking `Expect predicate `exists == 1` for object "Save Password" Button`
    t =    22.99s             Checking existence of `"Save Password" Button`
    t =    23.05s             Capturing element debug description
    t =    23.65s     Checking existence of `"Save Password" Button`
    t =    23.71s     Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.MyStoreScreen
    t =    24.73s         Checking `Expect predicate `isHittable == 1` for object "Your WooCommerce Store" StaticText`
    t =    24.74s             Find the "Your WooCommerce Store" StaticText
    t =    24.86s Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.TabNavComponent
    t =    25.90s     Checking `Expect predicate `isHittable == 1` for object "tab-bar-my-store-item" Button`
    t =    25.90s         Find the "tab-bar-my-store-item" Button
    t =    25.98s Tap "tab-bar-products-item" Button
    t =    25.98s     Wait for com.automattic.woocommerce to idle
    t =    26.02s     Find the "tab-bar-products-item" Button
    t =    26.04s     Check for interrupting elements affecting "tab-bar-products-item" Button
```

## Testing instructions
CI should be green.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
