### PR TITLE
Check Blaze eligibility for all entry points

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -99,8 +99,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .sdkLessGoogleSignIn:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .blaze:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shareProductAI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -212,10 +212,6 @@ public enum FeatureFlag: Int {
     ///
     case sdkLessGoogleSignIn
 
-    /// Enables promoting a product on WPCOM and Tumblr using Blaze for eligible sites and products.
-    ///
-    case blaze
-
     /// Enables generating share product content using AI
     ///
     case shareProductAI

--- a/Networking/Networking/Remote/FeatureFlagRemote.swift
+++ b/Networking/Networking/Remote/FeatureFlagRemote.swift
@@ -31,6 +31,7 @@ public enum RemoteFeatureFlag: Decodable {
     case oneDayAfterStoreCreationNameWithoutFreeTrial
     case oneDayBeforeFreeTrialExpiresNotification
     case oneDayAfterFreeTrialExpiresNotification
+    case blaze
 
     init?(rawValue: String) {
         switch rawValue {
@@ -42,6 +43,8 @@ public enum RemoteFeatureFlag: Decodable {
             self = .oneDayBeforeFreeTrialExpiresNotification
         case "woo_notification_1d_after_free_trial_expires":
             self = .oneDayAfterFreeTrialExpiresNotification
+        case "woo_blaze":
+            self = .blaze
         default:
             return nil
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -274,7 +274,7 @@ private extension StoreCreationCoordinator {
             .removeDuplicates()
             // There are usually three URLs in the webview that return a site URL - two with `*.wordpress.com` and the other the final URL.
             .debounce(for: .seconds(5), scheduler: DispatchQueue.main)
-            .asyncMap { [weak self] possibleSiteURLs -> Site? in
+            .tryAsyncMap { [weak self] possibleSiteURLs -> Site? in
                 // Waits for 5 seconds before syncing sites every time.
                 try await Task.sleep(nanoseconds: 5_000_000_000)
                 return try await self?.syncSites(forSiteThatMatchesPossibleURLs: possibleSiteURLs)

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationStatusChecker.swift
@@ -23,7 +23,7 @@ final class StoreCreationStatusChecker {
     @MainActor
     func waitForSiteToBeReady(siteID: Int64) -> AnyPublisher<Site, Error> {
         Just(siteID)
-            .asyncMap { [weak self] siteID -> Site? in
+            .tryAsyncMap { [weak self] siteID -> Site? in
                 guard let self else {
                     return nil
                 }

--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -1,13 +1,17 @@
 import Foundation
 import Yosemite
 
+/// Protocol for checking Blaze eligibility for easier unit testing.
+protocol BlazeEligibilityCheckerProtocol {
+    func isEligible() async -> Bool
+    func isEligible(product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool
+}
+
 /// Checks for Blaze eligibility for a site and its products.
-final class BlazeEligibilityChecker {
-    private let site: Site
+final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
     private let stores: StoresManager
 
-    init(site: Site, stores: StoresManager = ServiceLocator.stores) {
-        self.site = site
+    init(stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
     }
 
@@ -32,6 +36,9 @@ final class BlazeEligibilityChecker {
 private extension BlazeEligibilityChecker {
     @MainActor
     func isSiteEligible() async -> Bool {
+        guard let site = stores.sessionManager.defaultSite else {
+            return false
+        }
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
         }

--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Yosemite
+
+/// Checks for Blaze eligibility for a site and its products.
+final class BlazeEligibilityChecker {
+    private let site: Site
+    private let stores: StoresManager
+
+    init(site: Site, stores: StoresManager = ServiceLocator.stores) {
+        self.site = site
+        self.stores = stores
+    }
+
+    /// Checks if the site is eligible for Blaze.
+    /// - Returns: Whether the site is eligible for Blaze.
+    func isEligible() async -> Bool {
+        await isSiteEligible()
+    }
+
+    /// Checks if the product is eligible for Blaze.
+    /// - Parameter product: The product to check for Blaze eligibility.
+    /// - Parameter isPasswordProtected: Whether the product is password protected.
+    /// - Returns: Whether the product is eligible for Blaze.
+    func isEligible(product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
+        guard product.status == .published && isPasswordProtected == false else {
+            return false
+        }
+        return await isSiteEligible()
+    }
+}
+
+private extension BlazeEligibilityChecker {
+    @MainActor
+    func isSiteEligible() async -> Bool {
+        guard stores.isAuthenticatedWithoutWPCom == false else {
+            return false
+        }
+        guard await isRemoteFeatureFlagEnabled(.blaze) else {
+            return false
+        }
+        do {
+            return try await isBlazeApproved(for: site)
+        } catch {
+            DDLogError("⛔️ Unable to load Blaze status for site ID \(site.siteID): \(error)")
+            return false
+        }
+    }
+}
+
+private extension BlazeEligibilityChecker {
+    @MainActor
+    func isRemoteFeatureFlagEnabled(_ remoteFeatureFlag: RemoteFeatureFlag) async -> Bool {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(remoteFeatureFlag, defaultValue: false) { isEnabled in
+                continuation.resume(returning: isEnabled)
+            })
+        }
+    }
+
+    @MainActor
+    func isBlazeApproved(for site: Site) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(SiteAction.loadBlazeStatus(siteID: site.siteID) { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+}

--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -3,8 +3,8 @@ import Yosemite
 
 /// Protocol for checking Blaze eligibility for easier unit testing.
 protocol BlazeEligibilityCheckerProtocol {
-    func isEligible() async -> Bool
-    func isEligible(product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool
+    func isSiteEligible() async -> Bool
+    func isProductEligible(product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool
 }
 
 /// Checks for Blaze eligibility for a site and its products.
@@ -17,25 +17,25 @@ final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
 
     /// Checks if the site is eligible for Blaze.
     /// - Returns: Whether the site is eligible for Blaze.
-    func isEligible() async -> Bool {
-        await isSiteEligible()
+    func isSiteEligible() async -> Bool {
+        await checkSiteEligibility()
     }
 
     /// Checks if the product is eligible for Blaze.
     /// - Parameter product: The product to check for Blaze eligibility.
     /// - Parameter isPasswordProtected: Whether the product is password protected.
     /// - Returns: Whether the product is eligible for Blaze.
-    func isEligible(product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
+    func isProductEligible(product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
         guard product.status == .published && isPasswordProtected == false else {
             return false
         }
-        return await isSiteEligible()
+        return await checkSiteEligibility()
     }
 }
 
 private extension BlazeEligibilityChecker {
     @MainActor
-    func isSiteEligible() async -> Bool {
+    func checkSiteEligibility() async -> Bool {
         guard let site = stores.sessionManager.defaultSite else {
             return false
         }

--- a/WooCommerce/Classes/Extensions/Publisher+Concurrency.swift
+++ b/WooCommerce/Classes/Extensions/Publisher+Concurrency.swift
@@ -1,6 +1,24 @@
 import Combine
 
 extension Publisher {
+    /// Transforms the publisher with an async operator that does not throw an error.
+    ///
+    /// Original implementation:
+    /// https://www.swiftbysundell.com/articles/calling-async-functions-within-a-combine-pipeline
+    ///
+    /// - Parameter transform: a function that transforms the upstream publisher asynchronously that does not throw an error.
+    /// - Returns: a new publisher that is transformed by the given operator asynchronously.
+    func asyncMap<T>(_ transform: @escaping (Output) async -> T) ->
+    Publishers.FlatMap<Future<T, Never>, Self> {
+                           flatMap { value in
+                               Future { promise in
+                                   Task {
+                                       promise(.success(await transform(value)))
+                                   }
+                               }
+                           }
+                       }
+
     /// Transforms the publisher with an async throwable operator.
     ///
     /// Original implementation:
@@ -8,7 +26,7 @@ extension Publisher {
     ///
     /// - Parameter transform: a function that transforms the upstream publisher asynchronously with the option to throw an error.
     /// - Returns: a new publisher that is transformed by the given operator asynchronously.
-    func asyncMap<T>(_ transform: @escaping (Output) async throws -> T) ->
+    func tryAsyncMap<T>(_ transform: @escaping (Output) async throws -> T) ->
     Publishers.FlatMap<Future<T, Error>,
                        Publishers.SetFailureType<Self, Error>> {
                            flatMap { value in

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -65,6 +65,8 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private var isSiteEligibleForBlaze: Bool = false
 
+    private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
+
     private var cancellables: Set<AnyCancellable> = []
 
     let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
@@ -74,7 +76,8 @@ final class HubMenuViewModel: ObservableObject {
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          stores: StoresManager = ServiceLocator.stores,
-         generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings) {
+         generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
+         blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker()) {
         self.siteID = siteID
         self.navigationController = navigationController
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
@@ -82,6 +85,7 @@ final class HubMenuViewModel: ObservableObject {
         self.featureFlagService = featureFlagService
         self.generalAppSettings = generalAppSettings
         self.switchStoreEnabled = stores.isAuthenticatedWithoutWPCom == false
+        self.blazeEligibilityChecker = blazeEligibilityChecker
         observeSiteForUIUpdates()
         observePlanName()
         tapToPayBadgePromotionChecker.$shouldShowTapToPayBadges.share().assign(to: &$shouldShowNewFeatureBadgeOnPayments)
@@ -240,8 +244,7 @@ final class HubMenuViewModel: ObservableObject {
                 guard let self else {
                     return false
                 }
-                let blazeEligibilityChecker = BlazeEligibilityChecker(site: site, stores: self.stores)
-                return await blazeEligibilityChecker.isEligible()
+                return await self.blazeEligibilityChecker.isEligible()
             }
             .assign(to: &$isSiteEligibleForBlaze)
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -63,6 +63,8 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var shouldShowNewFeatureBadgeOnPayments: Bool = false
 
+    @Published private var isSiteEligibleForBlaze: Bool = false
+
     private var cancellables: Set<AnyCancellable> = []
 
     let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
@@ -137,20 +139,18 @@ final class HubMenuViewModel: ObservableObject {
                 self.generalElements.append(Coupons())
             }
         }
+        stores.dispatch(action)
 
         // Blaze menu.
-        // TODO: 9866 - async eligibility check
-        if featureFlagService.isFeatureFlagEnabled(.blaze) {
-            if let index = generalElements.firstIndex(where: { item in
-                type(of: item).id == Payments.id
-            }) {
+        if isSiteEligibleForBlaze {
+            if let index = generalElements.firstIndex(where: { $0.id == Payments.id }) {
                 generalElements.insert(Blaze(), at: index + 1)
             } else {
                 generalElements.append(Blaze())
             }
+        } else {
+            generalElements.removeAll(where: { $0.id == Blaze.id })
         }
-
-        stores.dispatch(action)
     }
 
     /// Present the `StorePickerViewController` using the `StorePickerCoordinator`, passing the navigation controller from the entry point.
@@ -231,6 +231,19 @@ final class HubMenuViewModel: ObservableObject {
                 return true
             }
             .assign(to: &$shouldAuthenticateAdminPage)
+
+        // Blaze menu.
+        stores.site
+            .compactMap { $0 }
+            .removeDuplicates()
+            .asyncMap { [weak self] site -> Bool in
+                guard let self else {
+                    return false
+                }
+                let blazeEligibilityChecker = BlazeEligibilityChecker(site: site, stores: self.stores)
+                return await blazeEligibilityChecker.isEligible()
+            }
+            .assign(to: &$isSiteEligibleForBlaze)
     }
 
     /// Observe the current site's plan name and assign it to the `planName` published property.

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -244,7 +244,7 @@ final class HubMenuViewModel: ObservableObject {
                 guard let self else {
                     return false
                 }
-                return await self.blazeEligibilityChecker.isEligible()
+                return await self.blazeEligibilityChecker.isSiteEligible()
             }
             .assign(to: &$isSiteEligibleForBlaze)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -289,7 +289,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             }
         }
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.blaze) {
+        if viewModel.canPromoteWithBlaze() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.promoteWithBlaze) { [weak self] _ in
                 self?.displayBlaze()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -693,7 +693,7 @@ private extension ProductFormViewModel {
 private extension ProductFormViewModel {
     func updateBlazeEligibility() {
         Task { @MainActor in
-            let isEligible = await blazeEligibilityChecker.isEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
+            let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -80,6 +80,8 @@ protocol ProductFormViewModelProtocol {
 
     func canShareProduct() -> Bool
 
+    func canPromoteWithBlaze() -> Bool
+
     func canDeleteProduct() -> Bool
 
     func canDuplicateProduct() -> Bool

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -172,6 +172,11 @@ extension ProductVariationFormViewModel {
         return isSitePublic && formType != .add && productHasLinkToShare
     }
 
+    func canPromoteWithBlaze() -> Bool {
+        // Product variations are not supported in Blaze.
+        false
+    }
+
     func canDeleteProduct() -> Bool {
         formType == .edit
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */; };
 		0269A5E72913FD22003B20EB /* StoreCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269A5E62913FD22003B20EB /* StoreCreationCoordinatorTests.swift */; };
 		0269A63C2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269A63B2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift */; };
+		026A23FF2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */; };
 		026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */; };
 		026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */; };
 		026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */; };
@@ -2576,6 +2577,7 @@
 		0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecTextViewAttachmentHandler.swift; sourceTree = "<group>"; };
 		0269A5E62913FD22003B20EB /* StoreCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269A63B2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingStepListView.swift; sourceTree = "<group>"; };
+		026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBlazeEligibilityChecker.swift; sourceTree = "<group>"; };
 		026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignment.swift; sourceTree = "<group>"; };
 		026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewController.swift; sourceTree = "<group>"; };
 		026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductVariationsViewController.xib; sourceTree = "<group>"; };
@@ -7473,6 +7475,7 @@
 				DE4D23B329B58C5A003A4B5D /* MockWordPressComAccountService.swift */,
 				0388E1A929E04715007DF84D /* MockDeepLinkForwarder.swift */,
 				B9DC770629F2D4910013B191 /* MockProductSelectorTopProductsProvider.swift */,
+				026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -12893,6 +12896,7 @@
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,
 				0271139A24DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift in Sources */,
 				57A5D8DF253500F300AA54D6 /* RefundConfirmationViewModelTests.swift in Sources */,
+				026A23FF2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift in Sources */,
 				023078FE25872CCF008EADEE /* PrintShippingLabelViewModelTests.swift in Sources */,
 				027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */,
 				025A1246247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -114,6 +114,8 @@
 		021E2A1C23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1B23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorCommand.swift */; };
 		021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */; };
 		021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */; };
+		021EBB362A3054BE003634CA /* BlazeEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EBB352A3054BE003634CA /* BlazeEligibilityChecker.swift */; };
+		021EBB382A3076F4003634CA /* BlazeEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */; };
 		021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */; };
 		0221121E288973C20028F0AF /* LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0221121D288973C20028F0AF /* LocalNotification.swift */; };
 		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
@@ -2416,6 +2418,8 @@
 		021E2A1B23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorCommand.swift; sourceTree = "<group>"; };
 		021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringInputFormatter.swift; sourceTree = "<group>"; };
 		021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		021EBB352A3054BE003634CA /* BlazeEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEligibilityChecker.swift; sourceTree = "<group>"; };
+		021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommand.swift; sourceTree = "<group>"; };
 		0221121D288973C20028F0AF /* LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotification.swift; sourceTree = "<group>"; };
 		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5114,6 +5118,7 @@
 			isa = PBXGroup;
 			children = (
 				024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */,
+				021EBB352A3054BE003634CA /* BlazeEligibilityChecker.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -5122,6 +5127,7 @@
 			isa = PBXGroup;
 			children = (
 				024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */,
+				021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -11854,6 +11860,7 @@
 				B58B4AB82108F14700076FDD /* NoticeNotificationInfo.swift in Sources */,
 				CE24BCD8212F25D4001CD12E /* StorageOrder+Woo.swift in Sources */,
 				DE2FE58A2925EAAE0018040A /* LoginJetpackSetupCoordinator.swift in Sources */,
+				021EBB362A3054BE003634CA /* BlazeEligibilityChecker.swift in Sources */,
 				02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */,
 				03E471C0293A158D001A58AD /* CardReaderConnectionAlertsProviding.swift in Sources */,
 				D8C2A291231BD0FD00F503E9 /* ReviewsDataSource.swift in Sources */,
@@ -12932,6 +12939,7 @@
 				022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */,
 				093B265927DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift in Sources */,
 				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,
+				021EBB382A3076F4003634CA /* BlazeEligibilityCheckerTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
@@ -3,7 +3,6 @@ import Foundation
 
 /// Mock version of `BlazeEligibilityChecker` for easier unit testing.
 final class MockBlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
-
     private let isSiteEligible: Bool
     private let isProductEligible: Bool
 
@@ -12,11 +11,11 @@ final class MockBlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
         self.isProductEligible = isProductEligible
     }
 
-    func isEligible() async -> Bool {
+    func isSiteEligible() async -> Bool {
         isSiteEligible
     }
 
-    func isEligible(product: WooCommerce.ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
+    func isProductEligible(product: WooCommerce.ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
         isProductEligible
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
@@ -1,0 +1,22 @@
+@testable import WooCommerce
+import Foundation
+
+/// Mock version of `BlazeEligibilityChecker` for easier unit testing.
+final class MockBlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
+
+    private let isSiteEligible: Bool
+    private let isProductEligible: Bool
+
+    init(isSiteEligible: Bool = false, isProductEligible: Bool = false) {
+        self.isSiteEligible = isSiteEligible
+        self.isProductEligible = isProductEligible
+    }
+
+    func isEligible() async -> Bool {
+        isSiteEligible
+    }
+
+    func isEligible(product: WooCommerce.ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
+        isProductEligible
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -128,8 +128,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isHideStoreOnboardingTaskListFeatureEnabled
         case .addProductToOrderViaSKUScanner:
             return isAddProductToOrderViaSKUScannerEnabled
-        case .blaze:
-            return isBlazeEnabled
         case .shareProductAI:
             return isShareProductAIEnabled
         default:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
@@ -17,7 +17,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - `isEligible` for site
+    // MARK: - `isSiteEligible` for site
 
     func test_isEligible_is_true_when_authenticated_with_wpcom_and_feature_flag_enabled_and_blaze_approved() async {
         // Given
@@ -28,7 +28,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         let checker = BlazeEligibilityChecker(stores: stores)
 
         // When
-        let isEligible = await checker.isEligible()
+        let isEligible = await checker.isSiteEligible()
 
         // Then
         XCTAssertTrue(isEligible)
@@ -47,7 +47,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
             let checker = BlazeEligibilityChecker(stores: stores)
 
             // When
-            let isEligible = await checker.isEligible()
+            let isEligible = await checker.isSiteEligible()
 
             // Then
             XCTAssertFalse(isEligible)
@@ -62,7 +62,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         let checker = BlazeEligibilityChecker(stores: stores)
 
         // When
-        let isEligible = await checker.isEligible()
+        let isEligible = await checker.isSiteEligible()
 
         // Then
         XCTAssertFalse(isEligible)
@@ -77,13 +77,13 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         let checker = BlazeEligibilityChecker(stores: stores)
 
         // When
-        let isEligible = await checker.isEligible()
+        let isEligible = await checker.isSiteEligible()
 
         // Then
         XCTAssertFalse(isEligible)
     }
 
-    // MARK: - `isEligible` for product
+    // MARK: - `isProductEligible`
 
     func test_isProductEligible_is_true_when_wpcom_auth_and_feature_flag_enabled_and_blaze_approved_and_product_public_without_password() async {
         // Given
@@ -95,7 +95,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
 
         // When
-        let isEligible = await checker.isEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
+        let isEligible = await checker.isProductEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
 
         // Then
         XCTAssertTrue(isEligible)
@@ -110,7 +110,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
             let product = Product.fake().copy(statusKey: nonPublicStatus.rawValue)
 
             // When
-            let isEligible = await checker.isEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
+            let isEligible = await checker.isProductEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
 
             // Then
             XCTAssertFalse(isEligible)
@@ -123,7 +123,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
 
         // When
-        let isEligible = await checker.isEligible(product: EditableProductModel(product: product), isPasswordProtected: true)
+        let isEligible = await checker.isProductEligible(product: EditableProductModel(product: product), isPasswordProtected: true)
 
         // Then
         XCTAssertFalse(isEligible)
@@ -142,7 +142,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
             let checker = BlazeEligibilityChecker(stores: stores)
 
             // When
-            let isEligible = await checker.isEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
+            let isEligible = await checker.isProductEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
 
             // Then
             XCTAssertFalse(isEligible)
@@ -157,7 +157,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
 
         // When
-        let isEligible = await checker.isEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
+        let isEligible = await checker.isProductEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
 
         // Then
         XCTAssertFalse(isEligible)
@@ -172,7 +172,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
 
         // When
-        let isEligible = await checker.isEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
+        let isEligible = await checker.isProductEligible(product: EditableProductModel(product: product), isPasswordProtected: false)
 
         // Then
         XCTAssertFalse(isEligible)

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -227,19 +227,44 @@ final class HubMenuViewModelTests: XCTestCase {
 
     func test_generalElements_includes_blaze_after_payments_when_feature_flag_is_enabled() throws {
         // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
+        // Setting site ID is required before setting `Site`.
+        stores.updateDefaultStore(storeID: sampleSiteID)
+        stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
+
         let featureFlagService = MockFeatureFlagService(isBlazeEnabled: true)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        var viewModel: HubMenuViewModel?
+        waitFor { promise in
+            stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+                guard case let .isRemoteFeatureFlagEnabled(_, _, completion) = action else {
+                    return  XCTFail()
+                }
+                completion(true)
+            }
+
+            stores.whenReceivingAction(ofType: SiteAction.self) { action in
+                guard case let .loadBlazeStatus(_, completion) = action else {
+                    return XCTFail()
+                }
+                completion(.success(true))
+                promise(())
+            }
+
+            viewModel = HubMenuViewModel(siteID: self.sampleSiteID,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         featureFlagService: featureFlagService)
-        viewModel.setupMenuElements()
+                                         featureFlagService: featureFlagService,
+                                         stores: stores)
+        }
+
+        let menuViewModel = try XCTUnwrap(viewModel)
+        menuViewModel.setupMenuElements()
 
         // Then
-        let blazeIndex = try XCTUnwrap(viewModel.generalElements.firstIndex(where: { item in
-            item.id == HubMenuViewModel.Blaze.id
-        }))
-        XCTAssertEqual(viewModel.generalElements[blazeIndex - 1].id, HubMenuViewModel.Payments.id)
+        let blazeIndex = try XCTUnwrap(menuViewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Blaze.id })
+        XCTAssertEqual(menuViewModel.generalElements[blazeIndex - 1].id, HubMenuViewModel.Payments.id)
     }
 
     func test_storeURL_when_site_has_storeURL_then_returns_storeURL() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -263,7 +263,7 @@ final class HubMenuViewModelTests: XCTestCase {
         menuViewModel.setupMenuElements()
 
         // Then
-        let blazeIndex = try XCTUnwrap(menuViewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Blaze.id })
+        let blazeIndex = try XCTUnwrap(menuViewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Blaze.id }))
         XCTAssertEqual(menuViewModel.generalElements[blazeIndex - 1].id, HubMenuViewModel.Payments.id)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -178,6 +178,32 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertTrue(canShareProduct)
     }
 
+    // MARK: - `canPromoteWithBlaze`
+
+    func test_canPromoteWithBlaze_is_true_when_product_is_eligible_for_blaze() {
+        // Given
+        let product = Product.fake()
+        let blazeEligibilityChecker = MockBlazeEligibilityChecker(isProductEligible: true)
+        let viewModel = createViewModel(product: product, formType: .edit, blazeEligibilityChecker: blazeEligibilityChecker)
+
+        // When
+        waitUntil {
+            viewModel.canPromoteWithBlaze()
+        }
+    }
+
+    func test_canPromoteWithBlaze_is_false_when_product_is_not_eligible_for_blaze() {
+        // Given
+        let product = Product.fake()
+        let blazeEligibilityChecker = MockBlazeEligibilityChecker(isProductEligible: false)
+        let viewModel = createViewModel(product: product, formType: .edit, blazeEligibilityChecker: blazeEligibilityChecker)
+
+        // When
+        waitUntil {
+            viewModel.canPromoteWithBlaze() == false
+        }
+    }
+
     // MARK: `canDeleteProduct`
 
     func test_edit_product_form_with_published_status_can_delete_product() {
@@ -675,13 +701,15 @@ private extension ProductFormViewModelTests {
     func createViewModel(product: Product,
                          formType: ProductFormType,
                          stores: StoresManager = ServiceLocator.stores,
-                         analytics: Analytics = ServiceLocator.analytics) -> ProductFormViewModel {
+                         analytics: Analytics = ServiceLocator.analytics,
+                         blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker()) -> ProductFormViewModel {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
                                     formType: formType,
                                     productImageActionHandler: productImageActionHandler,
                                     stores: stores,
-                                    analytics: analytics)
+                                    analytics: analytics,
+                                    blazeEligibilityChecker: blazeEligibilityChecker)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModelTests.swift
@@ -155,6 +155,17 @@ final class ProductVariationFormViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(canShareProduct)
     }
+
+    // MARK: - `canPromoteWithBlaze`
+
+    func test_canPromoteWithBlaze_is_false_when_variation_is_public() {
+        // Given
+        let product = ProductVariation.fake().copy(status: .published)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        XCTAssertFalse(viewModel.canPromoteWithBlaze())
+    }
 }
 
 private extension ProductVariationFormViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #9866

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The eligibility check for Blaze includes an API request to fetch the site's Blaze status, with more details in pe5sF9-1yI-p2#eligibility-ref. Additionally, there are a few client-side checks on the authentication method. When checking the eligibility for a product, client-side checks are also required. This PR implemented the async eligibility check for each entry point: menu tab and product more menu.

Site eligibility (for both entry points):
- First, we want to skip Blaze if the authentication is not wpcom
- A new remote feature flag `woo_blaze` has to be enabled (this won't be enabled until we're ready to release)
- The API check for Blaze status is approved

Product eligibility (for the product entry point):
🗒️ Blaze doesn’t apply to variations (variation IDs) from my testing.
- The product is published and not private
- The product is not password protected


## How

The main eligibility logic is in a new class `BlazeEligibilityChecker`, with a protocol to allow mocking in unit tests with `MockBlazeEligibilityChecker`.

### Menu entry point
- In `HubMenuViewModel`, since the general elements are updated every time the user lands on the menu tab (potentially more than once) I decided to observe the site (it can be `nil` at the beginning or the site properties can change) and then update a private observable variable `isSiteEligibleForBlaze`. Every time the user visits the menu tab, the latest value of `isSiteEligibleForBlaze` is used to determine whether to show the Blaze row
- Previously, we have an `asyncMap` publisher that allows an async transformer in Combine that can throw an error. In this case, we don't want to throw an error. I created another publisher `tryAsyncMap` for the pre-existing use cases, and updated `asyncMap` to not throw an error

### Product more menu entry point

Since the product form is shared for products and variations, a new function `canPromoteWithBlaze` was added to `ProductFormViewModelProtocol` for each implementation to have its own logic.

- Variations: since variations aren't supported from my testing, `canPromoteWithBlaze` is always `false` in `ProductVariationFormViewModel`
- Products: in `ProductFormViewModel` it starts an async task for Blaze eligibility check in init and whenever the product is reset (e.g. after the product is updated and saved remotely). The latest value will be used to show the Blaze CTA in the more menu

### Potential improvements

There's room to optimize the API requests for site Blaze eligibility to only check it when the site changes, and share the result throughout the app. It'd also be nice if we can dynamically update the menu elements async when the Blaze eligibility result comes back, but it's not very easy right now with the frequently updated general elements and observable site. We can look into these improvements when Blaze is doing well and widely used.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite 1: since the remote feature flag isn't implemented/enabled yet (will do it when we're ready to release to minimize the number of backend Diffs), please enable the remote feature locally. I'd recommend updating `FeatureFlagStore.isRemoteFeatureFlagEnabled` to return `true` in the successful completion block on L57. 

Prerequisite 2: the site is hosted on WPCOM and is public (not staging - you can publicize a store by tapping on the onboarding task). the site also has at least one product that is public and not password protected.

### Menu tab

- Log in to a store as in the prerequisites
- Go to the Menu tab --> the Blaze row should appear. if not, you can go to another tab and then come back to the Menu tab
- Tap on `Blaze` row --> it should navigate to a webview to promote products/posts/pages on Blaze
- Feel free to go through the flow (testing tips pe5sF9-1yI-p2#testing-tips)

### Product menu

- Go to the Products tab
- Tap on a product that is public and not password protected
- Tap on the ellipsis menu in the navigation bar --> `Promote with Blaze` action should appear. if not, you can go back to the product form and then tap on the ellipsis menu again since it's an async check
- Tap `Promote with Blaze` --> it should navigate to a webview to promote products/posts/pages on Blaze
- Feel free to play around the flow again, like checking the existing campaigns

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.