### PR TITLE
Fix wrong check for site plan sync

### DIFF
--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -387,7 +387,7 @@ private extension DefaultStoresManager {
 
         /// skips synchronizing site plan if logged in with WPOrg credentials
         /// because this requires a WPCom endpoint.
-        if isAuthenticatedWithoutWPCom {
+        if isAuthenticatedWithoutWPCom == false {
             group.enter()
             let sitePlanAction = AccountAction.synchronizeSitePlan(siteID: siteID) { result in
                 if case let .failure(error) = result {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Following up with an internal discussion: p1686154005250689/1686153929.996589-slack-C03L1NF1EA3
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
@joshheald found that I made a mistake in the check for plan site sync as the logic check for skipping the site plan sync should check for WPCom login instead of the other way around. This error was from #8638 when I switch the logic from using siteID to using `isAuthenticatedWithoutWPCom`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
It's not straightforward to test `DefaultStoresManager` for this fix, and the site sync doesn't work properly after creating a free trial site so it's tricky to test this issue. I'd suggest putting a breakpoint inside the `if` [block](https://github.com/woocommerce/woocommerce-ios/blob/1b022d73498b9a6897354171b84005704e5c166c/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#LL392C6-L392C6) to make sure that it's triggered only for when you log in with WPCom.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.