### PR TITLE
[Product Sharing] Fix Share sheet popover in iPad

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
@@ -3,10 +3,8 @@ import struct Yosemite.Product
 
 /// Hosting controller for `ProductSharingMessageGenerationView`.
 final class ProductSharingMessageGenerationHostingController: UIHostingController<ProductSharingMessageGenerationView> {
-    init(viewModel: ProductSharingMessageGenerationViewModel,
-         onShareMessage: @escaping (String) -> Void) {
-        super.init(rootView: ProductSharingMessageGenerationView(viewModel: viewModel,
-                                                                 onShareMessage: onShareMessage))
+    init(viewModel: ProductSharingMessageGenerationViewModel) {
+        super.init(rootView: ProductSharingMessageGenerationView(viewModel: viewModel))
     }
 
     @available(*, unavailable)
@@ -18,12 +16,9 @@ final class ProductSharingMessageGenerationHostingController: UIHostingControlle
 /// View for generating product sharing message with AI.
 struct ProductSharingMessageGenerationView: View {
     @ObservedObject private var viewModel: ProductSharingMessageGenerationViewModel
-    private let onShareMessage: (String) -> Void
 
-    init(viewModel: ProductSharingMessageGenerationViewModel,
-         onShareMessage: @escaping (String) -> Void) {
+    init(viewModel: ProductSharingMessageGenerationViewModel) {
         self.viewModel = viewModel
-        self.onShareMessage = onShareMessage
     }
 
     var body: some View {
@@ -138,7 +133,7 @@ struct ProductSharingMessageGenerationView_Previews: PreviewProvider {
     static var previews: some View {
         ProductSharingMessageGenerationView(viewModel: .init(siteID: 123,
                                                              productName: "Test",
-                                                             url: "https://example.com"),
-                                            onShareMessage: { _ in })
+                                                             url: "https://example.com",
+                                                             onShare: { }))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
@@ -97,6 +97,12 @@ struct ProductSharingMessageGenerationView: View {
                 viewModel.didTapShare()
             }
             .buttonStyle(PrimaryButtonStyle())
+            .sharePopover(isPresented: $viewModel.isSharePopoverPresented) {
+                viewModel.shareSheet
+            }
+            .shareSheet(isPresented: $viewModel.isShareSheetPresented) {
+                viewModel.shareSheet
+            }
         }
         .padding(insets: Constants.insets)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
@@ -139,7 +139,6 @@ struct ProductSharingMessageGenerationView_Previews: PreviewProvider {
     static var previews: some View {
         ProductSharingMessageGenerationView(viewModel: .init(siteID: 123,
                                                              productName: "Test",
-                                                             url: "https://example.com",
-                                                             onShare: { }))
+                                                             url: "https://example.com"))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
@@ -94,7 +94,7 @@ struct ProductSharingMessageGenerationView: View {
             Spacer()
 
             Button(Localization.shareMessage) {
-                onShareMessage(viewModel.messageContent)
+                viewModel.didTapShare()
             }
             .buttonStyle(PrimaryButtonStyle())
         }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -50,6 +50,7 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         self.viewTitle = String.localizedStringWithFormat(Localization.title, productName)
     }
 
+    @MainActor
     func generateShareMessage() async {
         // TODO: Analytics
         errorMessage = nil

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -3,6 +3,9 @@ import Yosemite
 
 /// View model for `ProductSharingMessageGenerationView`
 final class ProductSharingMessageGenerationViewModel: ObservableObject {
+    @Published var isSharePopoverPresented = false
+    @Published var isShareSheetPresented = false
+
     let viewTitle: String
 
     var generateButtonTitle: String {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -64,6 +64,15 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         }
         generationInProgress = false
     }
+
+    func didTapShare() {
+        if isPad {
+            isSharePopoverPresented = true
+        } else {
+            isShareSheetPresented = true
+        }
+        onShare()
+    }
 }
 
 private extension ProductSharingMessageGenerationViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -13,6 +13,16 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         messageContent.isEmpty ? "sparkles" : "arrow.counterclockwise"
     }
 
+    var shareSheet: ShareSheet {
+        let activityItems: [Any]
+        if let url = URL(string: url) {
+            activityItems = [messageContent, url]
+        } else {
+            activityItems = [messageContent]
+        }
+        return ShareSheet(activityItems: activityItems)
+    }
+
     @Published var messageContent: String = ""
     @Published private(set) var generationInProgress: Bool = false
     @Published private(set) var errorMessage: String?

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -34,17 +34,14 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
     private let url: String
     private let stores: StoresManager
     private let isPad: Bool
-    private let onShare: () -> Void
 
     init(siteID: Int64,
          productName: String,
          url: String,
-         onShare: @escaping () -> Void,
          isPad: Bool = UIDevice.isPad(),
          stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.url = url
-        self.onShare = onShare
         self.isPad = isPad
         self.stores = stores
         self.viewTitle = String.localizedStringWithFormat(Localization.title, productName)
@@ -72,7 +69,6 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         } else {
             isShareSheetPresented = true
         }
-        onShare()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -30,13 +30,19 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
     private let siteID: Int64
     private let url: String
     private let stores: StoresManager
+    private let isPad: Bool
+    private let onShare: () -> Void
 
     init(siteID: Int64,
          productName: String,
          url: String,
+         onShare: @escaping () -> Void,
+         isPad: Bool = UIDevice.isPad(),
          stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.url = url
+        self.onShare = onShare
+        self.isPad = isPad
         self.stores = stores
         self.viewTitle = String.localizedStringWithFormat(Localization.title, productName)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -243,8 +243,9 @@ private extension AddProductCoordinator {
         viewModel.onProductCreated = { [weak self] product in
             guard let self else { return }
             self.onProductCreated(product)
-            if self.isFirstProduct {
-                self.showFirstProductCreatedView(product: product,
+            if self.isFirstProduct, let url = URL(string: product.permalink) {
+                self.showFirstProductCreatedView(productURL: url,
+                                                 productName: product.name,
                                                  showShareProductButton: viewModel.canShareProduct())
             }
         }
@@ -304,8 +305,11 @@ private extension AddProductCoordinator {
 
     /// Presents the celebratory view for the first created product.
     ///
-    func showFirstProductCreatedView(product: Product, showShareProductButton: Bool) {
-        let viewController = FirstProductCreatedHostingController(product: product,
+    func showFirstProductCreatedView(productURL: URL,
+                                     productName: String,
+                                     showShareProductButton: Bool) {
+        let viewController = FirstProductCreatedHostingController(productURL: productURL,
+                                                                  productName: productName,
                                                                   showShareProductButton: showShareProductButton)
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -1,7 +1,6 @@
 import ConfettiSwiftUI
 import SwiftUI
 import struct Yosemite.Product
-import Fakes
 
 final class FirstProductCreatedHostingController: UIHostingController<FirstProductCreatedView> {
     /// The coordinator for sharing products

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -20,8 +20,8 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
                 return
             }
 
-            let shareProductCoordinator = ShareProductCoordinator(productURL: viewModel.productURL,
-                                                                  productName: viewModel.productName,
+            let shareProductCoordinator = ShareProductCoordinator(productURL: productURL,
+                                                                  productName: productName,
                                                                   shareSheetAnchorView: self.view,
                                                                   navigationController: navigationController)
             shareProductCoordinator.start()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -85,6 +85,9 @@ struct FirstProductCreatedView: View {
                 .sharePopover(isPresented: $viewModel.isSharePopoverPresented) {
                     viewModel.shareSheet
                 }
+                .shareSheet(isPresented: $viewModel.isShareSheetPresented) {
+                    viewModel.shareSheet
+                }
 
                 Spacer()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -77,7 +77,10 @@ struct FirstProductCreatedView: View {
                 })
                 .buttonStyle(PrimaryButtonStyle())
                 .padding(.horizontal)
-                .renderedIf(showShareProductButton)
+                .renderedIf(viewModel.showShareProductButton)
+                .sharePopover(isPresented: $viewModel.isSharePopoverPresented) {
+                    viewModel.shareSheet
+                }
 
                 Spacer()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
@@ -2,6 +2,7 @@ import Yosemite
 
 final class FirstProductCreatedViewModel: ObservableObject {
     @Published var isSharePopoverPresented = false
+    @Published var isShareSheetPresented = false
 
     let productURL: URL
     let productName: String
@@ -35,10 +36,15 @@ final class FirstProductCreatedViewModel: ObservableObject {
     func didTapShareProduct() {
         analytics.track(.firstCreatedProductShareTapped)
 
-        if !canGenerateShareProductMessageUsingAI && isPad {
+        guard !canGenerateShareProductMessageUsingAI else {
+            launchAISharingFlow?()
+            return
+        }
+
+        if isPad {
             isSharePopoverPresented = true
         } else {
-            launchAISharingFlow?()
+            isShareSheetPresented = true
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
@@ -1,0 +1,44 @@
+import Yosemite
+
+final class FirstProductCreatedViewModel: ObservableObject {
+    @Published var isSharePopoverPresented = false
+
+    let productURL: URL
+    let productName: String
+    let showShareProductButton: Bool
+    let shareSheet: ShareSheet
+
+    var launchAISharingFlow: (() -> Void)?
+
+    private let canGenerateShareProductMessageUsingAI: Bool
+    private let isPad: Bool
+    private let analytics: Analytics
+
+    init(productURL: URL,
+         productName: String,
+         showShareProductButton: Bool,
+         isPad: Bool = UIDevice.isPad(),
+         eligibilityChecker: ShareProductAIEligibilityChecker? = nil,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.productURL = productURL
+        self.productName = productName
+        self.showShareProductButton = showShareProductButton
+
+        let eligibilityChecker = eligibilityChecker ?? DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
+        self.canGenerateShareProductMessageUsingAI = eligibilityChecker.canGenerateShareProductMessageUsingAI
+
+        self.analytics = analytics
+        self.isPad = isPad
+        self.shareSheet = ShareSheet(activityItems: [productName, productURL])
+    }
+
+    func didTapShareProduct() {
+        analytics.track(.firstCreatedProductShareTapped)
+
+        if !canGenerateShareProductMessageUsingAI && isPad {
+            isSharePopoverPresented = true
+        } else {
+            launchAISharingFlow?()
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductAIEligibilityChecker.swift
@@ -1,7 +1,11 @@
 import protocol Experiments.FeatureFlagService
 import struct Yosemite.Site
 
-struct ShareProductAIEligibilityChecker {
+protocol ShareProductAIEligibilityChecker {
+    var canGenerateShareProductMessageUsingAI: Bool { get }
+}
+
+struct DefaultShareProductAIEligibilityChecker: ShareProductAIEligibilityChecker {
     private let site: Site?
     private let featureFlagService: FeatureFlagService
 

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -91,11 +91,10 @@ private extension ShareProductCoordinator {
             DDLogWarn("⚠️ No site found for generating product sharing message!")
             return
         }
-        let viewModel = ProductSharingMessageGenerationViewModel(siteID: siteID, productName: productName, url: productURL.absoluteString)
-        let controller = ProductSharingMessageGenerationHostingController(viewModel: viewModel) { [weak self] message in
-            self?.navigationController.topmostPresentedViewController.dismiss(animated: true) {
-                self?.presentShareSheet(with: message)
-            }
+        let viewModel = ProductSharingMessageGenerationViewModel(siteID: siteID,
+                                                                 productName: productName,
+                                                                 url: productURL.absoluteString,
+                                                                 onShare: {
             // TODO: Analytics
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -72,15 +72,15 @@ final class ShareProductCoordinator: Coordinator {
 
 // MARK: Navigation
 private extension ShareProductCoordinator {
-    func presentShareSheet(with message: String = "") {
+    func presentShareSheet() {
         if let shareSheetAnchorView {
             SharingHelper.shareURL(url: productURL,
-                                   title: message.isEmpty ? productName : message,
+                                   title: productName,
                                    from: shareSheetAnchorView,
                                    in: navigationController.topmostPresentedViewController)
         } else if let shareSheetAnchorItem {
             SharingHelper.shareURL(url: productURL,
-                                   title: message.isEmpty ? productName : message,
+                                   title: productName,
                                    from: shareSheetAnchorItem,
                                    in: navigationController.topmostPresentedViewController)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -93,10 +93,7 @@ private extension ShareProductCoordinator {
         }
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: siteID,
                                                                  productName: productName,
-                                                                 url: productURL.absoluteString,
-                                                                 onShare: {
-            // TODO: Analytics
-        })
+                                                                 url: productURL.absoluteString)
         let controller = ProductSharingMessageGenerationHostingController(viewModel: viewModel)
 
         let presenter = BottomSheetPresenter(configure: { bottomSheet in

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -96,7 +96,8 @@ private extension ShareProductCoordinator {
                                                                  url: productURL.absoluteString,
                                                                  onShare: {
             // TODO: Analytics
-        }
+        })
+        let controller = ProductSharingMessageGenerationHostingController(viewModel: viewModel)
 
         let presenter = BottomSheetPresenter(configure: { bottomSheet in
             var sheet = bottomSheet

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -23,7 +23,7 @@ final class ShareProductCoordinator: Coordinator {
         self.productName = productName
         self.shareSheetAnchorView = shareSheetAnchorView
         self.shareSheetAnchorItem = shareSheetAnchorItem
-        self.shareProductEligibilityChecker = ShareProductAIEligibilityChecker(site: site, featureFlagService: featureFlagService)
+        self.shareProductEligibilityChecker = DefaultShareProductAIEligibilityChecker(site: site, featureFlagService: featureFlagService)
         self.navigationController = navigationController
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ShareSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ShareSheet.swift
@@ -36,7 +36,12 @@ private struct ShareSheetView: UIViewControllerRepresentable {
 extension View {
     func shareSheet(isPresented: Binding<Bool>, content: @escaping () -> ShareSheet) -> some View {
         sheet(isPresented: isPresented) {
-            ShareSheetView(shareSheet: content())
+            if #available(iOS 16.0, *) {
+                ShareSheetView(shareSheet: content())
+                    .presentationDetents([.medium, .large])
+            } else {
+                ShareSheetView(shareSheet: content())
+            }
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2201,7 +2201,9 @@
 		EEB4E2DE29B61AAD00371C3C /* CouponInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */; };
 		EEBDF7DA2A2EF69B00EFEF47 /* ShareProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */; };
 		EEBDF7DF2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7DE2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift */; };
-		EEBDF7E22A2F685C00EFEF47 /* ShareProductAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E12A2F685C00EFEF47 /* ShareProductAIEligibilityCheckerTests.swift */; };
+		EEBDF7E22A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */; };
+		EEBDF7E52A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E42A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift */; };
+		EEBDF7E72A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */; };
 		EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */; };
 		EEC2D281292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */; };
 		EEC5E01129A70CC300416CAC /* StoreSetupProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */; };
@@ -4522,7 +4524,9 @@
 		EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponInputTransformer.swift; sourceTree = "<group>"; };
 		EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductCoordinator.swift; sourceTree = "<group>"; };
 		EEBDF7DE2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductAIEligibilityChecker.swift; sourceTree = "<group>"; };
-		EEBDF7E12A2F685C00EFEF47 /* ShareProductAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
+		EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShareProductAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
+		EEBDF7E42A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstProductCreatedViewModel.swift; sourceTree = "<group>"; };
+		EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstProductCreatedViewModelTests.swift; sourceTree = "<group>"; };
 		EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupHostingControllerTests.swift; sourceTree = "<group>"; };
 		EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginHostingViewControllerTests.swift; sourceTree = "<group>"; };
 		EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSetupProgressView.swift; sourceTree = "<group>"; };
@@ -5166,6 +5170,7 @@
 			children = (
 				024F1451250B65A40003030A /* AddProductCoordinatorTests.swift */,
 				02C3FDE9251091CE009569EE /* ProductFactoryTests.swift */,
+				EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */,
 			);
 			path = "Add Product";
 			sourceTree = "<group>";
@@ -5843,8 +5848,8 @@
 		02ECD1E224FF5DDD00735BE5 /* Add Product */ = {
 			isa = PBXGroup;
 			children = (
+				EEBDF7E32A317BBB00EFEF47 /* FirstProductCreated */,
 				02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */,
-				DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */,
 				02ECD1E524FFB4E900735BE5 /* ProductFactory.swift */,
 			);
 			path = "Add Product";
@@ -10302,9 +10307,18 @@
 		EEBDF7E02A2F684D00EFEF47 /* ShareProduct */ = {
 			isa = PBXGroup;
 			children = (
-				EEBDF7E12A2F685C00EFEF47 /* ShareProductAIEligibilityCheckerTests.swift */,
+				EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */,
 			);
 			path = ShareProduct;
+			sourceTree = "<group>";
+		};
+		EEBDF7E32A317BBB00EFEF47 /* FirstProductCreated */ = {
+			isa = PBXGroup;
+			children = (
+				DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */,
+				EEBDF7E42A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift */,
+			);
+			path = FirstProductCreated;
 			sourceTree = "<group>";
 		};
 		F4B77A83B2A3D94EA331691B /* Pods */ = {
@@ -11908,6 +11922,7 @@
 				0279F0DA252DB4BE0098D7DE /* ProductVariationDetailsFactory.swift in Sources */,
 				DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,
+				EEBDF7E52A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift in Sources */,
 				02C887712450285100E4470F /* BottomButtonContainerView.swift in Sources */,
 				B946881A29BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift in Sources */,
 				0235BFD9246E959500778909 /* ProductFormActionsFactory.swift in Sources */,
@@ -12781,7 +12796,7 @@
 				02AA586628531D0E0068B6F0 /* CloseAccountCoordinatorTests.swift in Sources */,
 				E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */,
 				D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */,
-				EEBDF7E22A2F685C00EFEF47 /* ShareProductAIEligibilityCheckerTests.swift in Sources */,
+				EEBDF7E22A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift in Sources */,
 				4572641B27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift in Sources */,
 				AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */,
 				DE4D23A829B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift in Sources */,
@@ -12834,6 +12849,7 @@
 				26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */,
 				EE2A57D929E39A9C009F61E1 /* CaseIterable+HelpersTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
+				EEBDF7E72A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift in Sources */,
 				DE74F2A727E47F620002FE59 /* EnableAnalyticsViewModelTests.swift in Sources */,
 				D8025496265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift in Sources */,
 				DEE183ED292BD900008818AB /* JetpackSetupViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -7,7 +7,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
 
     func test_viewTitle_is_correct() {
         // Given
-        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123, productName: "Test", url: "https://example.com")
+        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
+                                                                 productName: "Test",
+                                                                 url: "https://example.com",
+                                                                 onShare: {})
         let expectedTitle = String.localizedStringWithFormat(ProductSharingMessageGenerationViewModel.Localization.title, "Test")
 
         // Then
@@ -17,7 +20,11 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
     func test_generateShareMessage_updates_generationInProgress_correctly() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123, productName: "Test", url: "https://example.com", stores: stores)
+        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
+                                                                 productName: "Test",
+                                                                 url: "https://example.com",
+                                                                 onShare: {},
+                                                                 stores: stores)
         XCTAssertFalse(viewModel.generationInProgress)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
@@ -40,7 +47,11 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         // Given
         let expectedString = "Check out this product!"
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123, productName: "Test", url: "https://example.com", stores: stores)
+        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
+                                                                 productName: "Test",
+                                                                 url: "https://example.com",
+                                                                 onShare: {},
+                                                                 stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateProductSharingMessage(_, _, _, completion):
@@ -62,7 +73,11 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         // Given
         let expectedString = "Check out this product!"
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123, productName: "Test", url: "https://example.com", stores: stores)
+        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
+                                                                 productName: "Test",
+                                                                 url: "https://example.com",
+                                                                 onShare: {},
+                                                                 stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateProductSharingMessage(_, _, _, completion):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -71,7 +71,6 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
 
     func test_generateShareMessage_updates_errorMessage_on_failure() async {
         // Given
-        let expectedString = "Check out this product!"
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
                                                                  productName: "Test",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -9,8 +9,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         // Given
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
                                                                  productName: "Test",
-                                                                 url: "https://example.com",
-                                                                 onShare: {})
+                                                                 url: "https://example.com")
         let expectedTitle = String.localizedStringWithFormat(ProductSharingMessageGenerationViewModel.Localization.title, "Test")
 
         // Then
@@ -23,7 +22,6 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
                                                                  productName: "Test",
                                                                  url: "https://example.com",
-                                                                 onShare: {},
                                                                  stores: stores)
         XCTAssertFalse(viewModel.generationInProgress)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -50,7 +48,6 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
                                                                  productName: "Test",
                                                                  url: "https://example.com",
-                                                                 onShare: {},
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
@@ -75,7 +72,6 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
                                                                  productName: "Test",
                                                                  url: "https://example.com",
-                                                                 onShare: {},
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
@@ -123,7 +123,29 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSharePopoverPresented)
     }
 
-    func test_popover_is_not_presented_when_not_on_ipad_and_AI_eligible() throws {
+    // MARK: `isShareSheetPresented`
+
+    func test_sheet_is_presented_when_not_on_ipad_and_AI_not_eligible() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     isPad: false,
+                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false))
+
+        XCTAssertFalse(viewModel.isShareSheetPresented)
+
+        // When
+        viewModel.didTapShareProduct()
+
+        // Then
+        XCTAssertTrue(viewModel.isShareSheetPresented)
+    }
+
+    func test_sheet_is_not_presented_when_not_on_ipad_and_AI_eligible() throws {
         // Given
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
@@ -134,18 +156,18 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
                                                      isPad: false,
                                                      eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: true))
 
-        XCTAssertFalse(viewModel.isSharePopoverPresented)
+        XCTAssertFalse(viewModel.isShareSheetPresented)
 
         // When
         viewModel.didTapShareProduct()
 
         // Then
-        XCTAssertFalse(viewModel.isSharePopoverPresented)
+        XCTAssertFalse(viewModel.isShareSheetPresented)
     }
 
     // MARK: `launchAISharingFlow`
 
-    func test_it_does_not_fire_launchAISharingFlow_when_on_ipad_and_AI_not_eligible() throws {
+    func test_it_does_not_fire_launchAISharingFlow_AI_not_eligible() throws {
         // Given
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
@@ -153,7 +175,6 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
                                                      showShareProductButton: showShareProductButton,
-                                                     isPad: true,
                                                      eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false))
 
         // When
@@ -167,7 +188,7 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         }
     }
 
-    func test_it_fires_launchAISharingFlow_when_on_ipad_and_AI_eligible() throws {
+    func test_it_fires_launchAISharingFlow_when_AI_eligible() throws {
         // Given
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
@@ -178,27 +199,6 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
                                                      isPad: true,
                                                      eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: true))
 
-
-        // When
-        waitForExpectation { exp in
-            viewModel.launchAISharingFlow = {
-                exp.fulfill()
-            }
-
-            viewModel.didTapShareProduct()
-        }
-    }
-
-    func test_it_fires_launchAISharingFlow_when_not_on_ipad_and_AI_not_eligible() throws {
-        // Given
-        let productURL = try XCTUnwrap(Expectations.productURL)
-        let productName = Expectations.productName
-        let showShareProductButton = Expectations.showShareProductButton
-        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
-                                                     productName: productName,
-                                                     showShareProductButton: showShareProductButton,
-                                                     isPad: false,
-                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false))
 
         // When
         waitForExpectation { exp in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import WooCommerce
+import TestKit
+
+final class FirstProductCreatedViewModelTests: XCTestCase {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
+    func test_it_provides_expected_productURL() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+
+        // When
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton)
+        // Then
+        XCTAssertEqual(viewModel.productURL, productURL)
+    }
+
+    func test_it_provides_expected_productName() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+
+        // When
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton)
+        // Then
+        XCTAssertEqual(viewModel.productName, productName)
+    }
+
+    func test_it_provides_expected_showShareProductButton() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+
+        // When
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton)
+        // Then
+        XCTAssertEqual(viewModel.showShareProductButton, showShareProductButton)
+    }
+
+    // MARK: `didTapShareProduct`
+
+    func test_it_logs_an_event_when_share_product_button_is_tapped() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     analytics: analytics)
+        assertEmpty(analyticsProvider.receivedEvents)
+
+        // When
+        viewModel.didTapShareProduct()
+
+        // Then
+        let firstEvent = try XCTUnwrap(analyticsProvider.receivedEvents.first)
+        XCTAssertEqual(firstEvent, "first_created_product_share_tapped")
+    }
+
+    // MARK: `isSharePopoverPresented`
+
+    func test_popover_is_presented_when_on_ipad_and_AI_not_eligible() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     isPad: true,
+                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false))
+
+        XCTAssertFalse(viewModel.isSharePopoverPresented)
+
+        // When
+        viewModel.didTapShareProduct()
+
+        // Then
+        XCTAssertTrue(viewModel.isSharePopoverPresented)
+    }
+
+    func test_popover_is_not_presented_when_on_ipad_and_AI_eligible() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     isPad: true,
+                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: true))
+
+        XCTAssertFalse(viewModel.isSharePopoverPresented)
+
+        // When
+        viewModel.didTapShareProduct()
+
+        // Then
+        XCTAssertFalse(viewModel.isSharePopoverPresented)
+    }
+
+    func test_popover_is_not_presented_when_not_on_ipad_and_AI_eligible() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     isPad: false,
+                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: true))
+
+        XCTAssertFalse(viewModel.isSharePopoverPresented)
+
+        // When
+        viewModel.didTapShareProduct()
+
+        // Then
+        XCTAssertFalse(viewModel.isSharePopoverPresented)
+    }
+
+    // MARK: `launchAISharingFlow`
+
+    func test_it_does_not_fire_launchAISharingFlow_when_on_ipad_and_AI_not_eligible() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     isPad: true,
+                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false))
+
+        // When
+        waitForExpectation { exp in
+            exp.isInverted = true
+            viewModel.launchAISharingFlow = {
+                exp.fulfill()
+            }
+
+            viewModel.didTapShareProduct()
+        }
+    }
+
+    func test_it_fires_launchAISharingFlow_when_on_ipad_and_AI_eligible() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     isPad: true,
+                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: true))
+
+
+        // When
+        waitForExpectation { exp in
+            viewModel.launchAISharingFlow = {
+                exp.fulfill()
+            }
+
+            viewModel.didTapShareProduct()
+        }
+    }
+
+    func test_it_fires_launchAISharingFlow_when_not_on_ipad_and_AI_not_eligible() throws {
+        // Given
+        let productURL = try XCTUnwrap(Expectations.productURL)
+        let productName = Expectations.productName
+        let showShareProductButton = Expectations.showShareProductButton
+        let viewModel = FirstProductCreatedViewModel(productURL: productURL,
+                                                     productName: productName,
+                                                     showShareProductButton: showShareProductButton,
+                                                     isPad: false,
+                                                     eligibilityChecker: MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false))
+
+        // When
+        waitForExpectation { exp in
+            viewModel.launchAISharingFlow = {
+                exp.fulfill()
+            }
+
+            viewModel.didTapShareProduct()
+        }
+    }
+}
+
+private extension FirstProductCreatedViewModelTests {
+    private enum Expectations {
+        static let productURL = URL(string: "https://example.com/product")
+        static let productName = "Sample product"
+        static let showShareProductButton = true
+    }
+}
+
+private struct MockShareProductAIEligibilityChecker: ShareProductAIEligibilityChecker {
+    var canGenerateShareProductMessageUsingAI: Bool
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/DefaultShareProductAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/DefaultShareProductAIEligibilityCheckerTests.swift
@@ -1,11 +1,11 @@
 import XCTest
 @testable import WooCommerce
 
-final class ShareProductAIEligibilityCheckerTests: XCTestCase {
+final class DefaultShareProductAIEligibilityCheckerTests: XCTestCase {
     func test_canGenerateShareProductMessageUsingAI_is_enabled_when_site_is_wpcom() {
         // Given
         let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: true)
-        let checker = ShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
 
         // Then
         XCTAssertTrue(checker.canGenerateShareProductMessageUsingAI)
@@ -14,7 +14,7 @@ final class ShareProductAIEligibilityCheckerTests: XCTestCase {
     func test_canGenerateShareProductMessageUsingAI_is_disabled_when_site_is_not_wpcom() {
         // Given
         let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: true)
-        let checker = ShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: false), featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: false), featureFlagService: featureFlagService)
 
         // Then
         XCTAssertFalse(checker.canGenerateShareProductMessageUsingAI)
@@ -23,7 +23,7 @@ final class ShareProductAIEligibilityCheckerTests: XCTestCase {
     func test_canGenerateShareProductMessageUsingAI_is_disabled_when_site_is_nil() {
         // Given
         let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: true)
-        let checker = ShareProductAIEligibilityChecker(site: nil, featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: nil, featureFlagService: featureFlagService)
 
         // Then
         XCTAssertFalse(checker.canGenerateShareProductMessageUsingAI)
@@ -32,7 +32,7 @@ final class ShareProductAIEligibilityCheckerTests: XCTestCase {
     func test_canGenerateShareProductMessageUsingAI_is_disabled_when_site_is_wpcom_and_feature_flag_is_off() {
         // Given
         let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: false)
-        let checker = ShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
 
         // Then
         XCTAssertFalse(checker.canGenerateShareProductMessageUsingAI)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9882 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

The share sheet popover is not presented properly in iPad. This PR attempts to fix it by using the [ShareSheet](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI%20Components/ShareSheet.swift) helper.

- For First product view, the popover will be presented only when on iPad and only when AI generation is not enabled. If otherwise, the control will be handed over to `ShareProductCoordinator` which will take over the navigation. 
- For `ProductSharingMessageGenerationView` the share sheet or popover will be presented from SwiftUI without using `SharingHelper`

### Changes 

**Related to First product view**
- Refactor `FirstProductCreatedView` to work with a view model
- Add `ShareProductAIEligibilityChecker` protocol for unit testing. 
- Use [ShareSheet](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI%20Components/ShareSheet.swift) to show popover in iPad when applicable
- Introduce `FirstProductCreatedViewModel` for handling tracking and popover presentation
- Add unit tests to ensure that popover is presented only when on iPad and AI generation is not eligible.

**Related to ProductSharingMessageGenerationView**
- Use [ShareSheet](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI%20Components/ShareSheet.swift) to show share popover/sheet.
- Stop passing message to  `ShareProductCoordinator` and present the share sheet/popover directly from the `ProductSharingMessageGenerationView` SwiftUI view.

**Note**
- [x] To avoid bloating this PR I will add unit tests for `ProductSharingMessageGenerationViewModel` in a future PR - https://github.com/woocommerce/woocommerce-ios/pull/9910


## Testing instructions

**WPCOM store with AI**
1. Create a Free trial store. 
1. Ensure that it is launched and publicly available. (Use store credits to purchase plan)
1. Please test this on iPad (device/simulator is fine)
1. Open the site from the app
1. Create a first product by tapping on "Add your first product" onboarding task
1. You will be presented with a confetti screen after you finish creating and publishing a product
1. Tap on "Share product" and validate that you can generate message using AI
1. Tap "Share" and validate that a share popover is presented
1. Repeat these steps and test on iPhone

**JN site with No AI support**
1. Create a JN site
1. Please test this on iPad (device/simulator is fine)
1. Open the site from the app
1. Create a first product by tapping on "Add your first product" onboarding task
1. You will be presented with a confetti screen after you finish creating and publishing a product
1. Tap on "Share product" and validate that a share popover is presented on iPad.
1. Repeat these steps and test on iPhone

- [x] @selanthiraiyan To test the other share entry points work on iPhone and iPad


## Screenshots
| Store type | iPad | iPhone |
|--------|--------|--------|
| WPCOM | ![WPCOMiPad](https://github.com/woocommerce/woocommerce-ios/assets/524475/38812fcc-213a-44ad-88d3-2e1120c05740) |  ![WPCOMiPhone](https://github.com/woocommerce/woocommerce-ios/assets/524475/0bb9c3dd-9291-4520-bc5e-2dbbb848d4d5) |
| Self-hosted | ![SelfHostediPad](https://github.com/woocommerce/woocommerce-ios/assets/524475/82603935-5c74-420a-b4ad-92954c704c9c) | ![SelfHostediPhone](https://github.com/woocommerce/woocommerce-ios/assets/524475/740d3a77-e472-4ec0-bc54-8a1324932430) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
