### PR TITLE
[SKU Scanner] Handle barcode formats

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1304,16 +1304,18 @@ extension EditableOrderViewModel {
             guard let self = self else { return }
             switch result {
             case let .success(product):
-                self.updateOrderWithProductID(product.productID)
-                onCompletion(.success(()))
+                Task { @MainActor in
+                    self.updateOrderWithProductID(product.productID)
+                    onCompletion(.success(()))
+                }
             case .failure:
-                onCompletion(.failure(ScannerError.productNotFound))
-                self.autodismissableNotice = NoticeFactory.createProductNotFoundAfterSKUScanningErrorNotice(withRetryAction: { [weak self] in
-                    self?.autodismissableNotice = nil
-                    Task { @MainActor in
+                Task { @MainActor in
+                    onCompletion(.failure(ScannerError.productNotFound))
+                    self.autodismissableNotice = NoticeFactory.createProductNotFoundAfterSKUScanningErrorNotice(withRetryAction: { [weak self] in
+                        self?.autodismissableNotice = nil
                         onRetryRequested()
-                    }
-                })
+                    })
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -340,8 +340,7 @@ final class EditableOrderViewModel: ObservableObject {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
-         initialProductID: Int64? = nil,
-         barcodeSKUScannerProductFinder: BarcodeSKUScannerProductFinder = BarcodeSKUScannerProductFinder()) {
+         initialProductID: Int64? = nil) {
         self.siteID = siteID
         self.flow = flow
         self.stores = stores
@@ -353,7 +352,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.orderDurationRecorder = orderDurationRecorder
         self.permissionChecker = permissionChecker
         self.initialProductID = initialProductID
-        self.barcodeSKUScannerProductFinder = barcodeSKUScannerProductFinder
+        self.barcodeSKUScannerProductFinder = BarcodeSKUScannerProductFinder(stores: stores)
 
         // Set a temporary initial view model, as a workaround to avoid making it optional.
         // Needs to be reset before the view model is used.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -471,7 +471,7 @@ private extension ProductsSection {
 private struct ProductSKUInputScannerView: UIViewControllerRepresentable {
     typealias UIViewControllerType = ProductSKUInputScannerViewController
 
-    let onBarcodeScanned: ((String) -> Void)?
+    let onBarcodeScanned: ((ScannedBarcode) -> Void)?
 
     func makeUIViewController(context: Context) -> ProductSKUInputScannerViewController {
         ProductSKUInputScannerViewController(onBarcodeScanned: { barcode in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -349,7 +349,7 @@ private extension ProductInventorySettingsViewController {
 
         let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController) { [weak self] barcode in
             ServiceLocator.analytics.track(.productInventorySettingsSKUScanned)
-            self?.onSKUBarcodeScanned(barcode: barcode)
+            self?.onSKUBarcodeScanned(barcode: barcode.payloadStringValue)
         }
         view.endEditing(true)
         skuBarcodeScannerCoordinator = coordinator

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinder.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Yosemite
-import Vision
 
 /// Given a scanned barcode this struct searches for the matching product, refining the barcode if necessary to handle the format exceptions
 ///
@@ -52,8 +51,8 @@ struct BarcodeSKUScannerProductFinder {
 
 private extension ScannedBarcode {
     func removeCheckDigitIfPossible() -> ScannedBarcode? {
-        guard symbology == VNBarcodeSymbology.upce ||
-              symbology == VNBarcodeSymbology.ean13 else {
+        guard symbology == BarcodeSymbology.upce ||
+              symbology == BarcodeSymbology.ean13 else {
             return nil
         }
 
@@ -63,7 +62,7 @@ private extension ScannedBarcode {
     func removeCountryCodeIfPossible() -> ScannedBarcode? {
         // When we have an 12 digit UPC-A format barcode Apple adds a zero at the beginning as the country code and returns an EAN-13 format
         // See https://nationwidebarcode.com/are-upc-a-and-ean-13-the-same/
-        guard symbology == VNBarcodeSymbology.ean13,
+        guard symbology == BarcodeSymbology.ean13,
               payloadStringValue.characterCount == 13,
               payloadStringValue.hasPrefix("0") else {
             return nil

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinder.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 import Vision
 
-/// Given a scanned barcode searches for the matching product, refining the barcode if necessary to handle the format exceptions
+/// Given a scanned barcode this struct searches for the matching product, refining the barcode if necessary to handle the format exceptions
 ///
 struct BarcodeSKUScannerProductFinder {
     private let stores: StoresManager
@@ -15,12 +15,12 @@ struct BarcodeSKUScannerProductFinder {
         do {
             return try await retrieveProduct(from: barcode.payloadStringValue, siteID: siteID)
         } catch {
-            // If we couldn't find the product, let's do tries by refining the SKU search
+            // If we couldn't find the product, let's keep trying by refining the SKU search
             guard (error as? ProductLoadError) == .notFound else {
                 throw error
             }
 
-            // Re-start the search in case we can remove the country code (Apple adds it by default, but merchants might not have it)
+            // Re-start the search in case we can remove the country code (Apple adds it by default for UPC-A, but merchants might not have it)
             if let refinedBarcode = barcode.removeCountryCodeIfPossible() {
                 return try await findProduct(from: refinedBarcode, siteID: siteID)
             } else if let refinedBarcode = barcode.removeCheckDigitIfPossible() {
@@ -61,9 +61,10 @@ private extension ScannedBarcode {
     }
 
     func removeCountryCodeIfPossible() -> ScannedBarcode? {
-        // When we have an 12 digit UPC-A format barcode Apple adds a zero at the beginning and returns an EAN-13 format
+        // When we have an 12 digit UPC-A format barcode Apple adds a zero at the beginning as the country code and returns an EAN-13 format
         // See https://nationwidebarcode.com/are-upc-a-and-ean-13-the-same/
         guard symbology == VNBarcodeSymbology.ean13,
+              payloadStringValue.characterCount == 13,
               payloadStringValue.hasPrefix("0") else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinder.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Yosemite
+import Vision
+
+struct BarcodeSKUScannerProductFinder {
+    private let stores: StoresManager
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+    }
+
+    func findProduct(from barcode: ScannedBarcode, siteID: Int64) async throws -> Product {
+        var retryWasTriggered = false
+
+        do {
+            return try await retrieveProduct(from: barcode.payloadStringValue, siteID: siteID)
+        } catch {
+            if !retryWasTriggered,
+               (error as? ProductLoadError) == .notFound,
+               barcode.shouldRetryWithoutTheLastDigitWhenSearchingBySKU {
+                retryWasTriggered = true
+
+                return try await retrieveProduct(from: String(barcode.payloadStringValue.dropLast()), siteID: siteID)
+            } else {
+                throw error
+            }
+        }
+    }
+
+    private func retrieveProduct(from sku: String, siteID: Int64) async throws -> Product {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: siteID,
+                                                                        sku: sku) { result in
+                switch result {
+                case let .success(matchedProduct):
+                    continuation.resume(returning: matchedProduct)
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
+        }
+    }
+}
+
+extension ScannedBarcode {
+    var shouldRetryWithoutTheLastDigitWhenSearchingBySKU: Bool {
+        symbology == VNBarcodeSymbology.upce ||
+        symbology == VNBarcodeSymbology.ean13
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
@@ -5,11 +5,11 @@ import UIKit
 final class ProductSKUBarcodeScannerCoordinator: Coordinator {
     let navigationController: UINavigationController
     private let permissionChecker: CaptureDevicePermissionChecker
-    private let onSKUBarcodeScanned: (_ barcode: String) -> Void
+    private let onSKUBarcodeScanned: (_ barcode: ScannedBarcode) -> Void
 
     init(sourceNavigationController: UINavigationController,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
-         onSKUBarcodeScanned: @escaping (_ barcode: String) -> Void) {
+         onSKUBarcodeScanned: @escaping (_ barcode: ScannedBarcode) -> Void) {
         self.navigationController = sourceNavigationController
         self.permissionChecker = permissionChecker
         self.onSKUBarcodeScanned = onSKUBarcodeScanned

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
@@ -16,12 +16,12 @@ final class ProductSKUInputScannerViewController: UIViewController {
         }
     }()
 
-    private let onBarcodeScanned: (String) -> Void
+    private let onBarcodeScanned: (ScannedBarcode) -> Void
 
     /// Tracks whether a barcode has been detected because the barcode detection callback is only handled once.
     private var hasDetectedBarcode: Bool = false
 
-    init(onBarcodeScanned: @escaping (String) -> Void) {
+    init(onBarcodeScanned: @escaping (ScannedBarcode) -> Void) {
         self.onBarcodeScanned = onBarcodeScanned
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1570,6 +1570,7 @@
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		B90C65CD29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */; };
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
+		B90DACC02A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9151B3E2840EB330036180F /* WooFoundation.framework */; };
 		B9151B402840EB340036180F /* WooFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9151B3E2840EB330036180F /* WooFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -3879,6 +3880,7 @@
 		B6FEFFF02A0DDC0000C0F546 /* EUCustomsScenarioValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EUCustomsScenarioValidator.swift; sourceTree = "<group>"; };
 		B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentOnboardingStateCache.swift; sourceTree = "<group>"; };
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
+		B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerProductFinder.swift; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B9151B3E2840EB330036180F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B92639FE293E2D4C00A257E0 /* JustInTimeMessagesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessagesProvider.swift; sourceTree = "<group>"; };
@@ -5191,6 +5193,7 @@
 				025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */,
 				02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */,
 				02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */,
+				B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */,
 			);
 			path = "SKU Scanner";
 			sourceTree = "<group>";
@@ -12034,6 +12037,7 @@
 				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				DE74F2A527E41D740002FE59 /* EnableAnalyticsView.swift in Sources */,
+				B90DACC02A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift in Sources */,
 				D85A3C5626C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift in Sources */,
 				26B233D12A14208800926EAD /* PrivacyBannerPresenter.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1571,6 +1571,7 @@
 		B90C65CD29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */; };
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
 		B90DACC02A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */; };
+		B90DACC22A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACC12A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9151B3E2840EB330036180F /* WooFoundation.framework */; };
 		B9151B402840EB340036180F /* WooFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9151B3E2840EB330036180F /* WooFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -3881,6 +3882,7 @@
 		B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentOnboardingStateCache.swift; sourceTree = "<group>"; };
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
 		B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerProductFinder.swift; sourceTree = "<group>"; };
+		B90DACC12A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerProductFinderTests.swift; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B9151B3E2840EB330036180F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B92639FE293E2D4C00A257E0 /* JustInTimeMessagesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessagesProvider.swift; sourceTree = "<group>"; };
@@ -5727,6 +5729,7 @@
 			isa = PBXGroup;
 			children = (
 				02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */,
+				B90DACC12A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift */,
 			);
 			path = "SKU Scanner";
 			sourceTree = "<group>";
@@ -12955,6 +12958,7 @@
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
+				B90DACC22A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockAnalyticsProvider.swift in Sources */,
 				B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */,
 				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1602,24 +1602,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.capturePermissionStatus, .notPermitted)
     }
 
-    func test_addScannedProductToOrder_when_sku_is_nil_then_fails_to_add_product_and_returns_nilSKU_error() {
-        // Given
-        var capturedErrors: [EditableOrderViewModel.ScannerError] = []
-
-        // When
-        viewModel.addScannedProductToOrder(barcode: nil, onCompletion: { expectedError in
-            switch expectedError {
-            case let .failure(error as EditableOrderViewModel.ScannerError):
-                capturedErrors.append(error)
-            default:
-                XCTFail("Expected failure, got success")
-            }
-        }, onRetryRequested: {})
-
-        // Then
-        XCTAssertEqual(capturedErrors, [.nilSKU])
-    }
-
     func test_addScannedProductToOrder_when_sku_is_not_found_then_returns_productNotFound_error_and_shows_autodismissable_notice_with_retry_action() {
         // Given
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
@@ -1634,7 +1616,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         // When
         var onRetryRequested = false
         let expectedError = waitFor { promise in
-            self.viewModel.addScannedProductToOrder(barcode: "nonExistingSKU", onCompletion: { expectedError in
+            self.viewModel.addScannedProductToOrder(barcode: ScannedBarcode(payloadStringValue: "nonExistingSKU",
+                                                                            symbology: BarcodeSymbology.ean8), onCompletion: { expectedError in
                 switch expectedError {
                 case let .failure(error as EditableOrderViewModel.ScannerError):
                     promise(error)
@@ -1673,7 +1656,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // When
         let successWasReceived: Bool = waitFor { promise in
-            self.viewModel.addScannedProductToOrder(barcode: "existingSKU", onCompletion: { result in
+            self.viewModel.addScannedProductToOrder(barcode: ScannedBarcode(payloadStringValue: "existingSKU",
+                                                                            symbology: BarcodeSymbology.ean8), onCompletion: { result in
                 switch result {
                 case .success(()):
                     promise(true)
@@ -1711,7 +1695,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // When
         let initialProductID: Int64? = waitFor { promise in
-            self.viewModel.addScannedProductToOrder(barcode: "existingSKU", onCompletion: { result in
+            self.viewModel.addScannedProductToOrder(barcode: ScannedBarcode(payloadStringValue: "existingSKU",
+                                                                            symbology: BarcodeSymbology.ean8), onCompletion: { result in
                 switch result {
                 case .success(()):
                     promise(self.sampleProductID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -103,7 +103,7 @@ final class BarcodeSKUScannerProductFinderTests: XCTestCase {
         XCTAssertEqual(retrievedProduct, returningProduct)
     }
 
-    func assertTriesWithoutCheckDigit(for symbology: BarcodeSymbology) async {
+    private func assertTriesWithoutCheckDigit(for symbology: BarcodeSymbology) async {
         let returningProduct = Product.fake()
         let productSKU = "97802013796"
         let checkDigit = "3"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class BarcodeSKUScannerProductFinderTests: XCTestCase {
+    private var sut: BarcodeSKUScannerProductFinder!
+    var stores: MockStoresManager!
+    var storageManager: MockStorageManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .testingInstance)
+        storageManager = MockStorageManager()
+
+        sut = BarcodeSKUScannerProductFinder(stores: stores)
+
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        sut = nil
+        stores = nil
+        storageManager = nil
+    }
+
+    func test_findProduct_when_there_is_an_error_then_passes_it() async {
+        // Given
+        let testError = TestError.anError
+        stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
+            switch action {
+            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+                onCompletion(.failure(testError))
+            default:
+                XCTFail("Expected failure, got success")
+            }
+        })
+
+        let scannedBarcode = ScannedBarcode(payloadStringValue: "123456", symbology: .aztec)
+        var retrievedError: Error?
+
+        do {
+            _ = try await sut.findProduct(from: scannedBarcode, siteID: 1)
+        } catch {
+            retrievedError = error
+        }
+
+        XCTAssertEqual(retrievedError as? TestError, testError)
+    }
+
+    func test_findProduct_when_sku_matches_barcode_then_returns_product() async {
+        // Given
+        let returningProduct = Product.fake()
+        stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
+            switch action {
+            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+                onCompletion(.success(returningProduct))
+            default:
+                break
+            }
+        })
+
+        // When
+        let scannedBarcode = ScannedBarcode(payloadStringValue: "123456", symbology: .aztec)
+        let retrievedProduct = try? await sut.findProduct(from: scannedBarcode, siteID: 1)
+
+        // Then
+        XCTAssertEqual(retrievedProduct, returningProduct)
+    }
+
+    func test_findProduct_when_barcode_has_check_digit_and_right_symbology_then_it_tries_without_it_and_returns_product() async {
+
+        for symbology in [BarcodeSymbology.ean13, BarcodeSymbology.upce] {
+            await assertTriesWithoutCheckDigit(for: symbology)
+        }
+    }
+
+    func test_findProduct_when_barcode_is_ean13_and_has_country_code_retries_without_it_and_without_check_digit_and_returns_product() async {
+        let returningProduct = Product.fake()
+        let productSKU = "72527273070"
+        let scannedBarcode = ScannedBarcode(payloadStringValue: "0" + productSKU + "6", symbology: .ean13)
+
+        stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
+            switch action {
+            case let .retrieveFirstProductMatchFromSKU(_, givenSKU, onCompletion):
+                if givenSKU == productSKU {
+                    onCompletion(.success(returningProduct))
+                } else {
+                    onCompletion(.failure(ProductLoadError.notFound))
+                }
+            default:
+                break
+            }
+        })
+
+        // When
+        let retrievedProduct = try? await sut.findProduct(from: scannedBarcode, siteID: 1)
+
+        // Then
+        XCTAssertEqual(retrievedProduct, returningProduct)
+    }
+
+    func assertTriesWithoutCheckDigit(for symbology: BarcodeSymbology) async {
+        let returningProduct = Product.fake()
+        let productSKU = "97802013796"
+        let scannedBarcode = ScannedBarcode(payloadStringValue: productSKU + "3", symbology: symbology)
+
+        stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
+            switch action {
+            case let .retrieveFirstProductMatchFromSKU(_, givenSKU, onCompletion):
+                if givenSKU == productSKU {
+                    onCompletion(.success(returningProduct))
+                } else {
+                    onCompletion(.failure(ProductLoadError.notFound))
+                }
+            default:
+                break
+            }
+        })
+
+        // When
+        let retrievedProduct = try? await sut.findProduct(from: scannedBarcode, siteID: 1)
+
+        // Then
+        XCTAssertEqual(retrievedProduct, returningProduct)
+    }
+}
+
+private enum TestError: Error {
+    case anError
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -79,7 +79,9 @@ final class BarcodeSKUScannerProductFinderTests: XCTestCase {
     func test_findProduct_when_barcode_is_ean13_and_has_country_code_retries_without_it_and_without_check_digit_and_returns_product() async {
         let returningProduct = Product.fake()
         let productSKU = "72527273070"
-        let scannedBarcode = ScannedBarcode(payloadStringValue: "0" + productSKU + "6", symbology: .ean13)
+        let countryCode = "0"
+        let checkDigit = "6"
+        let scannedBarcode = ScannedBarcode(payloadStringValue: countryCode + productSKU + checkDigit, symbology: .ean13)
 
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
@@ -104,7 +106,8 @@ final class BarcodeSKUScannerProductFinderTests: XCTestCase {
     func assertTriesWithoutCheckDigit(for symbology: BarcodeSymbology) async {
         let returningProduct = Product.fake()
         let productSKU = "97802013796"
-        let scannedBarcode = ScannedBarcode(payloadStringValue: productSKU + "3", symbology: symbology)
+        let checkDigit = "3"
+        let scannedBarcode = ScannedBarcode(payloadStringValue: productSKU + checkDigit, symbology: symbology)
 
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9757
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we handle different barcode formats and their peculiarities so we can adapt the SKU search to its requirements. In order to achieve that we refactor the barcode scanning logic so we can also retrieve the barcode format, and we encapsulate the barcode-SKU search into its own class `BarcodeSKUScannerProductFinder`, where we add the formats handling specific logic. As this struct uses `async/await` for its API, we adapt its clients to that.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please test these cases:

1. Open the app
2. Tap on barcode scan button on the Order list, or tap to create a new order and find the barcode scanning button

### Happy Path:
Barcode matches your product SKU

### Your SKU doesn't have a check digit:
For UPC-A (EAN-13) and UPC-E, test the barcode scanning when your product SKU doesn't have the scanned check digit (last one).

### UPC-A:
As Apple converts 12-digit UPC-A barcodes into EAN-13 by adding a 0 at the beginning, please test when your SKU is in UPC-A format, both when your product SKU has the check digit and when not.

---
As this PR includes some logic refactoring in both scanning entry points, please test that they work properly.

You can use [this](https://barcode.tec-it.com/en/UPCA?data=72527273070) excellent resource to generate barcodes. Please check [here](pdfdoF-2Zq-p2) for a deeper reference about this issue.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.