### PR TITLE
[IAP] General `SubscriptionsView` and view model improvements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -67,10 +67,11 @@ struct SubscriptionsView: View {
             }
             .renderedIf(viewModel.shouldShowFreeTrialFeatures)
 
-            Button(Localization.cancelTrial) {
-                print("Cancel Free Trial tapped")
-            }
-            .foregroundColor(Color(.systemRed))
+            Button(role: .destructive, action: {
+                viewModel.onCancelPlanButtonTapped?()
+            }, label: {
+                Text(Localization.cancelTrial)
+            })
             .renderedIf(viewModel.shouldShowCancelTrialButton)
 
             Section(Localization.troubleshooting) {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -96,11 +96,11 @@ struct SubscriptionsView: View {
 private extension SubscriptionsView {
     enum Localization {
         static let title = NSLocalizedString("Subscriptions", comment: "Title for the Subscriptions / Upgrades view")
-        static let subscriptionStatus = NSLocalizedString("SUBSCRIPTION STATUS", comment: "Title for the plan section on the subscriptions view. Uppercased")
+        static let subscriptionStatus = NSLocalizedString("Subscription Status", comment: "Title for the plan section on the subscriptions view. Uppercased")
         static let experienceFeatures = NSLocalizedString("Experience more of our features and services beyond the app",
                                                     comment: "Title for the features list in the Subscriptions Screen")
         static let cancelTrial = NSLocalizedString("Cancel Free Trial", comment: "Title for the button to cancel a free trial")
-        static let troubleshooting = NSLocalizedString("TROUBLESHOOTING",
+        static let troubleshooting = NSLocalizedString("Troubleshooting",
                                                        comment: "Title for the section to contact support on the subscriptions view. Uppercased")
         static let report = NSLocalizedString("Report Subscription Issue", comment: "Title for the button to contact support on the Subscriptions view")
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -126,7 +126,7 @@ private extension SubscriptionsViewModel {
     /// Removes any occurrences of `WordPress.com` from the site's name.
     /// Free Trial's have an special handling!
     ///
-    private func getPlanName(from plan: WPComSitePlan) -> String {
+    func getPlanName(from plan: WPComSitePlan) -> String {
         let daysLeft = daysLeft(for: plan)
         if plan.isFreeTrial, daysLeft <= 0 {
             return Localization.trialEnded
@@ -142,7 +142,7 @@ private extension SubscriptionsViewModel {
 
     /// Returns a plan specific details information.
     ///
-    private func getPlanInfo(from plan: WPComSitePlan) -> String {
+    func getPlanInfo(from plan: WPComSitePlan) -> String {
         let daysLeft = daysLeft(for: plan)
         let planDuration = planDurationInDays(for: plan)
 
@@ -169,7 +169,7 @@ private extension SubscriptionsViewModel {
 
     /// Returns a site plan duration in days.
     ///
-    private func planDurationInDays(for plan: WPComSitePlan) -> Int {
+    func planDurationInDays(for plan: WPComSitePlan) -> Int {
         // Normalize dates in the same timezone.
         guard let subscribedDate = plan.subscribedDate?.startOfDay(timezone: .current),
               let expiryDate = plan.expiryDate?.startOfDay(timezone: .current) else {
@@ -182,7 +182,7 @@ private extension SubscriptionsViewModel {
 
     /// Returns how many days site  plan has left.
     ///
-    private func daysLeft(for plan: WPComSitePlan) -> Int {
+    func daysLeft(for plan: WPComSitePlan) -> Int {
         // Normalize dates in the same timezone.
         let today = Date().startOfDay(timezone: .current)
         guard let expiryDate = plan.expiryDate?.startOfDay(timezone: .current) else {
@@ -195,7 +195,7 @@ private extension SubscriptionsViewModel {
 
     /// Creates an error notice that allows to retry fetching a plan.
     ///
-    private func createErrorNotice() -> Notice {
+    func createErrorNotice() -> Notice {
         .init(title: Localization.fetchErrorNotice, feedbackType: .error, actionTitle: Localization.retry) { [weak self] in
              self?.loadPlan()
         }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -24,7 +24,7 @@ final class SubscriptionsViewModel: ObservableObject {
     ///
     private(set) var planDaysLeft = ""
 
-    /// Defines if the view should show the Full Plan features..
+    /// Defines if the view should show the Full Plan features.
     ///
     private(set) var shouldShowFreeTrialFeatures = false
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -99,9 +99,9 @@ private extension SubscriptionsViewModel {
     }
 
     func updateViewProperties(from plan: WPComSitePlan) {
-        planName = Self.getPlanName(from: plan)
-        planInfo = Self.getPlanInfo(from: plan)
-        planDaysLeft = Self.daysLeft(for: plan).formatted()
+        planName = getPlanName(from: plan)
+        planInfo = getPlanInfo(from: plan)
+        planDaysLeft = daysLeft(for: plan).formatted()
         errorNotice = nil
         showLoadingIndicator = false
         shouldShowFreeTrialFeatures = plan.isFreeTrial
@@ -126,7 +126,7 @@ private extension SubscriptionsViewModel {
     /// Removes any occurrences of `WordPress.com` from the site's name.
     /// Free Trial's have an special handling!
     ///
-    static func getPlanName(from plan: WPComSitePlan) -> String {
+    private func getPlanName(from plan: WPComSitePlan) -> String {
         let daysLeft = daysLeft(for: plan)
         if plan.isFreeTrial, daysLeft <= 0 {
             return Localization.trialEnded
@@ -142,7 +142,7 @@ private extension SubscriptionsViewModel {
 
     /// Returns a plan specific details information.
     ///
-    static func getPlanInfo(from plan: WPComSitePlan) -> String {
+    private func getPlanInfo(from plan: WPComSitePlan) -> String {
         let daysLeft = daysLeft(for: plan)
         let planDuration = planDurationInDays(for: plan)
 
@@ -169,7 +169,7 @@ private extension SubscriptionsViewModel {
 
     /// Returns a site plan duration in days.
     ///
-    static func planDurationInDays(for plan: WPComSitePlan) -> Int {
+    private func planDurationInDays(for plan: WPComSitePlan) -> Int {
         // Normalize dates in the same timezone.
         guard let subscribedDate = plan.subscribedDate?.startOfDay(timezone: .current),
               let expiryDate = plan.expiryDate?.startOfDay(timezone: .current) else {
@@ -182,7 +182,7 @@ private extension SubscriptionsViewModel {
 
     /// Returns how many days site  plan has left.
     ///
-    static func daysLeft(for plan: WPComSitePlan) -> Int {
+    private func daysLeft(for plan: WPComSitePlan) -> Int {
         // Normalize dates in the same timezone.
         let today = Date().startOfDay(timezone: .current)
         guard let expiryDate = plan.expiryDate?.startOfDay(timezone: .current) else {
@@ -195,7 +195,7 @@ private extension SubscriptionsViewModel {
 
     /// Creates an error notice that allows to retry fetching a plan.
     ///
-    func createErrorNotice() -> Notice {
+    private func createErrorNotice() -> Notice {
         .init(title: Localization.fetchErrorNotice, feedbackType: .error, actionTitle: Localization.retry) { [weak self] in
              self?.loadPlan()
         }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -60,6 +60,10 @@ final class SubscriptionsViewModel: ObservableObject {
     ///
     private let featureFlagService: FeatureFlagService
 
+    /// Closure to be invoked when the Cancel button is tapped
+    ///
+    var onCancelPlanButtonTapped: (() -> ())?
+
     init(stores: StoresManager = ServiceLocator.stores,
          storePlanSynchronizer: StorePlanSynchronizer = ServiceLocator.storePlanSynchronizer,
          analytics: Analytics = ServiceLocator.analytics,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9898 

## Description
This PR addresses the items from the Subscriptions view described here: https://github.com/woocommerce/woocommerce-ios/issues/9898

## Changes
* Removes uppercasing from several `NSLocalizedStrings`
* Adds a `.destructive` role to the cancellation button
* Adds an optional callback method to the view model rather than printing "Cancel Free Trial tapped"
* Removes unused static methods from `SubscriptionsViewModel`, in favor of private methods.

## Testing instructions
- On a Free Trial site, under Menu > Subscriptions. Confirm that "Subscription Status" and "Troubleshooting" still display uppercased
- At the moment the cancellation button is never rendered, as `viewModel.shouldShowCancelTrialButton` is always false. I'll ask if this is something that should be handled, otherwise we can remove the button altogether for simplicity.
