### PR TITLE
Restore missing site property in ShareProductCoordinator

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -6,6 +6,7 @@ import protocol Experiments.FeatureFlagService
 final class ShareProductCoordinator: Coordinator {
     let navigationController: UINavigationController
 
+    private let site: Site?
     private let productURL: URL
     private let productName: String
     private let shareSheetAnchorView: UIView?
@@ -21,6 +22,7 @@ final class ShareProductCoordinator: Coordinator {
                  shareSheetAnchorItem: UIBarButtonItem?,
                  featureFlagService: FeatureFlagService,
                  navigationController: UINavigationController) {
+        self.site = site
         self.productURL = productURL
         self.productName = productName
         self.shareSheetAnchorView = shareSheetAnchorView


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For some reason `site` was missing after I merged #9885 even though I didn't remove it. This PR restores the property to make the project build again.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
