### PR TITLE
Add MainActor to dispatch store action from main thread.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -49,6 +49,7 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
 }
 
 private extension ProductSharingMessageGenerationViewModel {
+    @MainActor
     func requestMessageFromAI() async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(ProductAction.generateProductSharingMessage(siteID: siteID,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description

Tapping the "Write it for me" button from the Share product screen crashes the application. 

This PR addresses a crash related to not dispatching to the store from the main thread.

Related to - https://github.com/woocommerce/woocommerce-ios/pull/9885

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a live WPCom site.
- On the Products tab, swipe to share a product or tap to share from its detail screen.
- Notice that a bottom sheet is displayed for AI-generated messages.
- Tap the button for generating message, notice that the loading state is displayed.
- When a message is generated, it should be displayed in a text editor. You should be able to change the content of the message.
- Tap Regenerate, a new message should be generated. Note: if you regenerate within 30 seconds of the last request, you'll get cached result from the last request.
- Tap Share, notice that the sheet is dismissed, and a native share sheet is displayed, and you can share both the product link and the generated message.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/117e5d9a-d58c-4068-8592-1df79969b58b


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
