### PR TITLE
[IAP] Resolve naming ambiguity for IAP product vs WC product when dealing with WPCom plans

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchases.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchases.swift
@@ -12,20 +12,20 @@ struct MockInAppPurchases {
         let displayPrice: String
     }
 
-    private let fetchProductsDuration: UInt64
-    private let products: [WPComPlanProduct]
+    private let fetchPlansDelayInNanoseconds: UInt64
+    private let plans: [WPComPlanProduct]
     private let userIsEntitledToPlan: Bool
     private let isIAPSupported: Bool
 
-    /// - Parameter fetchProductsDuration: How long to wait until the mock plan is returned, in nanoseconds.
-    /// - Parameter products: WPCOM products to return for purchase.
+    /// - Parameter fetchPlansDelayInNanoseconds: How long to wait until the mock plan is returned, in nanoseconds.
+    /// - Parameter plans: WPCom plans to return for purchase.
     /// - Parameter userIsEntitledToProduct: Whether the user is entitled to the matched IAP product.
-    init(fetchProductsDuration: UInt64 = 1_000_000_000,
-         products: [WPComPlanProduct] = Defaults.products,
+    init(fetchPlansDelayInNanoseconds: UInt64 = 1_000_000_000,
+         plans: [WPComPlanProduct] = Defaults.plans,
          userIsEntitledToPlan: Bool = false,
          isIAPSupported: Bool = true) {
-        self.fetchProductsDuration = fetchProductsDuration
-        self.products = products
+        self.fetchPlansDelayInNanoseconds = fetchPlansDelayInNanoseconds
+        self.plans = plans
         self.userIsEntitledToPlan = userIsEntitledToPlan
         self.isIAPSupported = isIAPSupported
     }
@@ -33,8 +33,8 @@ struct MockInAppPurchases {
 
 extension MockInAppPurchases: InAppPurchasesForWPComPlansProtocol {
     func fetchPlans() async throws -> [WPComPlanProduct] {
-        try await Task.sleep(nanoseconds: fetchProductsDuration)
-        return products
+        try await Task.sleep(nanoseconds: fetchPlansDelayInNanoseconds)
+        return plans
     }
 
     func userIsEntitledToPlan(with id: String) async throws -> Bool {
@@ -57,7 +57,7 @@ extension MockInAppPurchases: InAppPurchasesForWPComPlansProtocol {
 
 private extension MockInAppPurchases {
     enum Defaults {
-        static let products: [WPComPlanProduct] = [
+        static let plans: [WPComPlanProduct] = [
             Plan(displayName: "Debug Monthly",
                  description: "1 Month of Debug Woo",
                  id: "debug.woocommerce.ecommerce.monthly",

--- a/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchases.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchases.swift
@@ -14,7 +14,7 @@ struct MockInAppPurchases {
 
     private let fetchProductsDuration: UInt64
     private let products: [WPComPlanProduct]
-    private let userIsEntitledToProduct: Bool
+    private let userIsEntitledToPlan: Bool
     private let isIAPSupported: Bool
 
     /// - Parameter fetchProductsDuration: How long to wait until the mock plan is returned, in nanoseconds.
@@ -22,31 +22,31 @@ struct MockInAppPurchases {
     /// - Parameter userIsEntitledToProduct: Whether the user is entitled to the matched IAP product.
     init(fetchProductsDuration: UInt64 = 1_000_000_000,
          products: [WPComPlanProduct] = Defaults.products,
-         userIsEntitledToProduct: Bool = false,
+         userIsEntitledToPlan: Bool = false,
          isIAPSupported: Bool = true) {
         self.fetchProductsDuration = fetchProductsDuration
         self.products = products
-        self.userIsEntitledToProduct = userIsEntitledToProduct
+        self.userIsEntitledToPlan = userIsEntitledToPlan
         self.isIAPSupported = isIAPSupported
     }
 }
 
 extension MockInAppPurchases: InAppPurchasesForWPComPlansProtocol {
-    func fetchProducts() async throws -> [WPComPlanProduct] {
+    func fetchPlans() async throws -> [WPComPlanProduct] {
         try await Task.sleep(nanoseconds: fetchProductsDuration)
         return products
     }
 
-    func userIsEntitledToProduct(with id: String) async throws -> Bool {
-        userIsEntitledToProduct
+    func userIsEntitledToPlan(with id: String) async throws -> Bool {
+        userIsEntitledToPlan
     }
 
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
+    func purchasePlan(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
         // Returns `.pending` in case of success because `StoreKit.Transaction` cannot be easily mocked.
         .pending
     }
 
-    func retryWPComSyncForPurchasedProduct(with id: String) async throws {
+    func retryWPComSyncForPurchasedPlan(with id: String) async throws {
         // no-op
     }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Plan/WebPurchasesForWPComPlans.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Plan/WebPurchasesForWPComPlans.swift
@@ -20,7 +20,7 @@ struct WebPurchasesForWPComPlans {
 }
 
 extension WebPurchasesForWPComPlans: InAppPurchasesForWPComPlansProtocol {
-    func fetchProducts() async throws -> [WPComPlanProduct] {
+    func fetchPlans() async throws -> [WPComPlanProduct] {
         let result = await loadPlan(thatMatchesID: Constants.eCommerceMonthlyPlanProductID)
         switch result {
         case .success(let plan):
@@ -30,12 +30,12 @@ extension WebPurchasesForWPComPlans: InAppPurchasesForWPComPlansProtocol {
         }
     }
 
-    func userIsEntitledToProduct(with id: String) async throws -> Bool {
+    func userIsEntitledToPlan(with id: String) async throws -> Bool {
         // A newly created site does not have any WPCOM plans. In web, the user can purchase a WPCOM plan for every site.
         false
     }
 
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
+    func purchasePlan(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
         let createCartResult = await createCart(productID: id, for: remoteSiteId)
         switch createCartResult {
         case .success:
@@ -46,7 +46,7 @@ extension WebPurchasesForWPComPlans: InAppPurchasesForWPComPlansProtocol {
         }
     }
 
-    func retryWPComSyncForPurchasedProduct(with id: String) async throws {
+    func retryWPComSyncForPurchasedPlan(with id: String) async throws {
         // no-op
     }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -98,18 +98,18 @@ final class StoreCreationCoordinator: Coordinator {
                 guard await purchasesManager.inAppPurchasesAreSupported() else {
                     throw PlanPurchaseError.iapNotSupported
                 }
-                let products = try await purchasesManager.fetchPlans()
+                let plans = try await purchasesManager.fetchPlans()
                 let expectedPlanIdentifier = featureFlagService.isFeatureFlagEnabled(.storeCreationM2WithInAppPurchasesEnabled) ?
                 Constants.iapPlanIdentifier: Constants.webPlanIdentifier
-                guard let product = products.first,
-                      product.id == expectedPlanIdentifier else {
+                guard let plan = plans.first,
+                      plan.id == expectedPlanIdentifier else {
                     throw PlanPurchaseError.noMatchingProduct
                 }
-                guard try await purchasesManager.userIsEntitledToPlan(with: product.id) == false else {
+                guard try await purchasesManager.userIsEntitledToPlan(with: plan.id) == false else {
                     throw PlanPurchaseError.productNotEligible
                 }
 
-                startStoreCreationM2(from: storeCreationNavigationController, planToPurchase: product)
+                startStoreCreationM2(from: storeCreationNavigationController, planToPurchase: plan)
             } catch let error as PlanPurchaseError {
                 let isWebviewFallbackAllowed = featureFlagService.isFeatureFlagEnabled(.storeCreationM2WithInAppPurchasesEnabled) == false
                 navigationController.dismiss(animated: true) { [weak self] in

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -98,14 +98,14 @@ final class StoreCreationCoordinator: Coordinator {
                 guard await purchasesManager.inAppPurchasesAreSupported() else {
                     throw PlanPurchaseError.iapNotSupported
                 }
-                let products = try await purchasesManager.fetchProducts()
+                let products = try await purchasesManager.fetchPlans()
                 let expectedPlanIdentifier = featureFlagService.isFeatureFlagEnabled(.storeCreationM2WithInAppPurchasesEnabled) ?
                 Constants.iapPlanIdentifier: Constants.webPlanIdentifier
                 guard let product = products.first,
                       product.id == expectedPlanIdentifier else {
                     throw PlanPurchaseError.noMatchingProduct
                 }
-                guard try await purchasesManager.userIsEntitledToProduct(with: product.id) == false else {
+                guard try await purchasesManager.userIsEntitledToPlan(with: product.id) == false else {
                     throw PlanPurchaseError.productNotEligible
                 }
 
@@ -658,7 +658,7 @@ private extension StoreCreationCoordinator {
                       siteName: String,
                       planToPurchase: WPComPlanProduct) async {
         do {
-            let result = try await purchasesManager.purchaseProduct(with: planToPurchase.id, for: siteID)
+            let result = try await purchasesManager.purchasePlan(with: planToPurchase.id, for: siteID)
 
             if featureFlagService.isFeatureFlagEnabled(.storeCreationM2WithInAppPurchasesEnabled) {
                 switch result {

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -22,7 +22,8 @@ final class UpgradesViewModel: ObservableObject {
         entitledWpcomPlanProductIDs = []
     }
 
-    /// Iterates through all available products (In-App Purchases WPCom plans) and checks whether the merchant is entitled
+    /// Iterates through all available WPCom plans and checks whether the merchant is entitled to purchase them
+    /// via In-App Purchases
     ///
     func loadUserEntitlements() async {
         do {
@@ -40,9 +41,9 @@ final class UpgradesViewModel: ObservableObject {
         }
     }
 
-    /// Retrieves all products (In-App Purchases WPCom plans)
+    /// Retrieves all In-App Purchases WPCom plans
     ///
-    func loadProducts() async {
+    func loadPlans() async {
         do {
             guard await inAppPurchasesPlanManager.inAppPurchasesAreSupported() else {
                 DDLogError("IAP not supported")
@@ -58,21 +59,21 @@ final class UpgradesViewModel: ObservableObject {
         }
     }
 
-    /// Triggers the purchase of the specified In-App Purchases WPCom plans by the passed product ID
+    /// Triggers the purchase of the specified In-App Purchases WPCom plans by the passed plan ID
     /// linked to the current site ID
     ///
-    func purchaseProduct(with productID: String) async {
+    func purchasePlan(with planID: String) async {
         do {
             // TODO: Deal with purchase result
             // https://github.com/woocommerce/woocommerce-ios/issues/9886
-            let _ = try await inAppPurchasesPlanManager.purchaseProduct(with: productID, for: self.siteID)
+            let _ = try await inAppPurchasesPlanManager.purchaseProduct(with: planID, for: self.siteID)
         } catch {
             // TODO: Handle errors
-            DDLogError("purchaseProduct \(error)")
+            DDLogError("purchasePlan \(error)")
         }
     }
 
-    /// Retrieves a specific In-App Purchase WPCOM plan from the available products
+    /// Retrieves a specific In-App Purchase WPCom plan from the available products
     ///
     func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans ) -> WPComPlanProduct? {
         let match = type.rawValue

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -10,16 +10,16 @@ final class UpgradesViewModel: ObservableObject {
     private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansManager
     private let siteID: Int64
 
-    @Published var wpcomPlanProducts: [WPComPlanProduct]
-    @Published var entitledWpcomPlanProductIDs: Set<String>
+    @Published var wpcomPlans: [WPComPlanProduct]
+    @Published var entitledWpcomPlanIDs: Set<String>
 
     init(siteID: Int64) {
         self.siteID = siteID
         // TODO: Inject dependencies
         // https://github.com/woocommerce/woocommerce-ios/issues/9884
         inAppPurchasesPlanManager = InAppPurchasesForWPComPlansManager()
-        wpcomPlanProducts = []
-        entitledWpcomPlanProductIDs = []
+        wpcomPlans = []
+        entitledWpcomPlanIDs = []
     }
 
     /// Iterates through all available WPCom plans and checks whether the merchant is entitled to purchase them
@@ -27,11 +27,11 @@ final class UpgradesViewModel: ObservableObject {
     ///
     func loadUserEntitlements() async {
         do {
-            for wpcomPlan in self.wpcomPlanProducts {
+            for wpcomPlan in self.wpcomPlans {
                 if try await inAppPurchasesPlanManager.userIsEntitledToProduct(with: wpcomPlan.id) {
-                    self.entitledWpcomPlanProductIDs.insert(wpcomPlan.id)
+                    self.entitledWpcomPlanIDs.insert(wpcomPlan.id)
                 } else {
-                    self.entitledWpcomPlanProductIDs.remove(wpcomPlan.id)
+                    self.entitledWpcomPlanIDs.remove(wpcomPlan.id)
                 }
             }
         } catch {
@@ -50,7 +50,7 @@ final class UpgradesViewModel: ObservableObject {
                 return
             }
 
-            self.wpcomPlanProducts = try await inAppPurchasesPlanManager.fetchProducts()
+            self.wpcomPlans = try await inAppPurchasesPlanManager.fetchProducts()
             await loadUserEntitlements()
         } catch {
             // TODO: Handle errors
@@ -77,7 +77,7 @@ final class UpgradesViewModel: ObservableObject {
     ///
     func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans ) -> WPComPlanProduct? {
         let match = type.rawValue
-        guard let wpcomPlanProduct = wpcomPlanProducts.first(where: { $0.id == match }) else {
+        guard let wpcomPlanProduct = wpcomPlans.first(where: { $0.id == match }) else {
             return nil
         }
         return wpcomPlanProduct

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -10,27 +10,27 @@ final class UpgradesViewModel: ObservableObject {
     private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansManager
     private let siteID: Int64
 
-    @Published var products: [WPComPlanProduct]
-    @Published var entitledProductIDs: Set<String>
+    @Published var wpcomPlanProducts: [WPComPlanProduct]
+    @Published var entitledWpcomPlanProductIDs: Set<String>
 
     init(siteID: Int64) {
         self.siteID = siteID
         // TODO: Inject dependencies
         // https://github.com/woocommerce/woocommerce-ios/issues/9884
         inAppPurchasesPlanManager = InAppPurchasesForWPComPlansManager()
-        products = []
-        entitledProductIDs = []
+        wpcomPlanProducts = []
+        entitledWpcomPlanProductIDs = []
     }
 
     /// Iterates through all available products (In-App Purchases WPCom plans) and checks whether the merchant is entitled
     ///
     func loadUserEntitlements() async {
         do {
-            for product in self.products {
-                if try await inAppPurchasesPlanManager.userIsEntitledToProduct(with: product.id) {
-                    self.entitledProductIDs.insert(product.id)
+            for wpcomPlan in self.wpcomPlanProducts {
+                if try await inAppPurchasesPlanManager.userIsEntitledToProduct(with: wpcomPlan.id) {
+                    self.entitledWpcomPlanProductIDs.insert(wpcomPlan.id)
                 } else {
-                    self.entitledProductIDs.remove(product.id)
+                    self.entitledWpcomPlanProductIDs.remove(wpcomPlan.id)
                 }
             }
         } catch {
@@ -49,7 +49,7 @@ final class UpgradesViewModel: ObservableObject {
                 return
             }
 
-            self.products = try await inAppPurchasesPlanManager.fetchProducts()
+            self.wpcomPlanProducts = try await inAppPurchasesPlanManager.fetchProducts()
             await loadUserEntitlements()
         } catch {
             // TODO: Handle errors
@@ -76,7 +76,7 @@ final class UpgradesViewModel: ObservableObject {
     ///
     func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans ) -> WPComPlanProduct? {
         let match = type.rawValue
-        guard let wpcomPlanProduct = products.first(where: { $0.id == match }) else {
+        guard let wpcomPlanProduct = wpcomPlanProducts.first(where: { $0.id == match }) else {
             return nil
         }
         return wpcomPlanProduct

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -28,7 +28,7 @@ final class UpgradesViewModel: ObservableObject {
     func loadUserEntitlements() async {
         do {
             for wpcomPlan in self.wpcomPlans {
-                if try await inAppPurchasesPlanManager.userIsEntitledToProduct(with: wpcomPlan.id) {
+                if try await inAppPurchasesPlanManager.userIsEntitledToPlan(with: wpcomPlan.id) {
                     self.entitledWpcomPlanIDs.insert(wpcomPlan.id)
                 } else {
                     self.entitledWpcomPlanIDs.remove(wpcomPlan.id)
@@ -50,7 +50,7 @@ final class UpgradesViewModel: ObservableObject {
                 return
             }
 
-            self.wpcomPlans = try await inAppPurchasesPlanManager.fetchProducts()
+            self.wpcomPlans = try await inAppPurchasesPlanManager.fetchPlans()
             await loadUserEntitlements()
         } catch {
             // TODO: Handle errors
@@ -66,7 +66,7 @@ final class UpgradesViewModel: ObservableObject {
         do {
             // TODO: Deal with purchase result
             // https://github.com/woocommerce/woocommerce-ios/issues/9886
-            let _ = try await inAppPurchasesPlanManager.purchaseProduct(with: planID, for: self.siteID)
+            let _ = try await inAppPurchasesPlanManager.purchasePlan(with: planID, for: self.siteID)
         } catch {
             // TODO: Handle errors
             DDLogError("purchasePlan \(error)")

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -82,7 +82,7 @@ struct InAppPurchasesDebugView: View {
                             Task {
                                 isPurchasing = true
                                 do {
-                                    let result = try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
+                                    let result = try await inAppPurchasesForWPComPlansManager.purchasePlan(with: product.id, for: siteID)
                                     print("[IAP Debug] Purchase result: \(result)")
                                 } catch {
                                     purchaseError = PurchaseError(error: error)
@@ -139,7 +139,7 @@ struct InAppPurchasesDebugView: View {
                 return
             }
 
-            self.products = try await inAppPurchasesForWPComPlansManager.fetchProducts()
+            self.products = try await inAppPurchasesForWPComPlansManager.fetchPlans()
             await loadUserEntitlements()
         } catch {
             print("Error loading products: \(error)")
@@ -149,7 +149,7 @@ struct InAppPurchasesDebugView: View {
     private func loadUserEntitlements() async {
         do {
             for product in self.products {
-                if try await inAppPurchasesForWPComPlansManager.userIsEntitledToProduct(with: product.id) {
+                if try await inAppPurchasesForWPComPlansManager.userIsEntitledToPlan(with: product.id) {
                     self.entitledProductIDs.insert(product.id)
                 } else {
                     self.entitledProductIDs.remove(product.id)
@@ -164,7 +164,7 @@ struct InAppPurchasesDebugView: View {
     private func retryWPComSynchronizationForPurchasedProducts() {
         Task {
             for id in entitledProductIDs {
-                try await inAppPurchasesForWPComPlansManager.retryWPComSyncForPurchasedProduct(with: id)
+                try await inAppPurchasesForWPComPlansManager.retryWPComSyncForPurchasedPlan(with: id)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -40,8 +40,8 @@ private enum SiteIDSourceType: String, Equatable, CaseIterable {
 @MainActor
 struct InAppPurchasesDebugView: View {
     private let inAppPurchasesForWPComPlansManager = InAppPurchasesForWPComPlansManager()
-    @State var products: [WPComPlanProduct] = []
-    @State var entitledProductIDs: Set<String> = []
+    @State var wpcomPlans: [WPComPlanProduct] = []
+    @State var entitledWpcomPlanIDs: Set<String> = []
     @State var inAppPurchasesAreSupported = true
     @State var isPurchasing = false
     @State private var selectedSiteIDSourceType: SiteIDSourceType = .appUser
@@ -65,24 +65,24 @@ struct InAppPurchasesDebugView: View {
                 .pickerStyle(.segmented)
             }
             Section {
-                Button("Reload products") {
+                Button("Reload plans") {
                     Task {
-                        await loadProducts()
+                        await loadPlans()
                     }
                 }
             }
-            Section("Products") {
-                if products.isEmpty {
-                    Text("No products")
+            Section("Plans") {
+                if wpcomPlans.isEmpty {
+                    Text("No plans")
                 } else if isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else if let siteID = selectedSiteIDSourceType.retrieveUpgradingSiteID() {
-                    ForEach(products, id: \.id) { product in
-                        Button(entitledProductIDs.contains(product.id) ? "Entitled: \(product.description)" : product.description) {
+                    ForEach(wpcomPlans, id: \.id) { plan in
+                        Button(entitledWpcomPlanIDs.contains(plan.id) ? "Entitled: \(plan.description)" : plan.description) {
                             Task {
                                 isPurchasing = true
                                 do {
-                                    let result = try await inAppPurchasesForWPComPlansManager.purchasePlan(with: product.id, for: siteID)
+                                    let result = try await inAppPurchasesForWPComPlansManager.purchasePlan(with: plan.id, for: siteID)
                                     print("[IAP Debug] Purchase result: \(result)")
                                 } catch {
                                     purchaseError = PurchaseError(error: error)
@@ -94,15 +94,15 @@ struct InAppPurchasesDebugView: View {
                         .alert(isPresented: $presentAlert, error: purchaseError, actions: {})
                     }
                 } else {
-                    Text("No valid site id could be retrieved to purchase product. " + selectedSiteIDSourceType.noSourceIDFoundHint)
+                    Text("No valid site id could be retrieved to purchase WPCom plan. " + selectedSiteIDSourceType.noSourceIDFoundHint)
                     .foregroundColor(.red)
                 }
             }
 
             Section {
-                Button("Retry WPCom Synchronization for entitled products") {
+                Button("Retry WPCom Synchronization for entitled plans") {
                     retryWPComSynchronizationForPurchasedProducts()
-                }.disabled(!inAppPurchasesAreSupported || entitledProductIDs.isEmpty)
+                }.disabled(!inAppPurchasesAreSupported || entitledWpcomPlanIDs.isEmpty)
             }
 
             Section {
@@ -122,7 +122,7 @@ struct InAppPurchasesDebugView: View {
         }
         .navigationTitle("IAP Debug")
         .task {
-            await loadProducts()
+            await loadPlans()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             Task {
@@ -131,7 +131,7 @@ struct InAppPurchasesDebugView: View {
         }
     }
 
-    private func loadProducts() async {
+    private func loadPlans() async {
         do {
             inAppPurchasesAreSupported = await inAppPurchasesForWPComPlansManager.inAppPurchasesAreSupported()
 
@@ -139,7 +139,7 @@ struct InAppPurchasesDebugView: View {
                 return
             }
 
-            self.products = try await inAppPurchasesForWPComPlansManager.fetchPlans()
+            self.wpcomPlans = try await inAppPurchasesForWPComPlansManager.fetchPlans()
             await loadUserEntitlements()
         } catch {
             print("Error loading products: \(error)")
@@ -148,11 +148,11 @@ struct InAppPurchasesDebugView: View {
 
     private func loadUserEntitlements() async {
         do {
-            for product in self.products {
-                if try await inAppPurchasesForWPComPlansManager.userIsEntitledToPlan(with: product.id) {
-                    self.entitledProductIDs.insert(product.id)
+            for plan in self.wpcomPlans {
+                if try await inAppPurchasesForWPComPlansManager.userIsEntitledToPlan(with: plan.id) {
+                    self.entitledWpcomPlanIDs.insert(plan.id)
                 } else {
-                    self.entitledProductIDs.remove(product.id)
+                    self.entitledWpcomPlanIDs.remove(plan.id)
                 }
             }
         }
@@ -163,7 +163,7 @@ struct InAppPurchasesDebugView: View {
 
     private func retryWPComSynchronizationForPurchasedProducts() {
         Task {
-            for id in entitledProductIDs {
+            for id in entitledWpcomPlanIDs {
                 try await inAppPurchasesForWPComPlansManager.retryWPComSyncForPurchasedPlan(with: id)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
@@ -20,31 +20,31 @@ typealias InAppPurchaseResult = StoreKit.Product.PurchaseResult
 protocol InAppPurchasesForWPComPlansProtocol {
     /// Retrieves asynchronously all WPCom plans In-App Purchases products.
     ///
-    func fetchProducts() async throws -> [WPComPlanProduct]
+    func fetchPlans() async throws -> [WPComPlanProduct]
 
-    /// Returns whether the user is entitled the product identified with the passed id.
+    /// Returns whether the user is entitled the WPCom plan identified with the passed id.
     ///
     /// - Parameters:
-    ///     - id: the id of the product whose entitlement is to be verified
+    ///     - id: the id of the WPCom plan whose entitlement is to be verified
     ///
-    func userIsEntitledToProduct(with id: String) async throws -> Bool
+    func userIsEntitledToPlan(with id: String) async throws -> Bool
 
     /// Triggers the purchase of WPCom plan specified by the passed product id, linked to the passed site Id.
     ///
     /// - Parameters:
-    ///     id: the id of the product to be purchased
+    ///     id: the id of the WPCom plan to be purchased
     ///     remoteSiteId: the id of the site linked to the purchasing plan
     ///
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult
+    func purchasePlan(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult
 
-    /// Retries forwarding the product purchase to our backend, so the plan can be unlocked.
+    /// Retries forwarding the WPCom plan purchase to our backend, so the plan can be unlocked.
     /// This can happen when the purchase was previously successful but unlocking the WPCom plan request
     /// failed.
     ///
     /// - Parameters:
-    ///     id: the id of the purchased product whose WPCom plan unlock failed
+    ///     id: the id of the purchased WPCom plan whose unlock failed
     ///
-    func retryWPComSyncForPurchasedProduct(with id: String) async throws
+    func retryWPComSyncForPurchasedPlan(with id: String) async throws
 
     /// Returns whether In-App Purchases are supported for the current user configuration
     ///
@@ -59,7 +59,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         self.stores = stores
     }
 
-    func fetchProducts() async throws -> [WPComPlanProduct] {
+    func fetchPlans() async throws -> [WPComPlanProduct] {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.loadProducts(completion: { result in
                 continuation.resume(with: result)
@@ -67,7 +67,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
-    func userIsEntitledToProduct(with id: String) async throws -> Bool {
+    func userIsEntitledToPlan(with id: String) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.userIsEntitledToProduct(productID: id, completion: { result in
                 continuation.resume(with: result)
@@ -75,7 +75,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
+    func purchasePlan(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.purchaseProduct(siteID: remoteSiteId, productID: id, completion: { result in
                 continuation.resume(with: result)
@@ -83,7 +83,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
-    func retryWPComSyncForPurchasedProduct(with id: String) async throws {
+    func retryWPComSyncForPurchasedPlan(with id: String) async throws {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.retryWPComSyncForPurchasedProduct(productID: id, completion: { result in
                 continuation.resume(with: result)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -67,7 +67,7 @@ struct UpgradesView: View {
                             // TODO: Add product entitlement check
                             Task {
                                 isPurchasing = true
-                                await upgradesViewModel.purchaseProduct(with: wpcomPlan.id)
+                                await upgradesViewModel.purchasePlan(with: wpcomPlan.id)
                                 isPurchasing = false
                             }
                         }
@@ -76,7 +76,7 @@ struct UpgradesView: View {
             }
         }
         .task {
-            await upgradesViewModel.loadProducts()
+            await upgradesViewModel.loadPlans()
         }
         .navigationBarTitle(Constants.navigationTitle)
         .navigationBarTitleDisplayMode(.large)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -58,10 +58,10 @@ struct UpgradesView: View {
                 }
             }
             Section {
-                if upgradesViewModel.wpcomPlanProducts.isEmpty || isPurchasing {
+                if upgradesViewModel.wpcomPlans.isEmpty || isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
-                    ForEach(upgradesViewModel.wpcomPlanProducts, id: \.id) { wpcomPlan in
+                    ForEach(upgradesViewModel.wpcomPlans, id: \.id) { wpcomPlan in
                         let buttonText = String.localizedStringWithFormat(Constants.purchaseCTAButtonText, wpcomPlan.displayName)
                         Button(buttonText) {
                             // TODO: Add product entitlement check

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -58,16 +58,16 @@ struct UpgradesView: View {
                 }
             }
             Section {
-                if upgradesViewModel.products.isEmpty || isPurchasing {
+                if upgradesViewModel.wpcomPlanProducts.isEmpty || isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
-                    ForEach(upgradesViewModel.products, id: \.id) { product in
-                        let buttonText = String.localizedStringWithFormat(Constants.purchaseCTAButtonText, product.displayName)
+                    ForEach(upgradesViewModel.wpcomPlanProducts, id: \.id) { wpcomPlan in
+                        let buttonText = String.localizedStringWithFormat(Constants.purchaseCTAButtonText, wpcomPlan.displayName)
                         Button(buttonText) {
                             // TODO: Add product entitlement check
                             Task {
                                 isPurchasing = true
-                                await upgradesViewModel.purchaseProduct(with: product.id)
+                                await upgradesViewModel.purchaseProduct(with: wpcomPlan.id)
                                 isPurchasing = false
                             }
                         }

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
@@ -79,7 +79,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchases(fetchProductsDuration: 0))
+                                                   purchasesManager: MockInAppPurchases(fetchPlansDelayInNanoseconds: 0))
         waitFor { promise in
             self.navigationController.present(.init(), animated: false) {
                 promise(())
@@ -104,7 +104,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         let coordinator = StoreCreationCoordinator(source: .loggedOut(source: .loginEmailError),
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchases(fetchProductsDuration: 0))
+                                                   purchasesManager: MockInAppPurchases(fetchPlansDelayInNanoseconds: 0))
         XCTAssertNotNil(navigationController.topViewController)
         XCTAssertNil(navigationController.presentedViewController)
 
@@ -124,7 +124,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchases(fetchProductsDuration: 0, isIAPSupported: false))
+                                                   purchasesManager: MockInAppPurchases(fetchPlansDelayInNanoseconds: 0, isIAPSupported: false))
         waitFor { promise in
             self.navigationController.present(.init(), animated: false) {
                 promise(())
@@ -175,7 +175,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
         // 6 seconds = 6_000_000_000 nanoseconds.
-        let purchasesManager = MockInAppPurchases(fetchProductsDuration: 6_000_000_000)
+        let purchasesManager = MockInAppPurchases(fetchPlansDelayInNanoseconds: 6_000_000_000)
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
@@ -193,8 +193,8 @@ final class StoreCreationCoordinatorTests: XCTestCase {
     func test_AuthenticatedWebViewController_is_presented_when_no_matching_iap_product() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        let purchasesManager = MockInAppPurchases(fetchProductsDuration: 0,
-                                            products: [
+        let purchasesManager = MockInAppPurchases(fetchPlansDelayInNanoseconds: 0,
+                                            plans: [
                                                 MockInAppPurchases.Plan(displayName: "",
                                                                         description: "",
                                                                         id: "random.id",
@@ -217,7 +217,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
     func test_AuthenticatedWebViewController_is_presented_when_user_is_already_entitled_to_iap_product() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        let purchasesManager = MockInAppPurchases(fetchProductsDuration: 0, userIsEntitledToPlan: true)
+        let purchasesManager = MockInAppPurchases(fetchPlansDelayInNanoseconds: 0, userIsEntitledToPlan: true)
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
@@ -217,7 +217,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
     func test_AuthenticatedWebViewController_is_presented_when_user_is_already_entitled_to_iap_product() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        let purchasesManager = MockInAppPurchases(fetchProductsDuration: 0, userIsEntitledToProduct: true)
+        let purchasesManager = MockInAppPurchases(fetchProductsDuration: 0, userIsEntitledToPlan: true)
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/WebPurchasesForWPComPlansTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/WebPurchasesForWPComPlansTests.swift
@@ -31,7 +31,7 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
         }
 
         // When
-        let products = try await webPurchases.fetchProducts()
+        let products = try await webPurchases.fetchPlans()
 
         // Then
         XCTAssertEqual(products as? [WebPurchasesForWPComPlans.Plan],
@@ -48,7 +48,7 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
 
         await assertThrowsError({
             // When
-            _ = try await webPurchases.fetchProducts()
+            _ = try await webPurchases.fetchPlans()
         }) { error in
             // Then
             (error as? SampleError) == .first
@@ -66,7 +66,7 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
         }
 
         // When
-        let purchaseResult = try await webPurchases.purchaseProduct(with: "productID", for: 134)
+        let purchaseResult = try await webPurchases.purchasePlan(with: "productID", for: 134)
 
         // Then
         XCTAssertEqual(purchaseResult, .pending)
@@ -82,7 +82,7 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
 
         await assertThrowsError({
             // When
-            _ = try await webPurchases.purchaseProduct(with: "productID", for: 134)
+            _ = try await webPurchases.purchasePlan(with: "productID", for: 134)
         }) { error in
             // Then
             (error as? SampleError) == .first
@@ -93,7 +93,7 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
 
     func test_userIsEntitledToProduct_returns_false() async throws {
         // When
-        let userIsEntitledToProduct = try await webPurchases.userIsEntitledToProduct(with: "1021")
+        let userIsEntitledToProduct = try await webPurchases.userIsEntitledToPlan(with: "1021")
 
         // Then
         XCTAssertFalse(userIsEntitledToProduct)

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/WebPurchasesForWPComPlansTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/WebPurchasesForWPComPlansTests.swift
@@ -20,9 +20,9 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - `fetchProducts`
+    // MARK: - `fetchPlans`
 
-    func test_fetchProducts_returns_plan_from_PaymentAction_loadPlan() async throws {
+    func test_fetchPlans_returns_plan_from_PaymentAction_loadPlan() async throws {
         // Given
         stores.whenReceivingAction(ofType: PaymentAction.self) { action in
             if case let .loadPlan(_, completion) = action {
@@ -31,14 +31,14 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
         }
 
         // When
-        let products = try await webPurchases.fetchPlans()
+        let plans = try await webPurchases.fetchPlans()
 
         // Then
-        XCTAssertEqual(products as? [WebPurchasesForWPComPlans.Plan],
+        XCTAssertEqual(plans as? [WebPurchasesForWPComPlans.Plan],
                        [.init(displayName: "woo plan", description: "", id: "645", displayPrice: "$ 32.8")])
     }
 
-    func test_fetchProducts_returns_error_from_PaymentAction_loadPlan() async throws {
+    func test_fetchPlans_returns_error_from_PaymentAction_loadPlan() async throws {
         // Given
         stores.whenReceivingAction(ofType: PaymentAction.self) { action in
             if case let .loadPlan(_, completion) = action {
@@ -57,7 +57,7 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
 
     // MARK: - `purchaseProduct`
 
-    func test_purchaseProduct_returns_pending_result_from_PaymentAction_createCart_success() async throws {
+    func test_purchasePlan_returns_pending_result_from_PaymentAction_createCart_success() async throws {
         // Given
         stores.whenReceivingAction(ofType: PaymentAction.self) { action in
             if case let .createCart(_, _, completion) = action {
@@ -66,13 +66,13 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
         }
 
         // When
-        let purchaseResult = try await webPurchases.purchasePlan(with: "productID", for: 134)
+        let purchaseResult = try await webPurchases.purchasePlan(with: "planID", for: 134)
 
         // Then
         XCTAssertEqual(purchaseResult, .pending)
     }
 
-    func test_purchaseProduct_returns_error_from_PaymentAction_createCart_failure() async throws {
+    func test_purchasePlan_returns_error_from_PaymentAction_createCart_failure() async throws {
         // Given
         stores.whenReceivingAction(ofType: PaymentAction.self) { action in
             if case let .createCart(_, _, completion) = action {
@@ -82,16 +82,16 @@ final class WebPurchasesForWPComPlansTests: XCTestCase {
 
         await assertThrowsError({
             // When
-            _ = try await webPurchases.purchasePlan(with: "productID", for: 134)
+            _ = try await webPurchases.purchasePlan(with: "planID", for: 134)
         }) { error in
             // Then
             (error as? SampleError) == .first
         }
     }
 
-    // MARK: - `userIsEntitledToProduct`
+    // MARK: - `userIsEntitledToPlan`
 
-    func test_userIsEntitledToProduct_returns_false() async throws {
+    func test_userIsEntitledToPlan_returns_false() async throws {
         // When
         let userIsEntitledToProduct = try await webPurchases.userIsEntitledToPlan(with: "1021")
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -13,13 +13,13 @@ final class UpgradesViewModelTests: XCTestCase {
             // Given
             let sut = await UpgradesViewModel(siteID: sampleSiteID)
 
-            let initialProducts = await sut.products
-            let initialEntitledProducts = await sut.entitledProductIDs
+            let initialWpcomPlans = await sut.wpcomPlans
+            let initialEntitledWpcomPlanIDs = await sut.entitledWpcomPlanIDs
 
             // When/Then
             DispatchQueue.main.async {
-                XCTAssertTrue(initialProducts.isEmpty)
-                XCTAssertTrue(initialEntitledProducts.isEmpty)
+                XCTAssertTrue(initialWpcomPlans.isEmpty)
+                XCTAssertTrue(initialEntitledWpcomPlanIDs.isEmpty)
                 expectation.fulfill()
             }
         }


### PR DESCRIPTION
Closes: #9895 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR addresses refactoring the variable and method names that refer to IAP WPCom plans as IAP products, in order to avoid confusion with WooCommerce products.

## Question: 

What are your thoughts about where should we draw the boundary between a WPCom Plan and a `StoreKit.Product`? 

At the moment I draw it in the Yosemite layer and left `InAppPurchaseAction` and `InAppPurchaseStore` to deal with products rather than plans, as the result types are declared as `Result<[StoreKit.Product], Error>` and `Result<StoreKit.Product.PurchaseResult, Error>`. 

That said, we could also hide these details behind a type alias and define these as plans as well, but since we're interfacing with StoreKit directly, I'd decided to leave it like this for the moment, but happy to get some input and iterate as needed.

## Testing instructions
No business logic has been changed. Tests should pass.
