### PR TITLE
Product Sharing: Add parameter for disable cache for AI generated content API

### DIFF
--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -16,7 +16,8 @@ public protocol GenerativeContentRemoteProtocol {
 public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProtocol {
     public func generateText(siteID: Int64, base: String) async throws -> String {
         let path = "sites/\(siteID)/\(Path.text)"
-        let parameters = [ParameterKey.textContent: base]
+        /// We are skipping cache entirely to avoid showing outdated/duplicated text.
+        let parameters = [ParameterKey.textContent: base, ParameterKey.skipCache: "true"]
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
         return try await enqueue(request)
     }
@@ -31,5 +32,6 @@ private extension GenerativeContentRemote {
 
     enum ParameterKey {
         static let textContent = "content"
+        static let skipCache = "skip_cache"
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As mentioned in pe5sF9-1AH-p2#comment-2268 - there's an option to disable cache for AI-generated content on Jetpack AI API. This PR adds the new parameter with the default option to disable cache to avoid showing outdated/duplicated text.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a public WPCom site.
- Select a published product and tap Share.
- On the AI view, select Write it for me. 
- After a text is generated, tap Regenerate immediately.
- Notice that you get different text the second time.
- Please feel free to test with the swipe-to-share feature on the product list if you have more than 1 published product to make sure that you get appropriate generated text for different products.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/698520f5-3ffa-4e7a-a20e-b6ff5548484e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.