### PR TITLE
[IAP] Make `UpgradesViewModel` testable

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchasesForWPComPlansManager.swift
@@ -1,10 +1,8 @@
 import Foundation
 import StoreKit
 
-#if DEBUG
-
 /// Only used during store creation development before IAP server side is ready.
-struct MockInAppPurchases {
+struct MockInAppPurchasesForWPComPlansManager {
     struct Plan: WPComPlanProduct {
         let displayName: String
         let description: String
@@ -31,7 +29,7 @@ struct MockInAppPurchases {
     }
 }
 
-extension MockInAppPurchases: InAppPurchasesForWPComPlansProtocol {
+extension MockInAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProtocol {
     func fetchPlans() async throws -> [WPComPlanProduct] {
         try await Task.sleep(nanoseconds: fetchPlansDelayInNanoseconds)
         return plans
@@ -55,7 +53,7 @@ extension MockInAppPurchases: InAppPurchasesForWPComPlansProtocol {
     }
 }
 
-private extension MockInAppPurchases {
+private extension MockInAppPurchasesForWPComPlansManager {
     enum Defaults {
         static let plans: [WPComPlanProduct] = [
             Plan(displayName: "Debug Monthly",
@@ -65,5 +63,3 @@ private extension MockInAppPurchases {
         ]
     }
 }
-
-#endif

--- a/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchasesForWPComPlansManager.swift
@@ -19,7 +19,7 @@ struct MockInAppPurchasesForWPComPlansManager {
     /// - Parameter plans: WPCom plans to return for purchase.
     /// - Parameter userIsEntitledToProduct: Whether the user is entitled to the matched IAP product.
     init(fetchPlansDelayInNanoseconds: UInt64 = 1_000_000_000,
-         plans: [WPComPlanProduct] = Defaults.plans,
+         plans: [WPComPlanProduct] = Defaults.debugEcommercePlans,
          userIsEntitledToPlan: Bool = false,
          isIAPSupported: Bool = true) {
         self.fetchPlansDelayInNanoseconds = fetchPlansDelayInNanoseconds
@@ -53,13 +53,19 @@ extension MockInAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansPro
     }
 }
 
-private extension MockInAppPurchasesForWPComPlansManager {
+extension MockInAppPurchasesForWPComPlansManager {
     enum Defaults {
-        static let plans: [WPComPlanProduct] = [
+        static let debugEcommercePlans: [WPComPlanProduct] = [
             Plan(displayName: "Debug Monthly",
                  description: "1 Month of Debug Woo",
                  id: "debug.woocommerce.ecommerce.monthly",
                  displayPrice: "$69.99")
+        ]
+        static let debugInAppPurchasesPlans: [WPComPlanProduct] = [
+            Plan(displayName: "Debug Essential Monthly",
+                 description: "1 Month of Debug Essential",
+                 id: "debug.woocommerce.express.essential.monthly",
+                 displayPrice: "$99.99")
         ]
     }
 }

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -55,7 +55,7 @@ final class UpgradesViewModel: ObservableObject {
 
     /// Retrieves a specific In-App Purchase WPCom plan from the available products
     ///
-    func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans ) -> WPComPlanProduct? {
+    func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans) -> WPComPlanProduct? {
         let match = type.rawValue
         guard let wpcomPlanProduct = wpcomPlans.first(where: { $0.id == match }) else {
             return nil

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -7,17 +7,15 @@ import SwiftUI
 @MainActor
 final class UpgradesViewModel: ObservableObject {
 
-    private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansManager
+    private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol
     private let siteID: Int64
 
     @Published var wpcomPlans: [WPComPlanProduct]
     @Published var entitledWpcomPlanIDs: Set<String>
 
-    init(siteID: Int64) {
+    init(siteID: Int64, inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
         self.siteID = siteID
-        // TODO: Inject dependencies
-        // https://github.com/woocommerce/woocommerce-ios/issues/9884
-        inAppPurchasesPlanManager = InAppPurchasesForWPComPlansManager()
+        self.inAppPurchasesPlanManager = inAppPurchasesPlanManager
         wpcomPlans = []
         entitledWpcomPlanIDs = []
     }

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
@@ -51,7 +51,6 @@ protocol InAppPurchasesForWPComPlansProtocol {
     func inAppPurchasesAreSupported() async -> Bool
 }
 
-@MainActor
 final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProtocol {
     private let stores: StoresManager
 
@@ -59,6 +58,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         self.stores = stores
     }
 
+    @MainActor
     func fetchPlans() async throws -> [WPComPlanProduct] {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.loadProducts(completion: { result in
@@ -67,6 +67,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
+    @MainActor
     func userIsEntitledToPlan(with id: String) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.userIsEntitledToProduct(productID: id, completion: { result in
@@ -75,6 +76,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
+    @MainActor
     func purchasePlan(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.purchaseProduct(siteID: remoteSiteId, productID: id, completion: { result in
@@ -83,6 +85,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
+    @MainActor
     func retryWPComSyncForPurchasedPlan(with id: String) async throws {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.retryWPComSyncForPurchasedProduct(productID: id, completion: { result in
@@ -91,6 +94,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
+    @MainActor
     func inAppPurchasesAreSupported() async -> Bool {
         await withCheckedContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.inAppPurchasesAreSupported(completion: { result in

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -76,7 +76,7 @@ struct UpgradesView: View {
             }
         }
         .task {
-            await upgradesViewModel.loadPlans()
+            await upgradesViewModel.fetchPlans()
         }
         .navigationBarTitle(Constants.navigationTitle)
         .navigationBarTitleDisplayMode(.large)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -331,7 +331,7 @@
 		0282DD98233CA093006A5FDB /* OrderSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282DD97233CA093006A5FDB /* OrderSearchUICommand.swift */; };
 		0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */; };
 		02863F6A29246E18006A06AA /* StoreCreationPlanFeaturesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02863F6929246E18006A06AA /* StoreCreationPlanFeaturesView.swift */; };
-		02863F6F2925FC29006A06AA /* MockInAppPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02863F6E2925FC29006A06AA /* MockInAppPurchases.swift */; };
+		02863F6F2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */; };
 		0286837727B25930000E5785 /* HubMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286837627B25930000E5785 /* HubMenuViewModelTests.swift */; };
 		0286B27A23C7051F003D784B /* ProductImagesCollectionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */; };
 		0286B27B23C7051F003D784B /* ProductImagesCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286B27723C7051F003D784B /* ProductImagesCollectionViewController.swift */; };
@@ -2645,7 +2645,7 @@
 		0282DD97233CA093006A5FDB /* OrderSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchUICommand.swift; sourceTree = "<group>"; };
 		0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersSectionHeaderView.swift; sourceTree = "<group>"; };
 		02863F6929246E18006A06AA /* StoreCreationPlanFeaturesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationPlanFeaturesView.swift; sourceTree = "<group>"; };
-		02863F6E2925FC29006A06AA /* MockInAppPurchases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInAppPurchases.swift; sourceTree = "<group>"; };
+		02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		0286837627B25930000E5785 /* HubMenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubMenuViewModelTests.swift; sourceTree = "<group>"; };
 		0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductImagesCollectionViewController.xib; sourceTree = "<group>"; };
 		0286B27723C7051F003D784B /* ProductImagesCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductImagesCollectionViewController.swift; sourceTree = "<group>"; };
@@ -5873,7 +5873,7 @@
 				02EEA9272923338100D05F47 /* StoreCreationPlanView.swift */,
 				020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */,
 				02863F6929246E18006A06AA /* StoreCreationPlanFeaturesView.swift */,
-				02863F6E2925FC29006A06AA /* MockInAppPurchases.swift */,
+				02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */,
 				02EF1669292DE9E100D90AD6 /* WebPurchasesForWPComPlans.swift */,
 				02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */,
 			);
@@ -11701,7 +11701,7 @@
 				036CA6B9291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift in Sources */,
 				B6F379682937836700718561 /* AnalyticsHubTimeRange.swift in Sources */,
 				0227958D237A51F300787C63 /* OptionsTableViewController+Styles.swift in Sources */,
-				02863F6F2925FC29006A06AA /* MockInAppPurchases.swift in Sources */,
+				02863F6F2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift in Sources */,
 				B541B226218A412C008FE7C1 /* UIFont+Woo.swift in Sources */,
 				68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */,
 				4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -331,7 +331,6 @@
 		0282DD98233CA093006A5FDB /* OrderSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282DD97233CA093006A5FDB /* OrderSearchUICommand.swift */; };
 		0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */; };
 		02863F6A29246E18006A06AA /* StoreCreationPlanFeaturesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02863F6929246E18006A06AA /* StoreCreationPlanFeaturesView.swift */; };
-		02863F6F2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */; };
 		0286837727B25930000E5785 /* HubMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286837627B25930000E5785 /* HubMenuViewModelTests.swift */; };
 		0286B27A23C7051F003D784B /* ProductImagesCollectionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */; };
 		0286B27B23C7051F003D784B /* ProductImagesCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286B27723C7051F003D784B /* ProductImagesCollectionViewController.swift */; };
@@ -549,6 +548,7 @@
 		03191AE928E20C9200670723 /* PluginDetailsRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03191AE828E20C9200670723 /* PluginDetailsRowView.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		032E481D2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */; };
+		0331A7002A334982001D2C2C /* MockInAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */; };
 		03582BE2299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03582BE1299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift */; };
 		035BA3A8291000E90056F0AD /* JustInTimeMessageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A7291000E90056F0AD /* JustInTimeMessageViewModelTests.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
@@ -5873,7 +5873,6 @@
 				02EEA9272923338100D05F47 /* StoreCreationPlanView.swift */,
 				020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */,
 				02863F6929246E18006A06AA /* StoreCreationPlanFeaturesView.swift */,
-				02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */,
 				02EF1669292DE9E100D90AD6 /* WebPurchasesForWPComPlans.swift */,
 				02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */,
 			);
@@ -7506,6 +7505,7 @@
 				0388E1A929E04715007DF84D /* MockDeepLinkForwarder.swift */,
 				B9DC770629F2D4910013B191 /* MockProductSelectorTopProductsProvider.swift */,
 				026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */,
+				02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11701,7 +11701,6 @@
 				036CA6B9291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift in Sources */,
 				B6F379682937836700718561 /* AnalyticsHubTimeRange.swift in Sources */,
 				0227958D237A51F300787C63 /* OptionsTableViewController+Styles.swift in Sources */,
-				02863F6F2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift in Sources */,
 				B541B226218A412C008FE7C1 /* UIFont+Woo.swift in Sources */,
 				68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */,
 				4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */,
@@ -12716,6 +12715,7 @@
 				0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */,
 				5750BEE82764006F00388BE6 /* RefundFeesDetailsViewModelTests.swift in Sources */,
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
+				0331A7002A334982001D2C2C /* MockInAppPurchasesForWPComPlansManager.swift in Sources */,
 				02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
 				7E6A01A12725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
@@ -79,7 +79,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchases(fetchPlansDelayInNanoseconds: 0))
+                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0))
         waitFor { promise in
             self.navigationController.present(.init(), animated: false) {
                 promise(())
@@ -104,7 +104,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         let coordinator = StoreCreationCoordinator(source: .loggedOut(source: .loginEmailError),
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchases(fetchPlansDelayInNanoseconds: 0))
+                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0))
         XCTAssertNotNil(navigationController.topViewController)
         XCTAssertNil(navigationController.presentedViewController)
 
@@ -124,7 +124,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchases(fetchPlansDelayInNanoseconds: 0, isIAPSupported: false))
+                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0, isIAPSupported: false))
         waitFor { promise in
             self.navigationController.present(.init(), animated: false) {
                 promise(())
@@ -175,7 +175,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
         // 6 seconds = 6_000_000_000 nanoseconds.
-        let purchasesManager = MockInAppPurchases(fetchPlansDelayInNanoseconds: 6_000_000_000)
+        let purchasesManager = MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 6_000_000_000)
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
@@ -193,9 +193,9 @@ final class StoreCreationCoordinatorTests: XCTestCase {
     func test_AuthenticatedWebViewController_is_presented_when_no_matching_iap_product() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        let purchasesManager = MockInAppPurchases(fetchPlansDelayInNanoseconds: 0,
+        let purchasesManager = MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0,
                                             plans: [
-                                                MockInAppPurchases.Plan(displayName: "",
+                                                MockInAppPurchasesForWPComPlansManager.Plan(displayName: "",
                                                                         description: "",
                                                                         id: "random.id",
                                                                         displayPrice: "$25")
@@ -217,7 +217,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
     func test_AuthenticatedWebViewController_is_presented_when_user_is_already_entitled_to_iap_product() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        let purchasesManager = MockInAppPurchases(fetchPlansDelayInNanoseconds: 0, userIsEntitledToPlan: true)
+        let purchasesManager = MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0, userIsEntitledToPlan: true)
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
@@ -124,7 +124,8 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         let coordinator = StoreCreationCoordinator(source: .storePicker,
                                                    navigationController: navigationController,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0, isIAPSupported: false))
+                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0,
+                                                                                                            isIAPSupported: false))
         waitFor { promise in
             self.navigationController.present(.init(), animated: false) {
                 promise(())

--- a/WooCommerce/WooCommerceTests/Mocks/MockInAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockInAppPurchasesForWPComPlansManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import StoreKit
+@testable import WooCommerce
 
 /// Only used during store creation development before IAP server side is ready.
 struct MockInAppPurchasesForWPComPlansManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -60,7 +60,6 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
 
     func test_generateShareMessage_updates_errorMessage_on_failure() async {
         // Given
-        let expectedString = "Check out this product!"
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123, productName: "Test", url: "https://example.com", stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -4,49 +4,42 @@ import XCTest
 final class UpgradesViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 12345
+    private var mockInAppPurchasesManager: MockInAppPurchasesForWPComPlansManager!
+
+    private var sut: UpgradesViewModel!
+
+    override func setUp() {
+        let plans = MockInAppPurchasesForWPComPlansManager.Defaults.debugInAppPurchasesPlans
+        mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans)
+        sut = UpgradesViewModel(siteID: sampleSiteID, inAppPurchasesPlanManager: mockInAppPurchasesManager)
+    }
 
     func test_upgrades_are_initialized_with_empty_values() async {
         // Given, When
-        let sut = UpgradesViewModel(siteID: sampleSiteID)
+        let sut = UpgradesViewModel(siteID: sampleSiteID,
+                                    inAppPurchasesPlanManager: MockInAppPurchasesForWPComPlansManager(plans: []))
 
         // Then
-        XCTAssertTrue(sut.wpcomPlans.isEmpty)
-        XCTAssertTrue(sut.entitledWpcomPlanIDs.isEmpty)
-    }
-
-    func test_upgrades_when_fetchPlans_is_invoked_then_fetch_debug_wpcom_plan() async {
-        // Given
-        let sut = UpgradesViewModel(siteID: sampleSiteID)
-
-        // When
-        await sut.fetchPlans()
-
-        // Then
-        XCTAssertEqual(sut.wpcomPlans.first?.displayName, "Debug Monthly")
-        XCTAssertEqual(sut.wpcomPlans.first?.description, "1 Month of Debug Woo")
-        XCTAssertEqual(sut.wpcomPlans.first?.id, "debug.woocommerce.ecommerce.monthly")
-        XCTAssertEqual(sut.wpcomPlans.first?.displayPrice, "$69.99")
+        XCTAssert(sut.wpcomPlans.isEmpty)
+        XCTAssert(sut.entitledWpcomPlanIDs.isEmpty)
     }
 
     func test_upgrades_when_fetchPlans_is_invoked_then_fetch_mocked_wpcom_plan() async {
         // Given
-        let plans = MockInAppPurchasesForWPComPlansManager.Defaults.debugInAppPurchasesPlans
-        let inAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans)
-        let sut = UpgradesViewModel(siteID: sampleSiteID,
-                                    inAppPurchasesPlanManager: inAppPurchasesManager)
+        // see `setUp`
 
         // When
         await sut.fetchPlans()
 
         // Then
-        XCTAssertEqual(sut.wpcomPlans.first?.displayName, "Debug Essential Monthly")
-        XCTAssertEqual(sut.wpcomPlans.first?.description, "1 Month of Debug Essential")
-        XCTAssertEqual(sut.wpcomPlans.first?.id, "debug.woocommerce.express.essential.monthly")
-        XCTAssertEqual(sut.wpcomPlans.first?.displayPrice, "$99.99")
+        assertEqual("Debug Essential Monthly", sut.wpcomPlans.first?.displayName)
+        assertEqual("1 Month of Debug Essential", sut.wpcomPlans.first?.description)
+        assertEqual("debug.woocommerce.express.essential.monthly", sut.wpcomPlans.first?.id)
+        assertEqual("$99.99", sut.wpcomPlans.first?.displayPrice)
     }
 
     func test_upgrades_when_retrievePlanDetailsIfAvailable_retrieves_debug_wpcom_plan() async {
-        // Given
+        // Given (no injected plans)
         let fakeInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager()
         let sut = UpgradesViewModel(siteID: sampleSiteID,
                                     inAppPurchasesPlanManager: fakeInAppPurchasesManager)
@@ -63,8 +56,12 @@ final class UpgradesViewModelTests: XCTestCase {
 
     func test_upgrades_when_retrievePlanDetailsIfAvailable_retrieves_injected_wpcom_plan() async {
         // Given
-        let plans = MockInAppPurchasesForWPComPlansManager.Defaults.debugInAppPurchasesPlans
-        let inAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans)
+        let expectedPlan: WPComPlanProduct = MockInAppPurchasesForWPComPlansManager.Plan(
+                displayName: "Test awesome plan",
+                description: "All the Woo, all the time",
+                id: "debug.woocommerce.express.essential.monthly",
+                displayPrice: "$1.50")
+        let inAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: [expectedPlan])
         let sut = UpgradesViewModel(siteID: sampleSiteID,
                                     inAppPurchasesPlanManager: inAppPurchasesManager)
 
@@ -73,9 +70,9 @@ final class UpgradesViewModelTests: XCTestCase {
         let wpcomPlan = sut.retrievePlanDetailsIfAvailable(.essentialMonthly)
 
         // Then
-        XCTAssertEqual(wpcomPlan?.displayName, "Debug Essential Monthly")
-        XCTAssertEqual(wpcomPlan?.description, "1 Month of Debug Essential")
-        XCTAssertEqual(wpcomPlan?.id, "debug.woocommerce.express.essential.monthly")
-        XCTAssertEqual(wpcomPlan?.displayPrice, "$99.99")
+        assertEqual("Test awesome plan", wpcomPlan?.displayName)
+        assertEqual("All the Woo, all the time", wpcomPlan?.description)
+        assertEqual("debug.woocommerce.express.essential.monthly", wpcomPlan?.id)
+        assertEqual("$1.50", wpcomPlan?.displayPrice)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -5,34 +5,77 @@ final class UpgradesViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 12345
 
-    func test_initial_UpgradesViewModel_initializes_with_correct_empty_values() {
+    func test_upgrades_are_initialized_with_empty_values() async {
+        // Given, When
+        let sut = UpgradesViewModel(siteID: sampleSiteID)
 
-        let expectation = XCTestExpectation(description: "Waiting for main queue")
-
-        Task {
-            // Given
-            let sut = await UpgradesViewModel(siteID: sampleSiteID)
-
-            let initialWpcomPlans = await sut.wpcomPlans
-            let initialEntitledWpcomPlanIDs = await sut.entitledWpcomPlanIDs
-
-            // When/Then
-            DispatchQueue.main.async {
-                XCTAssertTrue(initialWpcomPlans.isEmpty)
-                XCTAssertTrue(initialEntitledWpcomPlanIDs.isEmpty)
-                expectation.fulfill()
-            }
-        }
-
-        wait(for: [expectation], timeout: 1.0)
+        // Then
+        XCTAssertTrue(sut.wpcomPlans.isEmpty)
+        XCTAssertTrue(sut.entitledWpcomPlanIDs.isEmpty)
     }
 
-    func test_inAppPurchasesPlanManager() {
-        /**
-         TODO: https://github.com/woocommerce/woocommerce-ios/issues/9884
-         In order to pass a `MockInAppPurchases` and test the view model behavior,
-         we need to inject it into the initializer via `InAppPurchasesForWPComPlansProtocol`.
-         This cannot be done at the moment due to the concrete `InAppPurchasesForWPComPlansManager` concrete implementation using `@MainActor` on class-level.
-         */
+    func test_upgrades_when_fetchPlans_is_invoked_then_fetch_debug_wpcom_plan() async {
+        // Given
+        let sut = UpgradesViewModel(siteID: sampleSiteID)
+
+        // When
+        await sut.fetchPlans()
+
+        // Then
+        XCTAssertEqual(sut.wpcomPlans.first?.displayName, "Debug Monthly")
+        XCTAssertEqual(sut.wpcomPlans.first?.description, "1 Month of Debug Woo")
+        XCTAssertEqual(sut.wpcomPlans.first?.id, "debug.woocommerce.ecommerce.monthly")
+        XCTAssertEqual(sut.wpcomPlans.first?.displayPrice, "$69.99")
+    }
+
+    func test_upgrades_when_fetchPlans_is_invoked_then_fetch_mocked_wpcom_plan() async {
+        // Given
+        let plans = MockInAppPurchasesForWPComPlansManager.Defaults.debugInAppPurchasesPlans
+        let inAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans)
+        let sut = UpgradesViewModel(siteID: sampleSiteID,
+                                    inAppPurchasesPlanManager: inAppPurchasesManager)
+
+        // When
+        await sut.fetchPlans()
+
+        // Then
+        XCTAssertEqual(sut.wpcomPlans.first?.displayName, "Debug Essential Monthly")
+        XCTAssertEqual(sut.wpcomPlans.first?.description, "1 Month of Debug Essential")
+        XCTAssertEqual(sut.wpcomPlans.first?.id, "debug.woocommerce.express.essential.monthly")
+        XCTAssertEqual(sut.wpcomPlans.first?.displayPrice, "$99.99")
+    }
+
+    func test_upgrades_when_retrievePlanDetailsIfAvailable_retrieves_debug_wpcom_plan() async {
+        // Given
+        let fakeInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager()
+        let sut = UpgradesViewModel(siteID: sampleSiteID,
+                                    inAppPurchasesPlanManager: fakeInAppPurchasesManager)
+
+        // When
+        await sut.fetchPlans()
+        XCTAssertEqual(sut.wpcomPlans.first?.displayName, "Debug Monthly", "Precondition")
+
+        let wpcomPlan = sut.retrievePlanDetailsIfAvailable(.essentialMonthly)
+
+        // Then
+        XCTAssertNil(wpcomPlan)
+    }
+
+    func test_upgrades_when_retrievePlanDetailsIfAvailable_retrieves_injected_wpcom_plan() async {
+        // Given
+        let plans = MockInAppPurchasesForWPComPlansManager.Defaults.debugInAppPurchasesPlans
+        let inAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans)
+        let sut = UpgradesViewModel(siteID: sampleSiteID,
+                                    inAppPurchasesPlanManager: inAppPurchasesManager)
+
+        // When
+        await sut.fetchPlans()
+        let wpcomPlan = sut.retrievePlanDetailsIfAvailable(.essentialMonthly)
+
+        // Then
+        XCTAssertEqual(wpcomPlan?.displayName, "Debug Essential Monthly")
+        XCTAssertEqual(wpcomPlan?.description, "1 Month of Debug Essential")
+        XCTAssertEqual(wpcomPlan?.id, "debug.woocommerce.express.essential.monthly")
+        XCTAssertEqual(wpcomPlan?.displayPrice, "$99.99")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9884 . Branched of https://github.com/woocommerce/woocommerce-ios/pull/9907, which should be merged first
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR makes `UpgradesViewModel` more testable by declaring a `InAppPurchasesForWPComPlansProtocol` dependency in its initializer, which defaults to an instance of `InAppPurchasesForWPComPlansManager` if none is given

## Changes
- We remove the class-level `@MainActor` declaration in `InAppPurchasesForWPComPlansManager` in favor of declaring it per-method basis. This is done so we can inject objects that conform to the protocol without the constraint of decorating them as `@MainActor` as well (for example when mocking), since we only need the current methods to run in the main thread due being async wrappers for existing `InAppPurchaseAction`s
- Add tests for fetchPlans(), and retrievePlanDetailsIfAvailable() methods. More tests will be added when we handle the result of purchasePlan() and the different errors.

## Testing instructions
- Upgrading a Free trial store should work
- Tests should pass
