### PR TITLE
Product Sharing: Add unit tests for ShareProductCoordinator

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -308,7 +308,8 @@ private extension AddProductCoordinator {
     func showFirstProductCreatedView(productURL: URL,
                                      productName: String,
                                      showShareProductButton: Bool) {
-        let viewController = FirstProductCreatedHostingController(productURL: productURL,
+        let viewController = FirstProductCreatedHostingController(siteID: siteID,
+                                                                  productURL: productURL,
                                                                   productName: productName,
                                                                   showShareProductButton: showShareProductButton)
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -11,9 +11,11 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
          productURL: URL,
          productName: String,
          showShareProductButton: Bool) {
+        let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton)
+                                                     showShareProductButton: showShareProductButton,
+                                                     eligibilityChecker: checker)
         super.init(rootView: FirstProductCreatedView(viewModel: viewModel))
         viewModel.launchAISharingFlow = { [weak self] in
             guard let self,
@@ -21,7 +23,6 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
                 return
             }
 
-            let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
             let shareProductCoordinator = ShareProductCoordinator(siteID: siteID,
                                                                   productURL: productURL,
                                                                   productName: productName,
@@ -131,19 +132,23 @@ private extension FirstProductCreatedView {
 
 struct FirstProductCreatedView_Previews: PreviewProvider {
     static var previews: some View {
+        let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
         FirstProductCreatedView(viewModel: .init(productURL: URL(string: "https://example.com/sampleproduct")!,
                                                  productName: "Sample product",
-                                                 showShareProductButton: true))
+                                                 showShareProductButton: true,
+                                                 eligibilityChecker: checker))
         .environment(\.colorScheme, .light)
 
         FirstProductCreatedView(viewModel: .init(productURL: URL(string: "https://example.com/sampleproduct")!,
                                                  productName: "Sample product",
-                                                 showShareProductButton: false))
+                                                 showShareProductButton: false,
+                                                 eligibilityChecker: checker))
         .environment(\.colorScheme, .light)
 
         FirstProductCreatedView(viewModel: .init(productURL: URL(string: "https://example.com/sampleproduct")!,
                                                  productName: "Sample product",
-                                                 showShareProductButton: false))
+                                                 showShareProductButton: false,
+                                                 eligibilityChecker: checker))
         .environment(\.colorScheme, .dark)
         .previewInterfaceOrientation(.landscapeLeft)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -132,23 +132,19 @@ private extension FirstProductCreatedView {
 
 struct FirstProductCreatedView_Previews: PreviewProvider {
     static var previews: some View {
-        let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
         FirstProductCreatedView(viewModel: .init(productURL: URL(string: "https://example.com/sampleproduct")!,
                                                  productName: "Sample product",
-                                                 showShareProductButton: true,
-                                                 eligibilityChecker: checker))
+                                                 showShareProductButton: true))
         .environment(\.colorScheme, .light)
 
         FirstProductCreatedView(viewModel: .init(productURL: URL(string: "https://example.com/sampleproduct")!,
                                                  productName: "Sample product",
-                                                 showShareProductButton: false,
-                                                 eligibilityChecker: checker))
+                                                 showShareProductButton: false))
         .environment(\.colorScheme, .light)
 
         FirstProductCreatedView(viewModel: .init(productURL: URL(string: "https://example.com/sampleproduct")!,
                                                  productName: "Sample product",
-                                                 showShareProductButton: false,
-                                                 eligibilityChecker: checker))
+                                                 showShareProductButton: false))
         .environment(\.colorScheme, .dark)
         .previewInterfaceOrientation(.landscapeLeft)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -11,11 +11,9 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
          productURL: URL,
          productName: String,
          showShareProductButton: Bool) {
-        let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton,
-                                                     eligibilityChecker: checker)
+                                                     showShareProductButton: showShareProductButton)
         super.init(rootView: FirstProductCreatedView(viewModel: viewModel))
         viewModel.launchAISharingFlow = { [weak self] in
             guard let self,
@@ -27,7 +25,6 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
                                                                   productURL: productURL,
                                                                   productName: productName,
                                                                   shareSheetAnchorView: self.view,
-                                                                  shareProductEligibilityChecker: checker,
                                                                   navigationController: navigationController)
             shareProductCoordinator.start()
             self.shareProductCoordinator = shareProductCoordinator

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedView.swift
@@ -7,7 +7,8 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
     ///
     private var shareProductCoordinator: ShareProductCoordinator?
 
-    init(productURL: URL,
+    init(siteID: Int64,
+         productURL: URL,
          productName: String,
          showShareProductButton: Bool) {
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
@@ -20,9 +21,12 @@ final class FirstProductCreatedHostingController: UIHostingController<FirstProdu
                 return
             }
 
-            let shareProductCoordinator = ShareProductCoordinator(productURL: productURL,
+            let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
+            let shareProductCoordinator = ShareProductCoordinator(siteID: siteID,
+                                                                  productURL: productURL,
                                                                   productName: productName,
                                                                   shareSheetAnchorView: self.view,
+                                                                  shareProductEligibilityChecker: checker,
                                                                   navigationController: navigationController)
             shareProductCoordinator.start()
             self.shareProductCoordinator = shareProductCoordinator

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
@@ -19,7 +19,7 @@ final class FirstProductCreatedViewModel: ObservableObject {
          productName: String,
          showShareProductButton: Bool,
          isPad: Bool = UIDevice.isPad(),
-         eligibilityChecker: ShareProductAIEligibilityChecker,
+         eligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
          analytics: Analytics = ServiceLocator.analytics) {
         self.productURL = productURL
         self.productName = productName

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
@@ -19,13 +19,13 @@ final class FirstProductCreatedViewModel: ObservableObject {
          productName: String,
          showShareProductButton: Bool,
          isPad: Bool = UIDevice.isPad(),
-         eligibilityChecker: ShareProductAIEligibilityChecker? = nil,
+         eligibilityChecker: ShareProductAIEligibilityChecker,
          analytics: Analytics = ServiceLocator.analytics) {
         self.productURL = productURL
         self.productName = productName
         self.showShareProductButton = showShareProductButton
 
-        let eligibilityChecker = eligibilityChecker ?? DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
+        let eligibilityChecker = eligibilityChecker
         self.canGenerateShareProductMessageUsingAI = eligibilityChecker.canGenerateShareProductMessageUsingAI
 
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -883,9 +883,12 @@ private extension ProductFormViewController {
             return
         }
 
-        let shareProductCoordinator = ShareProductCoordinator(productURL: url,
+        let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
+        let shareProductCoordinator = ShareProductCoordinator(siteID: product.siteID,
+                                                              productURL: url,
                                                               productName: product.name,
                                                               shareSheetAnchorItem: sourceView,
+                                                              shareProductEligibilityChecker: checker,
                                                               navigationController: navigationController)
         shareProductCoordinator.start()
         self.shareProductCoordinator = shareProductCoordinator

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -883,12 +883,10 @@ private extension ProductFormViewController {
             return
         }
 
-        let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
         let shareProductCoordinator = ShareProductCoordinator(siteID: product.siteID,
                                                               productURL: url,
                                                               productName: product.name,
                                                               shareSheetAnchorItem: sourceView,
-                                                              shareProductEligibilityChecker: checker,
                                                               navigationController: navigationController)
         shareProductCoordinator.start()
         self.shareProductCoordinator = shareProductCoordinator

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -954,7 +954,7 @@ extension ProductsViewController: UITableViewDelegate {
                   let navigationController = self.navigationController else {
                 return
             }
-            let shareProductCoordinator = ShareProductCoordinator(siteID: siteID,
+            let shareProductCoordinator = ShareProductCoordinator(siteID: self.siteID,
                                                                   productURL: url,
                                                                   productName: product.name,
                                                                   shareSheetAnchorView: cell,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -954,9 +954,12 @@ extension ProductsViewController: UITableViewDelegate {
                   let navigationController = self.navigationController else {
                 return
             }
-            let shareProductCoordinator = ShareProductCoordinator(productURL: url,
+            let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
+            let shareProductCoordinator = ShareProductCoordinator(siteID: siteID,
+                                                                  productURL: url,
                                                                   productName: product.name,
                                                                   shareSheetAnchorView: cell,
+                                                                  shareProductEligibilityChecker: checker,
                                                                   navigationController: navigationController)
             shareProductCoordinator.start()
             self.shareProductCoordinator = shareProductCoordinator

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -954,12 +954,10 @@ extension ProductsViewController: UITableViewDelegate {
                   let navigationController = self.navigationController else {
                 return
             }
-            let checker = DefaultShareProductAIEligibilityChecker(site: ServiceLocator.stores.sessionManager.defaultSite)
             let shareProductCoordinator = ShareProductCoordinator(siteID: siteID,
                                                                   productURL: url,
                                                                   productName: product.name,
                                                                   shareSheetAnchorView: cell,
-                                                                  shareProductEligibilityChecker: checker,
                                                                   navigationController: navigationController)
             shareProductCoordinator.start()
             self.shareProductCoordinator = shareProductCoordinator

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductAIEligibilityChecker.swift
@@ -9,7 +9,8 @@ struct DefaultShareProductAIEligibilityChecker: ShareProductAIEligibilityChecker
     private let site: Site?
     private let featureFlagService: FeatureFlagService
 
-    init(site: Site?, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(site: Site? = ServiceLocator.stores.sessionManager.defaultSite,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.site = site
         self.featureFlagService = featureFlagService
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -38,7 +38,7 @@ final class ShareProductCoordinator: Coordinator {
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorView: UIView,
-                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker,
+                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
                      navigationController: UINavigationController,
                      analytics: Analytics = ServiceLocator.analytics) {
         self.init(siteID: siteID,
@@ -55,7 +55,7 @@ final class ShareProductCoordinator: Coordinator {
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorItem: UIBarButtonItem,
-                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker,
+                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
                      navigationController: UINavigationController,
                      analytics: Analytics = ServiceLocator.analytics) {
         self.init(siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -11,7 +11,7 @@ final class ShareProductCoordinator: Coordinator {
     private let productName: String
     private let shareSheetAnchorView: UIView?
     private let shareSheetAnchorItem: UIBarButtonItem?
-    private let shareProductEligibilityChecker: ShareProductAIEligibilityChecker
+    private let eligibilityChecker: ShareProductAIEligibilityChecker
     private let analytics: Analytics
 
     private var bottomSheetPresenter: BottomSheetPresenter?
@@ -21,7 +21,7 @@ final class ShareProductCoordinator: Coordinator {
                  productName: String,
                  shareSheetAnchorView: UIView?,
                  shareSheetAnchorItem: UIBarButtonItem?,
-                 shareProductEligibilityChecker: ShareProductAIEligibilityChecker,
+                 eligibilityChecker: ShareProductAIEligibilityChecker,
                  navigationController: UINavigationController,
                  analytics: Analytics) {
         self.siteID = siteID
@@ -29,7 +29,7 @@ final class ShareProductCoordinator: Coordinator {
         self.productName = productName
         self.shareSheetAnchorView = shareSheetAnchorView
         self.shareSheetAnchorItem = shareSheetAnchorItem
-        self.shareProductEligibilityChecker = shareProductEligibilityChecker
+        self.eligibilityChecker = eligibilityChecker
         self.navigationController = navigationController
         self.analytics = analytics
     }
@@ -38,7 +38,7 @@ final class ShareProductCoordinator: Coordinator {
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorView: UIView,
-                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
+                     eligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
                      navigationController: UINavigationController,
                      analytics: Analytics = ServiceLocator.analytics) {
         self.init(siteID: siteID,
@@ -46,7 +46,7 @@ final class ShareProductCoordinator: Coordinator {
                   productName: productName,
                   shareSheetAnchorView: shareSheetAnchorView,
                   shareSheetAnchorItem: nil,
-                  shareProductEligibilityChecker: shareProductEligibilityChecker,
+                  eligibilityChecker: eligibilityChecker,
                   navigationController: navigationController,
                   analytics: analytics)
     }
@@ -55,7 +55,7 @@ final class ShareProductCoordinator: Coordinator {
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorItem: UIBarButtonItem,
-                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
+                     eligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
                      navigationController: UINavigationController,
                      analytics: Analytics = ServiceLocator.analytics) {
         self.init(siteID: siteID,
@@ -63,13 +63,13 @@ final class ShareProductCoordinator: Coordinator {
                   productName: productName,
                   shareSheetAnchorView: nil,
                   shareSheetAnchorItem: shareSheetAnchorItem,
-                  shareProductEligibilityChecker: shareProductEligibilityChecker,
+                  eligibilityChecker: eligibilityChecker,
                   navigationController: navigationController,
                   analytics: analytics)
     }
 
     func start() {
-        if shareProductEligibilityChecker.canGenerateShareProductMessageUsingAI {
+        if eligibilityChecker.canGenerateShareProductMessageUsingAI {
             presentShareProductAIGeneration()
         } else {
             presentShareSheet()

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductCoordinator.swift
@@ -6,7 +6,7 @@ import protocol Experiments.FeatureFlagService
 final class ShareProductCoordinator: Coordinator {
     let navigationController: UINavigationController
 
-    private let site: Site?
+    private let siteID: Int64
     private let productURL: URL
     private let productName: String
     private let shareSheetAnchorView: UIView?
@@ -16,54 +16,54 @@ final class ShareProductCoordinator: Coordinator {
 
     private var bottomSheetPresenter: BottomSheetPresenter?
 
-    private init(site: Site?,
+    private init(siteID: Int64,
                  productURL: URL,
                  productName: String,
                  shareSheetAnchorView: UIView?,
                  shareSheetAnchorItem: UIBarButtonItem?,
-                 featureFlagService: FeatureFlagService,
+                 shareProductEligibilityChecker: ShareProductAIEligibilityChecker,
                  navigationController: UINavigationController,
                  analytics: Analytics) {
-        self.site = site
+        self.siteID = siteID
         self.productURL = productURL
         self.productName = productName
         self.shareSheetAnchorView = shareSheetAnchorView
         self.shareSheetAnchorItem = shareSheetAnchorItem
-        self.shareProductEligibilityChecker = DefaultShareProductAIEligibilityChecker(site: site, featureFlagService: featureFlagService)
+        self.shareProductEligibilityChecker = shareProductEligibilityChecker
         self.navigationController = navigationController
         self.analytics = analytics
     }
 
-    convenience init(site: Site? = ServiceLocator.stores.sessionManager.defaultSite,
+    convenience init(siteID: Int64,
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorView: UIView,
-                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker,
                      navigationController: UINavigationController,
                      analytics: Analytics = ServiceLocator.analytics) {
-        self.init(site: site,
+        self.init(siteID: siteID,
                   productURL: productURL,
                   productName: productName,
                   shareSheetAnchorView: shareSheetAnchorView,
                   shareSheetAnchorItem: nil,
-                  featureFlagService: featureFlagService,
+                  shareProductEligibilityChecker: shareProductEligibilityChecker,
                   navigationController: navigationController,
                   analytics: analytics)
     }
 
-    convenience init(site: Site? = ServiceLocator.stores.sessionManager.defaultSite,
+    convenience init(siteID: Int64,
                      productURL: URL,
                      productName: String,
                      shareSheetAnchorItem: UIBarButtonItem,
-                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+                     shareProductEligibilityChecker: ShareProductAIEligibilityChecker,
                      navigationController: UINavigationController,
                      analytics: Analytics = ServiceLocator.analytics) {
-        self.init(site: site,
+        self.init(siteID: siteID,
                   productURL: productURL,
                   productName: productName,
                   shareSheetAnchorView: nil,
                   shareSheetAnchorItem: shareSheetAnchorItem,
-                  featureFlagService: featureFlagService,
+                  shareProductEligibilityChecker: shareProductEligibilityChecker,
                   navigationController: navigationController,
                   analytics: analytics)
     }
@@ -94,10 +94,6 @@ private extension ShareProductCoordinator {
     }
 
     func presentShareProductAIGeneration() {
-        guard let siteID = site?.siteID else {
-            DDLogWarn("⚠️ No site found for generating product sharing message!")
-            return
-        }
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: siteID,
                                                                  productName: productName,
                                                                  url: productURL.absoluteString)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2074,6 +2074,7 @@
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE96844B2A331AD2000FBF4E /* WooAnalyticsEvent+ProductSharingAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE96844A2A331AD2000FBF4E /* WooAnalyticsEvent+ProductSharingAI.swift */; };
+		DE96844D2A332CC2000FBF4E /* ShareProductCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE96844C2A332CC2000FBF4E /* ShareProductCoordinatorTests.swift */; };
 		DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */; };
 		DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */; };
 		DE9F2D2C2A1B1F5D004E5957 /* ConfettiSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */; };
@@ -4406,6 +4407,7 @@
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE96844A2A331AD2000FBF4E /* WooAnalyticsEvent+ProductSharingAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductSharingAI.swift"; sourceTree = "<group>"; };
+		DE96844C2A332CC2000FBF4E /* ShareProductCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductCoordinatorTests.swift; sourceTree = "<group>"; };
 		DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddStoreFooterView.swift; sourceTree = "<group>"; };
 		DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstProductCreatedView.swift; sourceTree = "<group>"; };
 		DEA426992875440500265B0C /* PaymentMethodsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsScreen.swift; sourceTree = "<group>"; };
@@ -10329,6 +10331,7 @@
 			isa = PBXGroup;
 			children = (
 				EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */,
+				DE96844C2A332CC2000FBF4E /* ShareProductCoordinatorTests.swift */,
 			);
 			path = ShareProduct;
 			sourceTree = "<group>";
@@ -12608,6 +12611,7 @@
 				3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */,
 				DEC51B04276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift in Sources */,
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
+				DE96844D2A332CC2000FBF4E /* ShareProductCoordinatorTests.swift in Sources */,
 				26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */,
 				263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */,
 				0279F0DC252DBF1F0098D7DE /* ProductVariationDetailsFactoryTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
@@ -20,6 +20,7 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
 
     func test_it_provides_expected_productURL() throws {
         // Given
+        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
@@ -27,13 +28,15 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         // When
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton)
+                                                     showShareProductButton: showShareProductButton,
+                                                     eligibilityChecker: checker)
         // Then
         XCTAssertEqual(viewModel.productURL, productURL)
     }
 
     func test_it_provides_expected_productName() throws {
         // Given
+        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
@@ -41,13 +44,15 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         // When
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton)
+                                                     showShareProductButton: showShareProductButton,
+                                                     eligibilityChecker: checker)
         // Then
         XCTAssertEqual(viewModel.productName, productName)
     }
 
     func test_it_provides_expected_showShareProductButton() throws {
         // Given
+        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
@@ -55,7 +60,8 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         // When
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton)
+                                                     showShareProductButton: showShareProductButton,
+                                                     eligibilityChecker: checker)
         // Then
         XCTAssertEqual(viewModel.showShareProductButton, showShareProductButton)
     }
@@ -64,12 +70,14 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
 
     func test_it_logs_an_event_when_share_product_button_is_tapped() throws {
         // Given
+        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
                                                      showShareProductButton: showShareProductButton,
+                                                     eligibilityChecker: checker,
                                                      analytics: analytics)
         assertEmpty(analyticsProvider.receivedEvents)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
@@ -219,6 +219,6 @@ private extension FirstProductCreatedViewModelTests {
     }
 }
 
-private struct MockShareProductAIEligibilityChecker: ShareProductAIEligibilityChecker {
+struct MockShareProductAIEligibilityChecker: ShareProductAIEligibilityChecker {
     var canGenerateShareProductMessageUsingAI: Bool
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
@@ -20,7 +20,6 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
 
     func test_it_provides_expected_productURL() throws {
         // Given
-        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
@@ -28,15 +27,13 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         // When
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton,
-                                                     eligibilityChecker: checker)
+                                                     showShareProductButton: showShareProductButton)
         // Then
         XCTAssertEqual(viewModel.productURL, productURL)
     }
 
     func test_it_provides_expected_productName() throws {
         // Given
-        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
@@ -44,15 +41,13 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         // When
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton,
-                                                     eligibilityChecker: checker)
+                                                     showShareProductButton: showShareProductButton)
         // Then
         XCTAssertEqual(viewModel.productName, productName)
     }
 
     func test_it_provides_expected_showShareProductButton() throws {
         // Given
-        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
@@ -60,8 +55,7 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
         // When
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
-                                                     showShareProductButton: showShareProductButton,
-                                                     eligibilityChecker: checker)
+                                                     showShareProductButton: showShareProductButton)
         // Then
         XCTAssertEqual(viewModel.showShareProductButton, showShareProductButton)
     }
@@ -70,14 +64,12 @@ final class FirstProductCreatedViewModelTests: XCTestCase {
 
     func test_it_logs_an_event_when_share_product_button_is_tapped() throws {
         // Given
-        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
         let productURL = try XCTUnwrap(Expectations.productURL)
         let productName = Expectations.productName
         let showShareProductButton = Expectations.showShareProductButton
         let viewModel = FirstProductCreatedViewModel(productURL: productURL,
                                                      productName: productName,
                                                      showShareProductButton: showShareProductButton,
-                                                     eligibilityChecker: checker,
                                                      analytics: analytics)
         assertEmpty(analyticsProvider.receivedEvents)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/ShareProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/ShareProductCoordinatorTests.swift
@@ -5,6 +5,8 @@ final class ShareProductCoordinatorTests: XCTestCase {
 
     private var navigationController: UINavigationController!
     private let productPath = "https://example.com"
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
 
     override func setUp() {
         navigationController = UINavigationController()
@@ -13,11 +15,16 @@ final class ShareProductCoordinatorTests: XCTestCase {
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
         window.rootViewController = navigationController
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         super.setUp()
     }
 
     override func tearDown() {
         navigationController = nil
+        analytics = nil
+        analyticsProvider = nil
         super.tearDown()
     }
 
@@ -40,4 +47,44 @@ final class ShareProductCoordinatorTests: XCTestCase {
         }
     }
 
+    func test_AI_sheet_is_displayed_when_AI_is_available() throws {
+        // Given
+        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: true)
+        let coordinator = ShareProductCoordinator(siteID: 123,
+                                                  productURL: try XCTUnwrap(URL(string: productPath)),
+                                                  productName: "Test",
+                                                  shareSheetAnchorItem: UIBarButtonItem(systemItem: .done),
+                                                  shareProductEligibilityChecker: checker,
+                                                  navigationController: navigationController)
+
+        // When
+        coordinator.start()
+
+        // Then
+        waitUntil {
+            self.navigationController.presentedViewController is ProductSharingMessageGenerationHostingController
+        }
+    }
+
+    func test_analytics_is_tracked_when_AI_sheet_is_displayed() throws {
+        // Given
+        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: true)
+        let coordinator = ShareProductCoordinator(siteID: 123,
+                                                  productURL: try XCTUnwrap(URL(string: productPath)),
+                                                  productName: "Test",
+                                                  shareSheetAnchorItem: UIBarButtonItem(systemItem: .done),
+                                                  shareProductEligibilityChecker: checker,
+                                                  navigationController: navigationController,
+                                                  analytics: analytics)
+
+        // When
+        coordinator.start()
+        waitUntil {
+            self.navigationController.presentedViewController is ProductSharingMessageGenerationHostingController
+        }
+
+        // Then
+        let firstEvent = try XCTUnwrap(analyticsProvider.receivedEvents.first)
+        XCTAssertEqual(firstEvent, "product_sharing_ai_displayed")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/ShareProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/ShareProductCoordinatorTests.swift
@@ -35,7 +35,7 @@ final class ShareProductCoordinatorTests: XCTestCase {
                                                   productURL: try XCTUnwrap(URL(string: productPath)),
                                                   productName: "Test",
                                                   shareSheetAnchorItem: UIBarButtonItem(systemItem: .done),
-                                                  shareProductEligibilityChecker: checker,
+                                                  eligibilityChecker: checker,
                                                   navigationController: navigationController)
 
         // When
@@ -54,7 +54,7 @@ final class ShareProductCoordinatorTests: XCTestCase {
                                                   productURL: try XCTUnwrap(URL(string: productPath)),
                                                   productName: "Test",
                                                   shareSheetAnchorItem: UIBarButtonItem(systemItem: .done),
-                                                  shareProductEligibilityChecker: checker,
+                                                  eligibilityChecker: checker,
                                                   navigationController: navigationController)
 
         // When
@@ -73,7 +73,7 @@ final class ShareProductCoordinatorTests: XCTestCase {
                                                   productURL: try XCTUnwrap(URL(string: productPath)),
                                                   productName: "Test",
                                                   shareSheetAnchorItem: UIBarButtonItem(systemItem: .done),
-                                                  shareProductEligibilityChecker: checker,
+                                                  eligibilityChecker: checker,
                                                   navigationController: navigationController,
                                                   analytics: analytics)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/ShareProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/ShareProductCoordinatorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import WooCommerce
+
+final class ShareProductCoordinatorTests: XCTestCase {
+
+    private var navigationController: UINavigationController!
+    private let productPath = "https://example.com"
+
+    override func setUp() {
+        navigationController = UINavigationController()
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        window.rootViewController = navigationController
+        super.setUp()
+    }
+
+    override func tearDown() {
+        navigationController = nil
+        super.tearDown()
+    }
+
+    func test_default_share_sheet_is_displayed_when_AI_is_not_available() throws {
+        // Given
+        let checker = MockShareProductAIEligibilityChecker(canGenerateShareProductMessageUsingAI: false)
+        let coordinator = ShareProductCoordinator(siteID: 123,
+                                                  productURL: try XCTUnwrap(URL(string: productPath)),
+                                                  productName: "Test",
+                                                  shareSheetAnchorItem: UIBarButtonItem(systemItem: .done),
+                                                  shareProductEligibilityChecker: checker,
+                                                  navigationController: navigationController)
+
+        // When
+        coordinator.start()
+
+        // Then
+        waitUntil {
+            self.navigationController.presentedViewController is UIActivityViewController
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR cleans up the code for `ShareProductCoordinator` and adds unit tests for it. I wanted to test the dismissal event of the AI sheet but it's only tracked when the sheet is dismissed interactively, not programmatically, so it's not possible unless we change the implementation.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Some refactoring was done to the `FirstProductCreatedView` and view model, so please test again to make sure that all the product-sharing features still work properly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
