### PR TITLE
[SKU scanner] Improve loading experience

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -240,6 +240,10 @@ private struct ProductsSection: View {
     ///
     @State private var showPermissionsSheet: Bool = false
 
+    /// Defines whether we should show a progress view instead of the barcode scanner button.
+    /// 
+    @State private var showAddProductViaSKUScannerLoading: Bool = false
+
     /// ID for Add Product button
     ///
     @Namespace var addProductButton
@@ -322,15 +326,21 @@ private struct ProductsSection: View {
                             logPermissionStatus(status: .permitted)
                         }
                     }, label: {
-                        Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                        if showAddProductViaSKUScannerLoading {
+                            ProgressView()
+                        } else {
+                            Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
                             .foregroundColor(Color(.brand))
+                        }
                     })
                     .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
                         scroll.scrollTo(addProductViaSKUScannerButton)
                     }, content: {
                         ProductSKUInputScannerView(onBarcodeScanned: { detectedBarcode in
+                            showAddProductViaSKUScanner = false
+                            showAddProductViaSKUScannerLoading = true
                             viewModel.addScannedProductToOrder(barcode: detectedBarcode, onCompletion: { _ in
-                                showAddProductViaSKUScanner.toggle()
+                                showAddProductViaSKUScannerLoading = false
                             }, onRetryRequested: {
                                 showAddProductViaSKUScanner = true
                             })

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -209,8 +209,10 @@ final class OrdersRootViewController: UIViewController {
 
         let productSKUBarcodeScannerCoordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                                                       onSKUBarcodeScanned: { [weak self] scannedBarcode in
+            self?.configureLeftButtonItemAsLoader()
             self?.handleScannedBarcode(scannedBarcode) { [weak self] result in
                 guard let self = self else { return }
+                self.configureLeftButtonItemAsProductScanningButton()
                 switch result {
                 case let .success(product):
                     self.presentOrderCreationFlowWithScannedProduct(with: product.productID)
@@ -327,13 +329,24 @@ private extension OrdersRootViewController {
     ///
     func configureNavigationButtons() {
         if featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner) {
-            navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
+            configureLeftButtonItemAsProductScanningButton()
         }
 
         navigationItem.rightBarButtonItems = [
             createAddOrderItem(),
             createSearchBarButtonItem()
         ]
+    }
+
+    func configureLeftButtonItemAsProductScanningButton() {
+        navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
+    }
+
+    func configureLeftButtonItemAsLoader() {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = .navigationBarLoadingIndicator
+        indicator.startAnimating()
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: indicator)
     }
 
     func configureFiltersBar() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9920
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we want to improve the loading user experience, by:

- On order creation, dismissing the camera as soon as a barcode is found, as it might be confusing for the user to stay with the camera on while searching for the product.
- Replacing the barcode scanner button with loading indicators in both the Order List and Order Creation screens while the product is being searched to communicate what's happening to the user.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Order List
Go to orders, tap on the barcode scanner button and scan a product. Check that we show a loading indicator while the product is being searched, and that it's reverted after it's found or there's a failure in the search.

### Order Creation
Go to orders, tap on the + button button, and scan a product once in the editable order view. Check that we dismiss the camera once the barcode is scanned and show a loading indicator while the product is being searched and that it's reverted after it's found (or the search ends in error).

Check Video below to see the whole flow including errors.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/8ce828c2-17e3-43e4-ab81-109a711cf8e7



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
