### PR TITLE
[Performance] Track waiting time when app is launched (app startup)

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -60,6 +60,7 @@ public extension ABTest {
             ExPlat.shared?.register(experiments: experimentNames)
 
             ExPlat.shared?.refresh {
+                NotificationCenter.default.post(name: .init(rawValue: "ExperimentAssignmentsFetched"), object: nil)
                 continuation.resume(returning: ())
             }
         } as Void

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -59,8 +59,9 @@ public extension ABTest {
             let experimentNames = experiments.map { $0.rawValue }
             ExPlat.shared?.register(experiments: experimentNames)
 
+            NotificationCenter.default.post(name: .fetchExperimentAssignments, object: "started")
             ExPlat.shared?.refresh {
-                NotificationCenter.default.post(name: .init(rawValue: "ExperimentAssignmentsFetched"), object: nil)
+                NotificationCenter.default.post(name: .fetchExperimentAssignments, object: "completed")
                 continuation.resume(returning: ())
             }
         } as Void
@@ -87,4 +88,10 @@ public enum ExperimentContext: Equatable {
     case loggedOut
     case loggedIn
     case none // For the `null` experiment case
+}
+
+// MARK: ABTest Notifications
+//
+extension NSNotification.Name {
+    public static let fetchExperimentAssignments = NSNotification.Name(rawValue: "FetchExperimentAssignments")
 }

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -52,7 +52,7 @@ public extension ABTest {
         let experiments = ABTest.genuineCases.filter { $0.context == context }
 
         await withCheckedContinuation { continuation in
-            guard !experiments.isEmpty else {
+            guard !experiments.isEmpty, ExPlat.shared != nil else {
                 return continuation.resume(returning: ())
             }
 

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -92,10 +92,10 @@ final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
         // End the waiting time tracker when no more actions are pending
         if startupActionsPending.isEmpty {
             notificationCenter.removeObserver(self) // Stop listening to any notifications
-            guard stores.isAuthenticated else {
-                return // Don't track the waiting time if the user is logged out
+            guard stores.isAuthenticated else { // Don't track the waiting time if the user is logged out
+                return
             }
-            // TODO: Call super.end() to fire the analytics event
+            super.end() // Calculate the elapsed time and trigger analytics event
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -20,6 +20,7 @@ final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
     /// Represents all of the app startup actions to observe notifications for.
     ///
     private let startupActionsToObserve: [NSNotification.Name] = [
+        .launchApp,
         .validateRoleEligibility,
         .checkFeatureAnnouncements,
         .restoreSessionSite,

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -53,6 +53,12 @@ final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
         startListeningToNotifications()
     }
 
+    /// Triggers a notification for the start or end of the provided startup action.
+    ///
+    static func notify(action: NSNotification.Name, withStatus status: ActionStatus, notificationCenter: NotificationCenter = .default) {
+        notificationCenter.post(name: action, object: status)
+    }
+
     /// Start listening to notifications that may occur on app startup.
     ///
     private func startListeningToNotifications() {

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -19,8 +19,12 @@ final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
 
     /// Represents all of the app startup actions to observe notifications for.
     ///
+    /// Not all of these actions will be triggered every time the app is started,
+    /// but they are all possible startup actions that contribute to the startup waiting time.
+    /// Actions can be added or removed from this list to include or exclude them from the waiting time calculation.
+    ///
     private let startupActionsToObserve: [NSNotification.Name] = [
-        .launchApp,
+        .launchApp, // Ensures tracker doesn't end before all launch actions are started
         .validateRoleEligibility,
         .checkFeatureAnnouncements,
         .restoreSessionSite,

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -10,21 +10,71 @@ final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
     ///
     private var appStartupWaitingActions = AppStartupAction.allCases
 
+    /// NotificationCenter Tokens
+    ///
+    private var trackingObservers: [NSObjectProtocol]?
+
+    /// NotificationCenter
+    ///
+    private let notificationCenter: NotificationCenter
+
     /// All actions that must be waited for on app startup.
     ///
     enum AppStartupAction: CaseIterable {
-        case appCoordinatorStart
+        case validateRoleEligibility
+        case checkFeatureAnnouncements
         case restoreSessionSite
         case syncEntities
-        case checkWooVersion
+        case checkMinimumWooVersion
         case syncDashboardStats
-        case syncJITMs
+        case syncTopPerformers
         case fetchExperimentAssignments
-        case mainTabBarInit
+        case syncJITMs
+        case syncPaymentConnectionTokens
+
+        var notificationName: NSNotification.Name {
+            switch self {
+            case .validateRoleEligibility:
+                return .RoleEligibilityValidated
+            case .checkFeatureAnnouncements:
+                return .FeatureAnnouncementsChecked
+            case .restoreSessionSite:
+                return .SessionSiteRestored
+            case .syncEntities:
+                return .EntitiesSynchronized
+            case .checkMinimumWooVersion:
+                return .MinimumWooVersionChecked
+            case .syncDashboardStats:
+                return .DashboardStatsSynced
+            case .syncTopPerformers:
+                return .TopPerformersSynced
+            case .fetchExperimentAssignments:
+                return .ExperimentAssignmentsFetched
+            case .syncJITMs:
+                return .JITMsSynced
+            case .syncPaymentConnectionTokens:
+                return .PaymentConnectionTokensSynced
+            }
+        }
     }
 
-    init() {
+    init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
+
         super.init(trackScenario: .appStartup)
+
+        startListeningToNotifications()
+    }
+
+    /// Starts listening for Notifications
+    ///
+    func startListeningToNotifications() {
+        for startupAction in AppStartupAction.allCases {
+            let observer = notificationCenter.addObserver(forName: startupAction.notificationName, object: nil, queue: .main) { [weak self] _ in
+                self?.end(startupAction)
+            }
+            trackingObservers?.append(observer)
+        }
     }
 
     /// End the waiting time for the provided startup action.
@@ -41,4 +91,19 @@ final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
             // TODO: Call super.end() to fire the analytics event
         }
     }
+}
+
+// MARK: App Startup Notifications
+//
+extension NSNotification.Name {
+    static let RoleEligibilityValidated = NSNotification.Name(rawValue: "RoleEligibilityValidated")
+    static let FeatureAnnouncementsChecked = NSNotification.Name(rawValue: "FeatureAnnouncementsChecked")
+    static let SessionSiteRestored = NSNotification.Name(rawValue: "SessionSiteRestored")
+    static let EntitiesSynchronized = NSNotification.Name(rawValue: "EntitiesSynchronized")
+    static let MinimumWooVersionChecked = NSNotification.Name(rawValue: "MinimumWooVersionChecked")
+    static let DashboardStatsSynced = NSNotification.Name(rawValue: "DashboardStatsSynced")
+    static let TopPerformersSynced = NSNotification.Name(rawValue: "TopPerformersSynced")
+    static let ExperimentAssignmentsFetched = NSNotification.Name(rawValue: "ExperimentAssignmentsFetched")
+    static let JITMsSynced = NSNotification.Name(rawValue: "JITMsSynced")
+    static let PaymentConnectionTokensSynced = NSNotification.Name(rawValue: "PaymentConnectionTokensSynced")
 }

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Tracks the waiting time for app startup, allowing to evaluate as analytics
+/// how much time in seconds it took between the init and the final `end` function call
+///
+final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
+    /// Represents all of the app startup actions that are waiting to be completed.
+    ///
+    /// This begins with all app startup actions, with each action removed as it ends.
+    ///
+    private var appStartupWaitingActions = AppStartupAction.allCases
+
+    /// All actions that must be waited for on app startup.
+    ///
+    enum AppStartupAction: CaseIterable {
+        case appCoordinatorStart
+        case restoreSessionSite
+        case syncEntities
+        case checkWooVersion
+        case syncDashboardStats
+        case syncJITMs
+        case fetchExperimentAssignments
+        case mainTabBarInit
+    }
+
+    init() {
+        super.init(trackScenario: .appStartup)
+    }
+
+    /// End the waiting time for the provided startup action.
+    /// If all startup actions are completed, evaluate the elapsed time from the init,
+    /// and send it as an analytics event.
+    ///
+    func end(_ appStartupAction: AppStartupAction) {
+        guard appStartupWaitingActions.isNotEmpty else {
+            return
+        }
+        appStartupWaitingActions.removeAll { $0 == appStartupAction }
+        if appStartupWaitingActions.isEmpty {
+            print("*** App startup complete. ***")
+            // TODO: Call super.end() to fire the analytics event
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
@@ -4,7 +4,7 @@ import Combine
 /// Tracks the waiting time for a given scenario, allowing to evaluate as analytics
 /// how much time in seconds it took between the init and `end` function call
 ///
-final class WaitingTimeTracker {
+class WaitingTimeTracker {
     private let trackScenario: WooAnalyticsEvent.WaitingTime.Scenario
     private let currentTimeInMillis: () -> TimeInterval
     private let analyticsService: Analytics

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2034,6 +2034,7 @@ extension WooAnalyticsEvent {
             case orderDetails
             case dashboardTopPerformers
             case dashboardMainStats
+            case appStartup
         }
 
         private enum Keys {
@@ -2048,6 +2049,8 @@ extension WooAnalyticsEvent {
                 return WooAnalyticsEvent(statName: .dashboardTopPerformersWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
             case .dashboardMainStats:
                 return WooAnalyticsEvent(statName: .dashboardMainStatsWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
+            case .appStartup:
+                return WooAnalyticsEvent(statName: .applicationOpenedWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
             }
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -25,6 +25,7 @@ public enum WooAnalyticsStat: String {
     case applicationUpgraded = "application_upgraded"
     case applicationOpened = "application_opened"
     case applicationClosed = "application_closed"
+    case applicationOpenedWaitingTimeLoaded = "application_opened_waiting_time_loaded"
 
     // MARK: Authentication Events
     //

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -108,6 +108,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Start app navigation.
         appCoordinator?.start()
 
+        // Track that app did finish launching
+        NotificationCenter.default.post(name: .launchApp, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+
         return true
     }
 
@@ -395,6 +398,7 @@ private extension AppDelegate {
     ///
     func setupStartupWaitingTimeTracker() {
         waitingTimeTracker = AppStartupWaitingTimeTracker()
+        NotificationCenter.default.post(name: .launchApp, object: AppStartupWaitingTimeTracker.ActionStatus.started)
     }
 
     func handleLaunchArguments() {
@@ -526,4 +530,10 @@ private extension AppDelegate {
 
         universalLinkRouter?.handle(url: linkURL)
     }
+}
+
+// MARK: - App Delegate Notifications
+
+extension NSNotification.Name {
+    static let launchApp = NSNotification.Name(rawValue: "LaunchApp")
 }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -483,8 +483,9 @@ extension AppDelegate {
             return
         }
 
+        NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.started)
         ServiceLocator.stores.synchronizeEntities {
-            NotificationCenter.default.post(name: .EntitiesSynchronized, object: nil)
+            NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
         }
     }
 
@@ -528,4 +529,10 @@ private extension AppDelegate {
 
         universalLinkRouter?.handle(url: linkURL)
     }
+}
+
+// MARK: - AppDelegate Notifications
+
+extension NSNotification.Name {
+    static let synchronizeEntities = NSNotification.Name(rawValue: "SynchronizeEntities")
 }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -483,10 +483,7 @@ extension AppDelegate {
             return
         }
 
-        NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.started)
-        ServiceLocator.stores.synchronizeEntities {
-            NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
-        }
+        ServiceLocator.stores.synchronizeEntities(onCompletion: nil)
     }
 
     /// Deauthenticates the user upon application password generation failure.
@@ -529,10 +526,4 @@ private extension AppDelegate {
 
         universalLinkRouter?.handle(url: linkURL)
     }
-}
-
-// MARK: - AppDelegate Notifications
-
-extension NSNotification.Name {
-    static let synchronizeEntities = NSNotification.Name(rawValue: "SynchronizeEntities")
 }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -51,10 +51,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var universalLinkRouter: UniversalLinkRouter?
 
+    private var waitingTimeTracker: AppStartupWaitingTimeTracker?
+
     // MARK: - AppDelegate Methods
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Setup Components
+        setupStartupWaitingTimeTracker()
         setupAnalytics()
         setupCocoaLumberjack()
         setupLibraryLogger()
@@ -388,6 +391,12 @@ private extension AppDelegate {
         _ = ServiceLocator.keyboardStateProvider
     }
 
+    /// Set up the app startup waiting time tracker
+    ///
+    func setupStartupWaitingTimeTracker() {
+        waitingTimeTracker = AppStartupWaitingTimeTracker()
+    }
+
     func handleLaunchArguments() {
         if ProcessConfiguration.shouldLogoutAtLaunch {
             ServiceLocator.stores.deauthenticate()
@@ -474,7 +483,9 @@ extension AppDelegate {
             return
         }
 
-        ServiceLocator.stores.synchronizeEntities(onCompletion: nil)
+        ServiceLocator.stores.synchronizeEntities {
+            NotificationCenter.default.post(name: .EntitiesSynchronized, object: nil)
+        }
     }
 
     /// Deauthenticates the user upon application password generation failure.

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -108,8 +108,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Start app navigation.
         appCoordinator?.start()
 
-        // Track that app did finish launching
-        NotificationCenter.default.post(name: .launchApp, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+        AppStartupWaitingTimeTracker.notify(action: .launchApp, withStatus: .completed)
 
         return true
     }
@@ -398,7 +397,7 @@ private extension AppDelegate {
     ///
     func setupStartupWaitingTimeTracker() {
         waitingTimeTracker = AppStartupWaitingTimeTracker()
-        NotificationCenter.default.post(name: .launchApp, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .launchApp, withStatus: .started)
     }
 
     func handleLaunchArguments() {

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -25,6 +25,10 @@ extension NSNotification.Name {
     /// Posted when the default site is being loaded in the session.
     ///
     public static let restoreSessionSite = NSNotification.Name(rawValue: "RestoreSessionSite")
+
+    /// Posted when all the session entities are being synchronized.
+    ///
+    public static let synchronizeEntities = NSNotification.Name(rawValue: "SynchronizeEntities")
 }
 
 private extension UserDefaults {

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -21,6 +21,10 @@ extension NSNotification.Name {
     /// Posted whenever the app is about to terminate.
     ///
     public static let applicationTerminating = Foundation.Notification.Name(rawValue: "ApplicationTerminating")
+
+    /// Posted when the default site is being loaded in the session.
+    ///
+    public static let restoreSessionSite = NSNotification.Name(rawValue: "RestoreSessionSite")
 }
 
 private extension UserDefaults {

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -42,11 +42,12 @@ class RequirementsChecker {
             return
         }
 
+        NotificationCenter.default.post(name: .checkMinimumWooVersion, object: AppStartupWaitingTimeTracker.ActionStatus.started)
         checkMinimumWooVersion(for: siteID) { result in
-            NotificationCenter.default.post(name: .MinimumWooVersionChecked, object: nil)
             if case .success(.invalidWCVersion) = result {
                 displayWCVersionAlert()
             }
+            NotificationCenter.default.post(name: .checkMinimumWooVersion, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
         }
     }
 
@@ -96,4 +97,10 @@ private extension RequirementsChecker {
             }
         }
     }
+}
+
+// MARK: - RequirementsChecker Notifications
+
+extension NSNotification.Name {
+    static let checkMinimumWooVersion = NSNotification.Name(rawValue: "CheckMinimumWooVersion")
 }

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -42,12 +42,12 @@ class RequirementsChecker {
             return
         }
 
-        NotificationCenter.default.post(name: .checkMinimumWooVersion, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .checkMinimumWooVersion, withStatus: .started)
         checkMinimumWooVersion(for: siteID) { result in
             if case .success(.invalidWCVersion) = result {
                 displayWCVersionAlert()
             }
-            NotificationCenter.default.post(name: .checkMinimumWooVersion, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+            AppStartupWaitingTimeTracker.notify(action: .checkMinimumWooVersion, withStatus: .completed)
         }
     }
 

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -43,6 +43,7 @@ class RequirementsChecker {
         }
 
         checkMinimumWooVersion(for: siteID) { result in
+            NotificationCenter.default.post(name: .MinimumWooVersionChecked, object: nil)
             if case .success(.invalidWCVersion) = result {
                 displayWCVersionAlert()
             }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -105,6 +105,7 @@ private extension AppCoordinator {
     func synchronizeAndShowWhatsNew() {
         stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] result in
             guard let self = self else { return }
+            NotificationCenter.default.post(name: .FeatureAnnouncementsChecked, object: nil)
             switch result {
             case .success(let announcement):
                 DDLogInfo("📣 Announcements Synced! AppVersion: \(announcement.appVersionName) | AnnouncementVersion: \(announcement.announcementVersion)")
@@ -301,6 +302,8 @@ private extension AppCoordinator {
 
         let action = AppSettingsAction.loadEligibilityErrorInfo { [weak self] result in
             guard let self = self else { return }
+
+            NotificationCenter.default.post(name: .RoleEligibilityValidated, object: nil)
 
             // if the previous role check indicates that the user is ineligible, let's show the error message.
             if let errorInfo = try? result.get() {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -103,9 +103,9 @@ private extension AppCoordinator {
     /// Synchronize announcements and present What's New Screen if needed
     ///
     func synchronizeAndShowWhatsNew() {
+        NotificationCenter.default.post(name: .checkFeatureAnnouncements, object: AppStartupWaitingTimeTracker.ActionStatus.started)
         stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] result in
             guard let self = self else { return }
-            NotificationCenter.default.post(name: .FeatureAnnouncementsChecked, object: nil)
             switch result {
             case .success(let announcement):
                 DDLogInfo("📣 Announcements Synced! AppVersion: \(announcement.appVersionName) | AnnouncementVersion: \(announcement.announcementVersion)")
@@ -117,6 +117,7 @@ private extension AppCoordinator {
                 }
             }
             self.showWhatsNewIfNeeded()
+            NotificationCenter.default.post(name: .checkFeatureAnnouncements, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
         }))
     }
 
@@ -300,10 +301,9 @@ private extension AppCoordinator {
             return
         }
 
+        NotificationCenter.default.post(name: .validateRoleEligibility, object: AppStartupWaitingTimeTracker.ActionStatus.started)
         let action = AppSettingsAction.loadEligibilityErrorInfo { [weak self] result in
             guard let self = self else { return }
-
-            NotificationCenter.default.post(name: .RoleEligibilityValidated, object: nil)
 
             // if the previous role check indicates that the user is ineligible, let's show the error message.
             if let errorInfo = try? result.get() {
@@ -321,6 +321,7 @@ private extension AppCoordinator {
                 }
             }
 
+            NotificationCenter.default.post(name: .validateRoleEligibility, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
             onSuccess()
         }
         stores.dispatch(action)
@@ -442,4 +443,10 @@ private extension AppCoordinator {
     enum Constants {
         static let animationDuration = TimeInterval(0.3)
     }
+}
+
+// MARK: App Coordinator Notifications
+extension NSNotification.Name {
+    static let validateRoleEligibility = NSNotification.Name(rawValue: "ValidateRoleEligibility")
+    static let checkFeatureAnnouncements = NSNotification.Name(rawValue: "CheckFeatureAnnouncements")
 }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -103,7 +103,7 @@ private extension AppCoordinator {
     /// Synchronize announcements and present What's New Screen if needed
     ///
     func synchronizeAndShowWhatsNew() {
-        NotificationCenter.default.post(name: .checkFeatureAnnouncements, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .checkFeatureAnnouncements, withStatus: .started)
         stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] result in
             guard let self = self else { return }
             switch result {
@@ -117,7 +117,7 @@ private extension AppCoordinator {
                 }
             }
             self.showWhatsNewIfNeeded()
-            NotificationCenter.default.post(name: .checkFeatureAnnouncements, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+            AppStartupWaitingTimeTracker.notify(action: .checkFeatureAnnouncements, withStatus: .completed)
         }))
     }
 
@@ -301,7 +301,7 @@ private extension AppCoordinator {
             return
         }
 
-        NotificationCenter.default.post(name: .validateRoleEligibility, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .validateRoleEligibility, withStatus: .started)
         let action = AppSettingsAction.loadEligibilityErrorInfo { [weak self] result in
             guard let self = self else { return }
 
@@ -321,7 +321,7 @@ private extension AppCoordinator {
                 }
             }
 
-            NotificationCenter.default.post(name: .validateRoleEligibility, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+            AppStartupWaitingTimeTracker.notify(action: .validateRoleEligibility, withStatus: .completed)
             onSuccess()
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -68,7 +68,7 @@ final class DashboardViewModel {
                    forceRefresh: Bool,
                    onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)
-        NotificationCenter.default.post(name: .syncDashboardStats, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .syncDashboardStats, withStatus: .started)
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
         let action = StatsActionV4.retrieveStats(siteID: siteID,
                                                  timeRange: timeRange,
@@ -90,7 +90,7 @@ final class DashboardViewModel {
                     self.statsVersion = .v4
                 }
             }
-            NotificationCenter.default.post(name: .syncDashboardStats, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+            AppStartupWaitingTimeTracker.notify(action: .syncDashboardStats, withStatus: .completed)
             onCompletion?(result)
         })
         stores.dispatch(action)
@@ -145,7 +145,7 @@ final class DashboardViewModel {
                              forceRefresh: Bool,
                              onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardTopPerformers)
-        NotificationCenter.default.post(name: .syncTopPerformers, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .syncTopPerformers, withStatus: .started)
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
         let action = StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
                                                           timeRange: timeRange,
@@ -165,7 +165,7 @@ final class DashboardViewModel {
             }
 
             let voidResult = result.map { _ in () } // Caller expects no entity in the result.
-            NotificationCenter.default.post(name: .syncTopPerformers, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+            AppStartupWaitingTimeTracker.notify(action: .syncTopPerformers, withStatus: .completed)
             onCompletion?(voidResult)
         })
         stores.dispatch(action)
@@ -248,7 +248,7 @@ final class DashboardViewModel {
             return
         }
 
-        NotificationCenter.default.post(name: .syncJITMs, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .syncJITMs, withStatus: .started)
         let viewModel = try? await justInTimeMessagesManager.loadMessage(for: .dashboard, siteID: siteID)
         viewModel?.$showWebViewSheet.assign(to: &self.$showWebViewSheet)
         switch viewModel?.template {
@@ -260,7 +260,7 @@ final class DashboardViewModel {
             announcementViewModel = nil
             modalJustInTimeMessageViewModel = nil
         }
-        NotificationCenter.default.post(name: .syncJITMs, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+        AppStartupWaitingTimeTracker.notify(action: .syncJITMs, withStatus: .completed)
     }
 
     /// Sets up observer to decide store onboarding task lists visibility

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -89,6 +89,7 @@ final class DashboardViewModel {
                     self.statsVersion = .v4
                 }
             }
+            NotificationCenter.default.post(name: .DashboardStatsSynced, object: nil)
             onCompletion?(result)
         })
         stores.dispatch(action)
@@ -162,6 +163,7 @@ final class DashboardViewModel {
             }
 
             let voidResult = result.map { _ in () } // Caller expects no entity in the result.
+            NotificationCenter.default.post(name: .TopPerformersSynced, object: nil)
             onCompletion?(voidResult)
         })
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
@@ -66,11 +66,11 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
     @MainActor
     func deviceSupportsLocalMobileReader() async -> Bool {
         await withCheckedContinuation { continuation in
-            NotificationCenter.default.post(name: .syncPaymentConnectionTokens, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+            AppStartupWaitingTimeTracker.notify(action: .syncPaymentConnectionTokens, withStatus: .started)
             let action = CardPresentPaymentAction.checkDeviceSupport(siteID: siteID,
                                                                      cardReaderType: .appleBuiltIn,
                                                                      discoveryMethod: .localMobile) { result in
-                NotificationCenter.default.post(name: .syncPaymentConnectionTokens, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+                AppStartupWaitingTimeTracker.notify(action: .syncPaymentConnectionTokens, withStatus: .completed)
                 continuation.resume(returning: result)
             }
             stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
@@ -66,12 +66,20 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
     @MainActor
     func deviceSupportsLocalMobileReader() async -> Bool {
         await withCheckedContinuation { continuation in
+            NotificationCenter.default.post(name: .syncPaymentConnectionTokens, object: AppStartupWaitingTimeTracker.ActionStatus.started)
             let action = CardPresentPaymentAction.checkDeviceSupport(siteID: siteID,
                                                                      cardReaderType: .appleBuiltIn,
                                                                      discoveryMethod: .localMobile) { result in
+                NotificationCenter.default.post(name: .syncPaymentConnectionTokens, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
                 continuation.resume(returning: result)
             }
             stores.dispatch(action)
         }
     }
+}
+
+// MARK: Card Reader Support Notifications
+//
+extension NSNotification.Name {
+    static let syncPaymentConnectionTokens = NSNotification.Name(rawValue: "SyncPaymentConnectionTokens")
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
@@ -19,7 +19,6 @@ final class TapToPayBadgePromotionChecker {
         listenToTapToPayBadgeReloadRequired()
         Task {
             await checkTapToPayBadgeVisibility()
-            NotificationCenter.default.post(name: .PaymentConnectionTokensSynced, object: nil)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
@@ -19,6 +19,7 @@ final class TapToPayBadgePromotionChecker {
         listenToTapToPayBadgeReloadRequired()
         Task {
             await checkTapToPayBadgeVisibility()
+            NotificationCenter.default.post(name: .PaymentConnectionTokensSynced, object: nil)
         }
     }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -169,8 +169,14 @@ class DefaultStoresManager: StoresManager {
     ///
     @discardableResult
     func synchronizeEntities(onCompletion: (() -> Void)? = nil) -> StoresManager {
-        let group = DispatchGroup()
+        // Syncing these entities requires AccountStore, which is not registered when authenticated without WPCom
+        guard !isAuthenticatedWithoutWPCom else {
+            onCompletion?()
+            return self
+        }
+
         NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        let group = DispatchGroup()
 
         group.enter()
         synchronizeAccount { [weak self] _ in

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -538,6 +538,10 @@ private extension DefaultStoresManager {
         synchronizeSitePlugins(siteID: siteID)
 
         sendTelemetryIfNeeded(siteID: siteID)
+
+        // TODO: Trigger notification when requests are completed
+        // Just for testing:
+        notificationCenter.post(name: .SessionSiteRestored, object: nil)
     }
 
     /// Load the site with the specified URL into the session if possible.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -170,6 +170,7 @@ class DefaultStoresManager: StoresManager {
     @discardableResult
     func synchronizeEntities(onCompletion: (() -> Void)? = nil) -> StoresManager {
         let group = DispatchGroup()
+        NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.started)
 
         group.enter()
         synchronizeAccount { [weak self] _ in
@@ -186,6 +187,7 @@ class DefaultStoresManager: StoresManager {
         }
 
         group.notify(queue: .main) {
+            NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
             onCompletion?()
         }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -175,7 +175,7 @@ class DefaultStoresManager: StoresManager {
             return self
         }
 
-        NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.started)
+        AppStartupWaitingTimeTracker.notify(action: .synchronizeEntities, withStatus: .started)
         let group = DispatchGroup()
 
         group.enter()
@@ -193,7 +193,7 @@ class DefaultStoresManager: StoresManager {
         }
 
         group.notify(queue: .main) {
-            NotificationCenter.default.post(name: .synchronizeEntities, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+            AppStartupWaitingTimeTracker.notify(action: .synchronizeEntities, withStatus: .completed)
             onCompletion?()
         }
 
@@ -533,8 +533,8 @@ private extension DefaultStoresManager {
             return
         }
 
+        AppStartupWaitingTimeTracker.notify(action: .restoreSessionSite, withStatus: .started)
         let group = DispatchGroup()
-        notificationCenter.post(name: .restoreSessionSite, object: AppStartupWaitingTimeTracker.ActionStatus.started)
 
         group.enter()
         if siteID == WooConstants.placeholderStoreID,
@@ -580,8 +580,8 @@ private extension DefaultStoresManager {
             group.leave()
         }
 
-        group.notify(queue: .main) { [weak self] in
-            self?.notificationCenter.post(name: .restoreSessionSite, object: AppStartupWaitingTimeTracker.ActionStatus.completed)
+        group.notify(queue: .main) {
+            AppStartupWaitingTimeTracker.notify(action: .restoreSessionSite, withStatus: .completed)
         }
 
         sendTelemetryIfNeeded(siteID: siteID)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1833,6 +1833,7 @@
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
 		CEA764F12A3240A50059187A /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA764F02A3240A50059187A /* AppStartupWaitingTimeTracker.swift */; };
+		CEA764F32A3729F20059187A /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA764F22A3729F20059187A /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
 		CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758B23D2227000486676 /* ProductDetailsCellViewModel.swift */; };
 		CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759423D6057E00486676 /* OrderItem+Woo.swift */; };
@@ -4163,6 +4164,7 @@
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
 		CEA764F02A3240A50059187A /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
+		CEA764F22A3729F20059187A /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
 		CECC758523D21AC200486676 /* AggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateOrderItem.swift; sourceTree = "<group>"; };
 		CECC758B23D2227000486676 /* ProductDetailsCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsCellViewModel.swift; sourceTree = "<group>"; };
@@ -7930,6 +7932,7 @@
 				746791622108D7C0007CF1DC /* WooAnalyticsTests.swift */,
 				26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */,
 				B622BC73289CF19400B10CEC /* WaitingTimeTrackerTests.swift */,
+				CEA764F22A3729F20059187A /* AppStartupWaitingTimeTrackerTests.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -12873,6 +12876,7 @@
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,
 				773077F3251E954300178696 /* ProductDownloadFileViewModelTests.swift in Sources */,
 				2602A64A27BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift in Sources */,
+				CEA764F32A3729F20059187A /* AppStartupWaitingTimeTrackerTests.swift in Sources */,
 				DE4B3B2E269455D400EEF2D8 /* MockShipmentActionStoresManager.swift in Sources */,
 				0246405F258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift in Sources */,
 				576D9F2924DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1832,6 +1832,7 @@
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
+		CEA764F12A3240A50059187A /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA764F02A3240A50059187A /* AppStartupWaitingTimeTracker.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
 		CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758B23D2227000486676 /* ProductDetailsCellViewModel.swift */; };
 		CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759423D6057E00486676 /* OrderItem+Woo.swift */; };
@@ -4161,6 +4162,7 @@
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
+		CEA764F02A3240A50059187A /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
 		CECC758523D21AC200486676 /* AggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateOrderItem.swift; sourceTree = "<group>"; };
 		CECC758B23D2227000486676 /* ProductDetailsCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsCellViewModel.swift; sourceTree = "<group>"; };
@@ -7541,6 +7543,7 @@
 				0247F511286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift */,
 				02AC30CE2888EC8100146A25 /* WooAnalyticsEvent+LoginOnboarding.swift */,
 				53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */,
+				CEA764F02A3240A50059187A /* AppStartupWaitingTimeTracker.swift */,
 				0263E3BA290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift */,
 				EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */,
 				0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */,
@@ -12117,6 +12120,7 @@
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */,
 				CCFBBCF829C4C8010081B595 /* ComponentSettings.swift in Sources */,
+				CEA764F12A3240A50059187A /* AppStartupWaitingTimeTracker.swift in Sources */,
 				02EAF5C029FA04850058071C /* ProductDescriptionGenerationViewModel.swift in Sources */,
 				025FDD3223717D2900824006 /* EditorFactory.swift in Sources */,
 				45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
@@ -1,0 +1,209 @@
+import XCTest
+@testable import WooCommerce
+
+final class AppStartupWaitingTimeTrackerTests: XCTestCase {
+    private var notificationCenter: NotificationCenter!
+    private var sessionManager: SessionManager!
+    private var stores: MockStoresManager!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+    private var tracker: AppStartupWaitingTimeTracker!
+
+    override func setUp() {
+        super.setUp()
+
+        notificationCenter = NotificationCenter()
+        sessionManager = .makeForTesting(authenticated: true)
+        stores = MockStoresManager(sessionManager: sessionManager)
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        sessionManager = nil
+        stores = nil
+        analyticsProvider = nil
+        notificationCenter = nil
+        tracker = nil
+
+        super.tearDown()
+    }
+
+    func test_tracker_does_not_trigger_analytics_stat_while_logged_out() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: false)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .launchApp)
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_triggers_expected_analytics_stat_while_logged_in_with_wpcom() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .launchApp)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_triggers_expected_analytics_stat_while_logged_in_without_wpcom() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .launchApp)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_only_ends_when_all_pending_actions_are_completed() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When some actions are completed
+        AppStartupWaitingTimeTracker.notify(action: .launchApp, withStatus: .started, notificationCenter: notificationCenter)
+        AppStartupWaitingTimeTracker.notify(action: .validateRoleEligibility, withStatus: .started, notificationCenter: notificationCenter)
+        AppStartupWaitingTimeTracker.notify(action: .launchApp, withStatus: .completed, notificationCenter: notificationCenter)
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+
+        // When all actions are completed
+        AppStartupWaitingTimeTracker.notify(action: .validateRoleEligibility, withStatus: .completed, notificationCenter: notificationCenter)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_validateRoleEligibility_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .validateRoleEligibility)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_checkFeatureAnnouncements_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .checkFeatureAnnouncements)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_restoreSessionSite_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .restoreSessionSite)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_synchronizeEntities_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .synchronizeEntities)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_checkMinimumWooVersion_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .checkMinimumWooVersion)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_syncDashboardStats_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .syncDashboardStats)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_syncTopPerformers_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .syncTopPerformers)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_fetchExperimentAssignments_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .fetchExperimentAssignments)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_syncJITMs_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .syncJITMs)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_observes_syncPaymentConnectionTokens_startup_action() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(notificationCenter: notificationCenter, stores: stores, analyticsService: analytics)
+
+        // When
+        triggerNotifications(for: .syncPaymentConnectionTokens)
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+}
+
+private extension AppStartupWaitingTimeTrackerTests {
+    /// Triggers expected notifications for provided action.
+    ///
+    func triggerNotifications(for action: NSNotification.Name) {
+        AppStartupWaitingTimeTracker.notify(action: action, withStatus: .started, notificationCenter: notificationCenter)
+        AppStartupWaitingTimeTracker.notify(action: action, withStatus: .completed, notificationCenter: notificationCenter)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9891
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to improve the loading time on app startup (when the app is launched). To measure any performance improvements, we are adding a new event:

* `application_opened_waiting_time_loaded` (prop: `waiting_time`) (Event registration: 1664-gh-tracks-events-registration)

The `waiting_time` property reflects the time it takes for all of the requested data to be retrieved when the app is first launched and the user is logged in.

### Changes:

* Adds `application_opened_waiting_time_loaded` to `WooAnalyticsStat`, and tracks it in `waitingFinished(scenario:elapsedTime:)`.
* Adds a new waiting time tracker `AppStartupWaitingTimeTracker` to track the app startup time:
   * The tracker has a list of notifications to observe (`startupActionsToObserve`). These are all actions (primarily API requests) that have been identified as occurring on app startup. Internal ref: pe5pgL-32Y-p2
   * When the tracker is initialized, it initializes `WaitingTimeTracker` with the `appStartup` scenario and starts listening for notifications in `startupActionsToObserve`.
   * It has a static method `notify(action:withStatus:)` that is used around the app to send a notification that a specific startup action has been started or completed.
   * When an action is started, it's added to a list of pending actions. This is because not all of the possible startup actions are done every time the app is launched, so we want to know which ones are pending for a given app launch.
   * When an action is ended, it's removed from the list of pending actions. If no more actions are pending, we stop listening for notifications and trigger the analytics event.
* Starts the waiting time tracker when the app is being launched.
* Adds notifications where the startup actions are started/completed throughout the app.
* Updates `ABTest` to only refresh experiment assignments if `ExPlat.shared != nil`. Otherwise, we call `ExPlat.shared?.refresh` but it never completes (which would cause `fetchExperimentAssignments` to start in the waiting time tracker but never end).
* Updates `DefaultStoresManager.synchronizeEntities()` to bail if the app is authenticated without WPCom. Otherwise, we try to sync the WPCom account, account settings, and sites, but the syncing never completes because there's no `AccountStore` to dispatch the actions (which would cause `synchronizeEntities` to start in the waiting time tracker but never end).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Logged out

1. Start logged out of the app.
2. Build and run the app.
3. When the app launches, confirm the event `application_opened_waiting_time_loaded` is **NOT** tracked.

### Logged in with WordPress.com account / Jetpack-connected store

1. Start logged in to the app with a WordPress.com account (with Jetpack-connected store).
2. Build and run the app.
3. When the app launches, confirm the event `application_opened_waiting_time_loaded` is tracked with the custom property `waiting_time` reflecting the startup waiting time in seconds.

### Logged in with the REST API

1. Start logged in to the app with the REST API (without a WordPress.com account / with a store not connected via Jetpack)
2. Build and run the app.
3. When the app launches, confirm the event `application_opened_waiting_time_loaded` is tracked with the custom property `waiting_time` reflecting the startup waiting time in seconds.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.