### PR TITLE
Hides IAP upgrade view for non administrators

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -8,6 +8,7 @@ final class UpgradesViewModel: ObservableObject {
 
     private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol
     private let siteID: Int64
+    private(set) var userIsAdministrator: Bool
 
     @Published var wpcomPlans: [WPComPlanProduct]
     @Published var entitledWpcomPlanIDs: Set<String>
@@ -15,6 +16,7 @@ final class UpgradesViewModel: ObservableObject {
     init(siteID: Int64, inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
         self.siteID = siteID
         self.inAppPurchasesPlanManager = inAppPurchasesPlanManager
+        userIsAdministrator = ServiceLocator.stores.sessionManager.defaultRoles.contains(.administrator)
         wpcomPlans = []
         entitledWpcomPlanIDs = []
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -44,14 +44,22 @@ struct UpgradesView: View {
     }
 
     var body: some View {
-        VStack(alignment: .center, spacing: Layout.contentSpacing) {
-            VStack {
+        VStack {
+            VStack(alignment: .leading, spacing: Layout.contentSpacing) {
                 Text(planText)
                 Text(daysLeftText)
-                Image(uiImage: upgradesViewModel.userIsAdministrator ? .emptyOrdersImage : .noStoreImage)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading)
+
             Spacer()
-            VStack {
+
+            Image(uiImage: upgradesViewModel.userIsAdministrator ? .emptyOrdersImage : .noStoreImage)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            Spacer()
+
+            VStack(alignment: .center, spacing: Layout.contentSpacing) {
                 Text(Localization.unableToUpgradeText)
                     .bold()
                     .headlineStyle()
@@ -63,7 +71,9 @@ struct UpgradesView: View {
                     .foregroundColor(.secondary)
             }
             .renderedIf(!upgradesViewModel.userIsAdministrator)
+
             Spacer()
+
             VStack {
                 if let availableProduct = upgradesViewModel.retrievePlanDetailsIfAvailable(.essentialMonthly) {
                     Text(availableProduct.displayName)
@@ -75,7 +85,9 @@ struct UpgradesView: View {
                 }
             }
             .renderedIf(upgradesViewModel.userIsAdministrator)
+
             Spacer()
+
             VStack {
                 if upgradesViewModel.wpcomPlans.isEmpty || isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
@@ -95,6 +107,7 @@ struct UpgradesView: View {
                 }
             }
             .renderedIf(upgradesViewModel.userIsAdministrator)
+
             Spacer()
         }
         .task {
@@ -127,11 +140,11 @@ private extension UpgradesView {
                                                        comment: "Subtitle that can be read under the Plan upgrade name")
         static let unableToUpgradeText = NSLocalizedString("Unable to upgrade",
                                                            comment: "Text describing that is not possible to upgrade the site's plan.")
-        static let unableToUpgradeInstructions = NSLocalizedString("Only the site owner can manage upgrades.",
+        static let unableToUpgradeInstructions = NSLocalizedString("Only the site owner can manage upgrades",
                                                                    comment: "Text describing that only the site owner can upgrade the site's plan.")
     }
 
-    enum Layout {
+    struct Layout {
         static let contentSpacing: CGFloat = 8
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -24,6 +24,7 @@ struct UpgradesView: View {
     @ObservedObject var upgradesViewModel: UpgradesViewModel
     @ObservedObject var subscriptionsViewModel: SubscriptionsViewModel
 
+    @State private var showingUpgradesNotAllowedSheetView = false
     @State var isPurchasing = false
 
     private var planText: String {
@@ -76,10 +77,23 @@ struct UpgradesView: View {
             }
         }
         .task {
-            await upgradesViewModel.fetchPlans()
+            if upgradesViewModel.userIsAdministrator {
+                await upgradesViewModel.fetchPlans()
+            } else {
+                showingUpgradesNotAllowedSheetView = true
+            }
         }
         .navigationBarTitle(Constants.navigationTitle)
         .navigationBarTitleDisplayMode(.large)
+        .fullScreenCover(isPresented: $showingUpgradesNotAllowedSheetView) {
+            UpgradesNotAllowedSheetView()
+        }
+    }
+}
+
+struct UpgradesNotAllowedSheetView: View {
+    var body: some View {
+        Text("Not the owner!")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -44,44 +44,42 @@ struct UpgradesView: View {
     }
 
     var body: some View {
-        List {
-            Section {
+        VStack(alignment: .center, spacing: Layout.contentSpacing) {
+            VStack {
                 Text(planText)
                 Text(daysLeftText)
-            }
-            Section {
                 Image(uiImage: upgradesViewModel.userIsAdministrator ? .emptyOrdersImage : .noStoreImage)
             }
-            Section {
-                VStack(alignment: .center, spacing: Layout.contentSpacing) {
-                    Text(Localization.unableToUpgradeText)
-                        .bold()
-                        .headlineStyle()
-                    if let siteName = siteName {
-                        Text(siteName)
-                    }
-                    Text(Localization.unableToUpgradeInstructions)
-                        .font(.body)
-                        .foregroundColor(.secondary)
+            Spacer()
+            VStack {
+                Text(Localization.unableToUpgradeText)
+                    .bold()
+                    .headlineStyle()
+                if let siteName = siteName {
+                    Text(siteName)
                 }
+                Text(Localization.unableToUpgradeInstructions)
+                    .font(.body)
+                    .foregroundColor(.secondary)
             }
             .renderedIf(!upgradesViewModel.userIsAdministrator)
-            Section {
-                VStack {
-                    if let availableProduct = upgradesViewModel.retrievePlanDetailsIfAvailable(.essentialMonthly) {
-                        Text(availableProduct.displayName)
-                            .font(.title)
-                        Text(Localization.upgradeSubtitle)
-                            .font(.body)
-                        Text(availableProduct.displayPrice)
-                            .font(.title)
-                    }
+            Spacer()
+            VStack {
+                if let availableProduct = upgradesViewModel.retrievePlanDetailsIfAvailable(.essentialMonthly) {
+                    Text(availableProduct.displayName)
+                        .font(.title)
+                    Text(Localization.upgradeSubtitle)
+                        .font(.body)
+                    Text(availableProduct.displayPrice)
+                        .font(.title)
                 }
             }
             .renderedIf(upgradesViewModel.userIsAdministrator)
-            Section {
+            Spacer()
+            VStack {
                 if upgradesViewModel.wpcomPlans.isEmpty || isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                    Spacer()
                 } else {
                     ForEach(upgradesViewModel.wpcomPlans, id: \.id) { wpcomPlan in
                         let buttonText = String.localizedStringWithFormat(Localization.purchaseCTAButtonText, wpcomPlan.displayName)
@@ -97,6 +95,7 @@ struct UpgradesView: View {
                 }
             }
             .renderedIf(upgradesViewModel.userIsAdministrator)
+            Spacer()
         }
         .task {
             if upgradesViewModel.userIsAdministrator {
@@ -105,6 +104,13 @@ struct UpgradesView: View {
         }
         .navigationBarTitle(Localization.navigationTitle)
         .padding(.top)
+    }
+}
+
+struct UpgradesView_Preview: PreviewProvider {
+    static var previews: some View {
+        UpgradesView(upgradesViewModel: UpgradesViewModel(siteID: 0),
+                     subscriptionsViewModel: SubscriptionsViewModel())
     }
 }
 
@@ -124,6 +130,7 @@ private extension UpgradesView {
         static let unableToUpgradeInstructions = NSLocalizedString("Only the site owner can manage upgrades.",
                                                                    comment: "Text describing that only the site owner can upgrade the site's plan.")
     }
+
     enum Layout {
         static let contentSpacing: CGFloat = 8
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -55,10 +55,14 @@ struct UpgradesView: View {
             Section {
                 VStack(alignment: .center, spacing: Layout.contentSpacing) {
                     Text(Localization.unableToUpgradeText)
+                        .bold()
+                        .headlineStyle()
                     if let siteName = siteName {
                         Text(siteName)
                     }
                     Text(Localization.unableToUpgradeInstructions)
+                        .font(.body)
+                        .foregroundColor(.secondary)
                 }
             }
             .renderedIf(!upgradesViewModel.userIsAdministrator)
@@ -115,10 +119,10 @@ private extension UpgradesView {
                                                        "Reads as 'Days left in trial: 15'")
         static let upgradeSubtitle = NSLocalizedString("Everything you need to launch an online store",
                                                        comment: "Subtitle that can be read under the Plan upgrade name")
-        static let unableToUpgradeText = NSLocalizedString("Unable to upgrade", comment: "")
-        static let unableToUpgradeInstructions = NSLocalizedString("Only the site owner can manage upgrades. " +
-                                                    "Please contact the site owner.", comment: "")
-        static let goBackButtonTitle = NSLocalizedString("Go back", comment: "")
+        static let unableToUpgradeText = NSLocalizedString("Unable to upgrade",
+                                                           comment: "Text describing that is not possible to upgrade the site's plan.")
+        static let unableToUpgradeInstructions = NSLocalizedString("Only the site owner can manage upgrades.",
+                                                                   comment: "Text describing that only the site owner can upgrade the site's plan.")
     }
     enum Layout {
         static let contentSpacing: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -37,6 +37,7 @@ struct UpgradesView: View {
     init(upgradesViewModel: UpgradesViewModel, subscriptionsViewModel: SubscriptionsViewModel) {
         self.upgradesViewModel = upgradesViewModel
         self.subscriptionsViewModel = subscriptionsViewModel
+        self.showingUpgradesNotAllowedSheetView = false
     }
 
     var body: some View {
@@ -92,8 +93,49 @@ struct UpgradesView: View {
 }
 
 struct UpgradesNotAllowedSheetView: View {
+    @Environment(\.dismiss) var dismiss
+
     var body: some View {
-        Text("Not the owner!")
+        VStack(alignment: .center, spacing: Layout.contentSpacing) {
+            Image(uiImage: .noStoreImage)
+            Text(Localization.title)
+                .secondaryTitleStyle()
+                .multilineTextAlignment(.center)
+            Text(Localization.siteName)
+                .frame(maxWidth: .infinity)
+                .headlineStyle()
+                .background(Color(.systemGray6))
+            Text(Localization.instructions)
+                .subheadlineStyle()
+                .multilineTextAlignment(.center)
+        }
+        .padding(Layout.contentSpacing)
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                Divider()
+                    .dividerStyle()
+                Button(Localization.goBackButtonTitle) {
+                    dismiss()
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(Layout.contentSpacing)
+            }
+            .background(Color(.systemBackground))
+        }
+        .navigationBarBackButtonHidden()
+    }
+}
+
+private extension UpgradesNotAllowedSheetView {
+    enum Localization {
+        static let title = NSLocalizedString("Unable to upgrade", comment: "")
+        static let siteName = NSLocalizedString("mysiteaddress.com", comment: "")
+        static let instructions = NSLocalizedString("Only the site owner can manage upgrades. " +
+                                                    "Please contact the site owner.", comment: "")
+        static let goBackButtonTitle = NSLocalizedString("Go back", comment: "")
+    }
+    enum Layout {
+        static let contentSpacing: CGFloat = 24
     }
 }
 


### PR DESCRIPTION
Partially addresses: #9929 

## Description
This PR deals with changing the content of the Upgrades view based on the user role. Since a user that is not the site owner cannot upgrade the site's plan via IAP, we check if the user is a site administrator in order to fetch IAP plans and display upgrade options, otherwise we avoid the network calls and display different messaging.

Ideally we'd want to check for site ownership rather than user role, but currently we cannot do so ( p1686573439824819-slack-CGPNUU63E )

## Changes
- Adds a `userIsAdministrator` check that will run when the view is initialized
- Adds `.renderedIf()` condition to the different blocks to render, based on the `userIsAdministrator` property
- Adds a check before calling `await upgradesViewModel.fetchPlans()`, so we avoid the call for non-administrators.

## Screenshots (Final designs TBD)

| Non-administrator | Administrator |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-13 at 09 41 22](https://github.com/woocommerce/woocommerce-ios/assets/3812076/3fb77c6c-fdb5-4115-bad8-f3732873c23b) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-13 at 09 41 41](https://github.com/woocommerce/woocommerce-ios/assets/3812076/8cc8a018-3a8d-4a9f-8cf0-2b58d9014cb4) | 

## Testing instructions
1. On a Free Trial test store where you're not the administrator, tap on "Upgrade now", see the non-administrator view ( I sent you an invite to `https://woo-always-unadulterated-collective.wpcomstaging.com/ `as a `shop_manager` to your a8c email, let me know if there's other I should use instead)
2. On a Free Trial test store where you're the administrator, tap on "Upgrade now", see the administrator view where IAP available plans are displayed