### PR TITLE
[Performance] Track analytics hub loading time

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2034,6 +2034,7 @@ extension WooAnalyticsEvent {
             case orderDetails
             case dashboardTopPerformers
             case dashboardMainStats
+            case analyticsHub
         }
 
         private enum Keys {
@@ -2048,6 +2049,8 @@ extension WooAnalyticsEvent {
                 return WooAnalyticsEvent(statName: .dashboardTopPerformersWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
             case .dashboardMainStats:
                 return WooAnalyticsEvent(statName: .dashboardMainStatsWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
+            case .analyticsHub:
+                return WooAnalyticsEvent(statName: .analyticsHubWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
             }
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -166,6 +166,7 @@ public enum WooAnalyticsStat: String {
     case analyticsHubDateRangeButtonTapped = "analytics_hub_date_range_button_tapped"
     case analyticsHubDateRangeOptionSelected = "analytics_hub_date_range_option_selected"
     case analyticsHubDateRangeSelectionFailed = "analytics_hub_date_range_selection_failed"
+    case analyticsHubWaitingTimeLoaded = "analytics_hub_waiting_time_loaded"
 
     // MARK: Blaze Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -109,7 +109,7 @@ final class AnalyticsHubViewModel: ObservableObject {
     @MainActor
     func updateData() async {
         do {
-            let tracker = WaitingTimeTracker(trackScenario: .analyticsHub)
+            let tracker = WaitingTimeTracker(trackScenario: .analyticsHub, analyticsService: analytics)
             try await retrieveData()
             tracker.end()
         } catch is AnalyticsHubTimeRangeSelection.TimeRangeGeneratorError {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -109,7 +109,9 @@ final class AnalyticsHubViewModel: ObservableObject {
     @MainActor
     func updateData() async {
         do {
+            let tracker = WaitingTimeTracker(trackScenario: .analyticsHub)
             try await retrieveData()
+            tracker.end()
         } catch is AnalyticsHubTimeRangeSelection.TimeRangeGeneratorError {
             dismissNotice = Notice(title: Localization.timeRangeGeneratorError, feedbackType: .error)
             ServiceLocator.analytics.track(event: .AnalyticsHub.dateRangeSelectionFailed(for: timeRangeSelectionType))

--- a/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
@@ -61,6 +61,20 @@ class WaitingTimeTrackerTests: XCTestCase {
         XCTAssertEqual(testAnalytics.lastReceivedStat, .dashboardMainStatsWaitingTimeLoaded)
     }
 
+    func test_analytics_hub_track_scenario_triggers_expected_analytics_stat() {
+        // Given
+        let waitingTracker = WaitingTimeTracker(trackScenario: .analyticsHub,
+                                                analyticsService: testAnalytics,
+                                                currentTimeInMillis: { 0 }
+        )
+
+        // When
+        waitingTracker.end()
+
+        // Then
+        XCTAssertEqual(testAnalytics.lastReceivedStat, .analyticsHubWaitingTimeLoaded)
+    }
+
     class TestAnalytics: Analytics {
         var lastReceivedStat: WooAnalyticsStat? = nil
         var lastReceivedWaitingTime: TimeInterval? = nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -185,4 +185,15 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         let optionSelectedEventProperty = try XCTUnwrap(analyticsProvider.receivedProperties.last?["option"] as? String)
         assertEqual("Week to Date", optionSelectedEventProperty)
     }
+
+    func test_retrieving_stats_tracks_expected_waiting_time_event() async {
+        // Given
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, analytics: analytics)
+
+        // When
+        await vm.updateData()
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.analyticsHubWaitingTimeLoaded.rawValue))
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -188,7 +188,19 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_retrieving_stats_tracks_expected_waiting_time_event() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, analytics: analytics)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores, analytics: analytics)
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveCustomStats(_, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            default:
+                break
+            }
+        }
 
         // When
         await vm.updateData()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9890
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to improve the Analytics Hub loading time. To measure any performance improvements, we are adding a new event:

* `analytics_hub_waiting_time_loaded` (prop: `waiting_time`) (Event registration: 1671-gh-tracks-events-registration)

The `waiting_time` property reflects the time it takes for all of the data to be retrieved when the Analytics Hub is opened, a new date range is selected, or the screen is refreshed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. On the My Store dashboard, select "See more" to open the analytics hub.
3. When the stats finish loading, confirm the event is tracked is tracked with the custom property `waiting_time` reflecting the loading time in seconds.
4. Select a new date range and confirm the event is tracked with the expected property.
5. Pull to refresh and confirm the event is tracked with the expected property.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
