### PR TITLE
[IAP] Add `manageSubscriptionsSheet(in:)` button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -32,6 +32,10 @@ struct SubscriptionsView: View {
     ///
     @StateObject var viewModel: SubscriptionsViewModel
 
+    /// Manages the visibility for Apple's In-App Purchases "Manage subscriptions" modal sheet
+    /// The sheet displays the customer’s currently active subscription, and the options to view, upgrade, downgrade, or cancel their subscription.
+    @State var presentingManageSubscriptions: Bool = false
+
     /// Closure to be invoked when the "Report Issue" button is tapped.
     ///
     var onReportIssueTapped: (() -> ())?
@@ -74,6 +78,11 @@ struct SubscriptionsView: View {
             })
             .renderedIf(viewModel.shouldShowCancelTrialButton)
 
+            // TODO: Handle button visibility for IAP vs other subs
+            Button(Localization.manageSubscriptionsButton) {
+                presentingManageSubscriptions.toggle()
+            }.manageSubscriptionsSheet(isPresented: $presentingManageSubscriptions)
+
             Section(Localization.troubleshooting) {
                 Button(Localization.report) {
                     onReportIssueTapped?()
@@ -97,6 +106,7 @@ struct SubscriptionsView: View {
 private extension SubscriptionsView {
     enum Localization {
         static let title = NSLocalizedString("Subscriptions", comment: "Title for the Subscriptions / Upgrades view")
+        static let manageSubscriptionsButton = NSLocalizedString("Manage Subscriptions", comment: "Title for the button to manage Subscriptions/Upgrades")
         static let subscriptionStatus = NSLocalizedString("Subscription Status", comment: "Title for the plan section on the subscriptions view. Uppercased")
         static let experienceFeatures = NSLocalizedString("Experience more of our features and services beyond the app",
                                                     comment: "Title for the features list in the Subscriptions Screen")


### PR DESCRIPTION
Work in progress. Depends on getting access to the `v1/sites/...`  `capabilities { own_site }` or `plan { user_is_owner }` properties to fetch site ownership. TODO:

- [ ] Render only for sites which have an IAP upgrade, not others
- [ ] Render only when there's an existing upgrade (no resubscriptions)
- [ ] Render only for site owners
- [ ] Site product needs to be linked to app store product. We know that an itunes user has bought X, but we do not know for which site.

Closes: #

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
