### PR TITLE
[SKU Scanner] Fix bug when adding product in Product Multiselector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1350,9 +1350,12 @@ extension EditableOrderViewModel {
     func updateOrderWithProductID(_ productID: Int64) {
         guard currentOrderItems.contains(where: { $0.productOrVariationID == productID }) else {
             // If it's not part of the current order, send the correct productType to the synchronizer
+            productSelectorViewModel.toggleSelection(id: productID)
             if let productVariation = retrieveVariation(for: productID) {
+                selectedProductVariations.append(productVariation)
                 orderSynchronizer.setProduct.send(.init(product: .variation(productVariation), quantity: 1))
             } else if let product = allProducts.first(where: { $0.productID == productID }) {
+                selectedProducts.append(product)
                 orderSynchronizer.setProduct.send(.init(product: .product(product), quantity: 1))
             } else {
                 DDLogError("⛔️ID \(productID) not found")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1640,7 +1640,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 case let .failure(error as EditableOrderViewModel.ScannerError):
                     promise(error)
                 default:
-                    XCTFail("Expected failure, got success")
+                    break
                 }
             }, onRetryRequested: {
                 onRetryRequested = true
@@ -1676,7 +1676,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 let product = Product.fake().copy(productID: self.sampleSiteID, purchasable: true)
                 onCompletion(.success(product))
             default:
-                XCTFail("Expected success, got failure")
+                break
             }
         })
 
@@ -1721,7 +1721,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
                 onCompletion(.success(product))
             default:
-                XCTFail("Expected failure, got success")
+                break
             }
         })
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9941 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix a bug causing the unintentional removal of a product via barcode scanner after we add a product via the Product Selector. We also didn't show the scanned item selected in the Product Selector. The reason behind this was that we were not updating the Product Selector or the selected items properties in the `EditableOrderViewModel`. Because of this, after completing a product selection session in the Product Selector the item added via the barcode scanner was not included.
We also tweak the unit tests to avoid failure if other cases are called when expecting `retrieveFirstProductMatchFromSKU`, as it doesn't interfere with the test purpose.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to orders
- Scan a product and add it to the order. This can be done via the barcode scanner button in the Order list, or inside the order creation screen.
- Tap on Add Product to go to the Product Selector. The scanned item should be selected (it wasn't before)
- Add a new product. Tap to complete the product selection session.
- Check that all the selected products are there, independently of the via they were added -scanning, manually-

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before

https://github.com/woocommerce/woocommerce-ios/assets/1864060/dcd6786b-aba0-4e77-9a63-fcadad065528

### After

https://github.com/woocommerce/woocommerce-ios/assets/1864060/24e29c73-cbc2-498c-83d3-9bc0a269e0c3



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
