### PR TITLE
[Performance] Don't sync refunds if order has none

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -535,6 +535,13 @@ extension OrderDetailsViewModel {
 
     func syncRefunds(onCompletion: ((Error?) -> ())? = nil) {
         let refundIDs = order.refunds.map { $0.refundID }
+
+        // If the order has no refunds, there is no need to sync them.
+        guard refundIDs.isNotEmpty else {
+            onCompletion?(nil)
+            return
+        }
+
         let action = RefundAction.retrieveRefunds(siteID: order.siteID, orderID: order.orderID, refundIDs: refundIDs, deleteStaleRefunds: true) { (error) in
             if let error = error {
                 DDLogError("⛔️ Error synchronizing detailed Refunds: \(error)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9893
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a check for whether an order has any refunds before syncing them from remote. Previously, we were making the request to sync refunds for an order even if we knew it had no refunds.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can use a tool like Charles proxy to confirm the expected requests are made:

1. Build and run the app.
2. Open the Orders tab.
3. Select an order without refunds and confirm no requests are made for the order's refunds (`GET /wc/v3/orders/{ORDER_ID}/refunds`).
4. Go back to the orders list.
5. Select an order with refunds and confirm the order's refunds are requested and loaded in order details.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
