### PR TITLE
[SKU Scanner] The item is not added to the order if it wasn't locally stored before

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -68,7 +68,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .addCouponToOrder:
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         case .addProductToOrderViaSKUScanner:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            return (buildConfig == .localDeveloper || buildConfig == .alpha)
         case .productBundles:
             return true
         case .freeTrial:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -942,8 +942,7 @@ private extension EditableOrderViewModel {
     /// Configures product row view models for each item in `orderDetails`.
     ///
     func configureProductRowViewModels() {
-        updateProductsResultsController()
-        updateProductVariationsResultsController()
+        updateLocalItemsReferences()
         orderSynchronizer.orderPublisher
             .map { $0.items }
             .removeDuplicates()
@@ -1231,6 +1230,11 @@ private extension EditableOrderViewModel {
         }
     }
 
+    func updateLocalItemsReferences() {
+        updateProductsResultsController()
+        updateProductVariationsResultsController()
+    }
+
     /// Syncs initial selected state for all items in the Order
     ///
     func syncInitialSelectedState() {
@@ -1313,6 +1317,9 @@ extension EditableOrderViewModel {
                     self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: self.flow.analyticsFlow,
                                                                                     source: .orderCreation,
                                                                                     addedVia: .scanning))
+                    // The scanned product or variation was added locally when it was found
+                    // Let's refresh our references so we can retrieve it
+                    self.updateLocalItemsReferences()
                     self.updateOrderWithProductID(product.productID)
                     onCompletion(.success(()))
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9946 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix a bug that was causing some scanned products not to be added to the order. The reason behind this was that the product wasn't part of `allProducts` or `allProductVariations` properties of `EditableOrderViewModel`, as these were synced with the local database when the order detail screen was created, and at that time the scanned item wasn't part of the database.
To solve this, we sync these properties with the local database once the scanned item is found, with the certainty that it will be there as it's upserted once the SKU search finishes.
Apart from that, we adapt a test case to include the case that was causing the bug.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Ensure that the scanned product or variation is not in the local DB. This can happen the first time we load the store, or after opening the Product Selector (if the product is not on the first page), as we remove the previously stored items. Then scan the code in the order creation: before It was not added to the order, but now it is.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://github.com/woocommerce/woocommerce-ios/assets/1864060/86eaf0de-76c3-48f9-b436-1e908499790f


### After

https://github.com/woocommerce/woocommerce-ios/assets/1864060/a4b402b9-3aaf-4283-9944-ac325afd959e


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
