### PR TITLE
[Performance] Remove unused fields from OrderStatsV4Totals model in Networking layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -693,13 +693,7 @@ extension Networking.OrderStatsV4Totals {
             totalOrders: .fake(),
             totalItemsSold: .fake(),
             grossRevenue: .fake(),
-            couponDiscount: .fake(),
-            totalCoupons: .fake(),
-            refunds: .fake(),
-            taxes: .fake(),
-            shipping: .fake(),
             netRevenue: .fake(),
-            totalProducts: .fake(),
             averageOrderValue: .fake()
         )
     }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -867,38 +867,20 @@ extension Networking.OrderStatsV4Totals {
         totalOrders: CopiableProp<Int> = .copy,
         totalItemsSold: CopiableProp<Int> = .copy,
         grossRevenue: CopiableProp<Decimal> = .copy,
-        couponDiscount: CopiableProp<Decimal> = .copy,
-        totalCoupons: CopiableProp<Int> = .copy,
-        refunds: CopiableProp<Decimal> = .copy,
-        taxes: CopiableProp<Decimal> = .copy,
-        shipping: CopiableProp<Decimal> = .copy,
         netRevenue: CopiableProp<Decimal> = .copy,
-        totalProducts: NullableCopiableProp<Int> = .copy,
         averageOrderValue: CopiableProp<Decimal> = .copy
     ) -> Networking.OrderStatsV4Totals {
         let totalOrders = totalOrders ?? self.totalOrders
         let totalItemsSold = totalItemsSold ?? self.totalItemsSold
         let grossRevenue = grossRevenue ?? self.grossRevenue
-        let couponDiscount = couponDiscount ?? self.couponDiscount
-        let totalCoupons = totalCoupons ?? self.totalCoupons
-        let refunds = refunds ?? self.refunds
-        let taxes = taxes ?? self.taxes
-        let shipping = shipping ?? self.shipping
         let netRevenue = netRevenue ?? self.netRevenue
-        let totalProducts = totalProducts ?? self.totalProducts
         let averageOrderValue = averageOrderValue ?? self.averageOrderValue
 
         return Networking.OrderStatsV4Totals(
             totalOrders: totalOrders,
             totalItemsSold: totalItemsSold,
             grossRevenue: grossRevenue,
-            couponDiscount: couponDiscount,
-            totalCoupons: totalCoupons,
-            refunds: refunds,
-            taxes: taxes,
-            shipping: shipping,
             netRevenue: netRevenue,
-            totalProducts: totalProducts,
             averageOrderValue: averageOrderValue
         )
     }

--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -6,36 +6,18 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
     public let totalOrders: Int
     public let totalItemsSold: Int
     public let grossRevenue: Decimal
-    public let couponDiscount: Decimal
-    public let totalCoupons: Int
-    public let refunds: Decimal
-    public let taxes: Decimal
-    public let shipping: Decimal
     public let netRevenue: Decimal
-    public let totalProducts: Int?
     public let averageOrderValue: Decimal
 
     public init(totalOrders: Int,
                 totalItemsSold: Int,
                 grossRevenue: Decimal,
-                couponDiscount: Decimal,
-                totalCoupons: Int,
-                refunds: Decimal,
-                taxes: Decimal,
-                shipping: Decimal,
                 netRevenue: Decimal,
-                totalProducts: Int?,
                 averageOrderValue: Decimal) {
         self.totalOrders = totalOrders
         self.totalItemsSold = totalItemsSold
         self.grossRevenue = grossRevenue
-        self.couponDiscount = couponDiscount
-        self.totalCoupons = totalCoupons
-        self.refunds = refunds
-        self.taxes = taxes
-        self.shipping = shipping
         self.netRevenue = netRevenue
-        self.totalProducts = totalProducts
         self.averageOrderValue = averageOrderValue
     }
 
@@ -44,25 +26,13 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
         let totalOrders = try container.decode(Int.self, forKey: .ordersCount)
         let totalItemsSold = try container.decode(Int.self, forKey: .itemsSold)
         let grossRevenue = try container.decode(Decimal.self, forKey: .grossRevenue)
-        let couponDiscount = try container.decode(Decimal.self, forKey: .couponDiscount)
-        let totalCoupons = try container.decode(Int.self, forKey: .coupons)
-        let refunds = try container.decode(Decimal.self, forKey: .refunds)
-        let taxes = try container.decode(Decimal.self, forKey: .taxes)
-        let shipping = try container.decode(Decimal.self, forKey: .shipping)
         let netRevenue = try container.decode(Decimal.self, forKey: .netRevenue)
-        let totalProducts = try container.decodeIfPresent(Int.self, forKey: .products)
         let averageOrderValue = try container.decode(Decimal.self, forKey: .averageOrderValue)
 
         self.init(totalOrders: totalOrders,
                   totalItemsSold: totalItemsSold,
                   grossRevenue: grossRevenue,
-                  couponDiscount: couponDiscount,
-                  totalCoupons: totalCoupons,
-                  refunds: refunds,
-                  taxes: taxes,
-                  shipping: shipping,
                   netRevenue: netRevenue,
-                  totalProducts: totalProducts,
                   averageOrderValue: averageOrderValue)
     }
 }
@@ -75,13 +45,7 @@ private extension OrderStatsV4Totals {
         case ordersCount = "orders_count"
         case itemsSold = "num_items_sold"
         case grossRevenue = "total_sales"
-        case couponDiscount = "coupons"
-        case coupons = "coupons_count"
-        case refunds
-        case taxes
-        case shipping
         case netRevenue = "net_revenue"
-        case products
         case averageOrderValue = "avg_order_value"
     }
 }

--- a/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
@@ -23,13 +23,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(hourlyStats.totals.totalOrders, 3)
         XCTAssertEqual(hourlyStats.totals.totalItemsSold, 5)
         XCTAssertEqual(hourlyStats.totals.grossRevenue, 800)
-        XCTAssertEqual(hourlyStats.totals.totalCoupons, 0)
-        XCTAssertEqual(hourlyStats.totals.couponDiscount, 0)
-        XCTAssertEqual(hourlyStats.totals.refunds, 0)
-        XCTAssertEqual(hourlyStats.totals.taxes, 0)
-        XCTAssertEqual(hourlyStats.totals.shipping, 0)
         XCTAssertEqual(hourlyStats.totals.netRevenue, 800)
-        XCTAssertEqual(hourlyStats.totals.totalProducts, 2)
         XCTAssertEqual(hourlyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(hourlyStats.intervals.count, 24)
@@ -41,13 +35,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
         XCTAssertEqual(nonZeroHourTotals.totalOrders, 2)
         XCTAssertEqual(nonZeroHourTotals.grossRevenue, 350)
-        XCTAssertEqual(nonZeroHourTotals.totalCoupons, 0)
-        XCTAssertEqual(nonZeroHourTotals.couponDiscount, 0)
-        XCTAssertEqual(nonZeroHourTotals.refunds, 0)
-        XCTAssertEqual(nonZeroHourTotals.taxes, 0)
-        XCTAssertEqual(nonZeroHourTotals.shipping, 0)
         XCTAssertEqual(nonZeroHourTotals.netRevenue, 350)
-        XCTAssertNil(nonZeroHourTotals.totalProducts)
         XCTAssertEqual(nonZeroHourTotals.averageOrderValue, 175)
     }
 
@@ -65,13 +53,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(dailyStats.totals.totalOrders, 3)
         XCTAssertEqual(dailyStats.totals.totalItemsSold, 5)
         XCTAssertEqual(dailyStats.totals.grossRevenue, 800)
-        XCTAssertEqual(dailyStats.totals.totalCoupons, 0)
-        XCTAssertEqual(dailyStats.totals.couponDiscount, 0)
-        XCTAssertEqual(dailyStats.totals.refunds, 0)
-        XCTAssertEqual(dailyStats.totals.taxes, 0)
-        XCTAssertEqual(dailyStats.totals.shipping, 0)
         XCTAssertEqual(dailyStats.totals.netRevenue, 800)
-        XCTAssertEqual(dailyStats.totals.totalProducts, 2)
         XCTAssertEqual(dailyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(dailyStats.intervals.count, 1)
@@ -83,13 +65,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
         XCTAssertEqual(nonZeroDayTotals.totalOrders, 3)
         XCTAssertEqual(nonZeroDayTotals.grossRevenue, 800)
-        XCTAssertEqual(nonZeroDayTotals.totalCoupons, 0)
-        XCTAssertEqual(nonZeroDayTotals.couponDiscount, 0)
-        XCTAssertEqual(nonZeroDayTotals.refunds, 0)
-        XCTAssertEqual(nonZeroDayTotals.taxes, 0)
-        XCTAssertEqual(nonZeroDayTotals.shipping, 0)
         XCTAssertEqual(nonZeroDayTotals.netRevenue, 800)
-        XCTAssertNil(nonZeroDayTotals.totalProducts)
         XCTAssertEqual(nonZeroDayTotals.averageOrderValue, 266)
     }
 
@@ -107,13 +83,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(weeklyStats.totals.totalOrders, 3)
         XCTAssertEqual(weeklyStats.totals.totalItemsSold, 5)
         XCTAssertEqual(weeklyStats.totals.grossRevenue, 800)
-        XCTAssertEqual(weeklyStats.totals.totalCoupons, 0)
-        XCTAssertEqual(weeklyStats.totals.couponDiscount, 0)
-        XCTAssertEqual(weeklyStats.totals.refunds, 0)
-        XCTAssertEqual(weeklyStats.totals.taxes, 0)
-        XCTAssertEqual(weeklyStats.totals.shipping, 0)
         XCTAssertEqual(weeklyStats.totals.netRevenue, 800)
-        XCTAssertEqual(weeklyStats.totals.totalProducts, 2)
         XCTAssertEqual(weeklyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(weeklyStats.intervals.count, 2)
@@ -125,13 +95,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
         XCTAssertEqual(nonZeroWeekTotals.totalOrders, 3)
         XCTAssertEqual(nonZeroWeekTotals.grossRevenue, 800)
-        XCTAssertEqual(nonZeroWeekTotals.totalCoupons, 0)
-        XCTAssertEqual(nonZeroWeekTotals.couponDiscount, 0)
-        XCTAssertEqual(nonZeroWeekTotals.refunds, 0)
-        XCTAssertEqual(nonZeroWeekTotals.taxes, 0)
-        XCTAssertEqual(nonZeroWeekTotals.shipping, 0)
         XCTAssertEqual(nonZeroWeekTotals.netRevenue, 800)
-        XCTAssertNil(nonZeroWeekTotals.totalProducts)
         XCTAssertEqual(nonZeroWeekTotals.averageOrderValue, 266)
     }
 
@@ -149,13 +113,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(monthlyStats.totals.totalOrders, 3)
         XCTAssertEqual(monthlyStats.totals.totalItemsSold, 5)
         XCTAssertEqual(monthlyStats.totals.grossRevenue, 800)
-        XCTAssertEqual(monthlyStats.totals.totalCoupons, 0)
-        XCTAssertEqual(monthlyStats.totals.couponDiscount, 0)
-        XCTAssertEqual(monthlyStats.totals.refunds, 0)
-        XCTAssertEqual(monthlyStats.totals.taxes, 0)
-        XCTAssertEqual(monthlyStats.totals.shipping, 0)
         XCTAssertEqual(monthlyStats.totals.netRevenue, 800)
-        XCTAssertEqual(monthlyStats.totals.totalProducts, 2)
         XCTAssertEqual(monthlyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(monthlyStats.intervals.count, 1)
@@ -167,13 +125,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
         XCTAssertEqual(nonZeroMonthTotals.totalOrders, 3)
         XCTAssertEqual(nonZeroMonthTotals.grossRevenue, 800)
-        XCTAssertEqual(nonZeroMonthTotals.totalCoupons, 0)
-        XCTAssertEqual(nonZeroMonthTotals.couponDiscount, 0)
-        XCTAssertEqual(nonZeroMonthTotals.refunds, 0)
-        XCTAssertEqual(nonZeroMonthTotals.taxes, 0)
-        XCTAssertEqual(nonZeroMonthTotals.shipping, 0)
         XCTAssertEqual(nonZeroMonthTotals.netRevenue, 800)
-        XCTAssertNil(nonZeroMonthTotals.totalProducts)
         XCTAssertEqual(nonZeroMonthTotals.averageOrderValue, 266)
     }
 
@@ -191,13 +143,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(yearlyStats.totals.totalOrders, 3)
         XCTAssertEqual(yearlyStats.totals.totalItemsSold, 5)
         XCTAssertEqual(yearlyStats.totals.grossRevenue, 800)
-        XCTAssertEqual(yearlyStats.totals.totalCoupons, 0)
-        XCTAssertEqual(yearlyStats.totals.couponDiscount, 0)
-        XCTAssertEqual(yearlyStats.totals.refunds, 0)
-        XCTAssertEqual(yearlyStats.totals.taxes, 0)
-        XCTAssertEqual(yearlyStats.totals.shipping, 0)
         XCTAssertEqual(yearlyStats.totals.netRevenue, 800)
-        XCTAssertEqual(yearlyStats.totals.totalProducts, 2)
         XCTAssertEqual(yearlyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(yearlyStats.intervals.count, 1)
@@ -209,13 +155,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
         XCTAssertEqual(nonZeroYearTotals.totalOrders, 3)
         XCTAssertEqual(nonZeroYearTotals.grossRevenue, 800)
-        XCTAssertEqual(nonZeroYearTotals.totalCoupons, 0)
-        XCTAssertEqual(nonZeroYearTotals.couponDiscount, 0)
-        XCTAssertEqual(nonZeroYearTotals.refunds, 0)
-        XCTAssertEqual(nonZeroYearTotals.taxes, 0)
-        XCTAssertEqual(nonZeroYearTotals.shipping, 0)
         XCTAssertEqual(nonZeroYearTotals.netRevenue, 800)
-        XCTAssertNil(nonZeroYearTotals.totalProducts)
         XCTAssertEqual(nonZeroYearTotals.averageOrderValue, 266)
     }
 
@@ -234,13 +174,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(yearlyStats.totals.totalOrders, 3)
         XCTAssertEqual(yearlyStats.totals.totalItemsSold, 5)
         XCTAssertEqual(yearlyStats.totals.grossRevenue, 800)
-        XCTAssertEqual(yearlyStats.totals.totalCoupons, 0)
-        XCTAssertEqual(yearlyStats.totals.couponDiscount, 0)
-        XCTAssertEqual(yearlyStats.totals.refunds, 0)
-        XCTAssertEqual(yearlyStats.totals.taxes, 0)
-        XCTAssertEqual(yearlyStats.totals.shipping, 0)
         XCTAssertEqual(yearlyStats.totals.netRevenue, 800)
-        XCTAssertEqual(yearlyStats.totals.totalProducts, 2)
         XCTAssertEqual(yearlyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(yearlyStats.intervals.count, 1)
@@ -252,13 +186,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
         XCTAssertEqual(nonZeroYearTotals.totalOrders, 3)
         XCTAssertEqual(nonZeroYearTotals.grossRevenue, 800)
-        XCTAssertEqual(nonZeroYearTotals.totalCoupons, 0)
-        XCTAssertEqual(nonZeroYearTotals.couponDiscount, 0)
-        XCTAssertEqual(nonZeroYearTotals.refunds, 0)
-        XCTAssertEqual(nonZeroYearTotals.taxes, 0)
-        XCTAssertEqual(nonZeroYearTotals.shipping, 0)
         XCTAssertEqual(nonZeroYearTotals.netRevenue, 800)
-        XCTAssertNil(nonZeroYearTotals.totalProducts)
         XCTAssertEqual(nonZeroYearTotals.averageOrderValue, 266)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -308,7 +308,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
                                       totals: .fake().copy(totalOrders: 3, grossRevenue: 62.7),
                                       intervals: [.fake().copy(dateStart: "2022-01-03 01:00:00",
                                                                dateEnd: "2022-01-03 01:59:59",
-                                                               subtotals: .fake().copy(totalProducts: 1))])
+                                                               subtotals: .fake())])
         insertOrderStats(orderStats, timeRange: timeRange)
 
         // `orderStatsIntervals` is emitted after order stats are updated.

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -432,13 +432,7 @@ extension MockObjectGraph {
             totalOrders: orderCount,
             totalItemsSold: 0,
             grossRevenue: revenue,
-            couponDiscount: 0,
-            totalCoupons: 0,
-            refunds: 0,
-            taxes: 0,
-            shipping: 0,
             netRevenue: 0,
-            totalProducts: 0,
             averageOrderValue: 0
         )
     }
@@ -508,13 +502,7 @@ private extension Array where Element == OrderStatsV4Interval {
             totalOrders: totalOrders,
             totalItemsSold: 0,
             grossRevenue: totalRevenue,
-            couponDiscount: 0,
-            totalCoupons: 0,
-            refunds: 0,
-            taxes: 0,
-            shipping: 0,
             netRevenue: 0,
-            totalProducts: 0,
             averageOrderValue: 0
         )
     }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatsV4+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatsV4+ReadOnlyConvertible.swift
@@ -31,13 +31,7 @@ extension Storage.OrderStatsV4: ReadOnlyConvertible {
         return OrderStatsV4Totals(totalOrders: 0,
                                   totalItemsSold: 0,
                                   grossRevenue: 0,
-                                  couponDiscount: 0,
-                                  totalCoupons: 0,
-                                  refunds: 0,
-                                  taxes: 0,
-                                  shipping: 0,
                                   netRevenue: 0,
-                                  totalProducts: 0,
                                   averageOrderValue: 0)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatsV4Interval+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatsV4Interval+ReadOnlyConvertible.swift
@@ -30,13 +30,7 @@ extension Storage.OrderStatsV4Interval: ReadOnlyConvertible {
         return OrderStatsV4Totals(totalOrders: 0,
                                   totalItemsSold: 0,
                                   grossRevenue: 0,
-                                  couponDiscount: 0,
-                                  totalCoupons: 0,
-                                  refunds: 0,
-                                  taxes: 0,
-                                  shipping: 0,
                                   netRevenue: 0,
-                                  totalProducts: 0,
                                   averageOrderValue: 0)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatsV4Totals+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatsV4Totals+ReadOnlyConvertible.swift
@@ -12,13 +12,7 @@ extension Storage.OrderStatsV4Totals: ReadOnlyConvertible {
         totalOrders = Int64(statsTotals.totalOrders)
         totalItemsSold = Int64(statsTotals.totalItemsSold)
         grossRevenue = NSDecimalNumber(decimal: statsTotals.grossRevenue)
-        couponDiscount = NSDecimalNumber(decimal: statsTotals.couponDiscount)
-        totalCoupons = Int64(statsTotals.totalCoupons)
-        refunds = NSDecimalNumber(decimal: statsTotals.refunds)
-        taxes = NSDecimalNumber(decimal: statsTotals.taxes)
-        shipping = NSDecimalNumber(decimal: statsTotals.shipping)
         netRevenue = NSDecimalNumber(decimal: statsTotals.netRevenue)
-        totalProducts = Int64(statsTotals.totalProducts ?? 0)
         averageOrderValue = NSDecimalNumber(decimal: statsTotals.averageOrderValue)
     }
 
@@ -28,13 +22,7 @@ extension Storage.OrderStatsV4Totals: ReadOnlyConvertible {
         return OrderStatsV4Totals(totalOrders: Int(totalOrders),
                                   totalItemsSold: Int(totalItemsSold),
                                   grossRevenue: grossRevenue.decimalValue,
-                                  couponDiscount: couponDiscount.decimalValue,
-                                  totalCoupons: Int(totalCoupons),
-                                  refunds: refunds.decimalValue,
-                                  taxes: taxes.decimalValue,
-                                  shipping: shipping.decimalValue,
                                   netRevenue: netRevenue.decimalValue,
-                                  totalProducts: Int(totalProducts),
                                   averageOrderValue: averageOrderValue.decimalValue)
     }
 }

--- a/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -2,8 +2,7 @@ import XCTest
 @testable import Yosemite
 
 final class OrderStatsV4Interval_DateTests: XCTestCase {
-    private let mockIntervalSubtotals = OrderStatsV4Totals(totalOrders: 0, totalItemsSold: 0, grossRevenue: 0, couponDiscount: 0, totalCoupons: 0,
-                                                           refunds: 0, taxes: 0, shipping: 0, netRevenue: 0, totalProducts: nil, averageOrderValue: 0)
+    private let mockIntervalSubtotals = OrderStatsV4Totals(totalOrders: 0, totalItemsSold: 0, grossRevenue: 0, netRevenue: 0, averageOrderValue: 0)
 
     func testDateStartAndDateEnd() {
         let dateStringInSiteTimeZone = "2019-08-08 10:45:00"

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -697,13 +697,7 @@ private extension StatsStoreV4Tests {
         return OrderStatsV4Totals(totalOrders: 3,
                                   totalItemsSold: 5,
                                   grossRevenue: 800,
-                                  couponDiscount: 0,
-                                  totalCoupons: 0,
-                                  refunds: 0,
-                                  taxes: 0,
-                                  shipping: 0,
                                   netRevenue: 800,
-                                  totalProducts: 2,
                                   averageOrderValue: 266)
     }
 
@@ -712,13 +706,7 @@ private extension StatsStoreV4Tests {
         return OrderStatsV4Totals(totalOrders: 3,
                                   totalItemsSold: 5,
                                   grossRevenue: 800,
-                                  couponDiscount: 0,
-                                  totalCoupons: 0,
-                                  refunds: 0,
-                                  taxes: 0,
-                                  shipping: 0,
                                   netRevenue: 800,
-                                  totalProducts: 0,
                                   averageOrderValue: 266)
     }
 
@@ -755,13 +743,7 @@ private extension StatsStoreV4Tests {
         return OrderStatsV4Totals(totalOrders: 10,
                                   totalItemsSold: 0,
                                   grossRevenue: 0,
-                                  couponDiscount: 0,
-                                  totalCoupons: 0,
-                                  refunds: 0,
-                                  taxes: 0,
-                                  shipping: 0,
                                   netRevenue: 0,
-                                  totalProducts: 0,
                                   averageOrderValue: 0)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9892
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When we load the My Store dashboard we sync the order stats, including `OrderStatsV4Totals`. However, that model includes fields that we don't use in the app. This PR removes those extra, unused fields from the `OrderStatsV4Totals` model in the Networking layer.

Future PRs will update the remote request so we only request the fields we need, and update the Storage layer to remove those attributes from Core Data.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Confirm tests pass and the My Store stats load as expected when you build and run the app. (You may need to clean the build folder first.)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
