### PR TITLE
Receive the `asyncMap` value on the main thread to try fixing a SwiftUI warning

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -242,13 +242,13 @@ final class HubMenuViewModel: ObservableObject {
         stores.site
             .compactMap { $0 }
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .asyncMap { [weak self] site -> Bool in
                 guard let self else {
                     return false
                 }
                 return await self.blazeEligibilityChecker.isSiteEligible()
             }
+            .receive(on: DispatchQueue.main)
             .assign(to: &$isSiteEligibleForBlaze)
     }
 


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Part of #9866 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After the Blaze eligibility checks were implemented with a new `asyncMap` publisher, I still see SwiftUI warnings on `Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates` on `asycMap` after about 1-2 minutes using the app (both simulators and physical devices). After trying to understand this warning more, since it's a SwiftUI warning, it's probably triggered because the downstream value from `asyncMap` `isSiteEligibleForBlaze` was published not on the main thread and it's a `@Published var` for SwiftUI.

As an attempted fix, I moved `.receive(on: DispatchQueue.main)` from before the `asyncMap` to be after.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Play around the app for 1-2 minutes --> no purple SwiftUI warnings should show up in Xcode

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
