### PR TITLE
Product description AI: update entry points to present/dismiss the bottom sheet with a coordinator

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -105,7 +105,7 @@ final class AztecEditorViewController: UIViewController, Editor {
     private let textViewAttachmentDelegate: TextViewAttachmentDelegate
 
     private let isAIGenerationEnabled: Bool
-    private var bottomSheetPresenter: BottomSheetPresenter?
+    private var descriptionAICoordinator: ProductDescriptionAICoordinator?
 
     required init(content: String?,
                   product: ProductFormDataModel,
@@ -156,7 +156,6 @@ final class AztecEditorViewController: UIViewController, Editor {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        dismissDescriptionGenerationBottomSheetIfNeeded()
     }
 }
 
@@ -306,7 +305,6 @@ extension AztecEditorViewController: UITextViewDelegate {
     }
 
     func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
-        dismissDescriptionGenerationBottomSheetIfNeeded()
         textView.inputAccessoryView = createInputAccessoryView()
         return true
     }
@@ -314,36 +312,21 @@ extension AztecEditorViewController: UITextViewDelegate {
 
 private extension AztecEditorViewController {
     func showDescriptionGenerationBottomSheet() {
-        let presenter = BottomSheetPresenter(configure: { bottomSheet in
-            var sheet = bottomSheet
-            sheet.prefersEdgeAttachedInCompactHeight = true
-            sheet.largestUndimmedDetentIdentifier = .none
-            sheet.prefersGrabberVisible = true
-            sheet.detents = [.medium(), .large()]
-        })
-        bottomSheetPresenter = presenter
-
-        let controller = ProductDescriptionGenerationHostingController(viewModel:
-                .init(siteID: product.siteID,
-                      name: product.name,
-                      description: product.description ?? "",
-                      onApply: { [weak self] output in
+        guard let navigationController else {
+            return
+        }
+        let coordinator = ProductDescriptionAICoordinator(product: product,
+                                                          navigationController: navigationController,
+                                                          source: .aztecEditor,
+                                                          analytics: ServiceLocator.analytics,
+                                                          onApply: { [weak self] output in
             guard let self else { return }
             self.content = output.description
             self.productName = output.name
             self.updateContent()
-            self.dismissDescriptionGenerationBottomSheetIfNeeded()
-        }))
-
-        view.endEditing(true)
-        presenter.present(controller, from: self, onDismiss: { [weak self] in
-            self?.richTextView.becomeFirstResponder()
         })
-        ServiceLocator.analytics.track(event: .ProductFormAI.productDescriptionAIButtonTapped(source: .aztecEditor))
-    }
-
-    func dismissDescriptionGenerationBottomSheetIfNeeded() {
-        bottomSheetPresenter?.dismiss(onDismiss: {})
+        descriptionAICoordinator = coordinator
+        coordinator.start()
     }
 
     func updateContent() {

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -153,10 +153,6 @@ final class AztecEditorViewController: UIViewController, Editor {
         super.viewDidAppear(animated)
         richTextView.becomeFirstResponder()
     }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-    }
 }
 
 private extension AztecEditorViewController {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
@@ -1,0 +1,64 @@
+import UIKit
+import struct Yosemite.Site
+
+/// Coordinates navigation for product description AI.
+final class ProductDescriptionAICoordinator: Coordinator {
+    typealias Source = WooAnalyticsEvent.ProductFormAI.ProductDescriptionAISource
+
+    let navigationController: UINavigationController
+
+    private let product: ProductFormDataModel
+    private let source: Source
+    private let analytics: Analytics
+    private let onApply: (ProductDescriptionGenerationOutput) -> Void
+
+    private var bottomSheetPresenter: BottomSheetPresenter?
+
+    init(product: ProductFormDataModel,
+         navigationController: UINavigationController,
+         source: Source,
+         analytics: Analytics,
+         onApply: @escaping (ProductDescriptionGenerationOutput) -> Void) {
+        self.product = product
+        self.navigationController = navigationController
+        self.source = source
+        self.analytics = analytics
+        self.onApply = onApply
+    }
+
+    func start() {
+        presentAIBottomSheet()
+    }
+}
+
+// MARK: Navigation
+private extension ProductDescriptionAICoordinator {
+    func presentAIBottomSheet() {
+        let presenter = BottomSheetPresenter(configure: { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.largestUndimmedDetentIdentifier = .none
+            sheet.prefersGrabberVisible = true
+            sheet.detents = [.medium(), .large()]
+        })
+        bottomSheetPresenter = presenter
+
+        let controller = ProductDescriptionGenerationHostingController(viewModel:
+                .init(siteID: product.siteID,
+                      name: product.name,
+                      description: product.description ?? "",
+                      onApply: { [weak self] output in
+            guard let self else { return }
+            self.onApply(output)
+            self.dismissDescriptionGenerationBottomSheetIfNeeded()
+        }))
+
+        navigationController.view.endEditing(true)
+        presenter.present(controller, from: navigationController)
+        analytics.track(event: .ProductFormAI.productDescriptionAIButtonTapped(source: source))
+    }
+
+    func dismissDescriptionGenerationBottomSheetIfNeeded() {
+        bottomSheetPresenter?.dismiss(onDismiss: {})
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 		02BA12852461674B008D8325 /* Optional+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA12842461674B008D8325 /* Optional+String.swift */; };
 		02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
+		02BA53432A380D7D0069224D /* ProductDescriptionAICoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA53422A380D7D0069224D /* ProductDescriptionAICoordinator.swift */; };
 		02BAB01F24D0232800F8B06E /* MockProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB01E24D0232800F8B06E /* MockProductVariation.swift */; };
 		02BAB02124D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02024D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift */; };
 		02BAB02324D0250300F8B06E /* ProductVariation+ProductFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02224D0250300F8B06E /* ProductVariation+ProductFormTests.swift */; };
@@ -519,6 +520,7 @@
 		02EEB5C52424AFAA00B8A701 /* TextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */; };
 		02EF166A292DE9E100D90AD6 /* WebPurchasesForWPComPlans.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF1669292DE9E100D90AD6 /* WebPurchasesForWPComPlans.swift */; };
 		02EF166C292DFE9A00D90AD6 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */; };
+		02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */; };
 		02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */; };
 		02F49ADA23BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F49AD923BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift */; };
 		02F49ADC23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F49ADB23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift */; };
@@ -2736,6 +2738,7 @@
 		02BA12842461674B008D8325 /* Optional+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+String.swift"; sourceTree = "<group>"; };
 		02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+VisibilityTests.swift"; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
+		02BA53422A380D7D0069224D /* ProductDescriptionAICoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAICoordinator.swift; sourceTree = "<group>"; };
 		02BAB01E24D0232800F8B06E /* MockProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductVariation.swift; sourceTree = "<group>"; };
 		02BAB02024D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductPriceSettingsViewModel+ProductVariationTests.swift"; sourceTree = "<group>"; };
 		02BAB02224D0250300F8B06E /* ProductVariation+ProductFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+ProductFormTests.swift"; sourceTree = "<group>"; };
@@ -2843,6 +2846,7 @@
 		02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextFieldTableViewCell.xib; sourceTree = "<group>"; };
 		02EF1669292DE9E100D90AD6 /* WebPurchasesForWPComPlans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPurchasesForWPComPlans.swift; sourceTree = "<group>"; };
 		02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
+		02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAICoordinatorTests.swift; sourceTree = "<group>"; };
 		02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPurchaseSuccessView.swift; sourceTree = "<group>"; };
 		02F49AD923BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TitleAndTextFieldTableViewCell.ViewModel+State.swift"; sourceTree = "<group>"; };
 		02F49ADB23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -5868,6 +5872,7 @@
 				02EAF5BF29FA04850058071C /* ProductDescriptionGenerationViewModel.swift */,
 				DE0134142A2EED52000A6F54 /* ProductSharingMessageGenerationView.swift */,
 				DE0134162A30364B000A6F54 /* ProductSharingMessageGenerationViewModel.swift */,
+				02BA53422A380D7D0069224D /* ProductDescriptionAICoordinator.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -5877,6 +5882,7 @@
 			children = (
 				02EAF5C229FA30FF0058071C /* ProductDescriptionGenerationViewModelTests.swift */,
 				DE0134182A304A72000A6F54 /* ProductSharingMessageGenerationViewModelTests.swift */,
+				02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -12150,6 +12156,7 @@
 				2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */,
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
+				02BA53432A380D7D0069224D /* ProductDescriptionAICoordinator.swift in Sources */,
 				FE28F7122684CA29004465C7 /* RoleErrorViewController.swift in Sources */,
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,
 				31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */,
@@ -12608,6 +12615,7 @@
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
 				093B265727DF05270026F92D /* UnitInputViewModelTests.swift in Sources */,
 				4552085B25829091001CF873 /* AddAttributeViewModelTests.swift in Sources */,
+				02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */,
 				CC33238C29CDF67D00CA9709 /* ComponentSettingsViewModelTests.swift in Sources */,
 				0261F5A728D454CF00B7AC72 /* ProductSearchUICommandTests.swift in Sources */,
 				098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionAICoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionAICoordinatorTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import WooCommerce
+
+final class ProductDescriptionAICoordinatorTests: XCTestCase {
+    private var navigationController: UINavigationController!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        navigationController = UINavigationController()
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        window.rootViewController = navigationController
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        navigationController = nil
+        super.tearDown()
+    }
+
+    func test_ProductDescriptionGenerationHostingController_is_presented_after_start_is_called() throws {
+        // Given
+        let coordinator = ProductDescriptionAICoordinator(product: EditableProductModel(product: .fake()),
+                                                          navigationController: navigationController,
+                                                          source: .productForm,
+                                                          analytics: analytics) { _ in }
+
+        // When
+        coordinator.start()
+
+        // Then
+        waitUntil {
+            self.navigationController.presentedViewController is ProductDescriptionGenerationHostingController
+        }
+    }
+
+    func test_productDescriptionAIButtonTapped_is_tracked_when_bottom_sheet_is_presented() throws {
+        // Given
+        let coordinator = ProductDescriptionAICoordinator(product: EditableProductModel(product: .fake()),
+                                                          navigationController: navigationController,
+                                                          source: .aztecEditor,
+                                                          analytics: analytics) { _ in }
+
+        // When
+        coordinator.start()
+        waitUntil {
+            self.navigationController.presentedViewController is ProductDescriptionGenerationHostingController
+        }
+
+        // Then
+        let firstEvent = try XCTUnwrap(analyticsProvider.receivedEvents.first)
+        XCTAssertEqual(firstEvent, "product_description_ai_button_tapped")
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(eventProperties["source"] as? String, "aztec_editor")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9928 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Currently, we have 2 entry points for the product description AI feature - product form and Aztec editor. The presentation/dismissal logic is duplicated in both view controllers, and this PR refactored these two entry points with a coordinator `ProductDescriptionAICoordinator`.

Previously, the Actec editor had to dismiss the bottom sheet in `viewWillDisappear` and `textViewShouldBeginEditing`. Because the bottom sheet style requires the background to be dimmed, any tap gestures outside of the bottom sheet dismiss the bottom sheet so I don't think we need to dismiss it manually anymore. Please share any regressions from this change!

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

We can do a confidence check to ensure the flow works as before for both entry points:

### Product form entry point

Prerequisite: the site is hosted on WPCOM

- Go to the products tab
- Create a product if needed
- Tap on an editable product --> a button "Write it for me" should be shown below the description row
- Tap on `Write it for me` --> a bottom sheet should be shown, and an event should be tracked `🔵 Tracked product_description_ai_button_tapped, properties: [AnyHashable("source"): "product_form", AnyHashable("is_wpcom_store"): true, ...]`
- Enter some features if needed
- Tap `Generate` when it's ready
- Tap `Apply` when a description is generated --> the generated description should be set to the product description, and `Save` CTA should be shown in the product form navigation bar

### Aztec editor entry point

Prerequisite: the site is hosted on WPCOM

- Go to the products tab
- Create a product if needed
- Tap on an editable product
- Tap on the description row
- In the keyboard toolbar, tap on the magic wand icon --> a bottom sheet should be shown, and an event should be tracked `🔵 Tracked product_description_ai_button_tapped, properties: [AnyHashable("source"): "aztec_editor", AnyHashable("is_wpcom_store"): true, ...]`
- Enter some features if needed
- Tap `Generate` when it's ready
- Tap `Apply` when a description is generated --> the generated description should be set to the product description text view in the editor
- Tap `Done` --> it should go back to the product form, and `Save` CTA should be shown in the product form navigation bar

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
