### PR TITLE
[Product description AI] Show celebration screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
@@ -10,6 +10,7 @@ final class ProductDescriptionAICoordinator: Coordinator {
     private let product: ProductFormDataModel
     private let source: Source
     private let analytics: Analytics
+    private let userDefaults: UserDefaults
     private let onApply: (ProductDescriptionGenerationOutput) -> Void
 
     private var productDescriptionGenerationBottomSheetPresenter: BottomSheetPresenter?
@@ -18,11 +19,13 @@ final class ProductDescriptionAICoordinator: Coordinator {
          navigationController: UINavigationController,
          source: Source,
          analytics: Analytics,
+         userDefaults: UserDefaults = .standard,
          onApply: @escaping (ProductDescriptionGenerationOutput) -> Void) {
         self.product = product
         self.navigationController = navigationController
         self.source = source
         self.analytics = analytics
+        self.userDefaults = userDefaults
         self.onApply = onApply
     }
 
@@ -67,5 +70,13 @@ private extension ProductDescriptionAICoordinator {
             sheet.prefersGrabberVisible = true
             sheet.detents = [.medium(), .large()]
         })
+    }
+}
+
+// MARK: UserDefaults helpers
+//
+private extension UserDefaults {
+    @objc dynamic var usedProductDescriptionAI: Bool {
+        bool(forKey: Key.usedProductDescriptionAI.rawValue)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
@@ -12,7 +12,7 @@ final class ProductDescriptionAICoordinator: Coordinator {
     private let analytics: Analytics
     private let onApply: (ProductDescriptionGenerationOutput) -> Void
 
-    private var bottomSheetPresenter: BottomSheetPresenter?
+    private var productDescriptionGenerationBottomSheetPresenter: BottomSheetPresenter?
 
     init(product: ProductFormDataModel,
          navigationController: UINavigationController,
@@ -34,14 +34,7 @@ final class ProductDescriptionAICoordinator: Coordinator {
 // MARK: Navigation
 private extension ProductDescriptionAICoordinator {
     func presentAIBottomSheet() {
-        let presenter = BottomSheetPresenter(configure: { bottomSheet in
-            var sheet = bottomSheet
-            sheet.prefersEdgeAttachedInCompactHeight = true
-            sheet.largestUndimmedDetentIdentifier = .none
-            sheet.prefersGrabberVisible = true
-            sheet.detents = [.medium(), .large()]
-        })
-        bottomSheetPresenter = presenter
+        productDescriptionGenerationBottomSheetPresenter = buildBottomSheetPresenter()
 
         let controller = ProductDescriptionGenerationHostingController(viewModel:
                 .init(siteID: product.siteID,
@@ -54,11 +47,25 @@ private extension ProductDescriptionAICoordinator {
         }))
 
         navigationController.view.endEditing(true)
-        presenter.present(controller, from: navigationController)
+        productDescriptionGenerationBottomSheetPresenter?.present(controller, from: navigationController)
         analytics.track(event: .ProductFormAI.productDescriptionAIButtonTapped(source: source))
     }
 
     func dismissDescriptionGenerationBottomSheetIfNeeded() {
-        bottomSheetPresenter?.dismiss(onDismiss: {})
+        productDescriptionGenerationBottomSheetPresenter?.dismiss(onDismiss: {})
+    }
+}
+
+// MARK: Bottom sheet helpers
+//
+private extension ProductDescriptionAICoordinator {
+    func buildBottomSheetPresenter() -> BottomSheetPresenter {
+        BottomSheetPresenter(configure: { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.largestUndimmedDetentIdentifier = .none
+            sheet.prefersGrabberVisible = true
+            sheet.detents = [.medium(), .large()]
+        })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionAICoordinator.swift
@@ -14,6 +14,7 @@ final class ProductDescriptionAICoordinator: Coordinator {
     private let onApply: (ProductDescriptionGenerationOutput) -> Void
 
     private var productDescriptionGenerationBottomSheetPresenter: BottomSheetPresenter?
+    private var celebrationViewBottomSheetPresenter: BottomSheetPresenter?
 
     init(product: ProductFormDataModel,
          navigationController: UINavigationController,
@@ -47,6 +48,10 @@ private extension ProductDescriptionAICoordinator {
             guard let self else { return }
             self.onApply(output)
             self.dismissDescriptionGenerationBottomSheetIfNeeded()
+            if !self.userDefaults.usedProductDescriptionAI {
+                self.userDefaults[.usedProductDescriptionAI] = true
+                self.showProductDescriptionAICelebrationView()
+            }
         }))
 
         navigationController.view.endEditing(true)
@@ -56,6 +61,15 @@ private extension ProductDescriptionAICoordinator {
 
     func dismissDescriptionGenerationBottomSheetIfNeeded() {
         productDescriptionGenerationBottomSheetPresenter?.dismiss(onDismiss: {})
+    }
+
+    func showProductDescriptionAICelebrationView() {
+        celebrationViewBottomSheetPresenter = buildBottomSheetPresenter()
+        let controller = ProductDescriptionGenerationCelebrationHostingController(viewModel: .init(onTappingGotIt: { [weak self] in
+            self?.celebrationViewBottomSheetPresenter?.dismiss()
+            self?.celebrationViewBottomSheetPresenter = nil
+        }))
+        celebrationViewBottomSheetPresenter?.present(controller, from: navigationController)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9934 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Shows the product description AI celebration screen when AI is used for the first time. 

## Testing instructions

Prerequisites
- A store hosted on WPCOM

**Write it for me flow**
- Login into the app
- Go to the products tab
- Create a product if needed
- Tap on an editable product --> a button "Write it for me" should be shown below the description row
- Tap on `Write it for me`
- Enter some features if needed
- Tap `Generate` when it's ready
- Tap `Apply` when a description is generated
- The AI celebration screen should be presented.
- Tapping "Got it" should dismiss the celebration screen.
- Save the product and redo the steps and validate that the AI celebration screen is not presented a second time. 

**Description toolbar flow**
- Switch stores or log out and log in to reset the user defaults value `usedProductDescriptionAI`, which tracks the usage of AI.
- Go to the products tab
- Create a product if needed
- Tap on an editable product --> Tap on the description row
- Tap on the text field and tap on the magic wand icon from the toolbar to launch the AI flow. 
- Enter some features if needed
- Tap `Generate` when it's ready
- Tap `Apply` when a description is generated
- The AI celebration screen should be presented.
- Tapping "Got it" should dismiss the celebration screen.
- Tap "Done" to go back to the product details screen.
- Redo the steps and validate that the AI celebration screen is not presented a second time. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
**Write it for me flow**
https://github.com/woocommerce/woocommerce-ios/assets/524475/85832e72-cdc7-4e8d-b1c6-328437535f06

**Description toolbar flow**
https://github.com/woocommerce/woocommerce-ios/assets/524475/652a8228-3c1b-4913-965a-965459fc9019

Magic wand
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/4762655b-5162-4153-92b4-692f47f40c3e" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
