### PR TITLE
[SKU scanner] select/deselect removes scanned product

### DIFF
--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -494,3 +494,13 @@ enum ProductVariationDecodingError: Error {
     case missingSiteID
     case missingProductID
 }
+
+// MARK: - Hashable Conformance
+//
+extension ProductVariation: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(siteID)
+        hasher.combine(productID)
+        hasher.combine(productVariationID)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -163,7 +163,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Products list
     ///
-    private var allProducts: [Product] = []
+    private var allProducts: Set<Product> = []
 
     /// Product Variations Results Controller.
     ///
@@ -175,7 +175,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Product Variations list
     ///
-    private var allProductVariations: [ProductVariation] = []
+    private var allProductVariations: Set<ProductVariation> = []
 
     /// View model for the product list
     ///
@@ -325,7 +325,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Initial product ID given to the order when is created, if any
     ///
-    private let initialProductID: Int64?
+    private let initialProduct: Product?
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
@@ -340,7 +340,7 @@ final class EditableOrderViewModel: ObservableObject {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
-         initialProductID: Int64? = nil) {
+         initialProduct: Product? = nil) {
         self.siteID = siteID
         self.flow = flow
         self.stores = stores
@@ -351,7 +351,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.featureFlagService = featureFlagService
         self.orderDurationRecorder = orderDurationRecorder
         self.permissionChecker = permissionChecker
-        self.initialProductID = initialProductID
+        self.initialProduct = initialProduct
         self.barcodeSKUScannerProductFinder = BarcodeSKUScannerProductFinder(stores: stores)
 
         // Set a temporary initial view model, as a workaround to avoid making it optional.
@@ -905,9 +905,7 @@ private extension EditableOrderViewModel {
     ///
     func addOrRemoveProductToOrder(_ product: Product) {
         // Needed because `allProducts` is only updated at start, so product from new pages are not synced.
-        if !allProducts.contains(product) {
-            allProducts.append(product)
-        }
+        allProducts.insert(product)
 
         if !selectedProducts.contains(where: { $0.productID == product.productID }) {
             selectedProducts.append(product)
@@ -922,13 +920,8 @@ private extension EditableOrderViewModel {
     ///
     func addOrRemoveProductVariationToOrder(_ variation: ProductVariation, parent product: Product) {
         // Needed because `allProducts` is only updated at start, so product from new pages are not synced.
-        if !allProducts.contains(product) {
-            allProducts.append(product)
-        }
-
-        if !allProductVariations.contains(variation) {
-            allProductVariations.append(variation)
-        }
+        allProducts.insert(product)
+        allProductVariations.insert(variation)
 
         if !selectedProductVariations.contains(where: { $0.productVariationID == variation.productVariationID }) {
             selectedProductVariations.append(variation)
@@ -951,17 +944,17 @@ private extension EditableOrderViewModel {
                 return self.createProductRows(items: items)
             }
             .assign(to: &$productRows)
-        configureInitialOrderFromScannedItemIfNeeded()
+        configureOrderWithInitialProductIfNeeded()
     }
 
     /// If given an initial product ID on initialization, updates the Order with the item
     ///
-    func configureInitialOrderFromScannedItemIfNeeded() {
-        guard let productID = self.initialProductID else {
+    func configureOrderWithInitialProductIfNeeded() {
+        guard let product = self.initialProduct else {
             return
         }
 
-        updateOrderWithProductID(productID)
+        updateOrderWithProduct(product)
     }
 
     /// Updates customer data viewmodel based on order addresses.
@@ -1213,7 +1206,7 @@ private extension EditableOrderViewModel {
     func updateProductsResultsController() {
         do {
             try productsResultsController.performFetch()
-            allProducts = productsResultsController.fetchedObjects
+            allProducts = Set(productsResultsController.fetchedObjects)
         } catch {
             DDLogError("⛔️ Error fetching products for order: \(error)")
         }
@@ -1224,7 +1217,7 @@ private extension EditableOrderViewModel {
     func updateProductVariationsResultsController() {
         do {
             try productVariationsResultsController.performFetch()
-            allProductVariations = productVariationsResultsController.fetchedObjects
+            allProductVariations = Set(productVariationsResultsController.fetchedObjects)
         } catch {
             DDLogError("⛔️ Error fetching product variations for order: \(error)")
         }
@@ -1317,10 +1310,7 @@ extension EditableOrderViewModel {
                     self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: self.flow.analyticsFlow,
                                                                                     source: .orderCreation,
                                                                                     addedVia: .scanning))
-                    // The scanned product or variation was added locally when it was found
-                    // Let's refresh our references so we can retrieve it
-                    self.updateLocalItemsReferences()
-                    self.updateOrderWithProductID(product.productID)
+                    self.updateOrderWithProduct(product)
                     onCompletion(.success(()))
                 }
             case .failure:
@@ -1354,23 +1344,26 @@ extension EditableOrderViewModel {
 
     /// Updates the Order with the given product
     ///
-    func updateOrderWithProductID(_ productID: Int64) {
-        guard currentOrderItems.contains(where: { $0.productOrVariationID == productID }) else {
+    func updateOrderWithProduct(_ product: Product) {
+        guard currentOrderItems.contains(where: { $0.productOrVariationID == product.productID }) else {
             // If it's not part of the current order, send the correct productType to the synchronizer
-            productSelectorViewModel.toggleSelection(id: productID)
-            if let productVariation = retrieveVariation(for: productID) {
+            productSelectorViewModel.toggleSelection(id: product.productID)
+
+            if let productVariation = product.toProductVariation() {
+                allProductVariations.insert(productVariation)
+
                 selectedProductVariations.append(productVariation)
                 orderSynchronizer.setProduct.send(.init(product: .variation(productVariation), quantity: 1))
-            } else if let product = allProducts.first(where: { $0.productID == productID }) {
+            } else {
+                allProducts.insert(product)
+
                 selectedProducts.append(product)
                 orderSynchronizer.setProduct.send(.init(product: .product(product), quantity: 1))
-            } else {
-                DDLogError("⛔️ID \(productID) not found")
             }
             return
         }
         // Increase quantity if exists
-        let match = productRows.first(where: { $0.productOrVariationID == productID })
+        let match = productRows.first(where: { $0.productOrVariationID == product.productID })
         match?.incrementQuantity()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -166,8 +166,8 @@ final class OrdersRootViewController: UIViewController {
 
     /// Presents the Order Creation flow with a scanned Product
     ///
-    private func presentOrderCreationFlowWithScannedProduct(with productID: Int64) {
-        let viewModel = EditableOrderViewModel(siteID: siteID, initialProductID: productID)
+    private func presentOrderCreationFlowWithScannedProduct(_ product: Product) {
+        let viewModel = EditableOrderViewModel(siteID: siteID, initialProduct: product)
         setupNavigation(viewModel: viewModel)
     }
 
@@ -222,7 +222,7 @@ final class OrdersRootViewController: UIViewController {
                     self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: .creation,
                                                                                     source: .orderList,
                                                                                     addedVia: .scanning))
-                    self.presentOrderCreationFlowWithScannedProduct(with: product.productID)
+                    self.presentOrderCreationFlowWithScannedProduct(product)
                 case .failure:
                     self.displayScannedProductErrorNotice()
                 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1705,7 +1705,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_order_creation_when_withInitialProduct_is_nil_then_currentOrderItems_are_zero() {
         // Given, When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, initialProductID: nil)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, initialProduct: nil)
 
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 0)
@@ -1759,7 +1759,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Confidence check
         XCTAssertEqual(viewModel.currentOrderItems.count, 0)
 
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProductID: product.productID)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProduct: product)
 
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)
@@ -1771,7 +1771,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         // When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProductID: product.productID)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProduct: product)
         let orderItem = viewModel.currentOrderItems.first(where: { $0.productID == product.productID})
 
         // Then
@@ -1784,14 +1784,12 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_order_created_when_initialProduct_is_productVariation_type_then_initial_order_contains_productVariation() {
         // Given
         let variationID: Int64 = 33
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, productTypeKey: "variable", variations: [variationID])
-        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID, productID: sampleProductID, productVariationID: variationID)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: variationID, productTypeKey: "variation")
 
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation, on: product)
 
         //When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProductID: variationID)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProduct: product)
         guard let orderItem = viewModel.currentOrderItems.first else {
             XCTFail("The Order should contain one item")
             return
@@ -1801,44 +1799,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)
         XCTAssertEqual(orderItem.variationID, variationID)
         XCTAssertEqual(orderItem.quantity, 1)
-    }
-
-    func test_order_with_no_products_when_updateOrderWithProduct_is_invoked_then_product_is_added() {
-        // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
-        storageManager.insertSampleProduct(readOnlyProduct: product)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
-
-        // Confidence check
-        let orderItem = viewModel.currentOrderItems.first
-        XCTAssertNil(orderItem)
-
-        // When
-        viewModel.updateOrderWithProductID(sampleProductID)
-
-        // Then
-        XCTAssertEqual(viewModel.currentOrderItems.count, 1)
-        XCTAssertEqual(viewModel.currentOrderItems.first?.quantity, 1)
-        XCTAssertEqual(viewModel.productRows[safe: 0]?.quantity, 1)
-    }
-
-    func test_order_with_products_when_updateOrderWithProduct_is_invoked_then_product_quantity_is_updated() {
-        // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
-        storageManager.insertSampleProduct(readOnlyProduct: product)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProductID: sampleProductID)
-
-        // Confidence check
-        let orderItem = viewModel.currentOrderItems.first
-        XCTAssertEqual(orderItem?.quantity, 1)
-
-        // When
-        viewModel.updateOrderWithProductID(sampleProductID)
-
-        // Then
-        XCTAssertEqual(viewModel.currentOrderItems.count, 1)
-        XCTAssertEqual(viewModel.currentOrderItems.first?.quantity, 2)
-        XCTAssertEqual(viewModel.productRows[safe: 0]?.quantity, 2)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9964  
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix a bug that caused a scanned product/variation to be removed after deselecting/selecting it in the Product Selector. The reason behind this was that the product/variation wasn't kept as selected because it wasn't added to the `allProducts` or `allProductVariations` of the `EditableOrderViewModel`. As it wasn't stored locally, we didn't have any reference of it.
To fix this we ensure that any scanned product or variation is kept in memory even if they aren't part of the local storage. Furthermore, I took the change to refactor some components:
- Make a function private
- Rename functions
- Convert arrays to Set to avoid duplicate code
- Remove duplicate tests
- Pass a product instance in the `EditableOrderViewModel` `init` instead of the productId so it can be kept.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

To test it:

Ensure that there are no products stored locally
- Go to the order list
- Scan a product/variation. The order creation details screen is open. The product/variation is added
- Tap on Add Products. Find the previously scanned product. Deselect and unselect.
- Tap on the confirm button of the product selector, and when going back, ensure that the product/variation is still there

### Before (around min 00:30)

https://github.com/woocommerce/woocommerce-ios/assets/1864060/4feb51d4-8d7c-41a8-990b-135d7d050693

### After

https://github.com/woocommerce/woocommerce-ios/assets/1864060/adfc74c9-6b1a-4c05-9e98-28b06775437b







## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
