### PR TITLE
[SKU Scanner] scanned product variations images

### DIFF
--- a/Yosemite/Yosemite/Tools/Products/Product+ProductVariation.swift
+++ b/Yosemite/Yosemite/Tools/Products/Product+ProductVariation.swift
@@ -13,7 +13,7 @@ public extension Product {
                          productID: parentID,
                          productVariationID: productID,
                          attributes: attributes.map { ProductVariationAttribute(id: $0.attributeID, name: $0.name, option: $0.options.first ?? "") },
-                         image: nil,
+                         image: images.first,
                          permalink: permalink,
                          dateCreated: dateCreated,
                          dateModified: dateModified,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9970 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we set the first image of the Product instance as the ProductVariation image when converting the former to the latter. With this, we fix the problem that was impeding us from showing the `ProductVariation` image after being scanned if it wasn't in the database before.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
With no products or variations in the DB:

- Go to Orders
- Scan a code for a product variation
- The Order creation detail screen is open with the product variation row added. Before we didn't show any image there, now we do.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before

https://github.com/woocommerce/woocommerce-ios/assets/1864060/52e00867-55c5-4d46-b4e8-03098cc449ce

### After

https://github.com/woocommerce/woocommerce-ios/assets/1864060/caa5e10c-360c-4fd2-98a9-7665d08ff616


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
