### PR TITLE
[SKU Scanner] Enable Feature Flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -68,7 +68,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .addCouponToOrder:
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         case .addProductToOrderViaSKUScanner:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha)
+            return true
         case .productBundles:
             return true
         case .freeTrial:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.1
 -----
 - [*] Plans: Expired or cancelled plans are now shown more reliably [https://github.com/woocommerce/woocommerce-ios/pull/9924]
+- [***] Orders: Users can add products to orders by scanning their sku barcode or QR-code [https://github.com/woocommerce/woocommerce-ios/pull/9972] 
 - [Internal] Store creation: a workaround was previously implemented that can result in an inaccurate app experience like when the free trial banner is not shown immediately after store creation due to out-of-sync site properties. Now that the API issue is fixed, the app now waits for the site for a bit longer but ensures all necessary properties are synced. [https://github.com/woocommerce/woocommerce-ios/pull/9957]
 - [Internal] Product details AI: Updated prompts to identify the language in provided text to use in responses for product description and sharing. [https://github.com/woocommerce/woocommerce-ios/pull/9961]
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9876 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we enable the SKU Scanner feature in Release builds. We leave the feature flag in place in case we have to react quickly when once it's released but will be removed in the future.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run the app with the Release build configuration and check that the SKU Scanner feature is available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
