### PR TITLE
[SKU Scanner] Camera permissions denied tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -471,6 +471,10 @@ extension WooAnalyticsEvent {
             case orderList = "order_list"
         }
 
+        enum BarcodeScanningFailureReason: String {
+            case cameraAccessNotPermitted = "camera_access_not_permitted"
+        }
+
         enum OrderProductAdditionVia: String {
             case scanning
             case manually
@@ -526,6 +530,11 @@ extension WooAnalyticsEvent {
 
         static func barcodeScanningSuccess(from source: BarcodeScanningSource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .barcodeScanningSuccess, properties: [Keys.source: source.rawValue])
+        }
+
+        static func barcodeScanningFailure(from source: BarcodeScanningSource, reason: BarcodeScanningFailureReason) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .barcodeScanningFailure, properties: [Keys.source: source.rawValue,
+                                                                              Keys.reason: reason.rawValue])
         }
 
         static func barcodeScanningSearchViaSKUSuccess(from source: BarcodeScanningSource) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -421,6 +421,7 @@ public enum WooAnalyticsStat: String {
         case orderCreationProductBarcodeScanningTapped = "order_creation_product_barcode_scanning_tapped"
         case orderListProductBarcodeScanningTapped = "order_list_product_barcode_scanning_tapped"
         case barcodeScanningSuccess = "barcode_scanning_success"
+        case barcodeScanningFailure = "barcode_scanning_failure"
         case orderProductSearchViaSKUSuccess = "product_search_via_sku_success"
         case orderProductSearchViaSKUFailure = "product_search_via_sku_failure"
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1354,6 +1354,10 @@ extension EditableOrderViewModel {
         analytics.track(event: WooAnalyticsEvent.Orders.productAddNewFromBarcodeScanningTapped())
     }
 
+    func trackBarcodeScanningNotPermitted() {
+        analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningFailure(from: .orderCreation, reason: .cameraAccessNotPermitted))
+    }
+
     /// Attempts to map SKU to Product
     ///
     private func mapFromScannedBarcodetoProduct(barcode: ScannedBarcode, onCompletion: @escaping (Result<Product, Error>) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -312,6 +312,7 @@ private struct ProductsSection: View {
                         let capturePermissionStatus = viewModel.capturePermissionStatus
                         switch capturePermissionStatus {
                         case .notPermitted:
+                            viewModel.trackBarcodeScanningNotPermitted()
                             logPermissionStatus(status: .notPermitted)
                             self.showPermissionsSheet = true
                         case .notDetermined:

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -230,7 +230,6 @@ final class OrdersRootViewController: UIViewController {
         }, onPermissionsDenied: { [weak self] in
             self?.analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningFailure(from: .orderList, reason: .cameraAccessNotPermitted))
         })
-    
         barcodeScannerCoordinator = productSKUBarcodeScannerCoordinator
         productSKUBarcodeScannerCoordinator.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -227,7 +227,10 @@ final class OrdersRootViewController: UIViewController {
                     self.displayScannedProductErrorNotice()
                 }
             }
+        }, onPermissionsDenied: { [weak self] in
+            self?.analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningFailure(from: .orderList, reason: .cameraAccessNotPermitted))
         })
+    
         barcodeScannerCoordinator = productSKUBarcodeScannerCoordinator
         productSKUBarcodeScannerCoordinator.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
@@ -6,19 +6,23 @@ final class ProductSKUBarcodeScannerCoordinator: Coordinator {
     let navigationController: UINavigationController
     private let permissionChecker: CaptureDevicePermissionChecker
     private let onSKUBarcodeScanned: (_ barcode: ScannedBarcode) -> Void
+    private let onPermissionsDenied: (() -> Void)?
 
     init(sourceNavigationController: UINavigationController,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
-         onSKUBarcodeScanned: @escaping (_ barcode: ScannedBarcode) -> Void) {
+         onSKUBarcodeScanned: @escaping (_ barcode: ScannedBarcode) -> Void,
+         onPermissionsDenied: (() -> Void)? = nil) {
         self.navigationController = sourceNavigationController
         self.permissionChecker = permissionChecker
         self.onSKUBarcodeScanned = onSKUBarcodeScanned
+        self.onPermissionsDenied = onPermissionsDenied
     }
 
     func start() {
         let cameraAuthorizationStatus = permissionChecker.authorizationStatus(for: .video)
         switch cameraAuthorizationStatus {
         case .denied, .restricted:
+            onPermissionsDenied?()
             UIAlertController.presentBarcodeScannerNoCameraPermissionAlert(viewController: navigationController) { [weak self] in
                 self?.navigationController.dismiss(animated: true, completion: nil)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -512,6 +512,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.barcodeScanningFailure.rawValue)
         XCTAssertEqual(analytics.receivedProperties.first?["reason"] as? String, "camera_access_not_permitted")
+        XCTAssertEqual(analytics.receivedProperties.first?["source"] as? String, "order_creation")
     }
 
     func test_add_product_to_order_via_sku_scanner_when_feature_flag_is_enabled_then_feature_support_returns_true() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -500,6 +500,20 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderCreationProductBarcodeScanningTapped.rawValue)
     }
 
+    func test_trackBarcodeScanningNotPermitted_tracks_right_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackBarcodeScanningNotPermitted()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.barcodeScanningFailure.rawValue)
+        XCTAssertEqual(analytics.receivedProperties.first?["reason"] as? String, "camera_access_not_permitted")
+    }
+
     func test_add_product_to_order_via_sku_scanner_when_feature_flag_is_enabled_then_feature_support_returns_true() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9660 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add tracking for a missing event: `barcode_scanning_failure` when the video permissions are not permitted

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Disable your camera access for Woo in the device settings Settings> Woo (at the bottom) > Allow Woo to Access Camera

Open the Woo app, go to Orders, and tap on the Barcode Scanner button (top left). You should see the event tracked:

`🔵 Tracked barcode_scanning_failure, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("source"): "order_list", AnyHashable("reason"): "camera_access_not_permitted", AnyHashable("blog_id"): 215063064]`

Repeat the process for the order creation screen:

`🔵 Tracked barcode_scanning_failure, properties: [AnyHashable("blog_id"): 215063064, AnyHashable("reason"): "camera_access_not_permitted", AnyHashable("source"): "order_creation", AnyHashable("is_wpcom_store"): false]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
