### PR TITLE
[Product multi-selector] Product is not added after close and confirm

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -300,9 +300,8 @@ private struct ProductsSection: View {
                         ProductSelectorNavigationView(
                             configuration: ProductSelectorView.Configuration.addProductToOrder(),
                             isPresented: $showAddProduct,
-                            viewModel: viewModel.productSelectorViewModel)
+                            viewModel: viewModel.createProductSelectorViewModelWithOrderItemsSelected())
                         .onDisappear {
-                            viewModel.productSelectorViewModel.clearSearchAndFilters()
                             navigationButtonID = UUID()
                         }
                     })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -31,9 +31,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows.count, 0)
     }
 
-    func test_view_model_product_list_is_initialized_with_expected_values() {
+    func test_createProductSelectorViewModelWithOrderItemsSelected_returns_instance_initialized_with_expected_values() {
         // Then
-        XCTAssertFalse(viewModel.productSelectorViewModel.toggleAllVariationsOnSelection)
+        XCTAssertFalse(viewModel.createProductSelectorViewModelWithOrderItemsSelected().toggleAllVariationsOnSelection)
     }
 
     func test_edition_view_model_inits_with_expected_values() {
@@ -246,10 +246,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
 
         // Then
         XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
@@ -264,10 +265,12 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
         storageManager.insertSampleProduct(readOnlyProduct: anotherProduct)
 
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: anotherProduct.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.changeSelectionStateForProduct(with: anotherProduct.productID)
+        productSelectorViewModel.completeMultipleSelection()
         // And when another product is added to the order (to confirm the first product's quantity change is retained)
         viewModel.productRows[0].incrementQuantity()
 
@@ -280,10 +283,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // Product quantity is 1
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
         XCTAssertEqual(viewModel.productRows[0].quantity, 1)
 
         // When
@@ -297,8 +301,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
 
         // When
         let expectedRow = viewModel.productRows[0]
@@ -314,11 +319,12 @@ final class EditableOrderViewModelTests: XCTestCase {
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         storageManager.insertProducts([product0, product1])
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // Given products are added to order
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product1.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
+        productSelectorViewModel.changeSelectionStateForProduct(with: product1.productID)
+        productSelectorViewModel.completeMultipleSelection()
 
         // When
         let expectedRemainingRow = viewModel.productRows[1]
@@ -526,10 +532,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When & Then
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
 
@@ -548,10 +555,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
         let testShippingLine = ShippingLine(shippingID: 0,
                                             methodTitle: "Flat Rate",
                                             methodID: "other",
@@ -586,10 +594,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
         let testFeeLine = OrderFeeLine(feeID: 0,
                                        name: "Fee",
                                        taxClass: "",
@@ -626,9 +635,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testCouponLine = OrderCouponLine(couponID: 0, code: "COUPONCODE", discount: "1.5", discountTax: "")
         viewModel.saveCouponLine(testCouponLine)
 
@@ -654,9 +664,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testShippingLine = ShippingLine(shippingID: 0,
                                             methodTitle: "Flat Rate",
                                             methodID: "other",
@@ -664,7 +675,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                             totalTax: "",
                                             taxes: [])
         viewModel.saveShippingLine(testShippingLine)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.completeMultipleSelection()
 
         // Then
         XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowShippingTotal)
@@ -692,9 +703,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testFeeLine = OrderFeeLine(feeID: 0,
                                        name: "Fee",
                                        taxClass: "",
@@ -704,7 +716,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                        taxes: [],
                                        attributes: [])
         viewModel.saveFeeLine(testFeeLine)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.completeMultipleSelection()
 
         // Then
         XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowFees)
@@ -732,10 +744,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
 
         let testShippingLine = ShippingLine(shippingID: 0,
                                             methodTitle: "Flat Rate",
@@ -860,10 +873,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
 
         // Then
         XCTAssertTrue(viewModel.hasChanges)
@@ -939,10 +953,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
 
         // Then
         XCTAssertTrue(analytics.receivedEvents.contains(where: { $0.description == WooAnalyticsStat.orderProductAdd.rawValue}))
@@ -967,10 +982,11 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                flow: .editing(initialOrder: .fake()),
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        productSelectorViewModel.completeMultipleSelection()
         viewModel.productRows[0].incrementQuantity()
 
         // Then
@@ -992,10 +1008,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
+        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // Given products are added to order
-        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
+        productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
+        productSelectorViewModel.completeMultipleSelection()
 
         // When
         let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)
@@ -1020,7 +1037,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
-        viewModel.productSelectorViewModel.clearSelection()
+        viewModel.createProductSelectorViewModelWithOrderItemsSelected().clearSelection()
 
         // Then
         XCTAssertTrue(analytics.receivedEvents.contains(where: {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9979 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix the bug causing products not to be synced properly between `EditableOrderViewModel` and `ProductsSelectorViewModel`. For instance, if we select some products in the Product Selector and then tap close, the products remained selected in the Product Selector: if we open it again the show selected indeed, but if we tap on 1 Product Selected they are not added to the order.

The reason behind this is that we reset selected items when tapping on Close in the Editable Order View Model, but not in the Product Selector, which causes that bug (see testing instructions).

To fix this we create a new `ProductsSelectorViewModel` every time we want to show that screen. With that, we ensure that we have a fresh start every time we open it, and furthermore, we do not have to sync with it every time a change happens in the order creation screen.

Moreover, I took the chance to convert the variable to a function to make it clearer that we are creating the `ProductsSelectorViewModel` anew every time we open that screen.
## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to create a new one
3. Tap on Add Products
4. Select one and tap close. Product is not added to the order, that's expected
5. Tap on Add Products. The product is not selected.
6. Select any product and tap on 1 Product Selected
7. The product is properly selected to the order 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://github.com/woocommerce/woocommerce-ios/assets/1864060/babbc6e4-e6da-42fb-b4d1-6aec0c43690e

### After

https://github.com/woocommerce/woocommerce-ios/assets/1864060/d98477cf-895e-4e66-a4f5-5173ea42f5f6

Now we don't show an item selected if we the user tapped on Close.
---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
