### PR TITLE
[IAP] Sync site data on app init and check for site ownership

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -9,7 +9,7 @@ final class UpgradesViewModel: ObservableObject {
 
     private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol
     private let siteID: Int64
-    private(set) var userIsAdministrator: Bool
+    private(set) var isSiteOwner: Bool
 
     @Published var wpcomPlans: [WPComPlanProduct]
     @Published var entitledWpcomPlanIDs: Set<String>
@@ -20,7 +20,8 @@ final class UpgradesViewModel: ObservableObject {
     init(siteID: Int64, inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
         self.siteID = siteID
         self.inAppPurchasesPlanManager = inAppPurchasesPlanManager
-        userIsAdministrator = ServiceLocator.stores.sessionManager.defaultRoles.contains(.administrator)
+        isSiteOwner = ServiceLocator.stores.sessionManager.defaultSite?.isSiteOwner ?? false
+
         wpcomPlans = []
         entitledWpcomPlanIDs = []
         if let essentialPlan = WooPlan() {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -95,6 +95,26 @@ final class AppCoordinator {
         localNotificationResponsesSubscription = pushNotesManager.localNotificationUserResponses.sink { [weak self] response in
             self?.handleLocalNotificationResponse(response)
         }
+        updateSitePropertiesIfNeeded()
+    }
+}
+
+private extension AppCoordinator {
+    // Fetch latest site properties and update the default store if anything has changed:
+    //
+    func updateSitePropertiesIfNeeded() {
+        if let siteID = stores.sessionManager.defaultSite?.siteID {
+            let action = SiteAction.syncSite(siteID: siteID, completion: { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let site):
+                    self.stores.updateDefaultStore(site)
+                case .failure(let error):
+                    DDLogError("⛔️ Failed to sync default store \(error)")
+                }
+            })
+            stores.dispatch(action)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -35,7 +35,7 @@ struct UpgradesView: View {
 
             Spacer()
 
-            if upgradesViewModel.userIsAdministrator {
+            if upgradesViewModel.isSiteOwner {
                 OwnerUpgradesView(upgradesViewModel: upgradesViewModel)
             } else {
                 NonOwnerUpgradesView(upgradesViewModel: upgradesViewModel)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9929 
Closes: #9977 

## Description
This PR adds a call to the `syncSite` action on app initialization when we start the app coordinator. This method is a wrapper that calls the `loadSite()` site remote and syncs the WPCOM site to storage if there's any change.

We use this within In-App Purchases to be sure to have the proper merchant capabilities (`own_site` in our case, via `isSiteOwner`) as soon as they're needed, as otherwise this could be outdated. At the moment we seem to do this only through certain flows, like store creation or when switching stores through the store picker, so a merchant could miss the flow and have the wrong capabilities set.

## Changes
- Adds `updateSitePropertiesIfNeeded()` to the AppCoordinator. This syncs the WPCOM site to storage and upserts any property that has changed.
- Update the `userIsAdministrator` check for a `isSiteOwner` check in the UpgradeViewModel, which now checks for ownership rather than only role.

## Testing instructions
- Create new free trial site
- Use a fresh simulator, so you can authenticate directly with this new store without using the store picker (as this would sync existing sites as well)
- Confirm that upon tapping "Upgrade Now", you can see the upgrades details if you're the site owner, or you can't if you're not:

| Site owner | Non-site-owner |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-16 at 10 07 14](https://github.com/woocommerce/woocommerce-ios/assets/3812076/21c75fa8-f121-4df7-b4d3-a4c934388c4a) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-06-16 at 13 51 13](https://github.com/woocommerce/woocommerce-ios/assets/3812076/03d9499c-ea8b-43f8-85b0-ccaaa893e0da) | 

