### PR TITLE
Product sharing AI: Fix rendering mode for regenerate button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
@@ -86,6 +86,7 @@ struct ProductSharingMessageGenerationView: View {
                         Text(viewModel.generateButtonTitle)
                     } icon: {
                         Image(uiImage: viewModel.generateButtonImage)
+                            .renderingMode(.template)
                     }
                 })
                 .buttonStyle(SecondaryLoadingButtonStyle(isLoading: viewModel.generationInProgress, loadingText: Localization.generateInProgress))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a minor issue with the rendering mode on the regenerate button of the product sharing AI sheet

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build and run the app in dark mode.
- Log in to a public WPCom site.
- Select a published product and tap Share.
- Tap Write with AI.
- After a text is generated, notice that the regenerate button has correct color for its icon.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ----- | ----- |
| <img width="353" alt="Screenshot 2023-06-16 at 15 22 45" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/accec174-2b00-463d-b6dd-a7846adee7f5"> | <img width="352" alt="Screenshot 2023-06-16 at 15 23 48" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/43e4bc6e-573f-44c8-aa0e-fb91a75f0e3a"> |



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
