### PR TITLE
[Performance] Track startup waiting time when app is launched (take 2)

### DIFF
--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -25,22 +25,16 @@ class AppStartupWaitingTimeTracker: WaitingTimeTracker {
     }
 
     /// Ends the waiting time for the provided startup action.
-    /// If all startup actions are completed without errors, evaluate the elapsed time from the init,
+    /// If all startup actions are completed, evaluate the elapsed time from the init,
     /// and send it as an analytics event.
     ///
-    func end(action: StartupAction, withError error: Error? = nil) {
+    func end(action: StartupAction) {
         // Ignore any actions after the pending startup actions are complete.
         guard startupActionsPending.isNotEmpty else {
             return
         }
 
         startupActionsPending.removeAll { $0 == action }
-
-        // If there was an error, stop all tracking and don't send the analytics event, to avoid skewing the analytics.
-        guard error == nil else {
-            end()
-            return
-        }
 
         // If all actions completed without any errors, send the analytics event.
         if startupActionsPending.isEmpty {
@@ -49,6 +43,9 @@ class AppStartupWaitingTimeTracker: WaitingTimeTracker {
     }
 
     /// Ends the tracker without sending an analytics event.
+    ///
+    /// This can be used to stop tracking in scenarios that would skew the waiting time analysis.
+    /// For example, when the app is backgrounded or a startup action has an API error or network connection error.
     ///
     override func end() {
         startupActionsPending.removeAll()

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Yosemite
+
+/// Tracks the waiting time for app startup, allowing to evaluate as analytics
+/// how much time in seconds it took between the init and the final `end(action:)` function call.
+///
+class AppStartupWaitingTimeTracker: WaitingTimeTracker {
+
+    /// All actions tracked in the app startup waiting time.
+    ///
+    /// This should include any actions that contribute to the **perceived** initial loading time on the dashboard.
+    ///
+    enum StartupAction: CaseIterable {
+        case syncDashboardStats
+        case loadOnboardingTasks
+    }
+
+    /// Represents all of the app startup actions waiting to be completed.
+    ///
+    private var startupActionsPending = StartupAction.allCases
+
+    init(analyticsService: Analytics = ServiceLocator.analytics,
+         currentTimeInMillis: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }) {
+        super.init(trackScenario: .appStartup, analyticsService: analyticsService, currentTimeInMillis: currentTimeInMillis)
+    }
+
+    /// Ends the waiting time for the provided startup action.
+    /// If all startup actions are completed without errors, evaluate the elapsed time from the init,
+    /// and send it as an analytics event.
+    ///
+    func end(action: StartupAction, withError error: Error? = nil) {
+        // Ignore any actions after the pending startup actions are complete.
+        guard startupActionsPending.isNotEmpty else {
+            return
+        }
+
+        startupActionsPending.removeAll { $0 == action }
+
+        // If there was an error, stop all tracking and don't send the analytics event, to avoid skewing the analytics.
+        guard error == nil else {
+            end()
+            return
+        }
+
+        // If all actions completed without any errors, send the analytics event.
+        if startupActionsPending.isEmpty {
+            super.end()
+        }
+    }
+
+    /// Ends the tracker without sending an analytics event.
+    ///
+    override func end() {
+        startupActionsPending.removeAll()
+    }
+}

--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -17,7 +17,7 @@ class AppStartupWaitingTimeTracker: WaitingTimeTracker {
 
     /// Represents all of the app startup actions waiting to be completed.
     ///
-    private var startupActionsPending = StartupAction.allCases
+    private(set) var startupActionsPending = StartupAction.allCases
 
     init(analyticsService: Analytics = ServiceLocator.analytics,
          currentTimeInMillis: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }) {

--- a/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
@@ -4,7 +4,7 @@ import Combine
 /// Tracks the waiting time for a given scenario, allowing to evaluate as analytics
 /// how much time in seconds it took between the init and `end` function call
 ///
-final class WaitingTimeTracker {
+class WaitingTimeTracker {
     private let trackScenario: WooAnalyticsEvent.WaitingTime.Scenario
     private let currentTimeInMillis: () -> TimeInterval
     private let analyticsService: Analytics

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2081,6 +2081,7 @@ extension WooAnalyticsEvent {
             case dashboardTopPerformers
             case dashboardMainStats
             case analyticsHub
+            case appStartup
         }
 
         private enum Keys {
@@ -2097,6 +2098,8 @@ extension WooAnalyticsEvent {
                 return WooAnalyticsEvent(statName: .dashboardMainStatsWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
             case .analyticsHub:
                 return WooAnalyticsEvent(statName: .analyticsHubWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
+            case .appStartup:
+                return WooAnalyticsEvent(statName: .applicationOpenedWaitingTimeLoaded, properties: [Keys.waitingTime: elapsedTime])
             }
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -25,6 +25,7 @@ public enum WooAnalyticsStat: String {
     case applicationUpgraded = "application_upgraded"
     case applicationOpened = "application_opened"
     case applicationClosed = "application_closed"
+    case applicationOpenedWaitingTimeLoaded = "application_opened_waiting_time_loaded"
 
     // MARK: Authentication Events
     //

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -51,10 +51,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var universalLinkRouter: UniversalLinkRouter?
 
-    /// Tracks the app startup waiting time.
-    ///
-    var startupWaitingTimeTracker: AppStartupWaitingTimeTracker?
-
     // MARK: - AppDelegate Methods
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -404,13 +400,15 @@ private extension AppDelegate {
     /// Set up the app startup waiting time tracker
     ///
     func setupStartupWaitingTimeTracker() {
-        startupWaitingTimeTracker = AppStartupWaitingTimeTracker()
+        // Simply _accessing_ it is enough. We only want the object to be initialized right away
+        // so it can start tracking the waiting time.
+        _ = ServiceLocator.startupWaitingTimeTracker
     }
 
     /// Cancel the app startup waiting time tracker
     ///
     func cancelStartupWaitingTimeTracker() {
-        startupWaitingTimeTracker = nil
+        ServiceLocator.startupWaitingTimeTracker.end()
     }
 
     func handleLaunchArguments() {

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -102,6 +102,10 @@ final class ServiceLocator {
 
     private static var _tapToPayReconnectionController: TapToPayReconnectionController = TapToPayReconnectionController()
 
+    /// Tracker for app startup waiting time
+    ///
+    private static var _startupWaitingTimeTracker: AppStartupWaitingTimeTracker = AppStartupWaitingTimeTracker()
+
     // MARK: - Getters
 
     /// Provides the access point to the analytics.
@@ -252,6 +256,12 @@ final class ServiceLocator {
 
     static var tapToPayReconnectionController: TapToPayReconnectionController {
         _tapToPayReconnectionController
+    }
+
+    /// Provides access point to the `AppStartupWaitingTimeTracker`.
+    ///
+    static var startupWaitingTimeTracker: AppStartupWaitingTimeTracker {
+        _startupWaitingTimeTracker
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -635,6 +635,7 @@ private extension DashboardViewController {
                 self.showOnboardingCard(site: site)
             } else {
                 self.removeOnboardingCard()
+                AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks)
             }
         }.store(in: &subscriptions)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -635,7 +635,7 @@ private extension DashboardViewController {
                 self.showOnboardingCard(site: site)
             } else {
                 self.removeOnboardingCard()
-                AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks)
+                ServiceLocator.startupWaitingTimeTracker.end(action: .loadOnboardingTasks)
             }
         }.store(in: &subscriptions)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -234,7 +234,7 @@ private extension StoreOnboardingViewModel {
                         return StoreOnboardingTask(isComplete: true, type: .launchStore)
                     }))
                 case .failure(let error):
-                    self?.waitingTimeTracker.end(action: .loadOnboardingTasks, withError: error)
+                    self?.waitingTimeTracker.end() // Stop the tracker if there is an error.
                     return continuation.resume(throwing: error)
                 }
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -100,7 +100,7 @@ class StoreOnboardingViewModel: ObservableObject {
 
     func reloadTasks() async {
         guard !defaults.completedAllStoreOnboardingTasks else {
-            await AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks)
+            ServiceLocator.startupWaitingTimeTracker.end(action: .loadOnboardingTasks)
             return
         }
 
@@ -205,7 +205,7 @@ private extension StoreOnboardingViewModel {
             stores.dispatch(StoreOnboardingTasksAction.loadOnboardingTasks(siteID: siteID) { result in
                 switch result {
                 case .success(let tasks):
-                    AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks)
+                    ServiceLocator.startupWaitingTimeTracker.end(action: .loadOnboardingTasks)
                     return continuation.resume(returning: tasks.filter({ task in
                         if case .unsupported = task.type {
                             return false
@@ -230,7 +230,7 @@ private extension StoreOnboardingViewModel {
                         return StoreOnboardingTask(isComplete: true, type: .launchStore)
                     }))
                 case .failure(let error):
-                    AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks, withError: error)
+                    ServiceLocator.startupWaitingTimeTracker.end(action: .loadOnboardingTasks, withError: error)
                     return continuation.resume(throwing: error)
                 }
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -66,6 +66,8 @@ class StoreOnboardingViewModel: ObservableObject {
 
     private let analytics: Analytics
 
+    private let waitingTimeTracker: AppStartupWaitingTimeTracker
+
     /// Emits when there are no tasks available for display after reload.
     /// i.e. When (request failed && No previously loaded local data available)
     ///
@@ -81,7 +83,8 @@ class StoreOnboardingViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          defaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         waitingTimeTracker: AppStartupWaitingTimeTracker = ServiceLocator.startupWaitingTimeTracker) {
         self.siteID = siteID
         self.isExpanded = isExpanded
         self.stores = stores
@@ -90,6 +93,7 @@ class StoreOnboardingViewModel: ObservableObject {
         self.analytics = analytics
         self.featureFlagService = featureFlagService
         isHideStoreOnboardingTaskListFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList)
+        self.waitingTimeTracker = waitingTimeTracker
 
         Publishers.CombineLatest3($noTasksAvailableForDisplay,
                                   defaults.publisher(for: \.completedAllStoreOnboardingTasks),
@@ -100,7 +104,7 @@ class StoreOnboardingViewModel: ObservableObject {
 
     func reloadTasks() async {
         guard !defaults.completedAllStoreOnboardingTasks else {
-            ServiceLocator.startupWaitingTimeTracker.end(action: .loadOnboardingTasks)
+            waitingTimeTracker.end(action: .loadOnboardingTasks)
             return
         }
 
@@ -202,10 +206,10 @@ private extension StoreOnboardingViewModel {
     @MainActor
     func fetchTasks() async throws -> [StoreOnboardingTask] {
         try await withCheckedThrowingContinuation({ continuation in
-            stores.dispatch(StoreOnboardingTasksAction.loadOnboardingTasks(siteID: siteID) { result in
+            stores.dispatch(StoreOnboardingTasksAction.loadOnboardingTasks(siteID: siteID) { [weak self] result in
                 switch result {
                 case .success(let tasks):
-                    ServiceLocator.startupWaitingTimeTracker.end(action: .loadOnboardingTasks)
+                    self?.waitingTimeTracker.end(action: .loadOnboardingTasks)
                     return continuation.resume(returning: tasks.filter({ task in
                         if case .unsupported = task.type {
                             return false
@@ -230,7 +234,7 @@ private extension StoreOnboardingViewModel {
                         return StoreOnboardingTask(isComplete: true, type: .launchStore)
                     }))
                 case .failure(let error):
-                    ServiceLocator.startupWaitingTimeTracker.end(action: .loadOnboardingTasks, withError: error)
+                    self?.waitingTimeTracker.end(action: .loadOnboardingTasks, withError: error)
                     return continuation.resume(throwing: error)
                 }
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -100,6 +100,7 @@ class StoreOnboardingViewModel: ObservableObject {
 
     func reloadTasks() async {
         guard !defaults.completedAllStoreOnboardingTasks else {
+            await AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks)
             return
         }
 
@@ -204,6 +205,7 @@ private extension StoreOnboardingViewModel {
             stores.dispatch(StoreOnboardingTasksAction.loadOnboardingTasks(siteID: siteID) { result in
                 switch result {
                 case .success(let tasks):
+                    AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks)
                     return continuation.resume(returning: tasks.filter({ task in
                         if case .unsupported = task.type {
                             return false
@@ -228,6 +230,7 @@ private extension StoreOnboardingViewModel {
                         return StoreOnboardingTask(isComplete: true, type: .launchStore)
                     }))
                 case .failure(let error):
+                    AppDelegate.shared.startupWaitingTimeTracker?.end(action: .loadOnboardingTasks, withError: error)
                     return continuation.resume(throwing: error)
                 }
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -460,7 +460,11 @@ private extension StoreStatsAndTopPerformersViewController {
     /// Notifies `AppStartupWaitingTimeTracker` when dashboard sync is complete.
     ///
     func trackDashboardStatsSyncComplete(withError error: Error? = nil) {
-        ServiceLocator.startupWaitingTimeTracker.end(action: .syncDashboardStats, withError: error)
+        guard error == nil else { // Stop the tracker if there is an error.
+            ServiceLocator.startupWaitingTimeTracker.end()
+            return
+        }
+        ServiceLocator.startupWaitingTimeTracker.end(action: .syncDashboardStats)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -179,6 +179,7 @@ private extension StoreStatsAndTopPerformersViewController {
                     onCompletion?(.failure(error))
                 } else {
                     self?.updateSiteVisitors(mode: .default)
+                    self?.trackDashboardStatsSyncComplete()
                     onCompletion?(.success(()))
                 }
             }
@@ -419,6 +420,7 @@ private extension StoreStatsAndTopPerformersViewController {
         switch error {
         case .noPermission:
             updateSiteVisitors(mode: .hidden)
+            trackDashboardStatsSyncComplete()
         case .statsModuleDisabled:
             let defaultSite = ServiceLocator.stores.sessionManager.defaultSite
             if defaultSite?.isJetpackCPConnected == true {
@@ -426,8 +428,10 @@ private extension StoreStatsAndTopPerformersViewController {
             } else {
                 updateSiteVisitors(mode: .hidden)
             }
+            trackDashboardStatsSyncComplete()
         default:
             displaySyncingError()
+            trackDashboardStatsSyncComplete(withError: error)
         }
     }
 
@@ -437,6 +441,7 @@ private extension StoreStatsAndTopPerformersViewController {
             handleSiteStatsStoreError(error: siteStatsStoreError)
         default:
             displaySyncingError()
+            trackDashboardStatsSyncComplete(withError: error)
         }
     }
 }
@@ -450,6 +455,12 @@ private extension StoreStatsAndTopPerformersViewController {
         }
 
         ServiceLocator.analytics.track(event: .Dashboard.dashboardMainStatsLoaded(timeRange: timeRange))
+    }
+
+    /// Notifies `AppStartupWaitingTimeTracker` when dashboard sync is complete.
+    ///
+    func trackDashboardStatsSyncComplete(withError error: Error? = nil) {
+        AppDelegate.shared.startupWaitingTimeTracker?.end(action: .syncDashboardStats, withError: error)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -460,7 +460,7 @@ private extension StoreStatsAndTopPerformersViewController {
     /// Notifies `AppStartupWaitingTimeTracker` when dashboard sync is complete.
     ///
     func trackDashboardStatsSyncComplete(withError error: Error? = nil) {
-        AppDelegate.shared.startupWaitingTimeTracker?.end(action: .syncDashboardStats, withError: error)
+        ServiceLocator.startupWaitingTimeTracker.end(action: .syncDashboardStats, withError: error)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1836,6 +1836,8 @@
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
+		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
+		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
 		CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758B23D2227000486676 /* ProductDetailsCellViewModel.swift */; };
 		CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759423D6057E00486676 /* OrderItem+Woo.swift */; };
@@ -4171,6 +4173,8 @@
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
+		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
+		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
 		CECC758523D21AC200486676 /* AggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateOrderItem.swift; sourceTree = "<group>"; };
 		CECC758B23D2227000486676 /* ProductDetailsCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsCellViewModel.swift; sourceTree = "<group>"; };
@@ -7557,6 +7561,7 @@
 				0247F511286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift */,
 				02AC30CE2888EC8100146A25 /* WooAnalyticsEvent+LoginOnboarding.swift */,
 				53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */,
+				CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */,
 				0263E3BA290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift */,
 				EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */,
 				0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */,
@@ -7943,6 +7948,7 @@
 				746791622108D7C0007CF1DC /* WooAnalyticsTests.swift */,
 				26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */,
 				B622BC73289CF19400B10CEC /* WaitingTimeTrackerTests.swift */,
+				CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -11709,6 +11715,7 @@
 				DEC6C51A2747758D006832D3 /* JCPJetpackInstallView.swift in Sources */,
 				DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */,
 				AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */,
+				CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */,
 				03BB9EA7292E50B600251E9E /* CardPresentModalSelectSearchType.swift in Sources */,
 				DE4D23A629B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift in Sources */,
 				D85806292642BA5400A8AB6C /* LegacyPaymentCaptureOrchestrator.swift in Sources */,
@@ -12611,6 +12618,7 @@
 				D802548C26552F41001B2CC1 /* CardPresentModalProcessingTests.swift in Sources */,
 				02952B5127808B08008E9BA3 /* StoreStatsPeriodViewModelTests.swift in Sources */,
 				B57C5C9F21B80E8300FF82B2 /* SampleError.swift in Sources */,
+				CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */,
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,
 				025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */,
 				0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
@@ -20,15 +20,15 @@ final class AppStartupWaitingTimeTrackerTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_tracker_triggers_expected_analytics_event_after_all_actions_are_complete() {
+    func test_tracker_triggers_expected_analytics_event_after_all_actions_end() {
         // Given
         tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
 
-        // When only one action is complete
+        // When only one action is ended
         tracker.end(action: .syncDashboardStats)
         XCTAssertEqual(analyticsProvider.receivedEvents.count, 0)
 
-        // When all actions are complete
+        // When all actions are ended
         tracker.end(action: .loadOnboardingTasks)
 
         // Then
@@ -36,18 +36,7 @@ final class AppStartupWaitingTimeTrackerTests: XCTestCase {
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
     }
 
-    func test_tracker_does_not_trigger_analytics_event_if_action_has_error() {
-        // Given
-        tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
-
-        // When
-        completeAllStartupActions(withError: MockError.mockError)
-
-        // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.count, 0)
-    }
-
-    func test_tracker_does_not_trigger_analytics_event_again_after_tracker_is_completed() {
+    func test_ending_action_again_after_all_actions_are_ended_does_not_trigger_analytics_event_again() {
         // Given
         tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
 
@@ -81,9 +70,9 @@ private extension AppStartupWaitingTimeTrackerTests {
         case mockError
     }
 
-    func completeAllStartupActions(withError error: Error? = nil) {
+    func completeAllStartupActions() {
         AppStartupWaitingTimeTracker.StartupAction.allCases.forEach { action in
-            tracker.end(action: action, withError: error)
+            tracker.end(action: action)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import WooCommerce
+
+final class AppStartupWaitingTimeTrackerTests: XCTestCase {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+    private var tracker: AppStartupWaitingTimeTracker!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        tracker = nil
+
+        super.tearDown()
+    }
+
+    func test_tracker_triggers_expected_analytics_event_after_all_actions_are_complete() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
+
+        // When only one action is complete
+        tracker.end(action: .syncDashboardStats)
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 0)
+
+        // When all actions are complete
+        tracker.end(action: .loadOnboardingTasks)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue))
+    }
+
+    func test_tracker_does_not_trigger_analytics_event_if_action_has_error() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
+
+        // When
+        completeAllStartupActions(withError: MockError.mockError)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 0)
+    }
+
+    func test_tracker_does_not_trigger_analytics_event_again_after_tracker_is_completed() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
+
+        // When all actions are complete
+        completeAllStartupActions()
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+
+        // When action is ended again
+        tracker.end(action: .syncDashboardStats)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+    }
+
+    func test_tracker_does_not_trigger_analytics_event_after_tracker_is_ended_manually() {
+        // Given
+        tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
+
+        // When
+        tracker.end()
+        completeAllStartupActions()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 0)
+    }
+
+}
+
+private extension AppStartupWaitingTimeTrackerTests {
+    enum MockError: Error {
+        case mockError
+    }
+
+    func completeAllStartupActions(withError error: Error? = nil) {
+        AppStartupWaitingTimeTracker.StartupAction.allCases.forEach { action in
+            tracker.end(action: action, withError: error)
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
@@ -75,6 +75,20 @@ class WaitingTimeTrackerTests: XCTestCase {
         XCTAssertEqual(testAnalytics.lastReceivedStat, .analyticsHubWaitingTimeLoaded)
     }
 
+    func test_appStartup_track_scenario_triggers_expected_analytics_stat() {
+        // Given
+        let waitingTracker = WaitingTimeTracker(trackScenario: .appStartup,
+                                                analyticsService: testAnalytics,
+                                                currentTimeInMillis: { 0 }
+        )
+
+        // When
+        waitingTracker.end()
+
+        // Then
+        XCTAssertEqual(testAnalytics.lastReceivedStat, .applicationOpenedWaitingTimeLoaded)
+    }
+
     class TestAnalytics: Analytics {
         var lastReceivedStat: WooAnalyticsStat? = nil
         var lastReceivedWaitingTime: TimeInterval? = nil


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9891
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is an alternate approach to tracking the app startup waiting time (see previous approach: #9930).

We want to improve the loading time on app startup (when the app is launched). To measure any performance improvements, we are adding a new event:

* `application_opened_waiting_time_loaded` (prop: `waiting_time`) (Event registration: 1664-gh-tracks-events-registration)

The `waiting_time` property reflects the perceived time it takes for the app to be ready to use when the app is first launched and the user is logged in. To do this, we start the tracker when the app is launched and end it when all of the actions that contribute to the perceived dashboard loading time are complete. (These are actions that show a visible loading view: syncing dashboard stats and loading store onboarding tasks.)

### Changes

* Adds `application_opened_waiting_time_loaded` to `WooAnalyticsStat`, and tracks it in `waitingFinished(scenario:elapsedTime:)`.
* Adds a new waiting time tracker `AppStartupWaitingTimeTracker` to track the app startup time:
   * When the tracker is initialized, it initializes `WaitingTimeTracker` with the `appStartup` scenario. This starts the tracker (recording the timestamp when it starts waiting).
   * The tracker has methods to end a startup action (which marks it as no longer pending and triggers the analytics event if all actions are ended) or end the tracker without triggering the analytics event.
* `AppStartupWaitingTimeTracker` is added as a global dependency in `ServiceLocator`. This allows us to start it in `AppDelegate` and end each action wherever needed.
* We only track the waiting time if the user is already logged in, and we stop the tracker if the user backgrounds the app before the dashboard finishes loading (to avoid tracking an inflated waiting time while the app is in the background) or if a startup action has an error (to avoid skewing the waiting time analysis).
* Adds unit tests where possible.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Logged out

1. Start logged out of the app.
2. Build and run the app.
3. Log in to the app and wait for the dashboard to finish loading. Confirm the event `application_opened_waiting_time_loaded` is **NOT** tracked.

### Logged in with a store with onboarding tasks to complete

1. Start logged in to the app with a store that has onboarding tasks to complete (the "Store setup" onboarding card is shown on the dashboard).
2. Build and run the app.
3. When the app launches and the dashboard is done loading, confirm the event `application_opened_waiting_time_loaded` is tracked with the custom property `waiting_time` reflecting the startup waiting time in seconds.

### Logged in with a store with no onboarding tasks

1. Start logged in to the app with a store with no onboarding tasks to complete (the "Store setup" onboarding card is **NOT** shown on the dashboard).
2. Build and run the app.
3. When the app launches and the dashboard is done loading, confirm the event `application_opened_waiting_time_loaded` is tracked with the custom property `waiting_time` reflecting the startup waiting time in seconds.

### Network connection error

1. Start logged in to the app.
2. Disable your network connection.
3. Build and run the app.
4. When the app launches and the dashboard is done loading (with an offline banner), confirm the event `application_opened_waiting_time_loaded` is **NOT** tracked.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
