### PR TITLE
[SKU Scanner] Improve SKU search logic

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 		B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6FCD320A373BA00A4F8E4 /* OrderMapper.swift */; };
 		B5C6FCD620A3768900A4F8E4 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = B5C6FCD520A3768900A4F8E4 /* order.json */; };
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
+		B918DDF12A3C960000E74DE5 /* products-sku-search-variation.json in Resources */ = {isa = PBXBuildFile; fileRef = B918DDF02A3C960000E74DE5 /* products-sku-search-variation.json */; };
 		B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */; };
 		BAB373722795A1FB00837B4A /* OrderTaxLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB373712795A1FB00837B4A /* OrderTaxLine.swift */; };
 		CC01CE5829B0EBED004FF537 /* product-bundle.json in Resources */ = {isa = PBXBuildFile; fileRef = CC01CE5729B0EBED004FF537 /* product-bundle.json */; };
@@ -1515,6 +1516,7 @@
 		B5C6FCD320A373BA00A4F8E4 /* OrderMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderMapper.swift; sourceTree = "<group>"; };
 		B5C6FCD520A3768900A4F8E4 /* order.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = order.json; sourceTree = "<group>"; };
 		B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsRemote.swift; sourceTree = "<group>"; };
+		B918DDF02A3C960000E74DE5 /* products-sku-search-variation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-sku-search-variation.json"; sourceTree = "<group>"; };
 		B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemRefundMetaData.swift; sourceTree = "<group>"; };
 		BAB373712795A1FB00837B4A /* OrderTaxLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTaxLine.swift; sourceTree = "<group>"; };
 		BD9439D9B8F2C1ED2EADAA51 /* Pods-NetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2642,6 +2644,7 @@
 				CCF434692906C9C300B4475A /* products-ids-only-empty.json */,
 				0282DD90233A120A006A5FDB /* products-search-photo.json */,
 				0261F5A828D4641500B7AC72 /* products-sku-search.json */,
+				B918DDF02A3C960000E74DE5 /* products-sku-search-variation.json */,
 				45D685F923D0C3CF005F87D0 /* product-search-sku.json */,
 				EEA6583F2966C05D00112DF0 /* product-search-sku-without-data.json */,
 				4599FC5B24A6276F0056157A /* product-tags-all.json */,
@@ -3630,6 +3633,7 @@
 				EEA658402966C05D00112DF0 /* product-search-sku-without-data.json in Resources */,
 				DE42F96D296BC67E00D514C2 /* wc-analytics-customers-without-data.json in Resources */,
 				DE4F2A4229751EAE00B0701C /* setting-coupon-without-data.json in Resources */,
+				B918DDF12A3C960000E74DE5 /* products-sku-search-variation.json in Resources */,
 				03EB99982907F4AA00F06A39 /* just-in-time-message-list-multiple.json in Resources */,
 				EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */,
 				451A97DE260B59870059D135 /* shipping-label-packages-success.json in Resources */,

--- a/Networking/NetworkingTests/Responses/products-sku-search-variation.json
+++ b/Networking/NetworkingTests/Responses/products-sku-search-variation.json
@@ -9,7 +9,7 @@
             "date_created_gmt": "2020-06-12T14:36:02",
             "date_modified": "2021-02-23T10:46:54",
             "date_modified_gmt": "2021-02-23T02:46:54",
-            "type": "simple",
+            "type": "variation",
             "status": "publish",
             "featured": false,
             "catalog_visibility": "visible",

--- a/Networking/NetworkingTests/Responses/products-sku-search.json
+++ b/Networking/NetworkingTests/Responses/products-sku-search.json
@@ -57,18 +57,12 @@
             "rating_count": 0,
             "upsell_ids": [],
             "cross_sell_ids": [],
-            "parent_id": 846,
+            "parent_id": 0,
             "purchase_note": "",
             "categories": [],
             "tags": [],
             "images": [],
-            "attributes": [
-                {
-                    "id": 0,
-                    "name": "Darkness",
-                    "option": "87%"
-                }
-            ],
+            "attributes": [],
             "default_attributes": [],
             "variations": [],
             "grouped_products": [],

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -5,6 +5,8 @@ import Experiments
 import WooFoundation
 import enum Networking.DotcomError
 
+typealias OrderBaseItem = SKUSearchResult
+
 /// View model used in Order Creation and Editing flows.
 ///
 final class EditableOrderViewModel: ObservableObject {
@@ -290,13 +292,13 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     private let orderSynchronizer: OrderSynchronizer
 
-    /// Initial product ID given to the order when is created, if any
+    /// Initial product or variation given to the order when is created, if any
     ///
-    private let initialProduct: Product?
+    private let initialItem: OrderBaseItem?
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
-    private let barcodeSKUScannerProductFinder: BarcodeSKUScannerProductFinder
+    private let barcodeSKUScannerItemFinder: BarcodeSKUScannerItemFinder
 
     init(siteID: Int64,
          flow: Flow = .creation,
@@ -307,7 +309,7 @@ final class EditableOrderViewModel: ObservableObject {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
-         initialProduct: Product? = nil) {
+         initialItem: OrderBaseItem? = nil) {
         self.siteID = siteID
         self.flow = flow
         self.stores = stores
@@ -318,8 +320,8 @@ final class EditableOrderViewModel: ObservableObject {
         self.featureFlagService = featureFlagService
         self.orderDurationRecorder = orderDurationRecorder
         self.permissionChecker = permissionChecker
-        self.initialProduct = initialProduct
-        self.barcodeSKUScannerProductFinder = BarcodeSKUScannerProductFinder(stores: stores)
+        self.initialItem = initialItem
+        self.barcodeSKUScannerItemFinder = BarcodeSKUScannerItemFinder(stores: stores)
 
         // Set a temporary initial view model, as a workaround to avoid making it optional.
         // Needs to be reset before the view model is used.
@@ -943,39 +945,39 @@ private extension EditableOrderViewModel {
                 return self.createProductRows(items: items)
             }
             .assign(to: &$productRows)
-        configureOrderWithInitialProductIfNeeded()
+        configureOrderWithinitialItemIfNeeded()
     }
 
     /// If given an initial product ID on initialization, updates the Order with the item
     ///
-    func configureOrderWithInitialProductIfNeeded() {
-        guard let product = self.initialProduct else {
+    func configureOrderWithinitialItemIfNeeded() {
+        guard let item = initialItem else {
             return
         }
 
-        updateOrderWithProduct(product)
+        updateOrderWithBaseItem(item)
     }
 
     /// Updates the Order with the given product
     ///
-    func updateOrderWithProduct(_ product: Product) {
-        guard currentOrderItems.contains(where: { $0.productOrVariationID == product.productID }) else {
+    func updateOrderWithBaseItem(_ item: OrderBaseItem) {
+        guard currentOrderItems.contains(where: { $0.productOrVariationID == item.itemID }) else {
             // If it's not part of the current order, send the correct productType to the synchronizer
-            if let productVariation = product.toProductVariation() {
-                allProductVariations.insert(productVariation)
-
-                selectedProductVariations.append(productVariation)
-                orderSynchronizer.setProduct.send(.init(product: .variation(productVariation), quantity: 1))
-            } else {
+            switch product {
+            case let .product(product):
                 allProducts.insert(product)
-
                 selectedProducts.append(product)
                 orderSynchronizer.setProduct.send(.init(product: .product(product), quantity: 1))
+            case let .variation(productVariation):
+                allProductVariations.insert(productVariation)
+                selectedProductVariations.append(productVariation)
+                orderSynchronizer.setProduct.send(.init(product: .variation(productVariation), quantity: 1))
             }
+
             return
         }
         // Increase quantity if exists
-        let match = productRows.first(where: { $0.productOrVariationID == product.productID })
+        let match = productRows.first(where: { $0.productOrVariationID == product.itemID })
         match?.incrementQuantity()
     }
 
@@ -1327,12 +1329,12 @@ extension EditableOrderViewModel {
         mapFromScannedBarcodetoProduct(barcode: barcode) { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case let .success(product):
+            case let .success(result):
                 Task { @MainActor in
                     self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: self.flow.analyticsFlow,
                                                                                     source: .orderCreation,
                                                                                     addedVia: .scanning))
-                    self.updateOrderWithProduct(product)
+                    self.updateOrderWithBaseItem(result)
                     onCompletion(.success(()))
                 }
             case .failure:
@@ -1357,11 +1359,11 @@ extension EditableOrderViewModel {
 
     /// Attempts to map SKU to Product
     ///
-    private func mapFromScannedBarcodetoProduct(barcode: ScannedBarcode, onCompletion: @escaping (Result<Product, Error>) -> Void) {
+    private func mapFromScannedBarcodetoProduct(barcode: ScannedBarcode, onCompletion: @escaping (Result<OrderBaseItem, Error>) -> Void) {
         Task {
             do {
-                let matchedProduct = try await barcodeSKUScannerProductFinder.findProduct(from: barcode, siteID: siteID, source: .orderCreation)
-                onCompletion(.success(matchedProduct))
+                let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: barcode, siteID: siteID, source: .orderCreation)
+                onCompletion(.success(result))
             } catch {
                 onCompletion(.failure(error))
             }
@@ -1443,6 +1445,17 @@ private extension EditableOrderViewModel {
             return product?.toProductVariation()
         }
         return variation
+    }
+}
+
+private extension OrderBaseItem {
+    var itemID: Int64 {
+        switch self {
+        case let .product(product):
+            return product.productID
+        case let .variation(variation):
+            return variation.productVariationID
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1327,7 +1327,7 @@ extension EditableOrderViewModel {
     ///
     func addScannedProductToOrder(barcode: ScannedBarcode, onCompletion: @escaping (Result<Void, Error>) -> Void, onRetryRequested: @escaping () -> Void) {
         analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningSuccess(from: .orderCreation))
-        mapFromScannedBarcodetoProduct(barcode: barcode) { [weak self] result in
+        mapScannedBarcodetoBaseItem(barcode: barcode) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case let .success(result):
@@ -1360,7 +1360,7 @@ extension EditableOrderViewModel {
 
     /// Attempts to map SKU to Product
     ///
-    private func mapFromScannedBarcodetoProduct(barcode: ScannedBarcode, onCompletion: @escaping (Result<OrderBaseItem, Error>) -> Void) {
+    private func mapScannedBarcodetoBaseItem(barcode: ScannedBarcode, onCompletion: @escaping (Result<OrderBaseItem, Error>) -> Void) {
         Task {
             do {
                 let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: barcode, siteID: siteID, source: .orderCreation)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -449,7 +449,8 @@ final class EditableOrderViewModel: ObservableObject {
             return nil
         }
 
-        if item.variationID != 0, let variation = retrieveVariation(for: item) {
+        if item.variationID != 0,
+            let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {
             let parent = allProducts.first(where: { $0.productID == item.parent })
             let attributes = ProductVariationFormatter().generateAttributes(for: variation, from: parent?.attributes ?? [])
             return ProductRowViewModel(id: item.itemID,
@@ -963,7 +964,7 @@ private extension EditableOrderViewModel {
     func updateOrderWithBaseItem(_ item: OrderBaseItem) {
         guard currentOrderItems.contains(where: { $0.productOrVariationID == item.itemID }) else {
             // If it's not part of the current order, send the correct productType to the synchronizer
-            switch product {
+            switch item {
             case let .product(product):
                 allProducts.insert(product)
                 selectedProducts.append(product)
@@ -977,7 +978,7 @@ private extension EditableOrderViewModel {
             return
         }
         // Increase quantity if exists
-        let match = productRows.first(where: { $0.productOrVariationID == product.itemID })
+        let match = productRows.first(where: { $0.productOrVariationID == item.itemID })
         match?.incrementQuantity()
     }
 
@@ -1423,28 +1424,6 @@ extension EditableOrderViewModel {
                 return false
             }
         }
-    }
-}
-
-private extension EditableOrderViewModel {
-    // Attempts to retrieve the product variation associated with a given OrderItem, if any, from locally stored variations.
-    // If none is found, falls back to attempt to retrieve the variation from a model parent
-    // If none is found, returns nil
-    // https://github.com/woocommerce/woocommerce-ios/issues/9808
-    func retrieveVariation(for item: OrderItem) -> ProductVariation? {
-        guard let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) else {
-            let product = allProducts.first(where: { $0.productID == item.variationID })
-            return product?.toProductVariation()
-        }
-        return variation
-    }
-
-    func retrieveVariation(for id: Int64) -> ProductVariation? {
-        guard let variation = allProductVariations.first(where: { $0.productVariationID == id }) else {
-            let product = allProducts.first(where: { $0.productID == id })
-            return product?.toProductVariation()
-        }
-        return variation
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -5,6 +5,8 @@ import Experiments
 import WooFoundation
 import enum Networking.DotcomError
 
+/// Encapsulates the item type an order can have, products or variations
+///
 typealias OrderBaseItem = SKUSearchResult
 
 /// View model used in Order Creation and Editing flows.
@@ -178,7 +180,6 @@ final class EditableOrderViewModel: ObservableObject {
     /// Product Variations list
     ///
     private var allProductVariations: Set<ProductVariation> = []
-
 
     /// View models for each product row in the order.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
@@ -43,7 +43,7 @@ struct BarcodeSKUScannerItemFinder {
 
     private func search(by sku: String, siteID: Int64) async throws -> SKUSearchResult {
         try await withCheckedThrowingContinuation { continuation in
-            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: siteID,
+            let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: siteID,
                                                                         sku: sku) { result in
                 switch result {
                 case let .success(matchedProduct):

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1581,7 +1581,7 @@
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		B90C65CD29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */; };
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
-		B90DACC02A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */; };
+		B90DACC02A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift */; };
 		B90DACC22A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACC12A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9151B3E2840EB330036180F /* WooFoundation.framework */; };
@@ -3912,7 +3912,7 @@
 		B6FEFFF02A0DDC0000C0F546 /* EUCustomsScenarioValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EUCustomsScenarioValidator.swift; sourceTree = "<group>"; };
 		B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentOnboardingStateCache.swift; sourceTree = "<group>"; };
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
-		B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerProductFinder.swift; sourceTree = "<group>"; };
+		B90DACBF2A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerItemFinder.swift; sourceTree = "<group>"; };
 		B90DACC12A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerProductFinderTests.swift; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B9151B3E2840EB330036180F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -5238,7 +5238,7 @@
 				025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */,
 				02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */,
 				02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */,
-				B90DACBF2A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift */,
+				B90DACBF2A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift */,
 			);
 			path = "SKU Scanner";
 			sourceTree = "<group>";
@@ -12133,7 +12133,7 @@
 				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				DE74F2A527E41D740002FE59 /* EnableAnalyticsView.swift in Sources */,
-				B90DACC02A30AEF000365897 /* BarcodeSKUScannerProductFinder.swift in Sources */,
+				B90DACC02A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift in Sources */,
 				D85A3C5626C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift in Sources */,
 				26B233D12A14208800926EAD /* PrivacyBannerPresenter.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1650,7 +1650,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
-            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+            case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Expected failure, got success")
@@ -1704,7 +1704,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
-            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+            case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
                 let product = Product.fake().copy(productID: self.sampleSiteID, purchasable: true)
                 onCompletion(.success(product))
             default:
@@ -1749,7 +1749,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { [weak self] action in
             switch action {
-            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+            case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
                 self?.storageManager.insertSampleProduct(readOnlyProduct: product)
                 onCompletion(.success(product))
             default:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1816,12 +1816,12 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_order_created_when_initialItem_is_productVariation_type_then_initial_order_contains_productVariation() {
         // Given
         let variationID: Int64 = 33
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: variationID, productTypeKey: "variation")
+        let variation = ProductVariation.fake().copy(siteID: sampleSiteID, productVariationID: variationID)
 
-        storageManager.insertSampleProduct(readOnlyProduct: product)
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: variation)
 
         //When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialItem: .product(product))
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialItem: .variation(variation))
         guard let orderItem = viewModel.currentOrderItems.first else {
             XCTFail("The Order should contain one item")
             return

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1706,7 +1706,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             switch action {
             case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
                 let product = Product.fake().copy(productID: self.sampleSiteID, purchasable: true)
-                onCompletion(.success(product))
+                onCompletion(.success(.product(product)))
             default:
                 break
             }
@@ -1735,9 +1735,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(analytics.receivedProperties.last?["added_via"] as? String, "scanning")
     }
 
-    func test_order_creation_when_withInitialProduct_is_nil_then_currentOrderItems_are_zero() {
+    func test_order_creation_when_withinitialItem_is_nil_then_currentOrderItems_are_zero() {
         // Given, When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, initialProduct: nil)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, initialItem: nil)
 
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 0)
@@ -1751,7 +1751,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             switch action {
             case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
                 self?.storageManager.insertSampleProduct(readOnlyProduct: product)
-                onCompletion(.success(product))
+                onCompletion(.success(.product(product)))
             default:
                 break
             }
@@ -1783,7 +1783,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(item.productID, sampleProductID)
     }
 
-    func test_order_creation_when_initialProduct_is_not_nil_and_product_exists_then_product_is_added_to_the_order() {
+    func test_order_creation_when_initialItem_is_not_nil_and_product_exists_then_product_is_added_to_the_order() {
         // Given, When
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
@@ -1791,19 +1791,19 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Confidence check
         XCTAssertEqual(viewModel.currentOrderItems.count, 0)
 
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProduct: product)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialItem: .product(product))
 
         // Then
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)
     }
 
-    func test_order_created_when_initialProduct_is_product_type_then_initial_order_contains_product() {
+    func test_order_created_when_initialItem_is_product_type_then_initial_order_contains_product() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         // When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProduct: product)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialItem: .product(product))
         let orderItem = viewModel.currentOrderItems.first(where: { $0.productID == product.productID})
 
         // Then
@@ -1813,7 +1813,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(orderItem?.quantity, 1)
     }
 
-    func test_order_created_when_initialProduct_is_productVariation_type_then_initial_order_contains_productVariation() {
+    func test_order_created_when_initialItem_is_productVariation_type_then_initial_order_contains_productVariation() {
         // Given
         let variationID: Int64 = 33
         let product = Product.fake().copy(siteID: sampleSiteID, productID: variationID, productTypeKey: "variation")
@@ -1821,7 +1821,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         //When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialProduct: product)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialItem: .product(product))
         guard let orderItem = viewModel.currentOrderItems.first else {
             XCTFail("The Order should contain one item")
             return

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -5,9 +5,10 @@ import Yosemite
 
 final class BarcodeSKUScannerItemFinderTests: XCTestCase {
     private var sut: BarcodeSKUScannerItemFinder!
-    var stores: MockStoresManager!
-    var storageManager: MockStorageManager!
-    var analyticsProvider: MockAnalyticsProvider!
+    private var stores: MockStoresManager!
+    private var storageManager: MockStorageManager!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
     var analytics: WooAnalytics!
 
     override func setUp() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -3,8 +3,8 @@ import XCTest
 import Yosemite
 @testable import WooCommerce
 
-final class BarcodeSKUScannerProductFinderTests: XCTestCase {
-    private var sut: BarcodeSKUScannerProductFinder!
+final class BarcodeSKUScannerItemFinderTests: XCTestCase {
+    private var sut: BarcodeSKUScannerItemFinder!
     var stores: MockStoresManager!
     var storageManager: MockStorageManager!
     var analyticsProvider: MockAnalyticsProvider!
@@ -17,7 +17,7 @@ final class BarcodeSKUScannerProductFinderTests: XCTestCase {
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
 
-        sut = BarcodeSKUScannerProductFinder(stores: stores, analytics: analytics)
+        sut = BarcodeSKUScannerItemFinder(stores: stores, analytics: analytics)
 
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -49,7 +49,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
         var retrievedError: Error?
 
         do {
-            _ = try await sut.findProduct(from: scannedBarcode, siteID: 1, source: source)
+            _ = try await sut.searchBySKU(from: scannedBarcode, siteID: 1, source: source)
         } catch {
             retrievedError = error
         }
@@ -67,7 +67,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
             case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
-                onCompletion(.success(returningProduct))
+                onCompletion(.success(.product(returningProduct)))
             default:
                 break
             }
@@ -75,7 +75,11 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
 
         // When
         let scannedBarcode = ScannedBarcode(payloadStringValue: "123456", symbology: .aztec)
-        let retrievedProduct = try? await sut.findProduct(from: scannedBarcode, siteID: 1, source: source)
+        let result = try? await sut.searchBySKU(from: scannedBarcode, siteID: 1, source: source)
+
+        guard case let .product(retrievedProduct) = result else {
+            return XCTFail("It didn't provide a product as expected")
+        }
 
         // Then
         XCTAssertEqual(retrievedProduct, returningProduct)
@@ -101,7 +105,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
             switch action {
             case let .retrieveFirstItemMatchFromSKU(_, givenSKU, onCompletion):
                 if givenSKU == productSKU {
-                    onCompletion(.success(returningProduct))
+                    onCompletion(.success(.product(returningProduct)))
                 } else {
                     onCompletion(.failure(ProductLoadError.notFound))
                 }
@@ -111,7 +115,12 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
         })
 
         // When
-        let retrievedProduct = try? await sut.findProduct(from: scannedBarcode, siteID: 1, source: .orderCreation)
+        let result = try? await sut.searchBySKU(from: scannedBarcode, siteID: 1, source: .orderCreation)
+
+        guard case let .product(retrievedProduct) = result else {
+            return XCTFail("It didn't provide a product as expected")
+        }
+
 
         // Then
         XCTAssertEqual(retrievedProduct, returningProduct)
@@ -127,7 +136,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
             switch action {
             case let .retrieveFirstItemMatchFromSKU(_, givenSKU, onCompletion):
                 if givenSKU == productSKU {
-                    onCompletion(.success(returningProduct))
+                    onCompletion(.success(.product(returningProduct)))
                 } else {
                     onCompletion(.failure(ProductLoadError.notFound))
                 }
@@ -137,7 +146,12 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
         })
 
         // When
-        let retrievedProduct = try? await sut.findProduct(from: scannedBarcode, siteID: 1, source: .orderCreation)
+        let result = try? await sut.searchBySKU(from: scannedBarcode, siteID: 1, source: .orderCreation)
+
+        guard case let .product(retrievedProduct) = result else {
+            return XCTFail("It didn't provide a product as expected")
+        }
+
 
         // Then
         XCTAssertEqual(retrievedProduct, returningProduct)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -9,7 +9,6 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
     private var storageManager: MockStorageManager!
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
-    var analytics: WooAnalytics!
 
     override func setUp() {
         super.setUp()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -38,7 +38,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
         let symbology = BarcodeSymbology.aztec
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
-            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+            case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
                 onCompletion(.failure(testError))
             default:
                 XCTFail("Expected failure, got success")
@@ -66,7 +66,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
         let returningProduct = Product.fake()
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
-            case .retrieveFirstProductMatchFromSKU(_, _, let onCompletion):
+            case .retrieveFirstItemMatchFromSKU(_, _, let onCompletion):
                 onCompletion(.success(returningProduct))
             default:
                 break
@@ -99,7 +99,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
-            case let .retrieveFirstProductMatchFromSKU(_, givenSKU, onCompletion):
+            case let .retrieveFirstItemMatchFromSKU(_, givenSKU, onCompletion):
                 if givenSKU == productSKU {
                     onCompletion(.success(returningProduct))
                 } else {
@@ -125,7 +125,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
-            case let .retrieveFirstProductMatchFromSKU(_, givenSKU, onCompletion):
+            case let .retrieveFirstItemMatchFromSKU(_, givenSKU, onCompletion):
                 if givenSKU == productSKU {
                     onCompletion(.success(returningProduct))
                 } else {

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		B9AECD442851D95600E78584 /* TotalRefundedCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD432851D95600E78584 /* TotalRefundedCalculationUseCase.swift */; };
 		B9AECD462851DBED00E78584 /* Order+CurrencyFormattedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD452851DBED00E78584 /* Order+CurrencyFormattedValues.swift */; };
 		B9AECD482851F28E00E78584 /* Order+CardPresentPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD472851F28E00E78584 /* Order+CardPresentPaymentTests.swift */; };
+		B9C0C1082A3C666A00DF84EA /* ProductVariationStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C0C1072A3C666A00DF84EA /* ProductVariationStorageManager.swift */; };
 		B9F146972A0E30ED0039E159 /* Product+ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F146962A0E30ED0039E159 /* Product+ProductVariation.swift */; };
 		BAB3737927964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */; };
 		CC24A4F129ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC24A4F029ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift */; };
@@ -800,6 +801,7 @@
 		B9AECD432851D95600E78584 /* TotalRefundedCalculationUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TotalRefundedCalculationUseCase.swift; sourceTree = "<group>"; };
 		B9AECD452851DBED00E78584 /* Order+CurrencyFormattedValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+CurrencyFormattedValues.swift"; sourceTree = "<group>"; };
 		B9AECD472851F28E00E78584 /* Order+CardPresentPaymentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Order+CardPresentPaymentTests.swift"; sourceTree = "<group>"; };
+		B9C0C1072A3C666A00DF84EA /* ProductVariationStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationStorageManager.swift; sourceTree = "<group>"; };
 		B9F146962A0E30ED0039E159 /* Product+ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductVariation.swift"; sourceTree = "<group>"; };
 		BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderTaxLine+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1434,6 +1436,7 @@
 		B56C1EBC20EABD1C00D749F9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				B9C0C1062A3C665300DF84EA /* ProductVariations */,
 				E18FDAFC28F97E9C008519BA /* InAppPurchases */,
 				02FF054423D983C40058E6E7 /* Media */,
 				0212AC60242C689600C51F6C /* Products */,
@@ -1784,6 +1787,14 @@
 			path = Tools;
 			sourceTree = "<group>";
 		};
+		B9C0C1062A3C665300DF84EA /* ProductVariations */ = {
+			isa = PBXGroup;
+			children = (
+				B9C0C1072A3C666A00DF84EA /* ProductVariationStorageManager.swift */,
+			);
+			path = ProductVariations;
+			sourceTree = "<group>";
+		};
 		D8652E1A26303D0600350F37 /* Payments */ = {
 			isa = PBXGroup;
 			children = (
@@ -2117,6 +2128,7 @@
 				74643EE1221F567E00EDC51A /* ShipmentAction.swift in Sources */,
 				02FF054E23D983F30058E6E7 /* MediaImageExporter.swift in Sources */,
 				2685C117263C98CF00D9EE97 /* AddOnGroupStore.swift in Sources */,
+				B9C0C1082A3C666A00DF84EA /* ProductVariationStorageManager.swift in Sources */,
 				CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */,
 				24163BA8257F41C500F94EC3 /* SessionManagerProtocol.swift in Sources */,
 				D83B093925DECFD900B21F45 /* CardPresentPaymentStore.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -69,7 +69,7 @@ public enum ProductAction: Action {
 
     /// Retrieves the first Product with exact-match SKU
     ///
-    case retrieveFirstProductMatchFromSKU(siteID: Int64, sku: String, onCompletion: (Result<SKUSearchResult, Error>) -> Void)
+    case retrieveFirstItemMatchFromSKU(siteID: Int64, sku: String, onCompletion: (Result<SKUSearchResult, Error>) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -1,6 +1,10 @@
 import Foundation
 import Networking
 
+public enum SKUSearchResult {
+    case product(Product)
+    case variation(ProductVariation)
+}
 
 /// ProductAction: Defines all of the Actions supported by the ProductStore.
 ///
@@ -65,7 +69,7 @@ public enum ProductAction: Action {
 
     /// Retrieves the first Product with exact-match SKU
     ///
-    case retrieveFirstProductMatchFromSKU(siteID: Int64, sku: String, onCompletion: (Result<Product, Error>) -> Void)
+    case retrieveFirstProductMatchFromSKU(siteID: Int64, sku: String, onCompletion: (Result<SKUSearchResult, Error>) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -55,8 +55,8 @@ public class ProductStore: Store {
             retrieveProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .retrieveProducts(let siteID, let productIDs, let pageNumber, let pageSize, let onCompletion):
             retrieveProducts(siteID: siteID, productIDs: productIDs, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .retrieveFirstProductMatchFromSKU(siteID: let siteID, sku: let sku, onCompletion: let onCompletion):
-            retrieveFirstProductMatchFromSKU(siteID: siteID, sku: sku, onCompletion: onCompletion)
+        case .retrieveFirstItemMatchFromSKU(siteID: let siteID, sku: let sku, onCompletion: let onCompletion):
+            retrieveFirstItemMatchFromSKU(siteID: siteID, sku: sku, onCompletion: onCompletion)
         case let.searchProductsInCache(siteID, keyword, pageSize, onCompletion):
             searchInCache(siteID: siteID, keyword: keyword, pageSize: pageSize, onCompletion: onCompletion)
         case let .searchProducts(siteID,
@@ -336,7 +336,7 @@ private extension ProductStore {
 
     /// Retrieves the first product associated with a given siteID and exact-matching SKU (if any)
     ///
-    func retrieveFirstProductMatchFromSKU(siteID: Int64, sku: String, onCompletion: @escaping (Result<SKUSearchResult, Error>) -> Void) {
+    func retrieveFirstItemMatchFromSKU(siteID: Int64, sku: String, onCompletion: @escaping (Result<SKUSearchResult, Error>) -> Void) {
         remote.searchProductsBySKU(for: siteID,
                                    keyword: sku,
                                    pageNumber: Remote.Default.firstPageNumber,

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -349,7 +349,10 @@ private extension ProductStore {
                 }
 
                 if let productVariation = product.toProductVariation() {
-                    self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation], siteID: siteID, productID: productVariation.productID, onCompletion: {
+                    self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                                                                                                  siteID: siteID,
+                                                                                                  productID: productVariation.productID,
+                                                                                                  onCompletion: {
                         onCompletion(.success(.variation(productVariation)))
                     })
                 } else {

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -6,6 +6,7 @@ import Storage
 //
 public final class ProductVariationStore: Store {
     private let remote: ProductVariationsRemoteProtocol
+    private let productVariationStorageManager: ProductVariationStorageManager
 
     private lazy var sharedDerivedStorage: StorageType = {
         return storageManager.writerDerivedStorage
@@ -17,6 +18,7 @@ public final class ProductVariationStore: Store {
     }
 
     init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: ProductVariationsRemoteProtocol) {
+        self.productVariationStorageManager = ProductVariationStorageManager(storageManager: storageManager)
         self.remote = remote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
@@ -100,11 +102,11 @@ private extension ProductVariationStore {
             }
 
             if pageNumber == Default.firstPageNumber {
-                self?.deleteStoredProductVariations(siteID: siteID,
+                self?.productVariationStorageManager.deleteStoredProductVariations(siteID: siteID,
                                                     productID: productID)
             }
 
-            self?.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
+            self?.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
                                                             siteID: siteID,
                                                             productID: productID) {
                 let couldBeMoreVariationsToFetch = productVariations.count == pageSize
@@ -125,7 +127,7 @@ private extension ProductVariationStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let productVariation):
-                self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
                                                                siteID: siteID, productID: productID) { [weak self] in
                    guard let storageProductVariation = self?.storageManager.viewStorage
                         .loadProductVariation(siteID: productVariation.siteID,
@@ -151,7 +153,7 @@ private extension ProductVariationStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let productVariation):
-                self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
                                                                siteID: siteID,
                                                                productID: productID) { [weak self] in
                     guard let storageProductVariation = self?.storageManager.viewStorage.loadProductVariation(siteID: siteID,
@@ -180,7 +182,7 @@ private extension ProductVariationStore {
             guard let self = self else { return }
             switch result {
             case .success(let productVariations):
-                self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
+                self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
                                                                siteID: siteID,
                                                                productID: productID) { [weak self] in
                     guard let storageProductVariation = self?.storageManager.viewStorage.loadProductVariations(siteID: siteID, productID: productID) else {
@@ -207,7 +209,7 @@ private extension ProductVariationStore {
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))
             case .success(let productVariation):
-                self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
                                                                siteID: productVariation.siteID,
                                                                productID: productVariation.productID) { [weak self] in
                                                                 guard let storageProductVariation = self?.storageManager.viewStorage
@@ -238,7 +240,7 @@ private extension ProductVariationStore {
             case .failure(let error):
                 completion(.failure(ProductUpdateError(error: error)))
             case .success(let productVariation):
-                self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
                                                                siteID: productVariation.siteID,
                                                                productID: productVariation.productID) { [weak self] in
                     guard let storageProductVariation = self?.storageManager.viewStorage
@@ -266,7 +268,7 @@ private extension ProductVariationStore {
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))
             case .success(let productVariations):
-                self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
+                self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
                                                                siteID: siteID,
                                                                productID: productID) { [weak self] in
                                                                 guard let storageProductVariation = self?.storageManager.viewStorage
@@ -304,7 +306,7 @@ private extension ProductVariationStore {
                     results.append(.failure(error))
                     group.leave()
                 case .success(let productVariation):
-                    self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                    self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
                                                                    siteID: order.siteID,
                                                                    productID: orderItem.productID) {
                         results.append(.success(productVariation))
@@ -332,7 +334,7 @@ private extension ProductVariationStore {
             guard let self = self else { return }
             switch result {
             case .success(let productVariation):
-                self.deleteStoredProductVariation(siteID: productVariation.siteID, productVariationID: productVariation.productVariationID)
+                self.productVariationStorageManager.deleteStoredProductVariation(siteID: productVariation.siteID, productVariationID: productVariation.productVariationID)
                 onCompletion(.success(()))
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))
@@ -340,149 +342,7 @@ private extension ProductVariationStore {
         }
     }
 }
-
-
-// MARK: - Storage: ProductVariation
-//
 private extension ProductVariationStore {
-
-    /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities *in a background thread*. onCompletion will be called
-    /// on the main thread!
-    ///
-    func upsertStoredProductVariationsInBackground(readOnlyProductVariations: [Networking.ProductVariation],
-                                                   siteID: Int64,
-                                                   productID: Int64,
-                                                   onCompletion: @escaping () -> Void) {
-        let derivedStorage = sharedDerivedStorage
-        derivedStorage.perform { [weak self] in
-            self?.upsertStoredProductVariations(readOnlyProductVariations: readOnlyProductVariations, in: derivedStorage, siteID: siteID, productID: productID)
-        }
-
-        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
-            DispatchQueue.main.async(execute: onCompletion)
-        }
-    }
-
-    /// Deletes any Storage.ProductVariation with the specified `siteID` and `productID`
-    ///
-    func deleteStoredProductVariations(siteID: Int64, productID: Int64) {
-        let storage = storageManager.viewStorage
-        storage.deleteProductVariations(siteID: siteID, productID: productID)
-        storage.saveIfNeeded()
-    }
-
-    /// Deletes any Storage.ProductVariation with the specified `siteID` and `productID`
-    ///
-    func deleteStoredProductVariation(siteID: Int64, productVariationID: Int64) {
-        let storage = storageManager.viewStorage
-        storage.deleteProductVariation(siteID: siteID, productVariationID: productVariationID)
-        storage.saveIfNeeded()
-    }
-}
-
-
-private extension ProductVariationStore {
-    /// Updates (OR Inserts) the specified ReadOnly ProductVariation Entities into the Storage Layer.
-    ///
-    /// - Parameters:
-    ///     - readOnlyProductVariations: Remote ProductVariation's to be persisted.
-    ///     - storage: Where we should save all the things!
-    ///     - siteID: site ID for looking up the Product.
-    ///     - productID: product ID for looking up the Product.
-    ///
-    func upsertStoredProductVariations(readOnlyProductVariations: [Networking.ProductVariation],
-                                       in storage: StorageType,
-                                       siteID: Int64,
-                                       productID: Int64) {
-        let product = storage.loadProduct(siteID: siteID, productID: productID)
-
-        // Upserts the Product Variations from the read-only version
-        for readOnlyProductVariation in readOnlyProductVariations {
-            let storageProductVariation = storage.loadProductVariation(siteID: siteID,
-                                                                       productVariationID: readOnlyProductVariation.productVariationID)
-                ?? storage.insertNewObject(ofType: Storage.ProductVariation.self)
-            storageProductVariation.update(with: readOnlyProductVariation)
-            storageProductVariation.product = product
-            handleProductDimensions(readOnlyProductVariation, storageProductVariation, storage)
-            handleProductVariationAttributes(readOnlyProductVariation, storageProductVariation, storage)
-            handleProductImage(readOnlyProductVariation, storageProductVariation, storage)
-            handleProductSubscription(readOnlyProductVariation, storageProductVariation, storage)
-        }
-    }
-
-    /// Updates or inserts the provided StorageProductVariation's dimensions using the provided read-only ProductVariation's dimensions
-    ///
-    func handleProductDimensions(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
-        if let existingStorageDimensions = storageVariation.dimensions {
-            existingStorageDimensions.update(with: readOnlyVariation.dimensions)
-        } else {
-            let newStorageDimensions = storage.insertNewObject(ofType: Storage.ProductDimensions.self)
-            newStorageDimensions.update(with: readOnlyVariation.dimensions)
-            storageVariation.dimensions = newStorageDimensions
-        }
-    }
-
-    /// Replaces the provided StorageProductVariation's attributes with the provided read-only
-    /// ProductVariation's attributes.
-    /// Because all local Product attributes have ID: Int64 = 0, they are not unique in Storage and we always replace the whole
-    /// attribute array.
-    ///
-    func handleProductVariationAttributes(_ readOnlyVariation: Networking.ProductVariation,
-                                          _ storageVariation: Storage.ProductVariation,
-                                          _ storage: StorageType) {
-        // Removes all the attributes first.
-        storageVariation.attributesArray.forEach { existingStorageAttribute in
-            storage.deleteObject(existingStorageAttribute)
-        }
-
-        // Inserts the attributes from the read-only product variation.
-        var storageAttributes = [StorageAttribute]()
-        for readOnlyAttribute in readOnlyVariation.attributes {
-            let newStorageAttribute = storage.insertNewObject(ofType: Storage.GenericAttribute.self)
-            newStorageAttribute.update(with: readOnlyAttribute)
-            storageAttributes.append(newStorageAttribute)
-        }
-        storageVariation.attributes = NSOrderedSet(array: storageAttributes)
-    }
-
-    /// Updates, inserts, or prunes the provided StorageProductVariation's image using the provided read-only ProductVariation's image
-    ///
-    func handleProductImage(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
-        guard let readOnlyImage = readOnlyVariation.image else {
-            if let existingStorageImage = storageVariation.image {
-                storage.deleteObject(existingStorageImage)
-            }
-            return
-        }
-
-        if let existingStorageImage = storageVariation.image {
-            existingStorageImage.update(with: readOnlyImage)
-        } else {
-            let newStorageImage = storage.insertNewObject(ofType: Storage.ProductImage.self)
-            newStorageImage.update(with: readOnlyImage)
-            storageVariation.image = newStorageImage
-        }
-    }
-
-    /// Updates, inserts, or prunes the provided StorageProductVariation's subscription using the provided read-only ProductVariation's subscription
-    ///
-    func handleProductSubscription(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
-        guard let readOnlySubscription = readOnlyVariation.subscription else {
-            if let existingStorageSubscription = storageVariation.subscription {
-                storage.deleteObject(existingStorageSubscription)
-            }
-            return
-        }
-
-        if let existingStorageSubscription = storageVariation.subscription {
-            existingStorageSubscription.update(with: readOnlySubscription)
-        } else {
-            let newStorageSubscription = storage.insertNewObject(ofType: Storage.ProductSubscription.self)
-            newStorageSubscription.update(with: readOnlySubscription)
-            storageVariation.subscription = newStorageSubscription
-        }
-    }
-
     /// Recursively sync all product variations starting with the given page number and using a maximum page size.
     ///
     private func recursivelySyncAllVariations(siteID: Int64,

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -334,7 +334,8 @@ private extension ProductVariationStore {
             guard let self = self else { return }
             switch result {
             case .success(let productVariation):
-                self.productVariationStorageManager.deleteStoredProductVariation(siteID: productVariation.siteID, productVariationID: productVariation.productVariationID)
+                self.productVariationStorageManager.deleteStoredProductVariation(siteID: productVariation.siteID,
+                                                                                 productVariationID: productVariation.productVariationID)
                 onCompletion(.success(()))
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))

--- a/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationStorageManager.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationStorageManager.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Networking
+import Storage
+
+final class ProductVariationStorageManager {
+    private let storageManager: StorageManagerType
+
+    private lazy var sharedDerivedStorage: StorageType = {
+        return storageManager.writerDerivedStorage
+    }()
+
+    init(storageManager: StorageManagerType) {
+        self.storageManager = storageManager
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities *in a background thread*. onCompletion will be called
+    /// on the main thread!
+    ///
+    func upsertStoredProductVariationsInBackground(readOnlyProductVariations: [Networking.ProductVariation],
+                                                   siteID: Int64,
+                                                   productID: Int64,
+                                                   onCompletion: @escaping () -> Void) {
+        let derivedStorage = sharedDerivedStorage
+        derivedStorage.perform { [weak self] in
+            self?.upsertStoredProductVariations(readOnlyProductVariations: readOnlyProductVariations, in: derivedStorage, siteID: siteID, productID: productID)
+        }
+
+        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+            DispatchQueue.main.async(execute: onCompletion)
+        }
+    }
+
+    /// Deletes any Storage.ProductVariation with the specified `siteID` and `productID`
+    ///
+    func deleteStoredProductVariations(siteID: Int64, productID: Int64) {
+        let storage = storageManager.viewStorage
+        storage.deleteProductVariations(siteID: siteID, productID: productID)
+        storage.saveIfNeeded()
+    }
+
+    /// Deletes any Storage.ProductVariation with the specified `siteID` and `productID`
+    ///
+    func deleteStoredProductVariation(siteID: Int64, productVariationID: Int64) {
+        let storage = storageManager.viewStorage
+        storage.deleteProductVariation(siteID: siteID, productVariationID: productVariationID)
+        storage.saveIfNeeded()
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly ProductVariation Entities into the Storage Layer.
+    ///
+    /// - Parameters:
+    ///     - readOnlyProductVariations: Remote ProductVariation's to be persisted.
+    ///     - storage: Where we should save all the things!
+    ///     - siteID: site ID for looking up the Product.
+    ///     - productID: product ID for looking up the Product.
+    ///
+    func upsertStoredProductVariations(readOnlyProductVariations: [Networking.ProductVariation],
+                                       in storage: StorageType,
+                                       siteID: Int64,
+                                       productID: Int64) {
+        let product = storage.loadProduct(siteID: siteID, productID: productID)
+
+        // Upserts the Product Variations from the read-only version
+        for readOnlyProductVariation in readOnlyProductVariations {
+            let storageProductVariation = storage.loadProductVariation(siteID: siteID,
+                                                                       productVariationID: readOnlyProductVariation.productVariationID)
+            ?? storage.insertNewObject(ofType: Storage.ProductVariation.self)
+            storageProductVariation.update(with: readOnlyProductVariation)
+            storageProductVariation.product = product
+            handleProductDimensions(readOnlyProductVariation, storageProductVariation, storage)
+            handleProductVariationAttributes(readOnlyProductVariation, storageProductVariation, storage)
+            handleProductImage(readOnlyProductVariation, storageProductVariation, storage)
+            handleProductSubscription(readOnlyProductVariation, storageProductVariation, storage)
+        }
+    }
+}
+
+private extension ProductVariationStorageManager {
+    /// Updates or inserts the provided StorageProductVariation's dimensions using the provided read-only ProductVariation's dimensions
+    ///
+    func handleProductDimensions(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
+        if let existingStorageDimensions = storageVariation.dimensions {
+            existingStorageDimensions.update(with: readOnlyVariation.dimensions)
+        } else {
+            let newStorageDimensions = storage.insertNewObject(ofType: Storage.ProductDimensions.self)
+            newStorageDimensions.update(with: readOnlyVariation.dimensions)
+            storageVariation.dimensions = newStorageDimensions
+        }
+    }
+
+    /// Replaces the provided StorageProductVariation's attributes with the provided read-only
+    /// ProductVariation's attributes.
+    /// Because all local Product attributes have ID: Int64 = 0, they are not unique in Storage and we always replace the whole
+    /// attribute array.
+    ///
+    func handleProductVariationAttributes(_ readOnlyVariation: Networking.ProductVariation,
+                                          _ storageVariation: Storage.ProductVariation,
+                                          _ storage: StorageType) {
+        // Removes all the attributes first.
+        storageVariation.attributesArray.forEach { existingStorageAttribute in
+            storage.deleteObject(existingStorageAttribute)
+        }
+
+        // Inserts the attributes from the read-only product variation.
+        var storageAttributes = [StorageAttribute]()
+        for readOnlyAttribute in readOnlyVariation.attributes {
+            let newStorageAttribute = storage.insertNewObject(ofType: Storage.GenericAttribute.self)
+            newStorageAttribute.update(with: readOnlyAttribute)
+            storageAttributes.append(newStorageAttribute)
+        }
+        storageVariation.attributes = NSOrderedSet(array: storageAttributes)
+    }
+
+    /// Updates, inserts, or prunes the provided StorageProductVariation's image using the provided read-only ProductVariation's image
+    ///
+    func handleProductImage(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
+        guard let readOnlyImage = readOnlyVariation.image else {
+            if let existingStorageImage = storageVariation.image {
+                storage.deleteObject(existingStorageImage)
+            }
+            return
+        }
+
+        if let existingStorageImage = storageVariation.image {
+            existingStorageImage.update(with: readOnlyImage)
+        } else {
+            let newStorageImage = storage.insertNewObject(ofType: Storage.ProductImage.self)
+            newStorageImage.update(with: readOnlyImage)
+            storageVariation.image = newStorageImage
+        }
+    }
+
+    /// Updates, inserts, or prunes the provided StorageProductVariation's subscription using the provided read-only ProductVariation's subscription
+    ///
+    func handleProductSubscription(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
+        guard let readOnlySubscription = readOnlyVariation.subscription else {
+            if let existingStorageSubscription = storageVariation.subscription {
+                storage.deleteObject(existingStorageSubscription)
+            }
+            return
+        }
+
+        if let existingStorageSubscription = storageVariation.subscription {
+            existingStorageSubscription.update(with: readOnlySubscription)
+        } else {
+            let newStorageSubscription = storage.insertNewObject(ofType: Storage.ProductSubscription.self)
+            newStorageSubscription.update(with: readOnlySubscription)
+            storageVariation.subscription = newStorageSubscription
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1929,9 +1929,9 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertTrue(base.contains(expectedDescription))
     }
 
-    // MARK: - ProductAction.retrieveFirstProductMatchFromSKU
+    // MARK: - ProductAction.retrieveFirstItemMatchFromSKU
 
-    func test_retrieveFirstProductMatchFromSKU_retrieves_product_when_successful_exact_SKU_match_then_returns_matched_product() throws {
+    func test_retrieveFirstItemMatchFromSKU_retrieves_product_when_successful_exact_SKU_match_then_returns_matched_product() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
@@ -1944,7 +1944,7 @@ final class ProductStoreTests: XCTestCase {
         // When
         let productSKU = "chocobars"
         let result = waitFor { promise in
-            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID,
+            let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: self.sampleSiteID,
                                                                         sku: productSKU,
                                                                         onCompletion: { product in
                 promise(product)
@@ -1958,7 +1958,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(productMatch.sku, expectedProductSKU)
     }
 
-    func test_retrieveFirstProductMatchFromSKU_when_partial_SKU_match_then_returns_not_found_error() throws {
+    func test_retrieveFirstItemMatchFromSKU_when_partial_SKU_match_then_returns_not_found_error() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
@@ -1966,7 +1966,7 @@ final class ProductStoreTests: XCTestCase {
         // When
         let productSKU = "choco"
         let result = waitFor { promise in
-            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID,
+            let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: self.sampleSiteID,
                                                                         sku: productSKU,
                                                                         onCompletion: { product in
                 promise(product)
@@ -1979,7 +1979,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(error, ProductLoadError.notFound)
     }
 
-    func test_retrieveFirstProductMatchFromSKU_when_unsuccessful_SKU_match_then_returns_not_found_error() throws {
+    func test_retrieveFirstItemMatchFromSKU_when_unsuccessful_SKU_match_then_returns_not_found_error() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
@@ -1987,7 +1987,7 @@ final class ProductStoreTests: XCTestCase {
         // When
         let productSKU = "non-existing-product-sku"
         let result = waitFor { promise in
-            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID,
+            let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: self.sampleSiteID,
                                                                         sku: productSKU,
                                                                         onCompletion: { product in
                 promise(product)
@@ -2001,7 +2001,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(error, ProductLoadError.notFound)
     }
 
-    func test_retrieveFirstProductMatchFromSKU_when_unsuccessful_SKU_match_then_does_not_upsert_product_to_storage() throws {
+    func test_retrieveFirstItemMatchFromSKU_when_unsuccessful_SKU_match_then_does_not_upsert_product_to_storage() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
@@ -2009,7 +2009,7 @@ final class ProductStoreTests: XCTestCase {
         // When
         let nonExistingProductSKU = "non-existing-product-sku"
         let onFailure = waitFor { promise in
-            let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID,
+            let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: self.sampleSiteID,
                                                                         sku: nonExistingProductSKU,
                                                                         onCompletion: { product in
                 promise(false)
@@ -2022,7 +2022,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: StorageProduct.self), 0)
     }
 
-    func test_retrieveFirstProductMatchFromSKU_when_successful_SKU_match_then_upserts_product_to_storage() {
+    func test_retrieveFirstItemMatchFromSKU_when_successful_SKU_match_then_upserts_product_to_storage() {
          // Given
          let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
          let expectedProductSKU = "chocobars"
@@ -2033,7 +2033,7 @@ final class ProductStoreTests: XCTestCase {
 
          // When
          let onSuccess: Bool = waitFor { promise in
-             let action = ProductAction.retrieveFirstProductMatchFromSKU(siteID: self.sampleSiteID, sku: expectedProductSKU, onCompletion: { product in
+             let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: self.sampleSiteID, sku: expectedProductSKU, onCompletion: { product in
                  promise(true)
              })
              store.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1963,7 +1963,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(productMatch.sku, expectedProductSKU)
     }
 
-    func ttest_retrieveFirstItemMatchFromSKU_when_successful_exact_SKU_match_product_variation_then_returns_matched_product_variation() throws {
+    func test_retrieveFirstItemMatchFromSKU_when_successful_exact_SKU_match_product_variation_then_returns_matched_product_variation() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search-variation")

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1931,7 +1931,7 @@ final class ProductStoreTests: XCTestCase {
 
     // MARK: - ProductAction.retrieveFirstItemMatchFromSKU
 
-    func test_retrieveFirstItemMatchFromSKU_retrieves_product_when_successful_exact_SKU_match_then_returns_matched_product() throws {
+    func test_retrieveFirstItemMatchFromSKU_when_successful_exact_SKU_match_product_then_returns_matched_product() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search")
@@ -1952,10 +1952,48 @@ final class ProductStoreTests: XCTestCase {
             store.onAction(action)
         }
 
-        let productMatch = try XCTUnwrap(result.get())
+        let skuSearchResult = try XCTUnwrap(result.get())
+
+        guard case let .product(productMatch) = skuSearchResult else {
+            return XCTFail("It didn't provide a product as expected")
+        }
+
         XCTAssertEqual(productMatch.productID, expectedProductID)
         XCTAssertEqual(productMatch.name, expectedProductName)
         XCTAssertEqual(productMatch.sku, expectedProductSKU)
+    }
+
+    func ttest_retrieveFirstItemMatchFromSKU_when_successful_exact_SKU_match_product_variation_then_returns_matched_product_variation() throws {
+        // Given
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search-variation")
+
+        // The product that is expected to be in the search results
+        let expectedProductID: Int64 = 2783
+        let expectedParentID: Int64 = 846
+        let expectedProductName = "Chocolate bars"
+        let expectedProductSKU = "chocobars"
+
+        // When
+        let productSKU = "chocobars"
+        let result = waitFor { promise in
+            let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: self.sampleSiteID,
+                                                                        sku: productSKU,
+                                                                        onCompletion: { product in
+                promise(product)
+            })
+            store.onAction(action)
+        }
+
+        let skuSearchResult = try XCTUnwrap(result.get())
+
+        guard case let .variation(variationMatch) = skuSearchResult else {
+            return XCTFail("It didn't provide a product as expected")
+        }
+
+        XCTAssertEqual(variationMatch.productVariationID, expectedProductID)
+        XCTAssertEqual(variationMatch.productID, expectedParentID)
+        XCTAssertEqual(variationMatch.sku, expectedProductSKU)
     }
 
     func test_retrieveFirstItemMatchFromSKU_when_partial_SKU_match_then_returns_not_found_error() throws {
@@ -2022,7 +2060,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: StorageProduct.self), 0)
     }
 
-    func test_retrieveFirstItemMatchFromSKU_when_successful_SKU_match_then_upserts_product_to_storage() {
+    func test_retrieveFirstItemMatchFromSKU_when_successful_SKU_match_product_then_upserts_product_to_storage() {
          // Given
          let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
          let expectedProductSKU = "chocobars"
@@ -2044,6 +2082,31 @@ final class ProductStoreTests: XCTestCase {
          // Then
          XCTAssertTrue(onSuccess)
          XCTAssertEqual(viewStorage.countObjects(ofType: StorageProduct.self), 1)
+         XCTAssertEqual(storedProduct?.sku, expectedProductSKU)
+     }
+
+    func test_retrieveFirstItemMatchFromSKU_when_successful_SKU_match_variation_then_upserts_product_to_storage() {
+         // Given
+         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+         let expectedProductSKU = "chocobars"
+         network.simulateResponse(requestUrlSuffix: "products", filename: "products-sku-search-variation")
+
+         // Confidence check:
+         XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 0)
+
+         // When
+         let onSuccess: Bool = waitFor { promise in
+             let action = ProductAction.retrieveFirstItemMatchFromSKU(siteID: self.sampleSiteID, sku: expectedProductSKU, onCompletion: { product in
+                 promise(true)
+             })
+             store.onAction(action)
+         }
+
+         let storedProduct = viewStorage.allObjects(ofType: StorageProductVariation.self, matching: nil, sortedBy: nil).map { $0 }.first
+
+         // Then
+         XCTAssertTrue(onSuccess)
+         XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 1)
          XCTAssertEqual(storedProduct?.sku, expectedProductSKU)
      }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Apologies for the big PR, most of the changes are moved resources to their own classes/files.

Part of: #9808
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The API Product search by SKU returns Product and Products Variations without differentiating them; all are returned as products. We parsed them before as such and stored them all as products, which made us have to convert them if we wanted to differentiate them, as in the case of the Order Creation after scanning a product. 

Another downside is that we didn't have those variations stored as ProductVariation locally, which might be troublesome if we assume that they are processed like that as it's done for all the other cases.

With this PR we refactor this mechanism by implementing that disambiguation directly in the `ProductStore` and store the result as `Product` or `ProductVariation` depending on the type. This will provide clarity for the `ProductStore` clients. In order to do that we extract the Product Variation storage information to its own class so it can be reused in the `ProductStore` as well.

On the next PR we will refactor the SKU search on the Product Selector and Product tab to follow the same pattern.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

* Unit tests pass
* Barcode Scanner Feature works fine:
   * Products can be scanned and added from the Order List
   * Variations can be scanned and added from the Order List
   * Products can be scanned and added from the Order Creation screen
   * Variations can be scanned and added from the Order Creation screen
   * Scanning the same product to increase the quantity works successfully

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
