### PR TITLE
Add a release note for Blaze

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [***] Orders: Users can add products to orders by scanning their sku barcode or QR-code [https://github.com/woocommerce/woocommerce-ios/pull/9972] 
 - [Internal] Store creation: a workaround was previously implemented that can result in an inaccurate app experience like when the free trial banner is not shown immediately after store creation due to out-of-sync site properties. Now that the API issue is fixed, the app now waits for the site for a bit longer but ensures all necessary properties are synced. [https://github.com/woocommerce/woocommerce-ios/pull/9957]
 - [Internal] Product details AI: Updated prompts to identify the language in provided text to use in responses for product description and sharing. [https://github.com/woocommerce/woocommerce-ios/pull/9961]
+- [*] Blaze: products can now be promoted in WordPress.com and Tumblr from the app if the site/product is eligible. Two entry points: 1) Menu tab > General, 2) Product form > more menu. [https://github.com/woocommerce/woocommerce-ios/pull/9906]
 
 14.0
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Release note for https://github.com/woocommerce/woocommerce-ios/issues/9866
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR just added a release note for the Blaze feature for release 14.1, now that the remote feature flag is enabled in D113461-code.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI, since there are no code changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.