### PR TITLE
[IAP] Loading state for fetch plans

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -133,9 +133,9 @@ final class UpgradesViewModel: ObservableObject {
 
     /// Retrieves a specific In-App Purchase WPCom plan from the available products
     ///
-    func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans,
-                                        from wpcomPlans: [WPComPlanProduct],
-                                        hardcodedPlanDataIsValid: Bool) -> WooWPComPlan? {
+    private func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans,
+                                                from wpcomPlans: [WPComPlanProduct],
+                                                hardcodedPlanDataIsValid: Bool) -> WooWPComPlan? {
         guard let wpcomPlanProduct = wpcomPlans.first(where: { $0.id == type.rawValue }),
               let wooPlan = localPlans.first(where: { $0.id == wpcomPlanProduct.id }) else {
             return nil

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -3,8 +3,8 @@ import SwiftUI
 import Yosemite
 
 enum UpgradeViewState {
-    case normal
     case loading
+    case loaded(WooWPComPlan)
     case waiting
     case completed
     case userNotAllowedToUpgrade
@@ -16,6 +16,7 @@ enum UpgradesError: Error {
     case fetchError
     case entitlementsError
     case inAppPurchasesNotSupported
+    case maximumSitesUpgraded
 }
 
 /// ViewModel for the Upgrades View
@@ -27,10 +28,7 @@ final class UpgradesViewModel: ObservableObject {
     private let siteID: Int64
     private let stores: StoresManager
 
-    @Published var wpcomPlans: [WPComPlanProduct]
     @Published var entitledWpcomPlanIDs: Set<String>
-    @Published var upgradePlan: WooWPComPlan? = nil
-    @Published var isHardcodedPlanDataStillValid = true
 
     @Published var upgradeViewState: UpgradeViewState = .loading
 
@@ -43,7 +41,6 @@ final class UpgradesViewModel: ObservableObject {
         self.inAppPurchasesPlanManager = inAppPurchasesPlanManager
         self.stores = stores
 
-        wpcomPlans = []
         entitledWpcomPlanIDs = []
 
         if let essentialPlan = WooPlan() {
@@ -64,7 +61,6 @@ final class UpgradesViewModel: ObservableObject {
     @MainActor
     private func fetchViewData() async {
         await fetchPlans()
-        await checkHardcodedPlanDataValidity()
     }
 
     /// Retrieves all In-App Purchases WPCom plans
@@ -73,27 +69,37 @@ final class UpgradesViewModel: ObservableObject {
     func fetchPlans() async {
         do {
             guard await inAppPurchasesPlanManager.inAppPurchasesAreSupported() else {
-                DDLogError("IAP not supported")
+                upgradeViewState = .error(.inAppPurchasesNotSupported)
                 return
             }
 
-            self.wpcomPlans = try await inAppPurchasesPlanManager.fetchPlans()
+            async let wpcomPlans = inAppPurchasesPlanManager.fetchPlans()
+            async let hardcodedPlanDataIsValid = checkHardcodedPlanDataValidity()
 
-            await loadUserEntitlements()
-            if entitledWpcomPlanIDs.isEmpty {
-                self.upgradePlan = retrievePlanDetailsIfAvailable(.essentialMonthly)
+            try await loadUserEntitlements(for: wpcomPlans)
+            guard entitledWpcomPlanIDs.isEmpty else {
+                upgradeViewState = .error(.maximumSitesUpgraded)
+                return
             }
-            upgradeViewState = .normal
+
+            guard let plan = try await retrievePlanDetailsIfAvailable(.essentialMonthly,
+                                                                      from: wpcomPlans,
+                                                                      hardcodedPlanDataIsValid: hardcodedPlanDataIsValid)
+            else {
+                upgradeViewState = .error(.fetchError)
+                return
+            }
+            upgradeViewState = .loaded(plan)
         } catch {
             DDLogError("fetchPlans \(error)")
-            upgradeViewState = .error(UpgradesError.fetchError)
+            upgradeViewState = .error(.fetchError)
         }
     }
 
 
     @MainActor
-    private func checkHardcodedPlanDataValidity() async {
-        isHardcodedPlanDataStillValid = await withCheckedContinuation { continuation in
+    private func checkHardcodedPlanDataValidity() async -> Bool {
+        return await withCheckedContinuation { continuation in
             stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(
                 .hardcodedPlanUpgradeDetailsMilestone1AreAccurate,
                 defaultValue: true) { isEnabled in
@@ -119,13 +125,16 @@ final class UpgradesViewModel: ObservableObject {
 
     /// Retrieves a specific In-App Purchase WPCom plan from the available products
     ///
-    func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans) -> WooWPComPlan? {
-        let match = type.rawValue
-        guard let wpcomPlanProduct = wpcomPlans.first(where: { $0.id == match }) else {
+    func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans,
+                                        from wpcomPlans: [WPComPlanProduct],
+                                        hardcodedPlanDataIsValid: Bool) -> WooWPComPlan? {
+        guard let wpcomPlanProduct = wpcomPlans.first(where: { $0.id == type.rawValue }),
+              let wooPlan = localPlans.first(where: { $0.id == wpcomPlanProduct.id }) else {
             return nil
         }
-        let wooPlan = localPlans.first { $0.id == wpcomPlanProduct.id }
-        return WooWPComPlan(wpComPlan: wpcomPlanProduct, wooPlan: wooPlan)
+        return WooWPComPlan(wpComPlan: wpcomPlanProduct,
+                            wooPlan: wooPlan,
+                            hardcodedPlanDataIsValid: hardcodedPlanDataIsValid)
     }
 }
 
@@ -134,9 +143,9 @@ private extension UpgradesViewModel {
     /// via In-App Purchases
     ///
     @MainActor
-    func loadUserEntitlements() async {
+    func loadUserEntitlements(for plans: [WPComPlanProduct]) async {
         do {
-            for wpcomPlan in self.wpcomPlans {
+            for wpcomPlan in plans {
                 if try await inAppPurchasesPlanManager.userIsEntitledToPlan(with: wpcomPlan.id) {
                     self.entitledWpcomPlanIDs.insert(wpcomPlan.id)
                 } else {
@@ -158,5 +167,6 @@ extension UpgradesViewModel {
 
 struct WooWPComPlan {
     let wpComPlan: WPComPlanProduct
-    let wooPlan: WooPlan?
+    let wooPlan: WooPlan
+    let hardcodedPlanDataIsValid: Bool
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -20,9 +20,7 @@ final class UpgradesViewModelTests: XCTestCase {
                                     inAppPurchasesPlanManager: MockInAppPurchasesForWPComPlansManager(plans: []))
 
         // Then
-        XCTAssert(sut.wpcomPlans.isEmpty)
         XCTAssert(sut.entitledWpcomPlanIDs.isEmpty)
-        XCTAssertNil(sut.upgradePlan)
     }
 
     func test_upgrades_when_fetchPlans_is_invoked_then_fetch_mocked_wpcom_plan() async {
@@ -33,26 +31,13 @@ final class UpgradesViewModelTests: XCTestCase {
         await sut.fetchPlans()
 
         // Then
-        assertEqual("Debug Essential Monthly", sut.wpcomPlans.first?.displayName)
-        assertEqual("1 Month of Debug Essential", sut.wpcomPlans.first?.description)
-        assertEqual("debug.woocommerce.express.essential.monthly", sut.wpcomPlans.first?.id)
-        assertEqual("$99.99", sut.wpcomPlans.first?.displayPrice)
-    }
-
-    func test_upgrades_when_retrievePlanDetailsIfAvailable_retrieves_debug_wpcom_plan() async {
-        // Given (no injected plans)
-        let fakeInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager()
-        let sut = UpgradesViewModel(siteID: sampleSiteID,
-                                    inAppPurchasesPlanManager: fakeInAppPurchasesManager)
-
-        // When
-        await sut.fetchPlans()
-        XCTAssertEqual(sut.wpcomPlans.first?.displayName, "Debug Monthly", "Precondition")
-
-        let wpcomPlan = sut.retrievePlanDetailsIfAvailable(.essentialMonthly)
-
-        // Then
-        XCTAssertNil(wpcomPlan)
+        guard case .loaded(let plan) = sut.upgradeViewState else {
+            return XCTFail("expected `.loaded` state not found")
+        }
+        assertEqual("Debug Essential Monthly", plan.wpComPlan.displayName)
+        assertEqual("1 Month of Debug Essential", plan.wpComPlan.description)
+        assertEqual("debug.woocommerce.express.essential.monthly", plan.wpComPlan.id)
+        assertEqual("$99.99", plan.wpComPlan.displayPrice)
     }
 
     func test_upgrades_when_retrievePlanDetailsIfAvailable_retrieves_injected_wpcom_plan() async {
@@ -68,12 +53,14 @@ final class UpgradesViewModelTests: XCTestCase {
 
         // When
         await sut.fetchPlans()
-        let wpcomPlan = sut.retrievePlanDetailsIfAvailable(.essentialMonthly)
 
         // Then
-        assertEqual("Test awesome plan", wpcomPlan?.wpComPlan.displayName)
-        assertEqual("All the Woo, all the time", wpcomPlan?.wpComPlan.description)
-        assertEqual("debug.woocommerce.express.essential.monthly", wpcomPlan?.wpComPlan.id)
-        assertEqual("$1.50", wpcomPlan?.wpComPlan.displayPrice)
+        guard case .loaded(let plan) = sut.upgradeViewState else {
+            return XCTFail("expected `.loaded` state not found")
+        }
+        assertEqual("Test awesome plan", plan.wpComPlan.displayName)
+        assertEqual("All the Woo, all the time", plan.wpComPlan.description)
+        assertEqual("debug.woocommerce.express.essential.monthly", plan.wpComPlan.id)
+        assertEqual("$1.50", plan.wpComPlan.displayPrice)
     }
 }

--- a/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
@@ -11,14 +11,14 @@ public struct WooPlan: Decodable {
     public let headerImageCardColor: Color
     public let planFeatureGroups: [WooPlanFeatureGroup]
 
-    init(id: String,
-         name: String,
-         shortName: String,
-         planFrequency: PlanFrequency,
-         planDescription: String,
-         headerImageFileName: String,
-         headerImageCardColor: Color,
-         planFeatureGroups: [WooPlanFeatureGroup]) {
+    public init(id: String,
+                name: String,
+                shortName: String,
+                planFrequency: PlanFrequency,
+                planDescription: String,
+                headerImageFileName: String,
+                headerImageCardColor: Color,
+                planFeatureGroups: [WooPlanFeatureGroup]) {
         self.id = id
         self.name = name
         self.shortName = shortName

--- a/Yosemite/Yosemite/Model/WooPlans/WooPlanFeatureGroup.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/WooPlanFeatureGroup.swift
@@ -51,4 +51,9 @@ public struct WooPlanFeatureGroup: Decodable {
 public struct WooPlanFeature: Codable {
     public let title: String
     public let description: String
+
+    public init(title: String, description: String) {
+        self.title = title
+        self.description = description
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9878 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We are adding the ability to purchase a Woo Express plan using In App Purchase. This PR adds a skeleton loading state for while we're fetching the plan details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open the app and go to a store with a free trial
2. Tap on `Upgrade now`
3. Observe that the loading state shows

If you want to see it for longer, put a breakpoint on https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags in Proxyman – the loading state will show until that call completes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/89e20f11-8b57-4e97-9200-1ce9c85da97a



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
