### PR TITLE
[IAP] Loading state for iap button

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -115,13 +115,11 @@ final class UpgradesViewModel: ObservableObject {
     @MainActor
     func purchasePlan(with planID: String) async {
         do {
-            upgradeViewState = .waiting
             let result = try await inAppPurchasesPlanManager.purchasePlan(with: planID,
                                                                           for: siteID)
             // TODO: handle `pending` here... somehow – requires research
             // TODO: handle `.success(.unverified(_))` here... somehow
             guard case .success(.verified(_)) = result else {
-                await fetchViewData()
                 return
             }
             upgradeViewState = .completed

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -77,64 +77,71 @@ struct OwnerUpgradesView: View {
     @State var isLoading: Bool = false
 
     var body: some View {
-        List {
-            Section {
-                Image(upgradePlan.wooPlan.headerImageFileName)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .listRowInsets(.zero)
-                    .listRowBackground(upgradePlan.wooPlan.headerImageCardColor)
-
-                VStack(alignment: .leading) {
-                    Text(upgradePlan.wooPlan.shortName)
-                        .font(.largeTitle)
-                    Text(upgradePlan.wooPlan.planDescription)
-                        .font(.subheadline)
-                }
-
-                VStack(alignment: .leading) {
-                    Text(upgradePlan.wpComPlan.displayPrice)
-                        .font(.largeTitle)
-                    Text(upgradePlan.wooPlan.planFrequency.localizedString)
-                        .font(.footnote)
-                }
-            }
-            .listRowSeparator(.hidden)
-
-            if upgradePlan.hardcodedPlanDataIsValid {
+        VStack {
+            List {
                 Section {
-                    ForEach(upgradePlan.wooPlan.planFeatureGroups, id: \.title) { featureGroup in
-                        NavigationLink(destination: WooPlanFeatureBenefitsView(wooPlanFeatureGroup: featureGroup)) {
-                            WooPlanFeatureGroupRow(featureGroup: featureGroup)
-                        }
-                        .disabled(isLoading)
-                    }
-                } header: {
-                    Text(String.localizedStringWithFormat(Localization.featuresHeaderTextFormat, upgradePlan.wooPlan.shortName))
-                }
-                .headerProminence(.increased)
-            } else {
-                NavigationLink(destination: {
-                    /// Note that this is a fallback only, and we should remove it once we load feature details remotely.
-                    AuthenticatedWebView(isPresented: .constant(true),
-                                         url: WooConstants.URLs.fallbackWooExpressHome.asURL())
-                }, label: {
-                    Text(Localization.featureDetailsUnavailableText)
-                })
-                .disabled(isLoading)
-            }
+                    Image(upgradePlan.wooPlan.headerImageFileName)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowInsets(.zero)
+                        .listRowBackground(upgradePlan.wooPlan.headerImageCardColor)
 
-            let buttonText = String.localizedStringWithFormat(Localization.purchaseCTAButtonText, upgradePlan.wpComPlan.displayName)
-            Button(buttonText) {
-                Task {
-                    isPurchasing = true
-                    await purchasePlanAction()
-                    isPurchasing = false
+                    VStack(alignment: .leading) {
+                        Text(upgradePlan.wooPlan.shortName)
+                            .font(.largeTitle)
+                        Text(upgradePlan.wooPlan.planDescription)
+                            .font(.subheadline)
+                    }
+
+                    VStack(alignment: .leading) {
+                        Text(upgradePlan.wpComPlan.displayPrice)
+                            .font(.largeTitle)
+                        Text(upgradePlan.wooPlan.planFrequency.localizedString)
+                            .font(.footnote)
+                    }
+                }
+                .listRowSeparator(.hidden)
+
+                if upgradePlan.hardcodedPlanDataIsValid {
+                    Section {
+                        ForEach(upgradePlan.wooPlan.planFeatureGroups, id: \.title) { featureGroup in
+                            NavigationLink(destination: WooPlanFeatureBenefitsView(wooPlanFeatureGroup: featureGroup)) {
+                                WooPlanFeatureGroupRow(featureGroup: featureGroup)
+                            }
+                            .disabled(isLoading)
+                        }
+                    } header: {
+                        Text(String.localizedStringWithFormat(Localization.featuresHeaderTextFormat, upgradePlan.wooPlan.shortName))
+                    }
+                    .headerProminence(.increased)
+                } else {
+                    NavigationLink(destination: {
+                        /// Note that this is a fallback only, and we should remove it once we load feature details remotely.
+                        AuthenticatedWebView(isPresented: .constant(true),
+                                             url: WooConstants.URLs.fallbackWooExpressHome.asURL())
+                    }, label: {
+                        Text(Localization.featureDetailsUnavailableText)
+                    })
+                    .disabled(isLoading)
                 }
             }
-            .disabled(isLoading)
+            .redacted(reason: isLoading ? .placeholder : [])
+            .shimmering(active: isLoading)
+            VStack {
+                let buttonText = String.localizedStringWithFormat(Localization.purchaseCTAButtonText, upgradePlan.wpComPlan.displayName)
+                Button(buttonText) {
+                    Task {
+                        isPurchasing = true
+                        await purchasePlanAction()
+                        isPurchasing = false
+                    }
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPurchasing))
+                .disabled(isLoading)
+                .redacted(reason: isLoading ? .placeholder : [])
+                .shimmering(active: isLoading)
+            }
+            .padding()
         }
-        .redacted(reason: isLoading ? .placeholder : [])
-        .shimmering(active: isLoading)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10008
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds a spinner to the `Purchase Plan` button on the Upgrade view, so the user can see that something's happening while we wait for the IAP screen to show.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app and select a Woo Express store in its free trial
2. Tap `Upgrade now` on the banner on the home screen
3. Tap `Purchase Debug Essential Monthly`
4. Observe that the button is disabled and shows a spinner
5. Cancel the IAP screen when it appears
6. Observe that the button is enabled and primary again

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/b0991031-7170-4722-bf45-70d49debc95d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
