### PR TITLE
Product description: Add learn more text for AI-generated content

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -73,7 +73,7 @@ private extension DefaultProductFormTableViewModel {
                 guard isDescriptionAIEnabled else {
                     return [descriptionRow]
                 }
-                return [descriptionRow, .descriptionAI]
+                return [descriptionRow, .descriptionAI, .learnMoreAboutAI]
             default:
                 fatalError("Unexpected action in the primary section: \(action)")
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -36,6 +36,8 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
             return [ImageAndTitleAndTextTableViewCell.self, BasicTableViewCell.self]
         case .descriptionAI:
             return [ButtonTableViewCell.self]
+        case .learnMoreAboutAI:
+            return [TextViewTableViewCell.self]
         }
     }
 
@@ -57,6 +59,8 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
             return description?.isEmpty == false ? ImageAndTitleAndTextTableViewCell.self: BasicTableViewCell.self
         case .descriptionAI:
             return ButtonTableViewCell.self
+        case .learnMoreAboutAI:
+            return TextViewTableViewCell.self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -29,6 +29,7 @@ final class ProductFormTableViewDataSource: NSObject {
     var openLinkedProductsAction: (() -> Void)?
     var reloadLinkedPromoAction: (() -> Void)?
     var descriptionAIAction: (() -> Void)?
+    var openAILegalPageAction: ((URL) -> Void)?
 
     init(viewModel: ProductFormTableViewModel,
          productImageStatuses: [ProductImageStatus],
@@ -98,6 +99,8 @@ private extension ProductFormTableViewDataSource {
             configureDescription(cell: cell, description: description, isEditable: editable, isAIEnabled: isAIEnabled)
         case .descriptionAI:
             configureDescriptionAI(cell: cell)
+        case .learnMoreAboutAI:
+            configureLearnMoreAI(cell: cell)
         }
     }
     func configureImages(cell: UITableViewCell, isEditable: Bool, allowsMultipleImages: Bool, isVariation: Bool) {
@@ -228,6 +231,50 @@ private extension ProductFormTableViewDataSource {
         cell.hideSeparator()
     }
 
+    func configureLearnMoreAI(cell: UITableViewCell) {
+        guard let cell = cell as? TextViewTableViewCell else {
+            fatalError("Unexpected table view cell for the AI legal cell")
+        }
+        let attributedText = {
+            let content = String.localizedStringWithFormat(Localization.legalText, Localization.learnMore)
+            let font: UIFont = .caption1
+            let foregroundColor: UIColor = .secondaryLabel
+            let linkColor: UIColor = .accent
+            let linkContent = Localization.learnMore
+
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.alignment = .left
+
+            let attributedString = NSMutableAttributedString(
+                string: content,
+                attributes: [.font: font,
+                             .foregroundColor: foregroundColor,
+                             .paragraphStyle: paragraphStyle,
+                            ]
+            )
+            let legalLink = NSAttributedString(string: linkContent,
+                                               attributes: [.font: font,
+                                                            .foregroundColor: linkColor,
+                                                            .underlineStyle: NSUnderlineStyle.single.rawValue,
+                                                            .underlineColor: linkColor,
+                                                            .link: Constants.legalURL])
+            attributedString.replaceFirstOccurrence(of: linkContent, with: legalLink)
+            return attributedString
+        }()
+        cell.configure(with: .init(attributedText: attributedText,
+                                   textViewMinimumHeight: Constants.learnMoreTextHeight,
+                                   isEditable: false,
+                                   isSelectable: true,
+                                   isScrollEnabled: false,
+                                   style: .caption,
+                                   edgeInsets: Constants.learnMoreTextInsets,
+                                   onLinkTapped: { [weak self] url in
+            self?.openAILegalPageAction?(url)
+        }))
+        cell.selectionStyle = .none
+        cell.hideSeparator()
+    }
+
     func configureLinkedProductsPromo(cell: UITableViewCell, viewModel: FeatureAnnouncementCardViewModel) {
         guard let cell = cell as? FeatureAnnouncementCardCell else {
             fatalError()
@@ -329,5 +376,24 @@ private extension ProductFormTableViewDataSource {
                                 numberOfLinesForTitle: 0,
                                 isActionable: false,
                                 showsSeparator: false))
+    }
+}
+
+private extension ProductFormTableViewDataSource {
+    enum Constants {
+        static let legalURL = URL(string: "https://automattic.com/ai-guidelines/")!
+        static let learnMoreTextHeight: CGFloat = 16
+        static let learnMoreTextInsets: UIEdgeInsets = .init(top: 8, left: 0, bottom: 0, right: 0)
+    }
+    enum Localization {
+        static let legalText = NSLocalizedString(
+            "Powered by AI. %1$@.",
+            comment: "Label to indicate AI-generated content in the product detail screen. " +
+            "Reads: Powered by AI. Learn more."
+        )
+        static let learnMore = NSLocalizedString(
+            "Learn more",
+            comment: "Title for the link to open the legal URL for AI-generated content in the product detail screen"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -383,7 +383,7 @@ private extension ProductFormTableViewDataSource {
     enum Constants {
         static let legalURL = URL(string: "https://automattic.com/ai-guidelines/")!
         static let learnMoreTextHeight: CGFloat = 16
-        static let learnMoreTextInsets: UIEdgeInsets = .init(top: 8, left: 0, bottom: 0, right: 0)
+        static let learnMoreTextInsets: UIEdgeInsets = .init(top: 4, left: 0, bottom: -8, right: 0)
     }
     enum Localization {
         static let legalText = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -21,6 +21,7 @@ enum ProductFormSection: Equatable {
         case variationName(name: String)
         case description(description: String?, isEditable: Bool, isDescriptionAIEnabled: Bool)
         case descriptionAI
+        case learnMoreAboutAI
     }
 
     enum SettingsRow: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -752,6 +752,10 @@ private extension ProductFormViewController {
         tableViewDataSource.descriptionAIAction = { [weak self] in
             self?.showProductDescriptionAI()
         }
+        tableViewDataSource.openAILegalPageAction = { [weak self] url in
+            guard let self else { return }
+            WebviewHelper.launch(url.absoluteString, with: self)
+        }
         tableViewDataSource.configureActions(onNameChange: { [weak self] name in
             self?.onEditProductNameCompletion(newName: name ?? "")
         }, onStatusChange: { [weak self] isEnabled in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -388,9 +388,9 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         XCTAssertEqual(quantityRulesViewModel?.details, expectedDetails)
     }
 
-    // MARK: - `descriptionAI`
+    // MARK: - `descriptionAI` & `learnMoreAboutAI`
 
-    func test_descriptionAI_row_is_shown_when_editable_and_descriptionAIEnabled() {
+    func test_descriptionAI_and_learnMoreAboutAI_rows_are_shown_when_editable_and_descriptionAIEnabled() {
         // Given
         let product = Product.fake().copy()
         let model = EditableProductModel(product: product)
@@ -411,6 +411,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         }
         var containsDescriptionRow = false
         var containsDescriptionAIRow = false
+        var containsLearnMoreAboutAIRow = false
         for row in rows {
             switch row {
             case let .description(_, isEditable, isDescriptionAIEnabled):
@@ -419,15 +420,18 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                 XCTAssertTrue(isDescriptionAIEnabled)
             case .descriptionAI:
                 containsDescriptionAIRow = true
+            case .learnMoreAboutAI:
+                containsLearnMoreAboutAIRow = true
             default:
                 continue
             }
         }
         XCTAssertTrue(containsDescriptionRow)
         XCTAssertTrue(containsDescriptionAIRow)
+        XCTAssertTrue(containsLearnMoreAboutAIRow)
     }
 
-    func test_descriptionAI_row_is_not_shown_when_form_is_readonly_with_nonempty_description() {
+    func test_descriptionAI_and_learnMoreAboutAI_rows_are_not_shown_when_form_is_readonly_with_nonempty_description() {
         // Given
         let product = Product.fake().copy(fullDescription: "desc")
         let model = EditableProductModel(product: product)
@@ -448,6 +452,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         }
         var containsDescriptionRow = false
         var containsDescriptionAIRow = false
+        var containsLearnMoreAboutAIRow = false
         for row in rows {
             switch row {
             case let .description(_, isEditable, isDescriptionAIEnabled):
@@ -456,15 +461,18 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                 XCTAssertFalse(isDescriptionAIEnabled)
             case .descriptionAI:
                 containsDescriptionAIRow = true
+            case .learnMoreAboutAI:
+                containsLearnMoreAboutAIRow =  true
             default:
                 continue
             }
         }
         XCTAssertTrue(containsDescriptionRow)
         XCTAssertFalse(containsDescriptionAIRow)
+        XCTAssertFalse(containsLearnMoreAboutAIRow)
     }
 
-    func test_descriptionAI_row_is_not_shown_when_descriptionAIEnabled_is_false() {
+    func test_descriptionAI_and_learnMoreAboutAI_rows_are_not_shown_when_descriptionAIEnabled_is_false() {
         // Given
         let product = Product.fake().copy()
         let model = EditableProductModel(product: product)
@@ -485,6 +493,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         }
         var containsDescriptionRow = false
         var containsDescriptionAIRow = false
+        var containsLearnMoreAboutAIRow = false
         for row in rows {
             switch row {
             case let .description(_, isEditable, isDescriptionAIEnabled):
@@ -493,15 +502,18 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                 XCTAssertFalse(isDescriptionAIEnabled)
             case .descriptionAI:
                 containsDescriptionAIRow = true
+            case .learnMoreAboutAI:
+                containsLearnMoreAboutAIRow = true
             default:
                 continue
             }
         }
         XCTAssertTrue(containsDescriptionRow)
         XCTAssertFalse(containsDescriptionAIRow)
+        XCTAssertFalse(containsLearnMoreAboutAIRow)
     }
 
-    func test_descriptionAI_row_is_not_shown_when_productDescriptionAIFromStoreOnboarding_feature_is_disabled() {
+    func test_descriptionAI_and_learnMoreAboutAI_rows_are_not_shown_when_productDescriptionAIFromStoreOnboarding_feature_is_disabled() {
         // Given
         let product = Product.fake().copy()
         let model = EditableProductModel(product: product)
@@ -522,6 +534,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         }
         var containsDescriptionRow = false
         var containsDescriptionAIRow = false
+        var containsLearnMoreAboutAIRow = false
         for row in rows {
             switch row {
             case let .description(_, isEditable, isDescriptionAIEnabled):
@@ -530,12 +543,15 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                 XCTAssertFalse(isDescriptionAIEnabled)
             case .descriptionAI:
                 containsDescriptionAIRow = true
+            case .learnMoreAboutAI:
+                containsLearnMoreAboutAIRow = true
             default:
                 continue
             }
         }
         XCTAssertTrue(containsDescriptionRow)
         XCTAssertFalse(containsDescriptionAIRow)
+        XCTAssertFalse(containsLearnMoreAboutAIRow)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9937 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a label with a link to the legal page for AI-generated content on the product detail screen. The amount of changes needed for this tiny bit makes it clear how SwiftUI makes our lives so much easier 😅.
- Updated the reusable `TextViewTableViewCell` to display an attributed text of type caption and a callback for handling taps on the contained link.
- Updated product form's classes to show a new cell for the legal text beneath the "Write with AI" button. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store.
- Switch to the Products tab and select a product or create one.
- Notice a new link to the legal page on the "Write with AI" button. Tap the link should open the legal page within the app.
- Switch to a self-hosted store.
- Notice that the new cell is not available since the site is not eligible for AI-generated content.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| WPCom site | Self-hosted site |
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/beb0b6f0-0132-41dc-bd20-f3579e28a3fa" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/2b9185e0-eabd-4713-9fa0-e85855046521" width=320 /> |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
