### PR TITLE
Add reset_simulator parameter in run_tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1162,13 +1162,14 @@ lane :test_without_building do |options|
     workspace: WORKSPACE_PATH,
     scheme: TEST_SCHEME,
     device: options[:device],
+    reset_simulator: true,
     parallel_testing: parallel_testing_value,
     concurrent_workers: CONCURRENT_SIMULATORS,
     max_concurrent_simulators: CONCURRENT_SIMULATORS,
     test_without_building: true,
     xctestrun: xctestrun_path,
     result_bundle: true,
-    # settins for XML test report generation via `trainer`
+    # settings for XML test report generation via `trainer`
     output_types: '',
     fail_build: false
   )


### PR DESCRIPTION
### Description
I noticed a few times where the UI test step failed because one of the test runners failed to start/crashed. On the build, the step is marked as failed, and the build failed as a result. On Test Analytics, however, the run is successful because the other test runner ran all the tests without issue. (example: [failing build](https://buildkite.com/automattic/woocommerce-ios/builds/13997#0188d0f5-2e14-45b3-be9a-07ba9aca755b), [passing Test Analytics](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios-ui-tests-iphone/runs/fcc8e114-a579-4f60-b750-8cb7e42b0fec))

Error:
```
Testing failed:
--
  | WooCommerceUITests-Runner (2441) encountered an error (Early unexpected exit, operation never finished bootstrapping - no restart will be attempted. (Underlying Error: Test crashed with signal kill before starting test execution. If you believe this error represents a bug, please attach the result bundle at /usr/local/var/buildkite-agent/builds/MV-MKE-X64-018/automattic/woocommerce-ios/fastlane/test_output/WooCommerce.xcresult))
```

On JPiOS we have the `reset_simulator` parameter set to true in `run_tests`. Coincidentally I've not seen this issue happening on JPiOS (there are other issues happening on JPiOS but I couldn't find any recent one with the same error log as the one above), so making this change to see if adding this and resetting the simulator at the start of the test would help prevent this from happening on WCiOS too.

### Testing
CI should be 🟢 