### PR TITLE
Issue/9886 show errors from iap purchase and store upgrade

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -9,11 +9,12 @@ enum UpgradeViewState {
     case waiting(WooWPComPlan)
     case completed
     case userNotAllowedToUpgrade
-    case error(UpgradesError)
+    case prePurchaseError(PrePurchaseError)
+    case purchaseUpgradeError(PurchaseUpgradeError)
 
     var shouldShowPlanDetailsView: Bool {
         switch self {
-        case .loading, .loaded, .purchasing, .error, .userNotAllowedToUpgrade:
+        case .loading, .loaded, .purchasing, .prePurchaseError, .userNotAllowedToUpgrade:
             return true
         default:
             return false
@@ -21,12 +22,16 @@ enum UpgradeViewState {
     }
 }
 
-enum UpgradesError: Error {
-    case purchaseError
+enum PrePurchaseError: Error {
     case fetchError
     case entitlementsError
     case inAppPurchasesNotSupported
     case maximumSitesUpgraded
+}
+
+enum PurchaseUpgradeError {
+    case inAppPurchaseFailed
+    case planActivationFailed
 }
 
 /// ViewModel for the Upgrades View
@@ -89,7 +94,7 @@ final class UpgradesViewModel: ObservableObject {
     func fetchPlans() async {
         do {
             guard await inAppPurchasesPlanManager.inAppPurchasesAreSupported() else {
-                upgradeViewState = .error(.inAppPurchasesNotSupported)
+                upgradeViewState = .prePurchaseError(.inAppPurchasesNotSupported)
                 return
             }
 
@@ -98,7 +103,7 @@ final class UpgradesViewModel: ObservableObject {
 
             try await loadUserEntitlements(for: wpcomPlans)
             guard entitledWpcomPlanIDs.isEmpty else {
-                upgradeViewState = .error(.maximumSitesUpgraded)
+                upgradeViewState = .prePurchaseError(.maximumSitesUpgraded)
                 return
             }
 
@@ -106,13 +111,13 @@ final class UpgradesViewModel: ObservableObject {
                                                                       from: wpcomPlans,
                                                                       hardcodedPlanDataIsValid: hardcodedPlanDataIsValid)
             else {
-                upgradeViewState = .error(.fetchError)
+                upgradeViewState = .prePurchaseError(.fetchError)
                 return
             }
             upgradeViewState = .loaded(plan)
         } catch {
             DDLogError("fetchPlans \(error)")
-            upgradeViewState = .error(.fetchError)
+            upgradeViewState = .prePurchaseError(.fetchError)
         }
     }
 
@@ -173,7 +178,7 @@ final class UpgradesViewModel: ObservableObject {
         } catch {
             DDLogError("purchasePlan \(error)")
             stopObservingInAppPurchaseDrawerDismissal()
-            upgradeViewState = .error(UpgradesError.purchaseError)
+            upgradeViewState = .purchaseUpgradeError(.inAppPurchaseFailed)
         }
     }
 
@@ -235,7 +240,7 @@ private extension UpgradesViewModel {
             }
         } catch {
             DDLogError("loadEntitlements \(error)")
-            upgradeViewState = .error(UpgradesError.entitlementsError)
+            upgradeViewState = .prePurchaseError(.entitlementsError)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -61,7 +61,8 @@ struct UpgradesView: View {
                                       onRetryButtonTapped: {
                         upgradesViewModel.retryFetch()
                     })
-                    .padding(Layout.padding)
+                    .padding(.top, Layout.errorViewTopPadding)
+                    .padding(.horizontal, Layout.errorViewHorizontalPadding)
 
                     Spacer()
                 }
@@ -131,12 +132,16 @@ struct PrePurchaseUpgradesErrorView: View {
         }
         .padding(.horizontal, Layout.horizontalEdgesPadding)
         .padding(.vertical, Layout.verticalEdgesPadding)
-        .background(Color(UIColor.secondarySystemGroupedBackground))
+        .background {
+            RoundedRectangle(cornerSize: .init(width: Layout.cornerRadius, height: Layout.cornerRadius))
+                .fill(Color(UIColor.secondarySystemGroupedBackground))
+                  }
     }
 
     private enum Layout {
         static let horizontalEdgesPadding: CGFloat = 16
         static let verticalEdgesPadding: CGFloat = 40
+        static let cornerRadius: CGFloat = 12
         static let spacingBetweenImageAndText: CGFloat = 32
         static let textSpacing: CGFloat = 16
     }
@@ -463,6 +468,8 @@ private extension UpgradesView {
     }
 
     struct Layout {
+        static let errorViewHorizontalPadding: CGFloat = 20
+        static let errorViewTopPadding: CGFloat = 36
         static let padding: CGFloat = 16
         static let contentSpacing: CGFloat = 8
         static let smallPadding: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -55,20 +55,19 @@ struct UpgradesView: View {
                 UpgradeWaitingView(planName: plan.wooPlan.shortName)
             case .completed:
                 EmptyCompletedView()
-            case .error(let upgradeError):
+            case .prePurchaseError(let error):
                 VStack {
-                    UpgradesErrorView(upgradeError,
+                    PrePurchaseUpgradesErrorView(error,
                                       onRetryButtonTapped: {
                         upgradesViewModel.retryFetch()
-                    },
-                                      onCancelUpgradeTapped: {
-                        presentationMode.wrappedValue.dismiss()
                     })
                     .padding(Layout.padding)
 
                     Spacer()
                 }
                 .background(Color(.listBackground))
+            case .purchaseUpgradeError(let error):
+                EmptyView()
             }
         }
         .navigationBarTitle(UpgradesView.Localization.navigationTitle)
@@ -76,24 +75,18 @@ struct UpgradesView: View {
     }
 }
 
-struct UpgradesErrorView: View {
+struct PrePurchaseUpgradesErrorView: View {
 
-    private let upgradeError: UpgradesError
+    private let error: PrePurchaseError
 
-    /// Closure invoked when the "Retry" or "Try payment again" button is tapped
+    /// Closure invoked when the "Retry" button is tapped
     ///
     var onRetryButtonTapped: (() -> Void)
 
-    /// Closure invoked when the "Cancel upgrade" button is tapped
-    /// 
-    var onCancelUpgradeTapped: (() -> Void) = {}
-
-    init(_ upgradeError: UpgradesError,
-         onRetryButtonTapped: @escaping (() -> Void),
-         onCancelUpgradeTapped: @escaping (() -> Void) ) {
-        self.upgradeError = upgradeError
+    init(_ error: PrePurchaseError,
+         onRetryButtonTapped: @escaping (() -> Void)) {
+        self.error = error
         self.onRetryButtonTapped = onRetryButtonTapped
-        self.onCancelUpgradeTapped = onCancelUpgradeTapped
     }
 
     var body: some View {
@@ -102,7 +95,7 @@ struct UpgradesErrorView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
 
             VStack(alignment: .center, spacing: Layout.textSpacing) {
-                switch upgradeError {
+                switch error {
                 case .fetchError, .entitlementsError:
                     VStack(alignment: .center) {
                         Text(Localization.fetchErrorMessage)
@@ -124,31 +117,6 @@ struct UpgradesErrorView: View {
                         .font(.body)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
-                case .purchaseError:
-                    Text(Localization.purchaseErrorTitleMessage)
-                        .font(.body)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .multilineTextAlignment(.center)
-                    Text(Localization.purchaseErrorAccentMessage)
-                        .bold()
-                        .headlineStyle()
-                        .multilineTextAlignment(.center)
-                    Text(Localization.purchaseErrorSubtitleMessage)
-                        .font(.body)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .multilineTextAlignment(.center)
-                    Button(Localization.retryPaymentButtonText) {
-                        onRetryButtonTapped()
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .fixedSize(horizontal: true, vertical: true)
-                    Button(Localization.cancelUpgradeButtonText) {
-                        onCancelUpgradeTapped()
-                    }
-                    .buttonStyle(SecondaryButtonStyle())
-                    .fixedSize(horizontal: true, vertical: true)
                 case .inAppPurchasesNotSupported:
                     Text(Localization.inAppPurchasesNotSupportedErrorMessage)
                         .bold()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9886
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're adding the ability to purchase Woo Express plans using In App Purchase.

This PR adds the views necessary to show errors with the In App Purchase, or activation of the plan after the purchase.

The `activation` errors do not yet show in the app, as we need a way to surface them from the InAppPurchaseStore first.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The easiest way to test is to force the errors to show, by changing UpgradesViewModel:117 to say `upgradeViewState = .purchaseUpgradeError(.planActivationFailed)` or `upgradeViewState = .purchaseUpgradeError(.inAppPurchaseFailed(plan))`

1. Then open the app and switch to a Woo Express free trial store
2. Tap `Upgrade Now` on the banner on My store
3. Observe that after the loading state, the error shows
4. Try the buttons, observe that they behave as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![in-app-purchase-failed](https://github.com/woocommerce/woocommerce-ios/assets/2472348/afc369a5-6582-4063-b160-f5e8deb5f997)
![activation-failed](https://github.com/woocommerce/woocommerce-ios/assets/2472348/537faa72-f54f-4340-8b25-177d6b5f790b)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
