### PR TITLE
[Product description AI] Track tooltip dismissal

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -582,6 +582,7 @@ public enum WooAnalyticsStat: String {
     case productDetailUpdateError = "product_detail_update_error"
     case productDetailViewProductNameTapped = "product_detail_view_product_name_tapped"
     case productDetailViewProductDescriptionTapped = "product_detail_view_product_description_tapped"
+    case productDetailViewProductDescriptionAITooltipDismissed = "product_detail_view_product_description_ai_tooltip_dismissed"
     case productDetailViewPriceSettingsTapped = "product_detail_view_price_settings_tapped"
     case productDetailViewShippingSettingsTapped = "product_detail_view_shipping_settings_tapped"
     case productDetailViewInventorySettingsTapped = "product_detail_view_inventory_settings_tapped"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -653,6 +653,7 @@ private extension ProductFormViewController {
             target: .point(tooltipTargetPoint),
             primaryTooltipAction: { [weak self] in
                 self?.tooltipUseCase.hasDismissedWriteWithAITooltip = true
+                ServiceLocator.analytics.track(.productDetailViewProductDescriptionAITooltipDismissed)
             }
         )
         tooltipPresenter?.tooltipVerticalPosition = .below


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9975
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions

Prerequisites
1. A store hosted on WPCOM
1. Logout of the app and login again to reset user defaults. (Need this step to reset user details. Only applicable if you have already viewed the AI tooltip 3 times)

**Steps**
1. Install and login into the store. 
2. Navigate to the Products tab
3. Open a product, and you can see the tooltip below the "Write with AI" button
4. Tap "Got it" to dismiss the tooltip
5. From XCode log validate that the following event is tracked

```
Tracked product_detail_view_product_description_ai_tooltip_dismissed
```

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
