### PR TITLE
[IAP] Non-owner view

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -8,13 +8,12 @@ enum UpgradeViewState {
     case purchasing(WooWPComPlan)
     case waiting(WooWPComPlan)
     case completed
-    case userNotAllowedToUpgrade
     case prePurchaseError(PrePurchaseError)
     case purchaseUpgradeError(PurchaseUpgradeError)
 
     var shouldShowPlanDetailsView: Bool {
         switch self {
-        case .loading, .loaded, .purchasing, .prePurchaseError, .userNotAllowedToUpgrade:
+        case .loading, .loaded, .purchasing, .prePurchaseError:
             return true
         default:
             return false
@@ -27,6 +26,7 @@ enum PrePurchaseError: Error {
     case entitlementsError
     case inAppPurchasesNotSupported
     case maximumSitesUpgraded
+    case userNotAllowedToUpgrade
 }
 
 enum PurchaseUpgradeError {
@@ -65,7 +65,7 @@ final class UpgradesViewModel: ObservableObject {
         }
 
         if let site = ServiceLocator.stores.sessionManager.defaultSite, !site.isSiteOwner {
-            self.upgradeViewState = .userNotAllowedToUpgrade
+            self.upgradeViewState = .prePurchaseError(.userNotAllowedToUpgrade)
         } else {
             Task {
                 await fetchViewData()

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -138,7 +138,14 @@ struct PrePurchaseUpgradesErrorView: View {
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
                 case .userNotAllowedToUpgrade:
-                    NonOwnerUpgradesView()
+                    Text(Localization.unableToUpgradeText)
+                        .bold()
+                        .headlineStyle()
+                        .multilineTextAlignment(.center)
+                    Text(Localization.unableToUpgradeInstructions)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
                 }
             }
         }
@@ -185,6 +192,14 @@ struct PrePurchaseUpgradesErrorView: View {
         static let inAppPurchasesNotSupportedErrorSubtitle = NSLocalizedString(
             "Please contact support for assistance.",
             comment: "Subtitle message displayed when In-App Purchases are not supported, redirecting to contact support if needed.")
+
+        static let unableToUpgradeText = NSLocalizedString(
+            "You can’t upgrade because you are not the store owner",
+            comment: "Text describing that is not possible to upgrade the site's plan.")
+
+        static let unableToUpgradeInstructions = NSLocalizedString(
+            "Please contact the store owner to upgrade your plan.",
+            comment: "Text describing that only the site owner can upgrade the site's plan.")
     }
 }
 
@@ -517,34 +532,6 @@ private extension WooWPComPlan {
     }
 }
 
-struct NonOwnerUpgradesView: View {
-    private var siteName: String? {
-        ServiceLocator.stores.sessionManager.defaultSite?.name
-    }
-
-    var body: some View {
-        VStack {
-
-            Image(uiImage: .noStoreImage)
-                .frame(maxWidth: .infinity, alignment: .center)
-
-            VStack(alignment: .center, spacing: UpgradesView.Layout.contentSpacing) {
-                Text(Localization.unableToUpgradeText)
-                    .bold()
-                    .headlineStyle()
-                if let siteName = siteName {
-                    Text(siteName)
-                }
-                Text(Localization.unableToUpgradeInstructions)
-                    .font(.body)
-                    .foregroundColor(.secondary)
-            }
-
-            Spacer()
-        }
-    }
-}
-
 private struct CurrentPlanDetailsView: View {
     @State var planName: String
     @State var daysLeft: String
@@ -608,15 +595,6 @@ private extension OwnerUpgradesView {
 
         static let featureDetailsUnavailableText = NSLocalizedString(
             "See plan details", comment: "Title for a link to view Woo Express plan details on the web, as a fallback.")
-    }
-}
-
-private extension NonOwnerUpgradesView {
-    struct Localization {
-        static let unableToUpgradeText = NSLocalizedString("You can’t upgrade because you are not the store owner",
-                                                           comment: "Text describing that is not possible to upgrade the site's plan.")
-        static let unableToUpgradeInstructions = NSLocalizedString("Please contact the store owner to upgrade your plan.",
-                                                                   comment: "Text describing that only the site owner can upgrade the site's plan.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -39,8 +39,6 @@ struct UpgradesView: View {
             .renderedIf(upgradesViewModel.upgradeViewState.shouldShowPlanDetailsView)
 
             switch upgradesViewModel.upgradeViewState {
-            case .userNotAllowedToUpgrade:
-                NonOwnerUpgradesView()
             case .loading:
                 OwnerUpgradesView(upgradePlan: .skeletonPlan(), purchasePlanAction: {}, isLoading: true)
             case .loaded(let plan):
@@ -139,6 +137,8 @@ struct PrePurchaseUpgradesErrorView: View {
                         .font(.body)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
+                case .userNotAllowedToUpgrade:
+                    NonOwnerUpgradesView()
                 }
             }
         }


### PR DESCRIPTION
Branched from https://github.com/woocommerce/woocommerce-ios/pull/10018 , which needs to be merged first.

## Description
We're adding the ability to purchase Woo Express plans using In App Purchase. 

The PR moves the existing `userNotAllowedToUpgrade` case, which will appear when a non-owner of a site attempts to go through the In-App Purchases upgrade flow, from being a `UpgradeViewState` case to a `PrePurchaseError`. With this we also update the view style to be consistent with the rest of errors.

## Testing instructions
1. Change `UpgradesViewModel:117` to `.prePurchaseError(.userNotAllowedToUpgrade)` state:
```
upgradeViewState = .prePurchaseError(.userNotAllowedToUpgrade)
```
2. On a Free Trial store, tap on "Upgrade Now" > See the error screen.

## Screenshots

<img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/a10b4f16-4b68-4735-a788-820370a0022f">
