### PR TITLE
Store Creation: Track when creating new site and enabling free trial completes

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -16,6 +16,8 @@ extension WooAnalyticsEvent {
             static let countryCode = "country_code"
             static let isFreeTrial = "is_free_trial"
             static let waitingTime = "waiting_time"
+            static let blogID = "blog_id"
+            static let initialDomain = "initial_domain"
         }
 
         /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
@@ -32,6 +34,13 @@ extension WooAnalyticsEvent {
                                            Key.flow: flow.rawValue,
                                            Key.isFreeTrial: isFreeTrial,
                                            Key.waitingTime: waitingTime])
+        }
+
+        /// Tracked when site creation request success
+        static func siteCreationRequestSuccess(siteID: Int64, domainName: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationFreeTrialCreatedSuccess,
+                              properties: [Key.blogID: siteID,
+                                           Key.initialDomain: domainName])
         }
 
         /// Tracked when site creation fails.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -16,7 +16,7 @@ extension WooAnalyticsEvent {
             static let countryCode = "country_code"
             static let isFreeTrial = "is_free_trial"
             static let waitingTime = "waiting_time"
-            static let blogID = "blog_id"
+            static let newSiteID = "new_site_id"
             static let initialDomain = "initial_domain"
         }
 
@@ -39,7 +39,7 @@ extension WooAnalyticsEvent {
         /// Tracked when site creation request success
         static func siteCreationRequestSuccess(siteID: Int64, domainName: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreationFreeTrialCreatedSuccess,
-                              properties: [Key.blogID: siteID,
+                              properties: [Key.newSiteID: siteID,
                                            Key.initialDomain: domainName])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -217,6 +217,7 @@ public enum WooAnalyticsStat: String {
     case siteCreationTryForFreeTapped = "site_creation_try_for_free_tapped"
     case siteCreationTimedOut = "site_creation_timed_out"
     case siteCreationPropertiesOutOfSync = "site_creation_properties_out_of_sync"
+    case siteCreationFreeTrialCreatedSuccess = "site_creation_free_trial_created_success"
     case loginPrologueCreateSiteTapped = "login_prologue_create_site_tapped"
     case signupFormLoginTapped = "signup_login_button_tapped"
     case signupSubmitted = "signup_submitted"

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -511,6 +511,10 @@ private extension StoreCreationCoordinator {
                 // Wait for jetpack to be installed
                 DDLogInfo("🟢 Free trial enabled on site. Waiting for jetpack to be installed...")
                 waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteResult.siteID, expectedStoreName: siteResult.name)
+                analytics.track(event: .StoreCreation.siteCreationRequestSuccess(
+                    siteID: siteResult.siteID,
+                    domainName: siteResult.url.trimHTTPScheme()
+                ))
                 analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
 
             case .failure(let error):

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -513,7 +513,7 @@ private extension StoreCreationCoordinator {
                 waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteResult.siteID, expectedStoreName: siteResult.name)
                 analytics.track(event: .StoreCreation.siteCreationRequestSuccess(
                     siteID: siteResult.siteID,
-                    domainName: siteResult.url.trimHTTPScheme()
+                    domainName: siteResult.siteSlug
                 ))
                 analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10030 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR follows the internal discussion [p1687174598489079-slack-C03L1NF1EA3] to add a new tracking event to determine stores created from mobile apps.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom site.
- Switch to Menu tab and open the store picker.
- Select Add a store -> Create a new store.
- Complete the store creation flow. After tapping the Start free trial button, notice in Xcode console: `🔵 Tracked site_creation_free_trial_created_success, properties: [AnyHashable("initial_domain"): "...", AnyHashable("blog_id"):<blog_id>, AnyHashable("is_wpcom_store"): true]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.