### PR TITLE
[Performance] Only sync single order from remote if needed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 14.2
 -----
-
+- [Internal] Performance: When loading a single order (e.g. in order details), we now load the order from storage unless it has been modified remotely. [https://github.com/woocommerce/woocommerce-ios/pull/10036]
 
 14.1
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9942
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to improve performance on the Order Details screen by relying on local storage if an order has been synced before.

This PR updates the action to load a single order. Instead of always fetching the order from remote, we now check if we have the up-to-date order in storage first:

* If the order is not in storage, we fetch it from remote.
* If the order is in storage, we check remote to see when the order was last modified.
   * If the last modified date matches what we have in storage, we return the stored order.
   * If the last modified dates don't match, we fetch the order from remote.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can use a tool like Charles proxy to check the API requests in the following steps:

1. Build and run the app.
2. Open the Orders tab.
3. Select an order and confirm there's a request to the `orders` endpoint for the order's `date_modified_gmt` field. Confirm no request is made to that endpoint for all the order fields.
4. Go back to the order list.
5. In a web browser, make a change to an order and save it.
6. In the app, open the order you just changed and confirm there's a request to the `orders` endpoint for the order's `date_modified_gmt` field. Then, confirm there's another request for all the order fields and the changes you made are reflected in the app.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
