### PR TITLE
[Product description AI] Check feature flag to configure Tool tip

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -637,6 +637,10 @@ private extension ProductFormViewController {
     }
 
     func configureTooltipPresenter() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productDescriptionAIFromStoreOnboarding) else {
+            return
+        }
+
         guard aiEligibilityChecker.isFeatureEnabled(.description) else {
             return
         }


### PR DESCRIPTION
Part of: #9975
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Check for feature flag before configuring the product description AI tooltip. 

## Testing instructions

Prerequisites
- Store hosted on WPCOM

Steps
1. Turn on `productDescriptionAIFromStoreOnboarding` feature flag
2. Install and login into the store
3. Navigate to the Products tab
4. Open a product
5. Validate that you can see the tooltip below the "Write with AI" button
6. Turn off `productDescriptionAIFromStoreOnboarding` feature flag and repeat steps 2-4
7. Validate that the tooltip is not displayed. Additionally, observe that the "Write with AI" button will not be visible.


## Screenshots
| `productDescriptionAIFromStoreOnboarding` true | `productDescriptionAIFromStoreOnboarding` false |
|--------|--------|
| ![Simulator Screen Shot - iPhone 14 - 2023-06-21 at 17 25 34](https://github.com/woocommerce/woocommerce-ios/assets/524475/6a111656-04d4-40ae-93c2-ab6c1a10b014) | ![Simulator Screen Shot - iPhone 14 - 2023-06-21 at 17 23 32](https://github.com/woocommerce/woocommerce-ios/assets/524475/bbd29f11-0fee-4287-9dab-4c478bddc1fc) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
