### PR TITLE
[SKU Scanner]Fix visual iPad issues

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
@@ -42,8 +42,8 @@ private extension ProductSKUBarcodeScannerCoordinator {
     func showSKUScanner() {
         let scannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] barcode in
             self?.onSKUBarcodeScanned(barcode)
-            self?.navigationController.popViewController(animated: true)
+            self?.navigationController.dismiss(animated: true)
         })
-        navigationController.show(scannerViewController, sender: self)
+        navigationController.present(scannerViewController, animated: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
@@ -39,7 +39,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         coordinator.start()
 
         // Then
-        assertThat(navigationController.topViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
+        assertThat(navigationController.presentedViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
     }
 
     func test_coordinator_does_nothing_after_denying_camera_access() {
@@ -69,7 +69,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         coordinator.start()
 
         // Then
-        assertThat(navigationController.topViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
+        assertThat(navigationController.presentedViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
     }
 
     func test_coordinator_shows_alert_when_permission_is_denied() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9991 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix several visual issues on iPad when the SKU scanner was initiated from the order list. By changing the navigation style from pushing to modally presenting the SKU scanner we solve al the issues from the original ticket:

1. The title of the scanning application says "Scan barcode to update SKU" when that isn't the workflow being done
2. "Scan product barcode" can easily get truncated from the front if the font size changes, and generally looks odd when not center aligned
3. If we’re creating an order via scanning, it’s confusing on iPad that the scanner only takes up the space of the left sidebar — the content on the right of the image above is related to the order that was selected in the sidebar previously and isn’t really relevant to what the user is doing now.

Furthermore, presenting the scanner modally looks also better on iPhone and it's consistent with the behavior on the Order Creation screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. On iPad, go to orders.
2. Tap on the barcode scanner button (top left corner). Ensure that the issues stated above don't happen now.
3. Scan a product and check that the process works fine.
4. Check also that the navigation change doesn't cause any issues on iPhone.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before
<img src="https://github.com/woocommerce/woocommerce-ios/assets/103850310/98a996c7-5ea6-468f-9f04-fb2c5a8152a7" width="375">

### After
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/981c2309-a5c2-48ef-a178-9c5b89e75d35" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
