### PR TITLE
[IAP] Use a modal view for the Upgrade flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -154,7 +154,7 @@ private extension FreeTrialBannerPresenter {
         Task { @MainActor in
             if inAppPurchasesUpgradeEnabled {
                 let upgradesController = UpgradesHostingController(siteID: siteID)
-                viewController.show(upgradesController, sender: self)
+                viewController.present(upgradesController, animated: true)
             } else {
                 let subscriptionsController = SubscriptionsHostingController(siteID: siteID)
                 viewController.show(subscriptionsController, sender: self)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -34,8 +34,14 @@ struct UpgradesView: View {
 
     var body: some View {
         VStack {
-            CurrentPlanDetailsView(planName: subscriptionsViewModel.planName,
-                                   daysLeft: subscriptionsViewModel.planDaysLeft)
+            VStack {
+                UpgradeTopBarView(dismiss: {
+                    presentationMode.wrappedValue.dismiss()
+                })
+
+                CurrentPlanDetailsView(planName: subscriptionsViewModel.planName,
+                                       daysLeft: subscriptionsViewModel.planDaysLeft)
+            }
             .renderedIf(upgradesViewModel.upgradeViewState.shouldShowPlanDetailsView)
 
             switch upgradesViewModel.upgradeViewState {
@@ -59,7 +65,7 @@ struct UpgradesView: View {
             case .prePurchaseError(let error):
                 VStack {
                     PrePurchaseUpgradesErrorView(error,
-                                      onRetryButtonTapped: {
+                                                 onRetryButtonTapped: {
                         upgradesViewModel.retryFetch()
                     })
                     .padding(.top, Layout.errorViewTopPadding)
@@ -67,7 +73,7 @@ struct UpgradesView: View {
 
                     Spacer()
                 }
-                .background(Color(.listBackground))
+                .background(Color(.systemGroupedBackground))
             case .purchaseUpgradeError(.inAppPurchaseFailed(let plan)):
                 PurchaseUpgradeErrorView(error: .inAppPurchaseFailed(plan)) {
                     Task {
@@ -84,8 +90,6 @@ struct UpgradesView: View {
                 })
             }
         }
-        .navigationBarTitle(UpgradesView.Localization.navigationTitle)
-        .padding(.top)
     }
 }
 
@@ -156,8 +160,8 @@ struct PrePurchaseUpgradesErrorView: View {
         .padding(.vertical, Layout.verticalEdgesPadding)
         .background {
             RoundedRectangle(cornerSize: .init(width: Layout.cornerRadius, height: Layout.cornerRadius))
-                .fill(Color(UIColor.secondarySystemGroupedBackground))
-                  }
+                .fill(Color(.secondarySystemGroupedBackground))
+        }
     }
 
     private enum Layout {
@@ -410,7 +414,7 @@ private extension UpgradeWaitingView {
         static let progressIndicatorSize: CGFloat = 56
         static let progressIndicatorLineWidth: CGFloat = 6
         static let horizontalPadding: CGFloat = 16
-        static let verticalPadding: CGFloat = 80
+        static let verticalPadding: CGFloat = 152
         static let spacing: CGFloat = 40
         static let textSpacing: CGFloat = 16
     }
@@ -469,7 +473,7 @@ struct CompletedUpgradeView: View {
     }
 
     private struct Layout {
-        static let completedUpgradeViewTopPadding: CGFloat = 30
+        static let completedUpgradeViewTopPadding: CGFloat = 70
         static let padding: CGFloat = 16
         static let groupSpacing: CGFloat = 32
         static let textSpacing: CGFloat = 16
@@ -652,6 +656,41 @@ private struct CurrentPlanDetailsView: View {
     }
 }
 
+private struct UpgradeTopBarView: View {
+    let dismiss: () -> Void
+
+    var body: some View {
+        HStack {
+            Spacer()
+
+            Text(Localization.navigationTitle)
+                .fontWeight(.bold)
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            Spacer()
+        }
+        .background(Color(.systemGroupedBackground))
+        .overlay(alignment: .leading) {
+            Button(action: dismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: Layout.closeButtonSize))
+                    .foregroundColor(Color(.label))
+                    .padding()
+                    .frame(alignment: .leading)
+            }
+        }
+    }
+
+    private enum Localization {
+        static let navigationTitle = NSLocalizedString("Upgrade", comment: "Navigation title for the Upgrades screen")
+    }
+
+    private enum Layout {
+        static let closeButtonSize: CGFloat = 16
+    }
+}
+
 struct UpgradesView_Preview: PreviewProvider {
     static var previews: some View {
         UpgradesView(upgradesViewModel: UpgradesViewModel(siteID: 0),
@@ -675,10 +714,6 @@ private extension OwnerUpgradesView {
 }
 
 private extension UpgradesView {
-    struct Localization {
-        static let navigationTitle = NSLocalizedString("Plans", comment: "Navigation title for the Upgrades screen")
-    }
-
     struct Layout {
         static let errorViewHorizontalPadding: CGFloat = 20
         static let errorViewTopPadding: CGFloat = 36

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
@@ -34,6 +34,7 @@ struct WooPlanFeatureBenefitsView: View {
             .padding()
         }
         .navigationTitle(wooPlanFeatureGroup.title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 
     private enum Layout {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've added an upgrade flow allowing the purchase of Woo Express plans using In App Purchase.

The design for this flow has it shown in a modal view, but our initial implementation used the pushed view similar to the existing Subscriptions link.

This PR changes the presentation to modal, and updates various details to match the designs after that change.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a Woo Express store with a free trial active

1. On the My Store screen, tap `Upgrade Now` to open the flow
2. Observe that it's shown in a modal
3. Follow the purchase flow
4. Observe that the screens match designs

<img width="1185" alt="CleanShot 2023-06-21 at 15 41 09@2x" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/fd236f44-e08a-4d0a-b7a0-91dd0349f232">

To see some of the screens, you may need to force the view state to change. You can do that in [UpgradesViewModel](https://github.com/woocommerce/woocommerce-ios/blob/ba3f05a9bcbffe2341683bfd43274c1250b2c65c/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift#L118) by changing the state. Try:

- `.prePurchaseError(.fetchError)`
- `.waiting(plan)`
- `.purchasing(plan)`
- `.purchaseUpgradeError(.planActivationFailed)`
- `.completed(plan)`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/54f49734-3c88-449e-ac58-e73e5fd85d51


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
