### PR TITLE
[IAP] Add `Get support` button to post-purchase errors

### DIFF
--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -77,6 +77,9 @@ extension CustomHelpCenterContent {
         /// No WooCommerce site error  using `NoWooErrorViewModel`
         ///
         case noWooError
+
+        /// The merchant is dealing with an error while they're purchasing a plan.
+        case purchasePlanError
     }
 
     init(screen: Screen, flow: AuthenticatorAnalyticsTracker.Flow) {
@@ -94,6 +97,9 @@ extension CustomHelpCenterContent {
         case .noWooError:
             step = "not_woo_store" // Matching Android `Step` value
             url = WooConstants.URLs.helpCenterForNoWooError.asURL()
+        case .purchasePlanError:
+            step = "purchase_plan_error"
+            url = WooConstants.URLs.helpCenter.asURL()
         }
 
         trackingProperties = [


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9886 (needs #10040 to be merged first)
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have added the ability to purchase plans using IAP. When this fails after the IAP, we show errors which can only really be resolved by talking to support.

This PR adds a button to open the support view

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hardcode the state of the screen to `.purchaseUpgradeError(.planActivationFailed)` or `.purchaseUpgradeError(.inAppPurchaseFailed(plan))` [in `UpgradesViewModel`](https://github.com/woocommerce/woocommerce-ios/blob/b6b5a734848184f61dfdab83d58dea595df86bca/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift#L117)

1. Start the app and select a Woo express store with a free trial active
2. Tap `Upgrade now`
3. Wait for the load to finish
4. Tap `Get support`
5. Observe that the Help screen opens


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/399b0669-0e66-416c-be4c-2158f1c3c625



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
