### PR TITLE
[IAP] Show correct purchase upgrade errors

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -30,8 +30,8 @@ enum PrePurchaseError: Error {
 }
 
 enum PurchaseUpgradeError {
-    case inAppPurchaseFailed(WooWPComPlan)
-    case planActivationFailed
+    case inAppPurchaseFailed(WooWPComPlan, InAppPurchaseStore.Errors)
+    case planActivationFailed(InAppPurchaseStore.Errors)
     case unknown
 }
 
@@ -188,18 +188,18 @@ final class UpgradesViewModel: ObservableObject {
             case .unverifiedTransaction,
                     .transactionProductUnknown,
                     .inAppPurchasesNotSupported:
-                upgradeViewState = .purchaseUpgradeError(.inAppPurchaseFailed(wooWPComPlan))
+                upgradeViewState = .purchaseUpgradeError(.inAppPurchaseFailed(wooWPComPlan, recognisedError))
             case .transactionMissingAppAccountToken,
                     .appAccountTokenMissingSiteIdentifier,
                     .storefrontUnknown:
-                upgradeViewState = .purchaseUpgradeError(.planActivationFailed)
+                upgradeViewState = .purchaseUpgradeError(.planActivationFailed(recognisedError))
             }
         }
     }
 
     private func planCanBePurchasedFromCurrentState() -> WooWPComPlan? {
         switch upgradeViewState {
-        case .loaded(let plan), .purchaseUpgradeError(.inAppPurchaseFailed(let plan)):
+        case .loaded(let plan), .purchaseUpgradeError(.inAppPurchaseFailed(let plan, _)):
             return plan
         default:
             return nil

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -98,8 +98,9 @@ struct UpgradesView: View {
                     } getSupportAction: {
                         supportHandler()
                     }
-                case .purchaseUpgradeError(.planActivationFailed):
-                    PurchaseUpgradeErrorView(error: .planActivationFailed,
+                case .purchaseUpgradeError(let underlyingError):
+                    // handles .planActivationFailed and .unknown underlyingErrors
+                    PurchaseUpgradeErrorView(error: underlyingError,
                                              primaryAction: nil,
                                              secondaryAction: {
                         presentationMode.wrappedValue.dismiss()
@@ -312,6 +313,8 @@ private extension PurchaseUpgradeError {
             return Localization.purchaseErrorTitle
         case .planActivationFailed:
             return Localization.activationErrorTitle
+        case .unknown:
+            return Localization.unknownErrorTitle
         }
     }
 
@@ -321,6 +324,8 @@ private extension PurchaseUpgradeError {
             return Localization.purchaseErrorDescription
         case .planActivationFailed:
             return Localization.activationErrorDescription
+        case .unknown:
+            return Localization.unknownErrorDescription
         }
     }
 
@@ -328,8 +333,8 @@ private extension PurchaseUpgradeError {
         switch self {
         case .inAppPurchaseFailed:
             return Localization.purchaseErrorActionDirection
-        case .planActivationFailed:
-            return Localization.activationErrorActionDirection
+        case .planActivationFailed, .unknown:
+            return Localization.errorContactSupportActionDirection
         }
     }
 
@@ -338,6 +343,8 @@ private extension PurchaseUpgradeError {
         case .inAppPurchaseFailed:
             return Localization.purchaseErrorActionHint
         case .planActivationFailed:
+            return nil
+        case .unknown:
             return nil
         }
     }
@@ -352,6 +359,8 @@ private extension PurchaseUpgradeError {
             return Localization.retryPaymentButtonText
         case .planActivationFailed:
             return nil
+        case .unknown:
+            return nil
         }
     }
 
@@ -359,7 +368,7 @@ private extension PurchaseUpgradeError {
         switch self {
         case .inAppPurchaseFailed:
             return Localization.cancelUpgradeButtonText
-        case .planActivationFailed:
+        case .planActivationFailed, .unknown:
             return Localization.returnToMyStoreButtonText
         }
     }
@@ -399,13 +408,22 @@ private extension PurchaseUpgradeError {
             "Your subscription is active, but there was an error activating the plan on your store.",
             comment: "Error description displayed when plan activation fails after purchasing a plan.")
 
-        static let activationErrorActionDirection = NSLocalizedString(
+        static let errorContactSupportActionDirection = NSLocalizedString(
             "Please contact support for assistance.",
             comment: "Bolded message advising the merchant to contact support when the plan activation failed.")
 
         static let returnToMyStoreButtonText = NSLocalizedString(
             "Return to My Store",
             comment: "Title of the secondary button displayed when activating the purchased plan fails, so the merchant can exit the flow.")
+
+        /// Unknown errors
+        static let unknownErrorTitle = NSLocalizedString(
+            "Error during purchase",
+            comment: "Title of an unknown error after purchasing a plan")
+
+        static let unknownErrorDescription = NSLocalizedString(
+            "Something went wrong during your purchase, and we can't tell whether your payment has completed, or your store plan been upgraded.",
+            comment: "Description of an unknown error after purchasing a plan")
     }
 }
 

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -327,7 +327,7 @@ public extension InAppPurchaseStore {
                     comment: "Error message used when we received a transaction for an unknown product")
             case .storefrontUnknown:
                 return NSLocalizedString(
-                    "Couldn't determine App Stoure country",
+                    "Couldn't determine App Store country",
                     comment: "Error message used when we can't determine the user's App Store country")
             case .inAppPurchasesNotSupported:
                 return NSLocalizedString(

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -335,6 +335,23 @@ public extension InAppPurchaseStore {
                     comment: "Error message used when In-app purchases are not supported for this user/site")
             }
         }
+
+        public var errorCode: String {
+            switch self {
+            case .unverifiedTransaction:
+                return "iap.T.100"
+            case .inAppPurchasesNotSupported:
+                return "iap.T.105"
+            case .transactionProductUnknown:
+                return "iap.T.110"
+            case .transactionMissingAppAccountToken:
+                return "iap.A.100"
+            case .appAccountTokenMissingSiteIdentifier:
+                return "iap.A.105"
+            case .storefrontUnknown:
+                return "iap.A.110"
+            }
+        }
     }
 
     enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9886 (follows from #10044 which should be merged first)
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have added the ability to purchase plans using IAP. When this fails after the IAP, we show errors which can only really be resolved by talking to support.

This PR adds the error code to those screens, and shows the appropriate screen based on the error raised by the InAppPurchaseStore.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hardcode the `InAppPurchaseStore` to show the error you want to test, by adding `throw Errors.transactionMissingAppAccountToken` or similar to the [first line of the do block in `purchaseProduct`](https://github.com/woocommerce/woocommerce-ios/blob/f8dfa09c44c59dad5d573fb6668099650be0e7bf/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift#L83).

1. Start the app and select a Woo express store with a free trial active
2. Tap `Upgrade now`
3. Wait for the load to finish
4. Tap `Purchase Debug Essential Monthly`
5. Observe that the expected error screen shows, and includes the error code if recognised.

### Errors to try:

#### Plan Activation Error
- `transactionMissingAppAccountToken`
- `appAccountTokenMissingSiteIdentifier`
- `storefrontUnknown`

#### Purchase Failed Error
- `unverifiedTransaction`
- `inAppPurchasesNotSupported`
- `transactionProductUnknown`

#### Unknown
`NSError(domain: "iap-example", code: 123)`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/542a989a-03cc-4bb7-bad6-d4e48edf1a3f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
