### PR TITLE
Fix (CoreData & Sentry) startup crashes.

### DIFF
--- a/WooCommerce/Classes/Tools/Logging/EventLogging.swift
+++ b/WooCommerce/Classes/Tools/Logging/EventLogging.swift
@@ -33,7 +33,11 @@ struct WCEventLoggingDelegate: EventLoggingDelegate {
     func didQueueLogForUpload(_ log: LogFile) {
         DDLogDebug("📜 Added log to queue: \(log.uuid)")
 
-        DDLogDebug("📜\t There are \(ServiceLocator.crashLogging.queuedLogFileCount) logs in the queue.")
+        // We should not access `ServiceLocator.crashLogging`(Owner of this) in the same runloop because there is a change that it has not yet been initialized
+        // And we will create a run loop by calling it recursively.
+        DispatchQueue.main.async {
+            DDLogDebug("📜\t There are \(ServiceLocator.crashLogging.queuedLogFileCount) logs in the queue.")
+        }
     }
 
     func didStartUploadingLog(_ log: LogFile) {
@@ -42,7 +46,12 @@ struct WCEventLoggingDelegate: EventLoggingDelegate {
 
     func didFinishUploadingLog(_ log: LogFile) {
         DDLogDebug("📜 Finished uploading encrypted log: \(log.uuid)")
-        DDLogDebug("📜\t There are \(ServiceLocator.crashLogging.queuedLogFileCount) logs remaining in the queue.")
+
+        // We should not access `ServiceLocator.crashLogging`(Owner of this) in the same runloop because there is a change that it has not yet been initialized
+        // And we will create a run loop by calling it recursively.
+        DispatchQueue.main.async {
+            DDLogDebug("📜\t There are \(ServiceLocator.crashLogging.queuedLogFileCount) logs remaining in the queue.")
+        }
     }
 
     func uploadFailed(withError error: Error, forLog log: LogFile) {


### PR DESCRIPTION
# Why

Investigating the recent surge in crashes I spotted two crashes that happen only on release builds. These crashes happen because we are deadlocking the service locator by accessing their properties recursively without them being completely initialized.

The two scenarios I found were

```
App Start -> ServiceLocator.stores -> ServiceLocator.storage -> Error ->
-> ServiceLocator.crashlogging -> ServiceLocator.stores -> DEADLOCK
```

And after that initial startup crash happens

```
App Start -> ServiceLocator.stores -> ServiceLocator.storage -> 
-> ServiceLocator.crashLogging (dependency of storage) -> Sentry (tries to send queued crashes) -> 
-> ServiceLocator.stores -> DEADLOCK
```

# How

- The fix is mostly to avoid calling the `ServiceLocator.stores` recursively on `WCCrashLoggingDataProvider.currentUser` when we know it hasn't been completely initialized( <- HACK) 

- Also dispatches some other accesses of `ServiceLocator.crashLogging` in the next run loop from a delegate it owns.

# How To Test

Testing this is tricky as it only happens on release builds.
One way we can achieve it.

- Install a 14.1 build - (pr9992-853f527)
- Open the app and load orders and products

----

- Install a 13.5 build - (pr9704-847fb0c)
- To generate a crash due to an impossible migration

----

- Install this build - (pr10049-84d2e48)
- See that the app starts working again.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
