### PR TITLE
Product sharing AI: Update UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
@@ -42,14 +42,15 @@ struct ProductSharingMessageGenerationView: View {
 
             // Generated message text field
             ZStack(alignment: .topLeading) {
-                TextEditor(text: viewModel.generationInProgress ? .constant("") : $viewModel.messageContent)
+                TextEditor(text: $viewModel.messageContent)
                     .bodyStyle()
                     .foregroundColor(.secondary)
+                    .disabled(viewModel.generationInProgress)
+                    .opacity(viewModel.generationInProgress ? 0 : 1)
                     .padding(insets: Constants.messageContentInsets)
                     .overlay(
                         RoundedRectangle(cornerRadius: Constants.cornerRadius).stroke(Color(.separator))
                     )
-                    .disabled(viewModel.generationInProgress)
 
                 // Placeholder text
                 Text(Localization.placeholder)
@@ -62,13 +63,16 @@ struct ProductSharingMessageGenerationView: View {
                                 viewModel.generationInProgress == false)
             }
             .overlay(
-                // Skeleton view for loading state
-                Text(Constants.dummyText)
-                    .bodyStyle()
-                    .redacted(reason: .placeholder)
-                    .shimmering()
-                    .padding(insets: Constants.placeholderInsets)
-                    .renderedIf(viewModel.generationInProgress)
+                VStack {
+                    // Skeleton view for loading state
+                    Text(Constants.dummyText)
+                        .bodyStyle()
+                        .redacted(reason: .placeholder)
+                        .shimmering()
+                        .padding(insets: Constants.placeholderInsets)
+                        .renderedIf(viewModel.generationInProgress)
+                    Spacer()
+                }
             )
 
             // Error message

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationView.swift
@@ -32,7 +32,7 @@ struct ProductSharingMessageGenerationView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Constants.defaultSpacing) {
+        ScrollableVStack(alignment: .leading, spacing: Constants.defaultSpacing) {
 
             // View title
             Text(viewModel.viewTitle)
@@ -42,13 +42,14 @@ struct ProductSharingMessageGenerationView: View {
 
             // Generated message text field
             ZStack(alignment: .topLeading) {
-                TextEditor(text: $viewModel.messageContent)
+                TextEditor(text: viewModel.generationInProgress ? .constant("") : $viewModel.messageContent)
                     .bodyStyle()
                     .foregroundColor(.secondary)
                     .padding(insets: Constants.messageContentInsets)
                     .overlay(
                         RoundedRectangle(cornerRadius: Constants.cornerRadius).stroke(Color(.separator))
                     )
+                    .disabled(viewModel.generationInProgress)
 
                 // Placeholder text
                 Text(Localization.placeholder)
@@ -57,25 +58,25 @@ struct ProductSharingMessageGenerationView: View {
                     .padding(insets: Constants.placeholderInsets)
                     // Allows gestures to pass through to the `TextEditor`.
                     .allowsHitTesting(false)
-                    .renderedIf(viewModel.messageContent.isEmpty)
+                    .renderedIf(viewModel.messageContent.isEmpty &&
+                                viewModel.generationInProgress == false)
             }
-            .renderedIf(viewModel.generationInProgress == false)
-
-            // Skeleton view for loading state
-            Text(Constants.dummyText)
-                .secondaryBodyStyle()
-                .redacted(reason: .placeholder)
-                .shimmering()
-                .padding(Constants.placeholderInsets)
-                .background(RoundedRectangle(cornerRadius: Constants.cornerRadius).stroke(Color(uiColor: .secondarySystemFill)))
-                .renderedIf(viewModel.generationInProgress)
+            .overlay(
+                // Skeleton view for loading state
+                Text(Constants.dummyText)
+                    .bodyStyle()
+                    .redacted(reason: .placeholder)
+                    .shimmering()
+                    .padding(insets: Constants.placeholderInsets)
+                    .renderedIf(viewModel.generationInProgress)
+            )
 
             // Error message
             viewModel.errorMessage.map { message in
                 Text(message).errorStyle()
             }
 
-            AdaptiveStack {
+            AdaptiveStack(spacing: Constants.horizontalSpacing) {
                 // Action button to generate message
                 Button(action: {
                     Task {
@@ -94,11 +95,8 @@ struct ProductSharingMessageGenerationView: View {
                            vertical: shouldKeepGenerateButtonAtFixedSize)
 
                 // Button for more information about legal
-                Button {
+                Button(Localization.learnMore) {
                     isShowingLegalPage = true
-                } label: {
-                    Image(systemName: "info.circle")
-                        .font(.headline)
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.accentColor)
@@ -118,7 +116,6 @@ struct ProductSharingMessageGenerationView: View {
             }
             .safariSheet(isPresented: $isShowingLegalPage, url: legalURL)
         }
-        .padding(insets: Constants.insets)
     }
 }
 
@@ -131,7 +128,10 @@ private extension ProductSharingMessageGenerationView {
         static let placeholderInsets: EdgeInsets = .init(top: 18, leading: 16, bottom: 18, trailing: 16)
         static let dummyText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit," +
         "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam," +
-        "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+        "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." +
+        "nisi ut aliquip ex ea commodo consequat."
+        static let dummyTextInsets: EdgeInsets = .init(top: 12, leading: 16, bottom: 12, trailing: 16)
+        static let horizontalSpacing: CGFloat = 8
     }
     enum Localization {
         static let generateInProgress = NSLocalizedString(
@@ -145,6 +145,10 @@ private extension ProductSharingMessageGenerationView {
         static let placeholder = NSLocalizedString(
             "Add an optional message",
             comment: "Placeholder text on the product sharing message generation screen"
+        )
+        static let learnMore = NSLocalizedString(
+            "Learn more",
+            comment: "Button to open the legal page for AI-generated contents on the product sharing message generation screen"
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds some small changes in the UI of the product sharing AI sheet following an internal discussion: p1687249458222559-slack-C03L1NF1EA3. Specifically:
- Made the content scrollable with `ScrollableVStack`.
- Changed the legal button label to "Learn more".
- Move the skeleton to the overlay of the `TextEditor` to prevent the Regenerate button to jump up and down between states. All this effort is needed since `redacted` doesn't work for `TextEditor`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a public WPCom site.
- Select an existing published product or create one.
- Select the Share button on the product detail screen.
- Notice that the UI is updated appropriately, especially when switching font size to an accessibility font : 
   - The view can be scrolled vertically.
   - The buttons are not cut off.
   - The buttons don't jump up when generation is in progress.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/e081d5d8-4d5e-4b8b-b3c5-44ac39ec40f3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.