### PR TITLE
[Product description AI] Show the tooltip only if the product description is empty.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -645,6 +645,10 @@ private extension ProductFormViewController {
             return
         }
 
+        guard product.description?.isEmpty == true else {
+            return
+        }
+
         guard tooltipUseCase.shouldShowTooltip && tooltipPresenter == nil else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -645,11 +645,16 @@ private extension ProductFormViewController {
             return
         }
 
+        if let tooltip = tooltipPresenter?.tooltip {
+            tooltip.removeFromSuperview()
+            self.tooltipPresenter = nil
+        }
+
         guard product.description?.isEmpty == true else {
             return
         }
 
-        guard tooltipUseCase.shouldShowTooltip && tooltipPresenter == nil else {
+        guard tooltipUseCase.shouldShowTooltip else {
             return
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9975 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Show the product description AI tooltip only if the description is empty.

Internal - NMncL2ViLjomfLhuyEhVM1-fi-236:85004

## Testing instructions

Prerequisites
1. A store hosted on WPCOM
1. Logout of the app and login again to reset tooltip display counter. (Need this step to reset user defaults. Only applicable if you have already viewed the AI tooltip 3 times)

**Steps**
1. Install and login into the store. 
2. Navigate to the Products tab
3. Tap "+" button to create a product, and validate that you can see the tooltip below the "Write with AI" button
4. Open a product with an empty description, and validate that you can see the tooltip below the "Write with AI" button
5. Open a product with a non-empty description, and validate that you don't see a tooltip below the "Write with AI" button


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Add new product | Product description empty | Product description non-empty |
|--------|--------|--------|
| ![AddNewProduct](https://github.com/woocommerce/woocommerce-ios/assets/524475/18135345-d368-4e7d-80b9-3db7c33fcfc9) | ![EmptyDescription](https://github.com/woocommerce/woocommerce-ios/assets/524475/79762e3a-8577-4cc8-8df5-28555e5fd23e) | ![NonEmptyDescription](https://github.com/woocommerce/woocommerce-ios/assets/524475/bb8737da-cbd9-4ceb-af01-2b6c05eaca9f) |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.