### PR TITLE
[Performance] Add networking support to fetch orders modified after a given date

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -13,6 +13,8 @@ public class OrdersRemote: Remote {
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - before: If given, limit response to resources published before a given compliant date.. Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
+    ///     - modifiedAfter: If given, limit response to resources modified after a given compliant date. Passing a local date is fine. This
+    ///               method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of Orders to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
@@ -21,6 +23,7 @@ public class OrdersRemote: Remote {
                               statuses: [String]? = nil,
                               after: Date? = nil,
                               before: Date? = nil,
+                              modifiedAfter: Date? = nil,
                               pageNumber: Int = Defaults.pageNumber,
                               pageSize: Int = Defaults.pageSize,
                               completion: @escaping (Result<[Order], Error>) -> Void) {
@@ -40,6 +43,9 @@ public class OrdersRemote: Remote {
             }
             if let before = before {
                 parameters[ParameterKeys.before] = utcDateFormatter.string(from: before)
+            }
+            if let modifiedAfter {
+                parameters[ParameterKeys.modifiedAfter] = utcDateFormatter.string(from: modifiedAfter)
             }
 
             return parameters
@@ -360,6 +366,7 @@ public extension OrdersRemote {
         static let after: String            = "after"
         static let before: String           = "before"
         static let force: String            = "force"
+        static let modifiedAfter: String    = "modified_after"
     }
 
     enum ParameterValues {

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -90,6 +90,30 @@ final class OrdersRemoteTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(result).isFailure)
     }
 
+    func test_loadAllOrders_includes_modifiedAfter_parameter_when_provided() {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let modifiedAfter = Date()
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
+
+        // When
+        _ = waitFor { promise in
+            remote.loadAllOrders(for: self.sampleSiteID, modifiedAfter: modifiedAfter) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        guard let queryParameters = network.queryParameters else {
+            XCTFail("Cannot parse query from the API request")
+            return
+        }
+
+        let dateFormatter = DateFormatter.Defaults.iso8601
+        let expectedParam = "modified_after=\(dateFormatter.string(from: modifiedAfter))"
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
+    }
+
     // MARK: - Load Order Tests
 
     /// Verifies that loadOrder properly parses the `order` sample response.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10042
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When the Orders tab is opened, we want to make a request using the `modified_after` parameter with the last sync date as the value, to only fetch more recent orders.

This PR adds support for that in the Networking layer. It adds `modified_after` as an optional parameter when retrieving all orders from remote.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This parameter isn't yet used in the app, but you can open the Orders tab in the app (and optionally filter or pull to refresh) to confirm the order list loads as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
