### PR TITLE
[Performance] Add yosemite support to fetch orders modified after a given date

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -35,7 +35,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -60,7 +60,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -86,7 +86,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -110,7 +110,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -132,7 +132,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statuses, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -154,7 +154,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statuses, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -183,7 +183,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -23,12 +23,15 @@ public enum OrderAction: Action {
     ///               doesn't matter. It will be converted to UTC later.
     ///     - before: Only include orders created before this date. The time zone of the `Date`
     ///               doesn't matter. It will be converted to UTC later.
+    ///     - modifiedAfter: Only include orders modified after this date. The time zone of the `Date`
+    ///               doesn't matter. It will be converted to UTC later.
     ///
     case fetchFilteredOrders(
         siteID: Int64,
         statuses: [String]?,
         after: Date? = nil,
         before: Date? = nil,
+        modifiedAfter: Date? = nil,
         deleteAllBeforeSaving: Bool,
         pageSize: Int,
         onCompletion: (TimeInterval, Error?) -> Void
@@ -41,11 +44,14 @@ public enum OrderAction: Action {
     ///               doesn't matter. It will be converted to UTC later.
     ///     - before: Only include orders created before this date. The time zone of the `Date`
     ///               doesn't matter. It will be converted to UTC later.
+    ///     - modifiedAfter: Only include orders modified after this date. The time zone of the `Date`
+    ///               doesn't matter. It will be converted to UTC later.
     ///
     case synchronizeOrders(siteID: Int64,
                            statuses: [String]?,
                            after: Date? = nil,
                            before: Date? = nil,
+                           modifiedAfter: Date? = nil,
                            pageNumber: Int,
                            pageSize: Int,
                            onCompletion: (TimeInterval, Error?) -> Void)

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
@@ -10,7 +10,7 @@ struct MockOrderActionHandler: MockActionHandler {
 
     func handle(action: ActionType) {
         switch action {
-            case .fetchFilteredOrders(let siteID, _, _, _, _, _, let onCompletion):
+            case .fetchFilteredOrders(let siteID, _, _, _, _, _, _, let onCompletion):
                 fetchFilteredAndAllOrders(siteID: siteID, onCompletion: onCompletion)
             case .retrieveOrder(let siteID, let orderID, let onCompletion):
                 onCompletion(objectGraph.order(forSiteId: siteID, orderId: orderID), nil)

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -41,19 +41,21 @@ public class OrderStore: Store {
             retrieveOrder(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
         case .searchOrders(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
             searchOrders(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .fetchFilteredOrders(let siteID, let statuses, let after, let before, let deleteAllBeforeSaving, let pageSize, let onCompletion):
+        case let .fetchFilteredOrders(siteID, statuses, after, before, modifiedAfter, deleteAllBeforeSaving, pageSize, onCompletion):
             fetchFilteredOrders(siteID: siteID,
                                 statuses: statuses,
                                 after: after,
                                 before: before,
+                                modifiedAfter: modifiedAfter,
                                 deleteAllBeforeSaving: deleteAllBeforeSaving,
                                 pageSize: pageSize,
                                 onCompletion: onCompletion)
-        case .synchronizeOrders(let siteID, let statuses, let after, let before, let pageNumber, let pageSize, let onCompletion):
+        case let .synchronizeOrders(siteID, statuses, after, before, modifiedAfter, pageNumber, pageSize, onCompletion):
             synchronizeOrders(siteID: siteID,
                               statuses: statuses,
                               after: after,
                               before: before,
+                              modifiedAfter: modifiedAfter,
                               pageNumber: pageNumber,
                               pageSize: pageSize,
                               onCompletion: onCompletion)
@@ -128,16 +130,19 @@ private extension OrderStore {
     ///
     /// The orders will only be deleted if one of the executed `GET` requests succeed.
     ///
-    /// - Parameter statuses The statuses to use for the filtered list. If this is not provided,
+    /// - Parameters:
+    ///     - statuses: The statuses to use for the filtered list. If this is not provided,
     ///                       only the all orders list will be fetched. See `OrderStatusEnum`
     ///                       for possible values.
-    /// - Parameter after Limit response to resources published after a given ISO8601 compliant date.
-    /// - Parameter before Limit response to resources published before a given ISO8601 compliant date.
+    ///     - after: Limit response to resources published after a given ISO8601 compliant date.
+    ///     - before: Limit response to resources published before a given ISO8601 compliant date.
+    ///     - modifiedAfter: Limit response to resources modified after a given ISO8601 compliant date.
     ///
     func fetchFilteredOrders(siteID: Int64,
                              statuses: [String]?,
                              after: Date?,
                              before: Date?,
+                             modifiedAfter: Date?,
                              deleteAllBeforeSaving: Bool,
                              pageSize: Int,
                              onCompletion: @escaping (TimeInterval, Error?) -> Void) {
@@ -176,11 +181,12 @@ private extension OrderStore {
                 return
             }
             self.remote.loadAllOrders(for: siteID,
-                                         statuses: statuses,
-                                         after: after,
-                                         before: before,
-                                         pageNumber: pageNumber,
-                                         pageSize: pageSize) { [weak self] result in
+                                      statuses: statuses,
+                                      after: after,
+                                      before: before,
+                                      modifiedAfter: modifiedAfter,
+                                      pageNumber: pageNumber,
+                                      pageSize: pageSize) { [weak self] result in
                 guard let self = self else {
                     return
                 }
@@ -231,6 +237,7 @@ private extension OrderStore {
                            statuses: [String]?,
                            after: Date?,
                            before: Date?,
+                           modifiedAfter: Date?,
                            pageNumber: Int,
                            pageSize: Int,
                            onCompletion: @escaping (TimeInterval, Error?) -> Void) {
@@ -239,6 +246,7 @@ private extension OrderStore {
                              statuses: statuses,
                              after: after,
                              before: before,
+                             modifiedAfter: modifiedAfter,
                              pageNumber: pageNumber,
                              pageSize: pageSize) { [weak self] result in
             switch result {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10042
⚠️ Depends on #10058 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When the Orders tab is opened, we want to make a request using the `modified_after` parameter with the last sync date as the value, to only fetch more recent orders.

This PR adds support for that in the Yosemite layer. It adds a `modifiedAfter` parameter to the two order actions that load all orders from remote: `fetchFilteredOrders` and `synchronizeOrders`. The parameter is then passed to the remote request (added in #10058).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This parameter isn't yet used in the app, but you can open the Orders tab in the app (and optionally filter or pull to refresh) to confirm the order list loads as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
