### PR TITLE
[IAP] Add StoreKit test configuration and scheme

### DIFF
--- a/WooCommerce/Resources/WooCommerceTestSynced.storekit
+++ b/WooCommerce/Resources/WooCommerceTestSynced.storekit
@@ -1,0 +1,158 @@
+{
+  "identifier" : "423461F8",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+
+  ],
+  "settings" : {
+    "_applicationInternalID" : "1389130815",
+    "_compatibilityTimeRate" : 6,
+    "_developerTeamID" : "PZYM8XX95Q",
+    "_failTransactionsEnabled" : false,
+    "_lastSynchronizedDate" : 709118083.66037405,
+    "_storeKitError" : 0,
+    "_timeRate" : 13
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "21032762",
+      "localizations" : [
+
+      ],
+      "name" : "test_subscription_group",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "69.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "1650562345",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "1 Month of Debug Woo",
+              "displayName" : "Debug Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "debug.woocommerce.ecommerce.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Debug Monthly",
+          "subscriptionGroupID" : "21032762",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "39.0",
+          "familyShareable" : false,
+          "groupNumber" : 3,
+          "internalID" : "6449843250",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Monthly Essential Plan",
+              "displayName" : "Debug Essential Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "debug.woocommerce.express.essential.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Debug Woo Express Essential Monthly",
+          "subscriptionGroupID" : "21032762",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "300.0",
+          "familyShareable" : false,
+          "groupNumber" : 3,
+          "internalID" : "6449843588",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Yearly Essential Plan",
+              "displayName" : "Debug Essential Yearly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "debug.woocommerce.express.essential.yearly",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Debug Woo Express Essential Yearly",
+          "subscriptionGroupID" : "21032762",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "70.0",
+          "familyShareable" : false,
+          "groupNumber" : 2,
+          "internalID" : "6449843372",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Monthly Performance Plan",
+              "displayName" : "Debug Performance Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "debug.woocommerce.express.performance.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Debug Woo Express Performance Monthly",
+          "subscriptionGroupID" : "21032762",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "539.99",
+          "familyShareable" : false,
+          "groupNumber" : 2,
+          "internalID" : "6449843478",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Yearly Performance Plan",
+              "displayName" : "Debug Performance Yearly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "debug.woocommerce.express.performance.yearly",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Debug Woo Express Performance Yearly",
+          "subscriptionGroupID" : "21032762",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 2,
+    "minor" : 0
+  }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2938,6 +2938,7 @@
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift; sourceTree = "<group>"; };
 		03A6C18528B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingErrorButtonViewModel.swift; sourceTree = "<group>"; };
+		03A8DA352A4448750003D5CF /* WooCommerceTestSynced.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = WooCommerceTestSynced.storekit; sourceTree = "<group>"; };
 		03A9F3B12A03E70700385673 /* AdaptiveAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveAsyncImage.swift; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -8219,6 +8220,7 @@
 				3F587028281B9C19004F7556 /* InfoPlist.strings */,
 				B56DB3D82049BFAA00D4AA8E /* Info.plist */,
 				E1B0839A291BC5DD001D99C8 /* WooCommerceTest.storekit */,
+				03A8DA352A4448750003D5CF /* WooCommerceTestSynced.storekit */,
 				B56C721921B5F65E00E5E85B /* Woo-Debug.entitlements */,
 				03180BE72763AA9000B938A8 /* Woo-Debug-macOS.entitlements */,
 				B56C721A21B5F65E00E5E85B /* Woo-Release.entitlements */,

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce IAP.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce IAP.xcscheme
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+               BuildableName = "WooCommerce.app"
+               BlueprintName = "WooCommerce"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+            BuildableName = "WooCommerce.app"
+            BlueprintName = "WooCommerce"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:WooCommerceTests/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:WooCommerceUITests/UITests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B56DB3DC2049BFAA00D4AA8E"
+               BuildableName = "WooCommerceTests.xctest"
+               BlueprintName = "WooCommerceTests"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B557D9EB209753AA005962F4"
+               BuildableName = "NetworkingTests.xctest"
+               BlueprintName = "NetworkingTests"
+               ReferencedContainer = "container:../Networking/Networking.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B54CA5A120A4BBA600F38CD1"
+               BuildableName = "StorageTests.xctest"
+               BlueprintName = "StorageTests"
+               ReferencedContainer = "container:../Storage/Storage.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5C9DDFD2087FEC0006B910A"
+               BuildableName = "YosemiteTests.xctest"
+               BlueprintName = "YosemiteTests"
+               ReferencedContainer = "container:../Yosemite/Yosemite.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCDC49C923FFFFF4003166BA"
+               BuildableName = "WooCommerceUITests.xctest"
+               BlueprintName = "WooCommerceUITests"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+            BuildableName = "WooCommerce.app"
+            BlueprintName = "WooCommerce"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "mocked-network-layer"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-stripe-verbose-logging"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-simulate-stripe-card-reader"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-force-crash-logging 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "wpcom-api-base-url"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "iap-debug-site-id"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <StoreKitConfigurationFileReference
+         identifier = "../WooCommerce/Resources/WooCommerceTestSynced.storekit">
+      </StoreKitConfigurationFileReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+            BuildableName = "WooCommerce.app"
+            BlueprintName = "WooCommerce"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds an IAP testing scheme, to allow Xcode-based testing of In-App purchases, using a new synced configuration file which grabs our test subscriptions from App Store Connect.

Purchases using this option don't successfully allow a store to be upgraded, but using this approach is the only way to simulate errors from the IAP purchase.

See the [Apple docs for more information on using this](https://developer.apple.com/documentation/xcode/setting-up-storekit-testing-in-xcode#Change-settings-and-initiate-test-conditions)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
