### PR TITLE
[Orders with Coupons] Track coupons count on order creation

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -506,6 +506,7 @@ extension WooAnalyticsEvent {
             static let searchFilter = "search_filter"
             static let barcodeFormat = "barcode_format"
             static let reason = "reason"
+            static let couponsCount = "coupons_count"
         }
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
@@ -633,8 +634,8 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderCreationSuccess(millisecondsSinceSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
-            var properties: [String: WooAnalyticsEventPropertyType] = [:]
+        static func orderCreationSuccess(millisecondsSinceSinceOrderAddNew: Int64?, couponsCount: Int64) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [Keys.couponsCount: couponsCount]
 
             if let lapseSinceLastOrderAddNew = millisecondsSinceSinceOrderAddNew {
                 properties[GlobalKeys.millisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1134,7 +1134,8 @@ private extension EditableOrderViewModel {
     ///
     func trackCreateOrderSuccess() {
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationSuccess(millisecondsSinceSinceOrderAddNew:
-                                                                                try? orderDurationRecorder.millisecondsSinceOrderAddNew()))
+                                                                                try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
+                                                                             couponsCount: Int64(orderSynchronizer.order.coupons.count)))
     }
 
     /// Tracks an order creation failure


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Please review https://github.com/woocommerce/woocommerce-ios/pull/10043 before

Closes: #10061 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we track how many coupons are added to a successfully created order. As we only handle the addition of one coupon for now, that's the max that can be tracked.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Coupons added
1. Go to orders
2. Tap to create a new one
3. Add a product
4. Add a valid coupon
5. Tap on Create. `coupons_count` should be tracked:

`🔵 Tracked order_creation_success, properties: [AnyHashable("coupons_count"): 1, AnyHashable("blog_id"): 214354650, AnyHashable("milliseconds_since_order_add_new"): 25222, AnyHashable("is_wpcom_store"): true]`

### No coupons added
1. Go to orders
2. Tap to create a new one
3. Add a product
4. Don't add any coupon, or try to add a not-applicable one for the added products (it will be removed after giving an error in the order syncing phase)
5. Tap on Create. `coupons_count` should be tracked:

`🔵 Tracked order_creation_success, properties: [AnyHashable("coupons_count"): 0, AnyHashable("blog_id"): 214354650, AnyHashable("milliseconds_since_order_add_new"): 25222, AnyHashable("is_wpcom_store"): true]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
