### PR TITLE
[IAP] Pass StoreKit errors for display to user

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -187,7 +187,9 @@ final class UpgradesViewModel: ObservableObject {
             switch recognisedError {
             case .unverifiedTransaction,
                     .transactionProductUnknown,
-                    .inAppPurchasesNotSupported:
+                    .inAppPurchasesNotSupported,
+                    .inAppPurchaseProductPurchaseFailed,
+                    .inAppPurchaseStoreKitFailed:
                 upgradeViewState = .purchaseUpgradeError(.inAppPurchaseFailed(wooWPComPlan, recognisedError))
             case .transactionMissingAppAccountToken,
                     .appAccountTokenMissingSiteIdentifier,

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -123,7 +123,13 @@ private extension InAppPurchaseStore {
                 completion(.success(purchaseResult))
             } catch {
                 logError("Error purchasing product \(productID) for site \(siteID): \(error)")
-                completion(.failure(error))
+                if let purchaseError = error as? StoreKit.Product.PurchaseError {
+                    completion(.failure(Errors.inAppPurchaseProductPurchaseFailed(purchaseError)))
+                } else if let storeKitError = error as? StoreKitError {
+                    completion(.failure(Errors.inAppPurchaseStoreKitFailed(storeKitError)))
+                } else {
+                    completion(.failure(error))
+                }
             }
         }
     }
@@ -307,6 +313,10 @@ public extension InAppPurchaseStore {
         ///
         case inAppPurchasesNotSupported
 
+        case inAppPurchaseProductPurchaseFailed(StoreKit.Product.PurchaseError)
+
+        case inAppPurchaseStoreKitFailed(StoreKitError)
+
         public var errorDescription: String? {
             switch self {
             case .unverifiedTransaction:
@@ -333,6 +343,14 @@ public extension InAppPurchaseStore {
                 return NSLocalizedString(
                     "In-app purchases are not supported for this user yet",
                     comment: "Error message used when In-app purchases are not supported for this user/site")
+            case .inAppPurchaseProductPurchaseFailed(let purchaseError):
+                return NSLocalizedString(
+                    "The In-App Purchase failed, with product purchase error: \(purchaseError)",
+                    comment: "Error message used when a purchase failed")
+            case .inAppPurchaseStoreKitFailed(let storeKitError):
+                return NSLocalizedString(
+                    "The In-App Purchase failed, with StoreKit error: \(storeKitError)",
+                    comment: "Error message used when a purchase failed with a store kit error")
             }
         }
 
@@ -344,6 +362,44 @@ public extension InAppPurchaseStore {
                 return "iap.T.105"
             case .transactionProductUnknown:
                 return "iap.T.110"
+            case .inAppPurchaseProductPurchaseFailed(let purchaseError):
+                switch purchaseError {
+                case .invalidQuantity:
+                    return "iap.T.115.1"
+                case .productUnavailable:
+                    return "iap.T.115.2"
+                case .purchaseNotAllowed:
+                    return "iap.T.115.3"
+                case .ineligibleForOffer:
+                    return "iap.T.115.4"
+                case .invalidOfferIdentifier:
+                    return "iap.T.115.5"
+                case .invalidOfferPrice:
+                    return "iap.T.115.6"
+                case .invalidOfferSignature:
+                    return "iap.T.115.7"
+                case .missingOfferParameters:
+                    return "iap.T.115.8"
+                @unknown default:
+                    return "iap.T.115.0"
+                }
+            case .inAppPurchaseStoreKitFailed(let storeKitError):
+                switch storeKitError {
+                case .unknown:
+                    return "iap.T.120.1"
+                case .userCancelled:
+                    return "iap.T.120.2"
+                case .networkError(let networkError):
+                    return "iap.T.120.3.\(networkError.errorCode)"
+                case .systemError(_):
+                    return "iap.T.120.4"
+                case .notAvailableInStorefront:
+                    return "iap.T.120.5"
+                case .notEntitled:
+                    return "iap.T.120.6"
+                @unknown default:
+                    return "iap.T.120.0"
+                }
             case .transactionMissingAppAccountToken:
                 return "iap.A.100"
             case .appAccountTokenMissingSiteIdentifier:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9886 (should be merged after #10062)
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have added the ability to purchase plans using IAP. When this fails after the IAP, we show errors which can only really be resolved by talking to support.

This PR surfaces StoreKit and IAP errors to the UpgradesViewModel, and displays the `inAppPurchaseFailed` error screen with the correct error code when they are received.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Select the `WooCommerce IAP` scheme in Xcode, and build the app.
2. Open the `WooCommerceTestSynced` file in Xcode, and set an error using `Editor (menu) > Fail transactions > {Any error}`
3. In the app, elect a Woo express store with a free trial active
4. Tap `Upgrade now`
5. Wait for the load to finish
6. Tap `Purchase Debug Essential Monthly`
7. Subscribe to the plan (observe that it's in `[Environment: Xcode]`)
8. Observe that the In-App Purchase error screen shows, and includes the error code.
9. Change it to no error in the Editor menu
10. Tap retry
11. Observe that another error shows – this is because the API does not recognise test IAP transactions, and they can't be used to purchase a plan.

## Screenshots


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
