### PR TITLE
[IAP] Fix pluralisation of days left

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -22,7 +22,7 @@ final class SubscriptionsViewModel: ObservableObject {
 
     /// Current store plan details information.
     ///
-    private(set) var planDaysLeft = ""
+    private(set) var planDaysLeft: Int?
 
     /// Defines if the view should show the Full Plan features.
     ///
@@ -136,7 +136,7 @@ private extension SubscriptionsViewModel {
     func updateViewProperties(from plan: WPComSitePlan) {
         planName = getPlanName(from: plan)
         planInfo = getPlanInfo(from: plan)
-        planDaysLeft = daysLeft(for: plan).formatted()
+        planDaysLeft = daysLeft(for: plan)
         errorNotice = nil
         showLoadingIndicator = false
         shouldShowFreeTrialFeatures = plan.isFreeTrial

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -679,10 +679,15 @@ private extension WooWPComPlan {
 
 private struct CurrentPlanDetailsView: View {
     @State var planName: String
-    @State var daysLeft: String
+    @State var daysLeft: Int?
 
     private var daysLeftText: String {
-        String.localizedStringWithFormat(Localization.daysLeftValue, daysLeft)
+        guard let daysLeft else {
+            return ""
+        }
+        return String.pluralize(daysLeft,
+                                singular: Localization.daysLeftValueSingular,
+                                plural: Localization.daysLeftValuePlural)
     }
 
     var body: some View {
@@ -716,8 +721,13 @@ private struct CurrentPlanDetailsView: View {
             "Days left in plan", comment: "Label for the text describing days left on a Plan to expire." +
             "Reads as 'Days left in plan: 15 days left'")
 
-        static let daysLeftValue = NSLocalizedString(
-            "%1$@ days left", comment: "Value describing the days left on a plan before expiry. Reads as '15 days left'")
+        static let daysLeftValuePlural = NSLocalizedString(
+            "%1ld days left", comment: "Value describing the days left on a plan before expiry (plural). " +
+            "%1ld must be included in the translation, and will be replaced with the count. Reads as '15 days left'")
+
+        static let daysLeftValueSingular = NSLocalizedString(
+            "%1$ld day left", comment: "Value describing the days left on a plan before expiry (singular). " +
+            "%1ld must be included in the translation, and will be replaced with the count. Reads as '1 day left'")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've added the ability to purchase a Woo Express plan using In-App purchases, if you have a free trial. The Upgrades screen shows the time left for the free trial, before you upgrade.

We previously showed `1 days left` without pluralising correctly for the singular case, this PR corrects that issue.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Set a breakpoint in Proxyman on `https://public-api.wordpress.com/rest/v1.3/sites/*/plans`
2. Open the app, and switch to a Woo Express store with a free trial (it's critical that you switch stores for this to work, so if you're already on the correct test store, switch to another then switch back.)
3. When the breakpoint is triggered, edit the response. Find the plan with `current_plan: true`, and change the `expiry` date to one day in the future
4. Tap upgrade now
5. Observe that the banner at the top of the screen shows `1 day left`

Repeat for plural days, and observe that the plural string is shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![0 days left](https://github.com/woocommerce/woocommerce-ios/assets/2472348/857588dd-a3d5-413c-b679-e3b905d6d17b)
![1 day left](https://github.com/woocommerce/woocommerce-ios/assets/2472348/b7cfb0ef-1d9d-4701-8d1b-31775430f513)
![9 days left](https://github.com/woocommerce/woocommerce-ios/assets/2472348/df0d72fd-4cbf-48c4-9083-d0fa975d2d98)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
