### PR TITLE
Product description AI Tooltip: Fix overlay issue

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -71,9 +71,9 @@ private extension DefaultProductFormTableViewModel {
                                                                                       isEditable: editable,
                                                                                       isDescriptionAIEnabled: isDescriptionAIEnabled)
                 guard isDescriptionAIEnabled else {
-                    return [descriptionRow]
+                    return [descriptionRow, .separator]
                 }
-                return [descriptionRow, .descriptionAI, .learnMoreAboutAI]
+                return [descriptionRow, .descriptionAI, .learnMoreAboutAI, .separator]
             default:
                 fatalError("Unexpected action in the primary section: \(action)")
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -38,6 +38,8 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
             return [ButtonTableViewCell.self]
         case .learnMoreAboutAI:
             return [TextViewTableViewCell.self]
+        case .separator:
+            return [WooBasicTableViewCell.self]
         }
     }
 
@@ -61,6 +63,8 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
             return ButtonTableViewCell.self
         case .learnMoreAboutAI:
             return TextViewTableViewCell.self
+        case .separator:
+            return WooBasicTableViewCell.self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -39,7 +39,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
         case .learnMoreAboutAI:
             return [TextViewTableViewCell.self]
         case .separator:
-            return [WooBasicTableViewCell.self]
+            return [SpacerTableViewCell.self]
         }
     }
 
@@ -64,7 +64,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
         case .learnMoreAboutAI:
             return TextViewTableViewCell.self
         case .separator:
-            return WooBasicTableViewCell.self
+            return SpacerTableViewCell.self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -395,7 +395,7 @@ private extension ProductFormTableViewDataSource {
     enum Constants {
         static let legalURL = URL(string: "https://automattic.com/ai-guidelines/")!
         static let learnMoreTextHeight: CGFloat = 16
-        static let learnMoreTextInsets: UIEdgeInsets = .init(top: 4, left: 0, bottom: 8, right: 0)
+        static let learnMoreTextInsets: UIEdgeInsets = .init(top: 4, left: 0, bottom: 4, right: 0)
         static let settingsHeaderHeight = CGFloat(16)
     }
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -279,7 +279,7 @@ private extension ProductFormTableViewDataSource {
 
     func configureSeparator(cell: UITableViewCell) {
         guard let cell = cell as? WooBasicTableViewCell else {
-            fatalError("Unexpected table view cell for the AI legal cell")
+            fatalError("Unexpected table view cell for the separator cell")
         }
         cell.selectionStyle = .none
         cell.bodyLabel.text = ""

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -101,6 +101,8 @@ private extension ProductFormTableViewDataSource {
             configureDescriptionAI(cell: cell)
         case .learnMoreAboutAI:
             configureLearnMoreAI(cell: cell)
+        case .separator:
+            configureSeparator(cell: cell)
         }
     }
     func configureImages(cell: UITableViewCell, isEditable: Bool, allowsMultipleImages: Bool, isVariation: Bool) {
@@ -275,6 +277,15 @@ private extension ProductFormTableViewDataSource {
         cell.hideSeparator()
     }
 
+    func configureSeparator(cell: UITableViewCell) {
+        guard let cell = cell as? WooBasicTableViewCell else {
+            fatalError("Unexpected table view cell for the AI legal cell")
+        }
+        cell.selectionStyle = .none
+        cell.bodyLabel.text = ""
+        cell.backgroundColor = .listBackground
+    }
+
     func configureLinkedProductsPromo(cell: UITableViewCell, viewModel: FeatureAnnouncementCardViewModel) {
         guard let cell = cell as? FeatureAnnouncementCardCell else {
             fatalError()
@@ -383,7 +394,7 @@ private extension ProductFormTableViewDataSource {
     enum Constants {
         static let legalURL = URL(string: "https://automattic.com/ai-guidelines/")!
         static let learnMoreTextHeight: CGFloat = 16
-        static let learnMoreTextInsets: UIEdgeInsets = .init(top: 4, left: 0, bottom: -8, right: 0)
+        static let learnMoreTextInsets: UIEdgeInsets = .init(top: 4, left: 0, bottom: 8, right: 0)
     }
     enum Localization {
         static let legalText = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -278,12 +278,13 @@ private extension ProductFormTableViewDataSource {
     }
 
     func configureSeparator(cell: UITableViewCell) {
-        guard let cell = cell as? WooBasicTableViewCell else {
+        guard let cell = cell as? SpacerTableViewCell else {
             fatalError("Unexpected table view cell for the separator cell")
         }
         cell.selectionStyle = .none
-        cell.bodyLabel.text = ""
         cell.backgroundColor = .listBackground
+        cell.showSeparator()
+        cell.configure(height: Constants.settingsHeaderHeight)
     }
 
     func configureLinkedProductsPromo(cell: UITableViewCell, viewModel: FeatureAnnouncementCardViewModel) {
@@ -395,6 +396,7 @@ private extension ProductFormTableViewDataSource {
         static let legalURL = URL(string: "https://automattic.com/ai-guidelines/")!
         static let learnMoreTextHeight: CGFloat = 16
         static let learnMoreTextInsets: UIEdgeInsets = .init(top: 4, left: 0, bottom: 8, right: 0)
+        static let settingsHeaderHeight = CGFloat(16)
     }
     enum Localization {
         static let legalText = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -274,6 +274,7 @@ private extension ProductFormTableViewDataSource {
             self?.openAILegalPageAction?(url)
         }))
         cell.selectionStyle = .none
+        cell.hideSeparator()
     }
 
     func configureSeparator(cell: UITableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -274,7 +274,6 @@ private extension ProductFormTableViewDataSource {
             self?.openAILegalPageAction?(url)
         }))
         cell.selectionStyle = .none
-        cell.hideSeparator()
     }
 
     func configureSeparator(cell: UITableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -22,6 +22,7 @@ enum ProductFormSection: Equatable {
         case description(description: String?, isEditable: Bool, isDescriptionAIEnabled: Bool)
         case descriptionAI
         case learnMoreAboutAI
+        case separator
     }
 
     enum SettingsRow: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1894,7 +1894,3 @@ private enum ActionSheetStrings {
     static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Options Action Sheet")
     static let duplicate = NSLocalizedString("Duplicate", comment: "Button title to duplicate a product in Product More Options Action Sheet")
 }
-
-private enum Constants {
-    static let settingsHeaderHeight = CGFloat(16)
-}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -510,29 +510,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     @objc private func shareProduct() {
         displayShareProduct(from: shareBarButtonItem, analyticSource: .productForm)
     }
-
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let section = tableViewModel.sections[section]
-        switch section {
-        case .settings:
-            return Constants.settingsHeaderHeight
-        default:
-            return 0
-        }
-    }
-
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let section = tableViewModel.sections[section]
-        switch section {
-        case .settings:
-            let clearView = UIView(frame: .zero)
-            clearView.backgroundColor = .listBackground
-
-            return clearView
-        default:
-            return nil
-        }
-    }
 }
 
 // MARK: - Configuration


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9975 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR attempts to fix issue with the table header view overlaying the tooltip on the product form. Since the table view's behavior is always stick the header view on top when scrolled down, it's best to get rid of it and use a custom cell for the separator instead. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a public WPCom site.
- Open a published product or create one without description.
- Notice the tooltip for product description AI is displayed. Rotate the screen and scroll the table view down, the tooltip should still be in the correct position with no overlay.
- Log in to a self-hosted site and open an existing product. There should still be a separator between the two sections in the product form.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/a8e604df-69f0-49c1-b248-08265eb471dc



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
