### PR TITLE
[IAP] Handle local authentication device identity

### DIFF
--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -93,6 +93,8 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Parental control check for In-App Purchases</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds an additional check for the user identity in order to verify whether they can proceed with In-App Purchases by using local biometry, passcode, or other available forms of device identify verification. This is mainly set for security, and parental control.

TODO:
- [ ] On physical device, we seem to trigger the loading state after we've authenticated identity, but before the we've actually entered the Apple ID credentials (if needed), which could be confusing UX-wise.
- [ ] Test and handle errors/failures to verify and provide correct UX-feedback.
- [ ] Confirm device permissions for local authentication work as expected, not only the first time we access them.

## Testing instructions

The flow and behaviour is different in simulator vs physical device, as well as based on the scheme we use (WooCommerce IAP vs WooCommerce) since there's some caveats to take into account:
- The simulator can handle Face ID by simulating it via Features > Face ID > Matching Face
- If the physical device doesn't support this biometry, will use others (like the device's passcode)
- Passing this check in the WooCommerce IAP scheme will process the purchase but fail to complete the process (since we can't trigger the WPCOM purchase)

* In `WooCommerce IAP` scheme (simulator or physical device): 
  * On a Free Trial store > Tap Upgrade Now > Tap Purchase > See biometry or passcode verification check* > See Apple ID subscription confirmation purchase > See loading screen > See error screen
  * If you're on a simulator, once the Face ID verification appears this can be granted under Features > Face ID > Matching Face
* In `WooCommerce` scheme, on a physical device: 
  * On a Free Trial store > Tap Upgrade Now > Tap Purchase > See biometry or passcode verification check, this will depend on your local device > See Apple ID subscription confirmation purchase > See loading screen > See success screen.

| Simulate Face ID in Xcode | In Simulator |
|--------|--------|
| <img width="600" alt="Screenshot 2023-06-23 at 12 26 29" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/6369804c-279a-405d-ab1f-b3a364efb531"> | ![Simulator Screen Recording - iPhone 11 Pro - 2023-06-23 at 14 28 20](https://github.com/woocommerce/woocommerce-ios/assets/3812076/875250ed-4741-4e5b-ad74-63cffb514047) | 

| Biometrics permissions | Simulated Face ID | Apple ID request |
|--------|--------|--------|
| <img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/7bb62ffa-a43d-4b0e-b46a-5659f665e5af"> | <img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/e34a544d-9543-41e4-ab12-0d66619afcae"> | <img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/1ec97e14-5b9d-47cb-acb9-6c26d2b38746"> | 

