### PR TITLE
[IAP] Show error when IAP transaction already used

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -193,7 +193,8 @@ final class UpgradesViewModel: ObservableObject {
                 upgradeViewState = .purchaseUpgradeError(.inAppPurchaseFailed(wooWPComPlan, recognisedError))
             case .transactionMissingAppAccountToken,
                     .appAccountTokenMissingSiteIdentifier,
-                    .storefrontUnknown:
+                    .storefrontUnknown,
+                    .transactionAlreadyAssociatedWithAnUpgrade:
                 upgradeViewState = .purchaseUpgradeError(.planActivationFailed(recognisedError))
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10075
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Initially, our IAP plan purchases only support upgrading a single site. Upgrading multiple sites is prevented by checking whether the merchant has already got an active entitlement to an In-App Purchase, and showing the Maximum sites upgraded error at the start of the Upgrade flow if they have.

Unfortunately, if the MobilePay server and Apple are out of sync, it's possible to make an In-App Purchase to upgrade a second site which will succeed with Apple (i.e. taking the merchants money), fail with MobilePay, but be announced as success in the app. The IAP Transaction will be marked as finished, (i.e. we're telling Apple that we've furnished the merchant with the upgrade they paid for) and the site will remain on the trial. We won't ever show the merchant an error.

We do get a 422 error in this situation, but previously, we ignored it.

422 errors are common in our implementation, as we get lots of renewal transactions which we have to handle on app start up – when we send these to the API, MobilePay already knows about them because of the server to server notifications from the App Store Connect API, so sends us a 422. We mark the transaction as finished and ignore the error, which is correct for renewals.

Unfortunately, we can't distinguish (using the transaction) between these renewals, and new purchases, because the `reasonStringRepresentation` property which Apple documents... doesn't seem to exist. Perhaps we can use the new `reason` property once iOS 17 reaches wider adoption.

### Mitigation
In this commit, we reduce the impact of this issue by surfacing any 422 errors that happen during the `purchaseProduct` flow, as opposed to being passed to the app on the transactions queue, at start up etc. We’ve still taken the merchants money without upgrading their site, but at least we are telling them that there’s an issue and that they need to contact support.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Using a sandbox App Store account, and a Woo Express free trial store,
2. Launch the app, and tap Upgrade Now
3. Upgrade the site and wait until the IAP expires (usually 1hr for sandbox users)
4. Edit the WC order in the backing store, change the status from `cancelled` to `completed`.
5. Launch the app and make a new free trial store
6. Upgrade the new store with IAP – observe that you can complete the payment
7. Observe that the `Error Activating Plan` screen is shown, saying that they should contact support.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/5f37156c-112a-4924-b834-03f115099805



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
