### PR TITLE
[IAP] Track events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2445,15 +2445,6 @@ extension WooAnalyticsEvent {
             case completed
         }
 
-        enum FeatureGroup: String {
-            case general
-            case payments
-            case productManagement = "product_management"
-            case themes
-            case marketing
-            case shipping
-        }
-
         enum InAppPurchasesError: String {
             case fetchError
             case entitlementsError
@@ -2480,9 +2471,9 @@ extension WooAnalyticsEvent {
                               properties: [Keys.step.rawValue: step.rawValue])
         }
 
-        static func planUpgradeFeatureScreenLoaded(featureGroup: FeatureGroup) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .planUpgradeScreenLoaded,
-                              properties: [Keys.featureGroup.rawValue: featureGroup.rawValue])
+        static func planUpgradeFeatureScreenLoaded(featureGroup: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeFeatureScreenLoaded,
+                              properties: [Keys.featureGroup.rawValue: featureGroup])
         }
 
         static func planUpgradePurchaseFailed(error: InAppPurchasesError) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2442,7 +2442,7 @@ extension WooAnalyticsEvent {
             case planDetails = "plan_details"
             case prePurchaseError = "pre_purchase_error"
             case purchaseUpgradeError = "purchase_upgrade_error"
-            case completed = "completed"
+            case completed
         }
 
         enum FeatureGroup: String {
@@ -2466,7 +2466,8 @@ extension WooAnalyticsEvent {
         }
 
         static func planUpgradePurchaseButtonTapped(_ productID: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .planUpgradePurchaseButtonTapped, properties: [Keys.productID.rawValue: productID])
+            WooAnalyticsEvent(statName: .planUpgradePurchaseButtonTapped,
+                              properties: [Keys.productID.rawValue: productID])
         }
 
         static func planUpgradeScreenLoaded(source: Source) -> WooAnalyticsEvent {
@@ -2485,9 +2486,9 @@ extension WooAnalyticsEvent {
         }
 
         static func planUpgradePurchaseFailed(error: InAppPurchasesError) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .planUpgradePurchaseFailed, properties: [Keys.error.rawValue: error.rawValue])
+            WooAnalyticsEvent(statName: .planUpgradePurchaseFailed,
+                              properties: [Keys.error.rawValue: error.rawValue])
         }
-
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2430,19 +2430,29 @@ extension WooAnalyticsEvent {
             case productID = "product_ID"
             case source
             case step
+            case featureGroup = "feature_group"
         }
 
         enum Source: String {
             case banner
         }
-        
+
         enum Step: String {
             case planDetails = "plan_details"
             case prePurchaseError = "pre_purchase_error"
             case purchaseUpgradeError = "purchase_upgrade_error"
             case completed = "completed"
         }
-        
+
+        enum FeatureGroup: String {
+            case general
+            case payments
+            case productManagement = "product_management"
+            case themes
+            case marketing
+            case shipping
+        }
+
         static func planUpgradePurchaseButtonTapped(_ productID: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradePurchaseButtonTapped, properties: [Keys.productID.rawValue: productID])
         }
@@ -2451,11 +2461,17 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradeScreenLoaded,
                               properties: [Keys.source.rawValue: source.rawValue])
         }
-        
+
         static func planUpgradeScreenDismissed(step: Step) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradeScreenDismissed,
                               properties: [Keys.step.rawValue: step.rawValue])
         }
+
+        static func planUpgradeFeatureScreenLoaded(featureGroup: FeatureGroup) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeScreenLoaded,
+                              properties: [Keys.featureGroup.rawValue: featureGroup.rawValue])
+        }
+
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2442,6 +2442,7 @@ extension WooAnalyticsEvent {
             case planDetails = "plan_details"
             case prePurchaseError = "pre_purchase_error"
             case purchaseUpgradeError = "purchase_upgrade_error"
+            case waiting
             case completed
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2442,7 +2442,7 @@ extension WooAnalyticsEvent {
             case planDetails = "plan_details"
             case prePurchaseError = "pre_purchase_error"
             case purchaseUpgradeError = "purchase_upgrade_error"
-            case waiting
+            case processing
             case completed
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2446,17 +2446,6 @@ extension WooAnalyticsEvent {
             case completed
         }
 
-        enum InAppPurchasesError: String {
-            case fetchError
-            case entitlementsError
-            case inAppPurchasesNotSupported
-            case maximumSitesUpgraded
-            case userNotAllowedToUpgrade
-            case inAppPurchaseFailed
-            case planActivationFailed
-            case unknown
-        }
-
         static func planUpgradePurchaseButtonTapped(_ productID: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradePurchaseButtonTapped,
                               properties: [Keys.productID.rawValue: productID])
@@ -2477,13 +2466,13 @@ extension WooAnalyticsEvent {
                               properties: [Keys.featureGroup.rawValue: featureGroup])
         }
 
-        static func planUpgradePrePurchaseFailed(error: PrePurchaseError) -> WooAnalyticsEvent {
+        static func planUpgradePrePurchaseFailed(error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradePurchaseFailed,
                               properties: [Keys.error.rawValue: error.localizedDescription],
                               error: error)
         }
 
-        static func planUpgradePurchaseFailed(error: PurchaseUpgradeError) -> WooAnalyticsEvent {
+        static func planUpgradePurchaseFailed(error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradePurchaseFailed,
                               properties: [Keys.error.rawValue: error.localizedDescription],
                               error: error)

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2429,10 +2429,18 @@ extension WooAnalyticsEvent {
         enum Keys: String {
             case productID = "product_ID"
             case source
+            case step
         }
 
         enum Source: String {
             case banner
+        }
+        
+        enum Step: String {
+            case planDetails = "plan_details"
+            case prePurchaseError = "pre_purchase_error"
+            case purchaseUpgradeError = "purchase_upgrade_error"
+            case completed = "completed"
         }
         
         static func planUpgradePurchaseButtonTapped(_ productID: String) -> WooAnalyticsEvent {
@@ -2442,6 +2450,11 @@ extension WooAnalyticsEvent {
         static func planUpgradeScreenLoaded(source: Source) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradeScreenLoaded,
                               properties: [Keys.source.rawValue: source.rawValue])
+        }
+        
+        static func planUpgradeScreenDismissed(step: Step) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeScreenDismissed,
+                              properties: [Keys.step.rawValue: step.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2431,6 +2431,7 @@ extension WooAnalyticsEvent {
             case source
             case step
             case featureGroup = "feature_group"
+            case error
         }
 
         enum Source: String {
@@ -2452,6 +2453,17 @@ extension WooAnalyticsEvent {
             case marketing
             case shipping
         }
+        
+        enum InAppPurchasesError: String {
+            case fetchError
+            case entitlementsError
+            case inAppPurchasesNotSupported
+            case maximumSitesUpgraded
+            case userNotAllowedToUpgrade
+            case inAppPurchaseFailed
+            case planActivationFailed
+            case unknown
+        }
 
         static func planUpgradePurchaseButtonTapped(_ productID: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradePurchaseButtonTapped, properties: [Keys.productID.rawValue: productID])
@@ -2470,6 +2482,10 @@ extension WooAnalyticsEvent {
         static func planUpgradeFeatureScreenLoaded(featureGroup: FeatureGroup) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradeScreenLoaded,
                               properties: [Keys.featureGroup.rawValue: featureGroup.rawValue])
+        }
+
+        static func planUpgradePurchaseFailed(error: InAppPurchasesError) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradePurchaseFailed, properties: [Keys.error.rawValue: error.rawValue])
         }
 
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2477,9 +2477,16 @@ extension WooAnalyticsEvent {
                               properties: [Keys.featureGroup.rawValue: featureGroup])
         }
 
-        static func planUpgradePurchaseFailed(error: InAppPurchasesError) -> WooAnalyticsEvent {
+        static func planUpgradePrePurchaseFailed(error: PrePurchaseError) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradePurchaseFailed,
-                              properties: [Keys.error.rawValue: error.rawValue])
+                              properties: [Keys.error.rawValue: error.localizedDescription],
+                              error: error)
+        }
+
+        static func planUpgradePurchaseFailed(error: PurchaseUpgradeError) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradePurchaseFailed,
+                              properties: [Keys.error.rawValue: error.localizedDescription],
+                              error: error)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2423,6 +2423,29 @@ extension WooAnalyticsEvent {
     }
 }
 
+// MARK: - In-App Purchases
+extension WooAnalyticsEvent {
+    enum InAppPurchases {
+        enum Keys: String {
+            case productID = "product_ID"
+            case source
+        }
+
+        enum Source: String {
+            case banner
+        }
+        
+        static func planUpgradePurchaseButtonTapped(_ productID: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradePurchaseButtonTapped, properties: [Keys.productID.rawValue: productID])
+        }
+
+        static func planUpgradeScreenLoaded(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeScreenLoaded,
+                              properties: [Keys.source.rawValue: source.rawValue])
+        }
+    }
+}
+
 // MARK: - EU Shipping Notice Banner
 //
 extension WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2453,7 +2453,7 @@ extension WooAnalyticsEvent {
             case marketing
             case shipping
         }
-        
+
         enum InAppPurchasesError: String {
             case fetchError
             case entitlementsError

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -944,6 +944,9 @@ public enum WooAnalyticsStat: String {
     case planUpgradeProcessingScreenLoaded = "plan_upgrade_processing_screen_loaded"
     case planUpgradeProcessingScreenDismissed = "plan_upgrade_processing_screen_dismissed"
     case planUpgradeCompletedScreenLoaded = "plan_upgrade_completed_screen_loaded"
+    case planUpgradePurchaseFailed = "plan_upgrade_purchase_failed"
+
+
     // MARK: Application password authorization in web view
     case applicationPasswordAuthorizationButtonTapped = "application_password_authorization_button_tapped"
     case applicationPasswordAuthorizationWebViewShown = "application_password_authorization_web_view_shown"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -942,7 +942,6 @@ public enum WooAnalyticsStat: String {
     case planUpgradeScreenDismissed = "plan_upgrade_screen_dismissed"
     case planUpgradeFeatureScreenLoaded = "plan_upgrade_feature_screen_loaded"
     case planUpgradeProcessingScreenLoaded = "plan_upgrade_processing_screen_loaded"
-    case planUpgradeProcessingScreenDismissed = "plan_upgrade_processing_screen_dismissed"
     case planUpgradeCompletedScreenLoaded = "plan_upgrade_completed_screen_loaded"
     case planUpgradePurchaseFailed = "plan_upgrade_purchase_failed"
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -936,6 +936,9 @@ public enum WooAnalyticsStat: String {
     case planUpgradeSuccess = "plan_upgrade_success"
     case planUpgradeAbandoned = "plan_upgrade_abandoned"
 
+    // MARK: In-App Purchases
+    case planUpgradePurchaseButtonTapped = "plan_upgrade_purchase_button_tapped"
+    case planUpgradeScreenLoaded = "plan_upgrade_screen_loaded"
     // MARK: Application password authorization in web view
     case applicationPasswordAuthorizationButtonTapped = "application_password_authorization_button_tapped"
     case applicationPasswordAuthorizationWebViewShown = "application_password_authorization_web_view_shown"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -941,6 +941,9 @@ public enum WooAnalyticsStat: String {
     case planUpgradeScreenLoaded = "plan_upgrade_screen_loaded"
     case planUpgradeScreenDismissed = "plan_upgrade_screen_dismissed"
     case planUpgradeFeatureScreenLoaded = "plan_upgrade_feature_screen_loaded"
+    case planUpgradeProcessingScreenLoaded = "plan_upgrade_processing_screen_loaded"
+    case planUpgradeProcessingScreenDismissed = "plan_upgrade_processing_screen_dismissed"
+    case planUpgradeCompletedScreenLoaded = "plan_upgrade_completed_screen_loaded"
     // MARK: Application password authorization in web view
     case applicationPasswordAuthorizationButtonTapped = "application_password_authorization_button_tapped"
     case applicationPasswordAuthorizationWebViewShown = "application_password_authorization_web_view_shown"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -939,6 +939,7 @@ public enum WooAnalyticsStat: String {
     // MARK: In-App Purchases
     case planUpgradePurchaseButtonTapped = "plan_upgrade_purchase_button_tapped"
     case planUpgradeScreenLoaded = "plan_upgrade_screen_loaded"
+    case planUpgradeScreenDismissed = "plan_upgrade_screen_dismissed"
     // MARK: Application password authorization in web view
     case applicationPasswordAuthorizationButtonTapped = "application_password_authorization_button_tapped"
     case applicationPasswordAuthorizationWebViewShown = "application_password_authorization_web_view_shown"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -940,6 +940,7 @@ public enum WooAnalyticsStat: String {
     case planUpgradePurchaseButtonTapped = "plan_upgrade_purchase_button_tapped"
     case planUpgradeScreenLoaded = "plan_upgrade_screen_loaded"
     case planUpgradeScreenDismissed = "plan_upgrade_screen_dismissed"
+    case planUpgradeFeatureScreenLoaded = "plan_upgrade_feature_screen_loaded"
     // MARK: Application password authorization in web view
     case applicationPasswordAuthorizationButtonTapped = "application_password_authorization_button_tapped"
     case applicationPasswordAuthorizationWebViewShown = "application_password_authorization_web_view_shown"

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -290,6 +290,10 @@ extension UpgradesViewModel {
     func trackDismiss(step: WooAnalyticsEvent.InAppPurchases.Step) {
         analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: step))
     }
+    
+    func track(_ stat: WooAnalyticsStat) {
+        analytics.track(stat)
+    }
 }
 
 extension UpgradesViewModel {

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -295,7 +295,7 @@ private extension UpgradeViewState {
         case .loaded:
             return .planDetails
         case .waiting:
-            return .waiting
+            return .processing
         case .completed:
             return .completed
         case .prePurchaseError:

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -101,6 +101,8 @@ final class UpgradesViewModel: ObservableObject {
                 self?.analytics.track(.planUpgradeProcessingScreenLoaded)
             case .loaded:
                 self?.analytics.track(.planUpgradeScreenLoaded)
+            case .completed:
+                self?.analytics.track(.planUpgradeCompletedScreenLoaded)
             case .prePurchaseError(let error):
                 self?.analytics.track(event: .InAppPurchases.planUpgradePrePurchaseFailed(error: error))
             case .purchaseUpgradeError(let error):
@@ -210,7 +212,6 @@ final class UpgradesViewModel: ObservableObject {
                 upgradeViewState = .loaded(wooWPComPlan)
             case .success(.verified(_)):
                 upgradeViewState = .completed(wooWPComPlan)
-                analytics.track(.planUpgradeCompletedScreenLoaded)
             default:
                 // TODO: handle `pending` here... somehow – requires research
                 // TODO: handle `.success(.unverified(_))` here... somehow

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -148,6 +148,7 @@ final class UpgradesViewModel: ObservableObject {
         }
 
         upgradeViewState = .purchasing(wooWPComPlan)
+        ServiceLocator.analytics.track(.planUpgradeScreenLoaded)
 
         observeInAppPurchaseDrawerDismissal { [weak self] in
             /// The drawer gets dismissed when the IAP is cancelled too. That gets dealt with in the `do-catch`
@@ -170,8 +171,10 @@ final class UpgradesViewModel: ObservableObject {
             switch result {
             case .userCancelled:
                 upgradeViewState = .loaded(wooWPComPlan)
+                ServiceLocator.analytics.track(.planUpgradeProcessingScreenDismissed)
             case .success(.verified(_)):
                 upgradeViewState = .completed(wooWPComPlan)
+                ServiceLocator.analytics.track(.planUpgradeCompletedScreenLoaded)
             default:
                 // TODO: handle `pending` here... somehow – requires research
                 // TODO: handle `.success(.unverified(_))` here... somehow

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -50,7 +50,7 @@ final class UpgradesViewModel: ObservableObject {
 
     private let localPlans: [WooPlan]
 
-    let analytics: Analytics
+    private let analytics: Analytics
 
     init(siteID: Int64,
          inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager(),
@@ -283,6 +283,12 @@ private extension UpgradesViewModel {
             upgradeViewState = .prePurchaseError(.entitlementsError)
             analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .entitlementsError))
         }
+    }
+}
+
+extension UpgradesViewModel {
+    func trackDismiss(step: WooAnalyticsEvent.InAppPurchases.Step) {
+        analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: step))
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -50,7 +50,7 @@ final class UpgradesViewModel: ObservableObject {
 
     private let localPlans: [WooPlan]
 
-    private let analytics: Analytics
+    let analytics: Analytics
 
     init(siteID: Int64,
          inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager(),

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -290,7 +290,7 @@ extension UpgradesViewModel {
     func trackDismiss(step: WooAnalyticsEvent.InAppPurchases.Step) {
         analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: step))
     }
-    
+
     func track(_ stat: WooAnalyticsStat) {
         analytics.track(stat)
     }

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -34,6 +34,17 @@ enum PurchaseUpgradeError: Error {
     case inAppPurchaseFailed(WooWPComPlan, InAppPurchaseStore.Errors)
     case planActivationFailed(InAppPurchaseStore.Errors)
     case unknown
+
+    var analyticErrorDetail: Error {
+        switch self {
+        case .inAppPurchaseFailed(_, let error):
+            return error
+        case .planActivationFailed(let error):
+            return error
+        default:
+            return self
+        }
+    }
 }
 
 /// ViewModel for the Upgrades View
@@ -91,7 +102,7 @@ final class UpgradesViewModel: ObservableObject {
             case .prePurchaseError(let error):
                 self?.analytics.track(event: .InAppPurchases.planUpgradePrePurchaseFailed(error: error))
             case .purchaseUpgradeError(let error):
-                self?.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: error))
+                self?.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: error.analyticErrorDetail))
             default:
                 break
             }

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -67,6 +67,7 @@ final class UpgradesViewModel: ObservableObject {
 
         if let site = ServiceLocator.stores.sessionManager.defaultSite, !site.isSiteOwner {
             self.upgradeViewState = .prePurchaseError(.userNotAllowedToUpgrade)
+            ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .userNotAllowedToUpgrade))
         } else {
             Task {
                 await fetchViewData()
@@ -96,6 +97,7 @@ final class UpgradesViewModel: ObservableObject {
         do {
             guard await inAppPurchasesPlanManager.inAppPurchasesAreSupported() else {
                 upgradeViewState = .prePurchaseError(.inAppPurchasesNotSupported)
+                ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .inAppPurchasesNotSupported))
                 return
             }
 
@@ -105,6 +107,7 @@ final class UpgradesViewModel: ObservableObject {
             try await loadUserEntitlements(for: wpcomPlans)
             guard entitledWpcomPlanIDs.isEmpty else {
                 upgradeViewState = .prePurchaseError(.maximumSitesUpgraded)
+                ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .maximumSitesUpgraded))
                 return
             }
 
@@ -113,12 +116,14 @@ final class UpgradesViewModel: ObservableObject {
                                                                       hardcodedPlanDataIsValid: hardcodedPlanDataIsValid)
             else {
                 upgradeViewState = .prePurchaseError(.fetchError)
+                ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .fetchError))
                 return
             }
             upgradeViewState = .loaded(plan)
         } catch {
             DDLogError("fetchPlans \(error)")
             upgradeViewState = .prePurchaseError(.fetchError)
+            ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .fetchError))
         }
     }
 
@@ -185,6 +190,7 @@ final class UpgradesViewModel: ObservableObject {
             stopObservingInAppPurchaseDrawerDismissal()
             guard let recognisedError = error as? InAppPurchaseStore.Errors else {
                 upgradeViewState = .purchaseUpgradeError(.unknown)
+                ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .unknown))
                 return
             }
 
@@ -271,6 +277,7 @@ private extension UpgradesViewModel {
         } catch {
             DDLogError("loadEntitlements \(error)")
             upgradeViewState = .prePurchaseError(.entitlementsError)
+            ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: .entitlementsError))
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -99,6 +99,8 @@ final class UpgradesViewModel: ObservableObject {
             switch state {
             case .waiting:
                 self?.analytics.track(.planUpgradeProcessingScreenLoaded)
+            case .loaded:
+                self?.analytics.track(.planUpgradeScreenLoaded)
             case .prePurchaseError(let error):
                 self?.analytics.track(event: .InAppPurchases.planUpgradePrePurchaseFailed(error: error))
             case .purchaseUpgradeError(let error):
@@ -152,7 +154,6 @@ final class UpgradesViewModel: ObservableObject {
                 return
             }
             upgradeViewState = .loaded(plan)
-            analytics.track(.planUpgradeScreenLoaded)
         } catch {
             DDLogError("fetchPlans \(error)")
             upgradeViewState = .prePurchaseError(.fetchError)

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -142,6 +142,7 @@ final class UpgradesViewModel: ObservableObject {
     ///
     @MainActor
     func purchasePlan(with planID: String) async {
+        ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradePurchaseButtonTapped(planID))
         guard let wooWPComPlan = planCanBePurchasedFromCurrentState() else {
             return
         }

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -180,7 +180,6 @@ final class UpgradesViewModel: ObservableObject {
             switch result {
             case .userCancelled:
                 upgradeViewState = .loaded(wooWPComPlan)
-                analytics.track(.planUpgradeProcessingScreenDismissed)
             case .success(.verified(_)):
                 upgradeViewState = .completed(wooWPComPlan)
                 analytics.track(.planUpgradeCompletedScreenLoaded)
@@ -262,6 +261,32 @@ final class UpgradesViewModel: ObservableObject {
                             wooPlan: wooPlan,
                             hardcodedPlanDataIsValid: hardcodedPlanDataIsValid)
     }
+
+    func onDisappear() {
+        guard let stepTracked = upgradeViewState.analyticsStep else {
+            return
+        }
+        analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: stepTracked))
+    }
+}
+
+private extension UpgradeViewState {
+    var analyticsStep: WooAnalyticsEvent.InAppPurchases.Step? {
+        switch self {
+        case .loading, .purchasing:
+            return nil
+        case .loaded:
+            return .planDetails
+        case .waiting:
+            return .waiting
+        case .completed:
+            return .completed
+        case .prePurchaseError:
+            return .prePurchaseError
+        case .purchaseUpgradeError:
+            return .purchaseUpgradeError
+        }
+    }
 }
 
 private extension UpgradesViewModel {
@@ -287,10 +312,6 @@ private extension UpgradesViewModel {
 }
 
 extension UpgradesViewModel {
-    func trackDismiss(step: WooAnalyticsEvent.InAppPurchases.Step) {
-        analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: step))
-    }
-
     func track(_ stat: WooAnalyticsStat) {
         analytics.track(stat)
     }

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -124,6 +124,7 @@ final class UpgradesViewModel: ObservableObject {
                 return
             }
             upgradeViewState = .loaded(plan)
+            analytics.track(.planUpgradeScreenLoaded)
         } catch {
             DDLogError("fetchPlans \(error)")
             upgradeViewState = .prePurchaseError(.fetchError)
@@ -157,7 +158,6 @@ final class UpgradesViewModel: ObservableObject {
         }
 
         upgradeViewState = .purchasing(wooWPComPlan)
-        analytics.track(.planUpgradeScreenLoaded)
 
         observeInAppPurchaseDrawerDismissal { [weak self] in
             /// The drawer gets dismissed when the IAP is cancelled too. That gets dealt with in the `do-catch`

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -109,9 +109,6 @@ struct UpgradesView: View {
                 }
             }
             .navigationBarHidden(true)
-            .onAppear {
-                upgradesViewModel.analytics.track(event: WooAnalyticsEvent.InAppPurchases.planUpgradeScreenLoaded(source: .banner))
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -69,9 +69,7 @@ struct UpgradesView: View {
                 case .purchasing(let plan):
                     OwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
                 case .waiting(let plan):
-                    UpgradeWaitingView(planName: plan.wooPlan.shortName, onViewLoaded: {
-                        upgradesViewModel.track(.planUpgradeProcessingScreenLoaded)
-                    })
+                    UpgradeWaitingView(planName: plan.wooPlan.shortName)
                 case .completed(let plan):
                     CompletedUpgradeView(planName: plan.wooPlan.shortName,
                                          doneAction: {
@@ -443,7 +441,6 @@ private extension PurchaseUpgradeError {
 
 struct UpgradeWaitingView: View {
     let planName: String
-    var onViewLoaded: (() -> Void)
 
     var body: some View {
         VStack {
@@ -462,9 +459,6 @@ struct UpgradeWaitingView: View {
             .padding(.vertical, Layout.verticalPadding)
 
             Spacer()
-        }
-        .onAppear {
-            onViewLoaded()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -108,6 +108,9 @@ struct UpgradesView: View {
                 }
             }
             .navigationBarHidden(true)
+            .onAppear {
+                ServiceLocator.analytics.track(event: WooAnalyticsEvent.InAppPurchases.planUpgradeScreenLoaded(source: .banner))
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -30,7 +30,7 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
 }
 
 struct UpgradesView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
 
     @ObservedObject var upgradesViewModel: UpgradesViewModel
     @ObservedObject var subscriptionsViewModel: SubscriptionsViewModel
@@ -49,7 +49,7 @@ struct UpgradesView: View {
                 VStack {
                     // TODO: Once we remove iOS 15 support, we can do this with .toolbar instead.
                     UpgradeTopBarView(dismiss: {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                     })
 
                     CurrentPlanDetailsView(planName: subscriptionsViewModel.planName,
@@ -79,7 +79,7 @@ struct UpgradesView: View {
                 case .completed(let plan):
                     CompletedUpgradeView(planName: plan.wooPlan.shortName,
                                          doneAction: {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                         upgradesViewModel.trackDismiss(step: .completed)
                     })
                 case .prePurchaseError(let error):
@@ -102,7 +102,7 @@ struct UpgradesView: View {
                             await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
                         }
                     } secondaryAction: {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                         upgradesViewModel.trackDismiss(step: .purchaseUpgradeError)
                     } getSupportAction: {
                         supportHandler()
@@ -112,7 +112,7 @@ struct UpgradesView: View {
                     PurchaseUpgradeErrorView(error: underlyingError,
                                              primaryAction: nil,
                                              secondaryAction: {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                         upgradesViewModel.trackDismiss(step: .purchaseUpgradeError)
                     },
                                              getSupportAction: supportHandler)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -595,7 +595,7 @@ struct OwnerUpgradesView: View {
     @State var isPurchasing = false
     let purchasePlanAction: () -> Void
     @State var isLoading: Bool = false
-    
+
     var onDismiss: (() -> Void)?
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -69,7 +69,11 @@ struct UpgradesView: View {
                 case .purchasing(let plan):
                     OwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
                 case .waiting(let plan):
-                    UpgradeWaitingView(planName: plan.wooPlan.shortName)
+                    UpgradeWaitingView(planName: plan.wooPlan.shortName, onViewLoaded: {
+                        upgradesViewModel.track(.planUpgradeProcessingScreenLoaded)
+                    }, onViewDismissed: {
+                        upgradesViewModel.track(.planUpgradeProcessingScreenDismissed)
+                    })
                 case .completed(let plan):
                     CompletedUpgradeView(planName: plan.wooPlan.shortName,
                                          doneAction: {
@@ -452,6 +456,8 @@ private extension PurchaseUpgradeError {
 
 struct UpgradeWaitingView: View {
     let planName: String
+    var onViewLoaded: (() -> Void)
+    var onViewDismissed: (() -> Void)
 
     var body: some View {
         VStack {
@@ -470,6 +476,12 @@ struct UpgradeWaitingView: View {
             .padding(.vertical, Layout.verticalPadding)
 
             Spacer()
+        }
+        .onAppear {
+            onViewLoaded()
+        }
+        .onDisappear {
+            onViewDismissed()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -49,6 +49,7 @@ struct UpgradesView: View {
                 VStack {
                     // TODO: Once we remove iOS 15 support, we can do this with .toolbar instead.
                     UpgradeTopBarView(dismiss: {
+                        ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: .planDetails))
                         presentationMode.wrappedValue.dismiss()
                     })
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -65,6 +65,8 @@ struct UpgradesView: View {
                         Task {
                             await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
                         }
+                    }, onDismiss: {
+                        upgradesViewModel.trackDismiss(step: .planDetails)
                     })
                 case .purchasing(let plan):
                     OwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
@@ -593,6 +595,8 @@ struct OwnerUpgradesView: View {
     @State var isPurchasing = false
     let purchasePlanAction: () -> Void
     @State var isLoading: Bool = false
+    
+    var onDismiss: (() -> Void)?
 
     var body: some View {
         VStack {
@@ -656,6 +660,9 @@ struct OwnerUpgradesView: View {
                 .shimmering(active: isLoading)
             }
             .padding()
+        }
+        .onDisappear {
+            onDismiss?()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -49,7 +49,7 @@ struct UpgradesView: View {
                 VStack {
                     // TODO: Once we remove iOS 15 support, we can do this with .toolbar instead.
                     UpgradeTopBarView(dismiss: {
-                        ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: .planDetails))
+                        upgradesViewModel.analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: .planDetails))
                         presentationMode.wrappedValue.dismiss()
                     })
 
@@ -110,7 +110,7 @@ struct UpgradesView: View {
             }
             .navigationBarHidden(true)
             .onAppear {
-                ServiceLocator.analytics.track(event: WooAnalyticsEvent.InAppPurchases.planUpgradeScreenLoaded(source: .banner))
+                upgradesViewModel.analytics.track(event: WooAnalyticsEvent.InAppPurchases.planUpgradeScreenLoaded(source: .banner))
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
@@ -36,7 +36,8 @@ struct WooPlanFeatureBenefitsView: View {
         .navigationTitle(wooPlanFeatureGroup.title)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradeFeatureScreenLoaded(featureGroup: .general))
+            ServiceLocator.analytics.track(event:
+                    .InAppPurchases.planUpgradeFeatureScreenLoaded(featureGroup: wooPlanFeatureGroup.title))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
@@ -35,6 +35,9 @@ struct WooPlanFeatureBenefitsView: View {
         }
         .navigationTitle(wooPlanFeatureGroup.title)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            ServiceLocator.analytics.track(event: .InAppPurchases.planUpgradeFeatureScreenLoaded(featureGroup: .general))
+        }
     }
 
     private enum Layout {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10023 . Ref: pdfdoF-3d1-p2

## Description

This PR adds track events for In-App Purchases related events. Unit Tests will be added on a different PR.

## Changes
* Added the following `WooAnalyticsStats` and `WooAnalyticsEvents`:
  * `plan_upgrade_purchase_button_tapped`
  * `plan_upgrade_screen_loaded`
  * `plan_upgrade_screen_dismissed`
  * `plan_upgrade_feature_screen_loaded`
  * `plan_upgrade_processing_screen_loaded`
  * `plan_upgrade_processing_screen_dismissed`
  * `plan_upgrade_completed_screen_loaded`
  * `plan_upgrade_purchase_failed`
  * `planUpgradePurchaseButtonTapped(productID: String)`
  * `planUpgradeScreenLoaded(source: Source)`
  * `planUpgradeScreenDismissed(step: Step)`
  * `planUpgradeFeatureScreenLoaded(featureGroup: String)`
  * `planUpgradePurchaseFailed(error: InAppPurchasesError)`

## Testing instructions:
#### Unhappy path:

When running the app and attempting the unhappy path, for example a purchase via the WooCommerce IAP scheme, we'll go through the following flow and track the following events:

1. Tap on "Upgrade Now", see tracked event when the screen effectively loads the plan information: 🔵 Tracked plan_upgrade_screen_loaded

```
2023-06-26 11:04:37.984820+0700 WooCommerce[89036:73989858] 🔵 Tracked plan_upgrade_screen_loaded, properties: [AnyHashable("blog_id"): 220379441, AnyHashable("is_wpcom_store"): true]`
```

2. Dismiss the screen:  🔵 Tracked plan_upgrade_screen_dismissed - Step: plan_details

```
2023-06-26 14:56:26.632233+0700 WooCommerce[6629:3154589] 🔵 Tracked plan_upgrade_screen_dismissed, properties: [AnyHashable("blog_id"): 220579378, AnyHashable("is_wpcom_store"): true, AnyHashable("step"): "plan_details"]
```

3. Tap again and scroll and tap on any of the plan properties: 🔵 Tracked plan_upgrade_feature_screen_loaded, with specific feature_group:

```
2023-06-26 14:43:12.727861+0700 WooCommerce[94405:74084810] 🔵 Tracked plan_upgrade_feature_screen_loaded, properties: [AnyHashable("feature_group"): "General features", AnyHashable("blog_id"): 220579378, AnyHashable("is_wpcom_store"): true]
```

4. Tap "Purchase Debug Essential Monthly": 🔵 Tracked plan_upgrade_purchase_button_tapped, with product_ID = debug.woocommerce.express.essential.monthly

```
2023-06-26 09:47:27.383473+0700 WooCommerce[84628:73924741] 🔵 Tracked plan_upgrade_purchase_button_tapped, properties: [AnyHashable("blog_id"): 220379441, AnyHashable("is_wpcom_store"): true, AnyHashable("product_ID"): "debug.woocommerce.express.essential.monthly"]
```

5. When the processing screen starts loading: 🔵 Tracked plan_upgrade_processing_screen_loaded

```
2023-06-26 14:30:59.365559+0700 WooCommerce[93484:74076645] 🔵 Tracked plan_upgrade_processing_screen_loaded, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 220379441]
```

6. When the purchase process fails: 🔵 Tracked plan_upgrade_purchase_failed, with a specific error (or unknown if that's the case)

```
2023-06-26 14:31:03.801571+0700 WooCommerce[93484:74076645] 🔵 Tracked plan_upgrade_purchase_failed, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 220379441, AnyHashable("error"): "unknown"]
```

7. When the error screen is dismissed: 🔵 Tracked plan_upgrade_processing_screen_dismissed

```
2023-06-26 14:31:03.821092+0700 WooCommerce[93484:74076646] 🔵 Tracked plan_upgrade_processing_screen_dismissed, properties: [AnyHashable("blog_id"): 220379441, AnyHashable("is_wpcom_store"): true]
```

8. We dismiss the purchase screen: 🔵 Tracked plan_upgrade_screen_dismissed

```
2023-06-26 14:33:00.211026+0700 WooCommerce[93484:74077749] 🔵 Tracked plan_upgrade_screen_dismissed, properties: [AnyHashable("step"): "purchase_upgrade_error", AnyHashable("blog_id"): 220379441, AnyHashable("is_wpcom_store"): true]
```

#### Happy path:

If we attempt the purchase via the physical simulator on the WooCommerce scheme, we will see the additional tracks:

1. When the completed screen is shown: 🔵 Tracked plan_upgrade_completed_screen_loaded

```
2023-06-26 14:59:16.031235+0700 WooCommerce[6629:3157076] 🔵 Tracked plan_upgrade_completed_screen_loaded, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 220579378]
```

2. When we tap in "Done": 🔵 Tracked plan_upgrade_screen_dismissed - step: Completed

```
2023-06-26 14:59:36.326650+0700 WooCommerce[6629:3157220] 🔵 Tracked plan_upgrade_screen_dismissed, properties: [AnyHashable("blog_id"): 220579378, AnyHashable("is_wpcom_store"): true, AnyHashable("step"): "completed"]
```