### PR TITLE
Requirement checker: Use web view purchase for the expired wpcom alert

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -643,13 +643,12 @@ private extension StorePickerViewController {
     func displayExpiredWPComPlanAlert(siteID: Int64) {
         UIAlertController.presentExpiredWPComPlanAlert(from: self) { [weak self] in
             guard let self else { return }
-            if self.featureFlagService.isFeatureFlagEnabled(.freeTrialInAppPurchasesUpgradeM1) {
-                let upgradesController = UpgradesHostingController(siteID: siteID)
-                self.topmostPresentedViewController.present(upgradesController, animated: true)
-            } else {
-                let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .expiredWPComPlanAlert)
-                self.topmostPresentedViewController.present(controller, animated: true)
-            }
+            /// Since we cannot tell if the site is eligible for upgrading with IAP,
+            /// it's safer to navigate to the plans page just in case the site is not suitable
+            /// for upgrading WooExpress plans (e.g: expired Business plan).
+            /// Please place IAP here if we have a solution to check the case.
+            let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .expiredWPComPlanAlert)
+            self.topmostPresentedViewController.present(controller, animated: true)
         }
     }
 }

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -128,13 +128,12 @@ private extension RequirementsChecker {
         }
         UIAlertController.presentExpiredWPComPlanAlert(from: baseViewController) { [weak self] in
             guard let self else { return }
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.freeTrialInAppPurchasesUpgradeM1) {
-                let upgradesController = UpgradesHostingController(siteID: siteID)
-                self.baseViewController?.present(upgradesController, animated: true)
-            } else {
-                let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .expiredWPComPlanAlert)
-                self.baseViewController?.present(controller, animated: true)
-            }
+            /// Since we cannot tell if the site is eligible for upgrading with IAP,
+            /// it's safer to navigate to the plans page just in case the site is not suitable
+            /// for upgrading WooExpress plans (e.g: expired Business plan).
+            /// Please place IAP here if we have a solution to check the case.
+            let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .expiredWPComPlanAlert)
+            self.baseViewController?.present(controller, animated: true)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Follow-up of #10033 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In #10059 I introduced an update to `RequirementsChecker` to show an alert with a CTA to upgrade to a plan when a site is reverted back to a simple site. As confirmed by payments team in [p1687521082456599-slack-C025A8VV728], we don't yet have a solution to check if a site is eligible for IAP as IAP is current supported upgrading Woo Express plans only. Our alert can still be displayed for sites with expired Business or WooCommerce plans, so showing the IAP flow to them would not be appropriate.

This PR updates the handling for the upgrade CTA of the alert by showing navigating to the web view purchase screen only, to make sure that we present the appropriate plans for users.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Since an Atomic site is still accessible 7 days after its plan's expiration, it's not straightforward to test this case. Make sure that you have tested Woo Express free trial in the past and have at least one site whose plan expired at least 7 days ago.
- With Autoproxxy on, open Store Admin and enter your username.
- You should see a list of sites that you own. Scroll down to the bottom and look for an expired Woo Express site:
<img width="1087" alt="ảnh" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/beee3a7d-7827-43da-96c0-c7bc153ab946">
- Copy the site ID and paste it in `SiteAPIRemote`'s `loadAPIInformation` line 20:

https://github.com/woocommerce/woocommerce-ios/blob/3cddc1f1355c9dbeab530dfdea610f966583af94/Networking/Networking/Remote/SiteAPIRemote.swift#L20

And in `loadSiteCurrentPlan` of `PaymentRemote`: 

https://github.com/woocommerce/woocommerce-ios/blob/3cddc1f1355c9dbeab530dfdea610f966583af94/Networking/Networking/Remote/PaymentRemote.swift#L57

And in `UpgradePlanCoordinatingController`:

https://github.com/woocommerce/woocommerce-ios/blob/08e7db0d9369d1331299fd2bfde288e0b0a00914/WooCommerce/Classes/ViewRelated/Upgrades/UpgradePlanCoordinatingController.swift#L87

- Build and run the app. You should see an alert saying the site plan is expired. Tapping on Upgrade should navigate to the the web view purchase screen.
- Feel free to test again with a site with an expired Business/WooCommerce plan. You should see that the web view purchase page show plans appropriate to that site, not the WooExpress plans.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Expired Free Trial | Expired Business plan |
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/28d543ae-a43c-44f2-b92b-b6710fb546a2" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/f625dd40-1941-47cc-ae0b-177860ef298c" width=320 /> |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.