### PR TITLE
Tooltip - Fix autolayout warnings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -88,6 +88,7 @@ final class TooltipPresenter {
     }
 
     func showTooltip() {
+        tooltip.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(tooltip)
         self.tooltip.alpha = 0
         tooltip.addArrowHead(toXPosition: arrowOffsetX(), arrowPosition: tooltipOrientation())
@@ -146,8 +147,6 @@ final class TooltipPresenter {
     }
 
     private func setUpTooltipConstraints() {
-        tooltip.translatesAutoresizingMaskIntoConstraints = false
-
         var tooltipConstraints = [
             tooltip.centerXAnchor.constraint(equalTo: containerView.centerXAnchor, constant: extraArrowOffsetX())
         ]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9975
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Sets `translatesAutoresizingMaskIntoConstraints` as false before adding tooltip as subview to remove autolayout warnings. 

## Testing instructions
Prerequisites
1. A store hosted on WPCOM
1. Logout of the app and login again to reset tooltip display counter. (Need this step to reset user defaults. Only applicable if you have already viewed the AI tooltip 3 times)

**Steps**
1. Install and login into the store. 
2. Navigate to the Products tab
3. Open a product with an empty product description
4. Validate that you can see the tooltip below the "Write with AI" button
5. Check the Xcode logs and validate that there are no autolayout warnings

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/79762e3a-8577-4cc8-8df5-28555e5fd23e" width="320"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
