### PR TITLE
[IPP UK Expansion] Remove Feature Flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -77,8 +77,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .compositeProducts:
             return true
-        case .IPPUKExpansion:
-            return true
         case .readOnlySubscriptions:
             return true
         case .productDescriptionAI:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -168,10 +168,6 @@ public enum FeatureFlag: Int {
     ///
     case compositeProducts
 
-    /// Enables UK-based stores taking In-Person Payments
-    ///
-    case IPPUKExpansion
-
     /// Enables read-only support for the Subscriptions extension in product and order details
     ///
     case readOnlySubscriptions

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -1,23 +1,16 @@
 import Foundation
-import Experiments
 import Yosemite
 
 final class CardPresentConfigurationLoader {
-    let shouldReturnConfigurationForGB: Bool
-
-    init(stores: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(stores: StoresManager = ServiceLocator.stores) {
         // This initializer is kept since this is where we'd check for
         // feature flags while developing support for a new country
         // See https://github.com/woocommerce/woocommerce-ios/pull/6954
-
-        shouldReturnConfigurationForGB = featureFlagService.isFeatureFlagEnabled(.IPPUKExpansion)
     }
 
     var configuration: CardPresentPaymentsConfiguration {
         .init(
-            country: SiteAddress().countryCode,
-            shouldReturnConfigurationForGB: shouldReturnConfigurationForGB
+            country: SiteAddress().countryCode
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -17,7 +17,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isFreeTrial: Bool
     private let jetpackSetupWithApplicationPassword: Bool
     private let isTapToPayOnIPhoneMilestone2On: Bool
-    private let isIPPUKExpansionEnabled: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
     private let isProductDescriptionAIEnabled: Bool
     private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
@@ -42,7 +41,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isFreeTrial: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          isTapToPayOnIPhoneMilestone2On: Bool = false,
-         isIPPUKExpansionEnabled: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
          isProductDescriptionAIEnabled: Bool = false,
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
@@ -66,7 +64,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isFreeTrial = isFreeTrial
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isTapToPayOnIPhoneMilestone2On = isTapToPayOnIPhoneMilestone2On
-        self.isIPPUKExpansionEnabled = isIPPUKExpansionEnabled
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
         self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
@@ -109,8 +106,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return jetpackSetupWithApplicationPassword
         case .tapToPayOnIPhoneMilestone2:
             return isTapToPayOnIPhoneMilestone2On
-        case .IPPUKExpansion:
-            return isIPPUKExpansionEnabled
         case .readOnlySubscriptions:
             return isReadOnlySubscriptionsEnabled
         case .productDescriptionAI:

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -67,30 +67,16 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         XCTAssertFalse(configuration.isSupportedCountry)
     }
 
-    func test_configuration_for_UK_when_enabled_returns_supported() {
+    func test_configuration_for_UK() {
         // Given
         setupCountry(country: .gb)
 
         // When
-        let featureFlagService = MockFeatureFlagService(isIPPUKExpansionEnabled: true)
-        let loader = CardPresentConfigurationLoader(stores: stores, featureFlagService: featureFlagService)
+        let loader = CardPresentConfigurationLoader(stores: stores)
         let configuration = loader.configuration
 
         // Then
         XCTAssertTrue(configuration.isSupportedCountry)
-    }
-
-    func test_configuration_for_UK_when_disabled_returns_not_supported() {
-        // Given
-        setupCountry(country: .gb)
-
-        // When
-        let featureFlagService = MockFeatureFlagService(isIPPUKExpansionEnabled: false)
-        let loader = CardPresentConfigurationLoader(stores: stores, featureFlagService: featureFlagService)
-        let configuration = loader.configuration
-
-        // Then
-        XCTAssertFalse(configuration.isSupportedCountry)
     }
 }
 

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -29,7 +29,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
         self.stripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
     }
 
-    public init(country: String, shouldReturnConfigurationForGB: Bool = false) {
+    public init(country: String) {
         /// Changing `minimumVersion` values here? You'll need to also update `CardPresentPaymentsOnboardingUseCaseTests`
         switch country {
         case "US":
@@ -57,7 +57,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
-        case "GB" where shouldReturnConfigurationForGB:
+        case "GB":
             self.init(
                 countryCode: country,
                 paymentMethods: [.cardPresent],


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Now that the IPP UK Expansion feature is been out for a while, we can remove the feature flag with confidence. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Switch to a UK-based store.

1. Go then to Menu.
2. Tap on Payments.
3. Tap on Collect Payment
4. Follow the Simple Payment Flow.
5. Select Card Reader as Payment Method
6. Ensure that the payment is collected successfully.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
