### PR TITLE
[SKU Scanner]Add SKU to error messages.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 14.3
 -----
-
+- [*] SKU Scanner: Add the SKU to the error message after a failure. [https://github.com/woocommerce/woocommerce-ios/pull/10085]
 
 14.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1393,7 +1393,9 @@ extension EditableOrderViewModel {
             return Notice(title: Localization.errorMessageOrderCreation, feedbackType: .error)
         }
 
-        static func createProductNotFoundAfterSKUScanningErrorNotice(for error: Error, code: ScannedBarcode, withRetryAction action: @escaping () -> Void) -> Notice {
+        static func createProductNotFoundAfterSKUScanningErrorNotice(for error: Error,
+                                                                     code: ScannedBarcode,
+                                                                     withRetryAction action: @escaping () -> Void) -> Notice {
             BarcodeSKUScannerErrorNoticeFactory.notice(for: error, code: code, actionHandler: action)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1346,7 +1346,9 @@ extension EditableOrderViewModel {
             case let .failure(error):
                 Task { @MainActor in
                     onCompletion(.failure(ScannerError.productNotFound))
-                    self.autodismissableNotice = NoticeFactory.createProductNotFoundAfterSKUScanningErrorNotice(for: error, withRetryAction: { [weak self] in
+                    self.autodismissableNotice = NoticeFactory.createProductNotFoundAfterSKUScanningErrorNotice(for: error,
+                                                                                                                code: barcode,
+                                                                                                                withRetryAction: { [weak self] in
                         self?.autodismissableNotice = nil
                         onRetryRequested()
                     })
@@ -1391,8 +1393,8 @@ extension EditableOrderViewModel {
             return Notice(title: Localization.errorMessageOrderCreation, feedbackType: .error)
         }
 
-        static func createProductNotFoundAfterSKUScanningErrorNotice(for error: Error, withRetryAction action: @escaping () -> Void) -> Notice {
-            BarcodeSKUScannerErrorNoticeFactory.notice(for: error, actionHandler: action)
+        static func createProductNotFoundAfterSKUScanningErrorNotice(for error: Error, code: ScannedBarcode, withRetryAction action: @escaping () -> Void) -> Notice {
+            BarcodeSKUScannerErrorNoticeFactory.notice(for: error, code: code, actionHandler: action)
         }
 
         /// Returns an order sync error notice.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -224,7 +224,7 @@ final class OrdersRootViewController: UIViewController {
                                                                                     addedVia: .scanning))
                     self.presentOrderCreationFlowWithScannedProduct(product)
                 case let .failure(error):
-                    self.displayScannedProductErrorNotice(error)
+                    self.displayScannedProductErrorNotice(error, code: scannedBarcode)
                 }
             }
         }, onPermissionsDenied: { [weak self] in
@@ -252,8 +252,8 @@ final class OrdersRootViewController: UIViewController {
 
     /// Presents an Error notice
     ///
-    private func displayScannedProductErrorNotice(_ error: Error) {
-        let notice = BarcodeSKUScannerErrorNoticeFactory.notice(for: error) { [weak self] in
+    private func displayScannedProductErrorNotice(_ error: Error, code: ScannedBarcode) {
+        let notice = BarcodeSKUScannerErrorNoticeFactory.notice(for: error, code: code) { [weak self] in
             self?.presentOrderCreationFlowByProductScanning()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactory.swift
@@ -5,22 +5,23 @@ import Yosemite
 /// 
 struct BarcodeSKUScannerErrorNoticeFactory {
     static func notice(for error: Error, code: ScannedBarcode, actionHandler: @escaping ((() -> Void))) -> Notice {
-        Notice(title: noticeTitle(for: error, code: code),
+        Notice(title: Localization.defaultTitle,
+               message: noticeMessage(for: error, code: code),
                feedbackType: .error,
                actionTitle: Localization.retryActionTitle,
                actionHandler: actionHandler)
     }
 
-    private static func noticeTitle(for error: Error, code: ScannedBarcode) -> String {
+    private static func noticeMessage(for error: Error, code: ScannedBarcode) -> String {
         guard let productLoadError = error as? ProductLoadError else {
             return Localization.defaultTitle
         }
 
         switch productLoadError {
         case .notFound:
-            return String(format: Localization.productNotFoundTitle, code.payloadStringValue)
+            return String(format: Localization.productNotFoundMessage, code.payloadStringValue)
         case .notPurchasable:
-            return String(format: Localization.productNotPurchasableTitle, code.payloadStringValue)
+            return String(format: Localization.productNotPurchasableMessage, code.payloadStringValue)
         default:
             return Localization.defaultTitle
         }
@@ -31,9 +32,9 @@ private extension BarcodeSKUScannerErrorNoticeFactory {
     enum Localization {
         static let defaultTitle = NSLocalizedString("Cannot add Product to Order.",
                                                     comment: "Generic error when a product can't be added to an order after being scanned.")
-        static let productNotFoundTitle = NSLocalizedString("Product with SKU \"%@\" not found.",
+        static let productNotFoundMessage = NSLocalizedString("Product with SKU \"%@\" not found.",
                                                             comment: "Error message when the scanner cannot find a matching product. %@ is the SKU code.")
-        static let productNotPurchasableTitle = NSLocalizedString("Product with SKU \"%@\" is not purchasable.",
+        static let productNotPurchasableMessage = NSLocalizedString("Product with SKU \"%@\" is not purchasable.",
                                                                   comment: "Error message when the scanner found a product but isn't purchasable." +
                                                                   "%@ is the SKU code.")
         static let retryActionTitle = NSLocalizedString("Retry",

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactory.swift
@@ -4,23 +4,23 @@ import Yosemite
 /// Provides the relevant notice given an error after the SKU scanned fails to provide an order item
 /// 
 struct BarcodeSKUScannerErrorNoticeFactory {
-    static func notice(for error: Error, actionHandler: @escaping ((() -> Void))) -> Notice {
-        Notice(title: noticeTitle(for: error),
+    static func notice(for error: Error, code: ScannedBarcode, actionHandler: @escaping ((() -> Void))) -> Notice {
+        Notice(title: noticeTitle(for: error, code: code),
                feedbackType: .error,
                actionTitle: Localization.retryActionTitle,
                actionHandler: actionHandler)
     }
 
-    private static func noticeTitle(for error: Error) -> String {
+    private static func noticeTitle(for error: Error, code: ScannedBarcode) -> String {
         guard let productLoadError = error as? ProductLoadError else {
             return Localization.defaultTitle
         }
 
         switch productLoadError {
         case .notFound:
-            return Localization.productNotFoundTitle
+            return String(format: Localization.productNotFoundTitle, code.payloadStringValue)
         case .notPurchasable:
-            return Localization.productNotPurchasableTitle
+            return String(format: Localization.productNotPurchasableTitle, code.payloadStringValue)
         default:
             return Localization.defaultTitle
         }
@@ -31,10 +31,11 @@ private extension BarcodeSKUScannerErrorNoticeFactory {
     enum Localization {
         static let defaultTitle = NSLocalizedString("Cannot add Product to Order.",
                                                     comment: "Generic error when a product can't be added to an order after being scanned.")
-        static let productNotFoundTitle = NSLocalizedString("Product not found. Failed to add Product to Order.",
-                                                            comment: "Error message when the scanner cannot find a matching product")
-        static let productNotPurchasableTitle = NSLocalizedString("Product not purchasable. Failed to add Product to Order.",
-                                                                  comment: "Error message when the scanner found a product but isn't purchasable.")
+        static let productNotFoundTitle = NSLocalizedString("Product with SKU \"%@\" not found.",
+                                                            comment: "Error message when the scanner cannot find a matching product. %@ is the SKU code.")
+        static let productNotPurchasableTitle = NSLocalizedString("Product with SKU \"%@\" is not purchasable.",
+                                                                  comment: "Error message when the scanner found a product but isn't purchasable." +
+                                                                  "%@ is the SKU code.")
         static let retryActionTitle = NSLocalizedString("Retry",
                                                           comment: "Retry button title when the scanner cannot find" +
                                                           "a matching product and create a new order")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1673,12 +1673,13 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                stores: stores,
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
+        let scannedBarcode = ScannedBarcode(payloadStringValue: "nonExistingSKU",
+                                            symbology: BarcodeSymbology.ean8)
 
         // When
         var onRetryRequested = false
         let expectedError = waitFor { promise in
-            viewModel.addScannedProductToOrder(barcode: ScannedBarcode(payloadStringValue: "nonExistingSKU",
-                                                                            symbology: BarcodeSymbology.ean8), onCompletion: { expectedError in
+            viewModel.addScannedProductToOrder(barcode: scannedBarcode, onCompletion: { expectedError in
                 switch expectedError {
                 case let .failure(error as EditableOrderViewModel.ScannerError):
                     promise(error)
@@ -1690,7 +1691,9 @@ final class EditableOrderViewModelTests: XCTestCase {
             })
         }
 
-        let expectedNotice = EditableOrderViewModel.NoticeFactory.createProductNotFoundAfterSKUScanningErrorNotice(for: actionError, withRetryAction: {})
+        let expectedNotice = EditableOrderViewModel.NoticeFactory.createProductNotFoundAfterSKUScanningErrorNotice(for: actionError,
+                                                                                                                   code: scannedBarcode,
+                                                                                                                   withRetryAction: {})
 
         // Then
         XCTAssertEqual(expectedError, .productNotFound)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactoryTests.swift
@@ -5,6 +5,7 @@ import Yosemite
 
 final class BarcodeSKUScannerErrorNoticeFactoryTests: XCTestCase {
     let barcode = ScannedBarcode(payloadStringValue: "test-sku", symbology: .ean13)
+    let noticeTitle = NSLocalizedString("Cannot add Product to Order.", comment: "")
 
     func test_notice_when_a_generic_error_is_passed_then_returns_generic_notice() {
         let error = NSError(domain: "disconnect", code: 134)
@@ -16,13 +17,15 @@ final class BarcodeSKUScannerErrorNoticeFactoryTests: XCTestCase {
     func test_notice_when_a_product_not_found_error_is_passed_then_returns_right_notice() {
         let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notFound, code: barcode, actionHandler: {})
 
-        XCTAssertEqual(result.title, NSLocalizedString("Product with SKU \"\(barcode.payloadStringValue)\" not found.", comment: ""))
+        XCTAssertEqual(result.title, noticeTitle)
+        XCTAssertEqual(result.message, NSLocalizedString("Product with SKU \"\(barcode.payloadStringValue)\" not found.", comment: ""))
     }
 
     func test_notice_when_a_product_not_purchasable_error_is_passed_then_returns_right_notice() {
         let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notPurchasable, code: barcode, actionHandler: {})
 
-        XCTAssertEqual(result.title, NSLocalizedString("Product with SKU \"\(barcode.payloadStringValue)\" is not purchasable.", comment: ""))
+        XCTAssertEqual(result.title, noticeTitle)
+        XCTAssertEqual(result.message, NSLocalizedString("Product with SKU \"\(barcode.payloadStringValue)\" is not purchasable.", comment: ""))
     }
 
     func test_notice_passes_right_action_handler() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactoryTests.swift
@@ -4,28 +4,30 @@ import Yosemite
 @testable import WooCommerce
 
 final class BarcodeSKUScannerErrorNoticeFactoryTests: XCTestCase {
+    let barcode = ScannedBarcode(payloadStringValue: "test-sku", symbology: .ean13)
+
     func test_notice_when_a_generic_error_is_passed_then_returns_generic_notice() {
         let error = NSError(domain: "disconnect", code: 134)
-        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: error, actionHandler: {})
+        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: error, code: barcode, actionHandler: {})
 
         XCTAssertEqual(result.title, NSLocalizedString("Cannot add Product to Order.", comment: ""))
     }
 
     func test_notice_when_a_product_not_found_error_is_passed_then_returns_right_notice() {
-        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notFound, actionHandler: {})
+        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notFound, code: barcode, actionHandler: {})
 
-        XCTAssertEqual(result.title, NSLocalizedString("Product not found. Failed to add Product to Order.", comment: ""))
+        XCTAssertEqual(result.title, NSLocalizedString("Product with SKU \"\(barcode.payloadStringValue)\" not found.", comment: ""))
     }
 
     func test_notice_when_a_product_not_purchasable_error_is_passed_then_returns_right_notice() {
-        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notPurchasable, actionHandler: {})
+        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notPurchasable, code: barcode, actionHandler: {})
 
-        XCTAssertEqual(result.title, NSLocalizedString("Product not purchasable. Failed to add Product to Order.", comment: ""))
+        XCTAssertEqual(result.title, NSLocalizedString("Product with SKU \"\(barcode.payloadStringValue)\" is not purchasable.", comment: ""))
     }
 
     func test_notice_passes_right_action_handler() {
         var actionHandlerIsCalled = false
-        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notPurchasable, actionHandler: {
+        let result = BarcodeSKUScannerErrorNoticeFactory.notice(for: ProductLoadError.notPurchasable, code: barcode, actionHandler: {
             actionHandlerIsCalled = true
         })
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10084
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the scanned SKU to the error messages after a barcode scanning action. With this, we help merchants to investigate the reason behind the error. As the message can grow long depending on the SKU length, I used the message (that is line expandable) to hold it.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders.
2. Tap on the scan button.
3. Scan a barcode with an SKU that doesn't match any product in your store.
4. The error message should show the SKU Number (See screenshot)

Repeat the process with the order creation flow and with a non-purchasable product (e.g., without price, or in draft status. You can also try long SKU and see how the message is expanded.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/713073b8-5781-4184-b81e-933854f50364" width="375">
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/77b6218e-c0fe-4e1d-b1d8-d2daa009828a" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
