### PR TITLE
[IAP] Handle pending transactions

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -172,7 +172,6 @@ final class UpgradesViewModel: ObservableObject {
             case .success(.verified(_)):
                 upgradeViewState = .completed(wooWPComPlan)
             default:
-                // TODO: handle `pending` here... somehow – requires research
                 // TODO: handle `.success(.unverified(_))` here... somehow
                 return
             }

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -5,12 +5,24 @@ import StoreKit
 import Networking
 
 public class InAppPurchaseStore: Store {
+    public typealias PurchaseCompletionHandler = (Result<StoreKit.Product.PurchaseResult, Error>) -> Void
     // ISO 3166-1 Alpha-3 country code representation.
     private let supportedCountriesCodes = ["USA"]
     private var listenTask: Task<Void, Error>?
     private let remote: InAppPurchasesRemote
     private var useBackend = true
     private var pauseTransactionListener = CurrentValueSubject<Bool, Never>(false)
+
+    /// When an IAP transaction requires further action, e.g. Strong Customer Auth in a banking app
+    /// or parental approval, it will be returned as a `.pending` transaction.
+    /// In those cases, we handle the transaction when it comes up in the `.updates` stream of
+    /// Transactions, which we listen to for handling unfinished transactions on app strat.
+    /// `pendingTransactionCompletionHandler`, holds the completion handler so that we
+    /// can update the original purchase flow, if it's still on screen.
+    /// N.B. Apple do not notify us about declined pending transactions, so we cannot handle them –
+    /// the user must dismiss the waiting screen and try again.
+    /// https://developer.apple.com/forums/thread/685183?answerId=682554022#682554022
+    private var pendingTransactionCompletionHandler: PurchaseCompletionHandler? = nil
 
     public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         remote = InAppPurchasesRemote(network: network)
@@ -77,7 +89,7 @@ private extension InAppPurchaseStore {
         }
     }
 
-    func purchaseProduct(siteID: Int64, productID: String, completion: @escaping (Result<StoreKit.Product.PurchaseResult, Error>) -> Void) {
+    func purchaseProduct(siteID: Int64, productID: String, completion: @escaping PurchaseCompletionHandler) {
         Task {
             do {
                 try await assertInAppPurchasesAreSupported()
@@ -113,14 +125,16 @@ private extension InAppPurchaseStore {
 
                     try await submitTransaction(transaction)
                     await transaction.finish()
+                    completion(.success(purchaseResult))
                 case .userCancelled:
                     logInfo("User cancelled the purchase flow")
+                    completion(.success(purchaseResult))
                 case .pending:
-                    logError("Purchase returned in a pending state, it might succeed in the future")
+                    logInfo("Purchase returned in a pending state, it might succeed in the future")
+                    pendingTransactionCompletionHandler = completion
                 @unknown default:
                     logError("Unknown result for purchase: \(purchaseResult)")
                 }
-                completion(.success(purchaseResult))
             } catch {
                 logError("Error purchasing product \(productID) for site \(siteID): \(error)")
                 if let purchaseError = error as? StoreKit.Product.PurchaseError {
@@ -158,6 +172,8 @@ private extension InAppPurchaseStore {
             logInfo("Verified transaction \(transaction.id) (Original ID: \(transaction.originalID)) for product \(transaction.productID)")
             try await submitTransaction(transaction)
         }
+        pendingTransactionCompletionHandler?(.success(.success(result)))
+        pendingTransactionCompletionHandler = nil
         logInfo("Marking transaction \(transaction.id) as finished")
         await transaction.finish()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have added the ability to purchase Woo Express plans using In-App Purchase.

During an In-App Purchase, Strong Customer Auth or Parental controls can result in a `.pending` transaction state, then later receipt of the successful transaction on `Transaction.updates`.

While the app correctly handles these results when they’re recieved on the updates queue, previously, the app would have sat on the `Waiting` screen forever in this case.

This PR updates our InAppPurchaseStore so that it:
1. keeps the completion handler around until the pending result is confirmed, and
2. does not call the completion handler with a pending result (because we can only call it once.)

Unfortunately, Apple does not update us to tell us about a `.declined` transaction, so the app will still be in the waiting state forever if the parental consent is declined or SCA is failed. For that reason, the screen can be dismissed and the upgrade tried again, [as recommended by Apple.](https://developer.apple.com/forums/thread/685183?answerId=682554022#682554022)

> There is no way to track the progress of the child's request in any environment, but if the purchase succeeds a transaction will be emitted from [Transaction.updates](https://developer.apple.com/documentation/storekit/transaction/3851206-updates). If the request for parental permission expires or is declined, there will be no notification of failure, which is why the [SKTestTransaction](https://developer.apple.com/documentation/storekittest/sktesttransaction)'s [state](https://developer.apple.com/documentation/storekittest/sktesttransaction/3579513-state) property will never change to [.failed.](https://developer.apple.com/documentation/storekit/skpaymenttransactionstate/failed) You should allow the user to initiate another purchase after [purchase(options:)](https://developer.apple.com/documentation/storekit/product/3791971-purchase/) returns [.pending,](https://developer.apple.com/documentation/storekit/product/purchaseresult/pending) in the case a request for parental permission expires or is declined

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N.B. This flow can only be tested in the Xcode (or production, but we can't do that yet) environment. However, the MobilePay backend cannot process upgrades from the Xcode environment, only Sandbox or Production.

To workaround the error that's thrown, update [InAppPurchaseStore.submitTransaction](https://github.com/woocommerce/woocommerce-ios/blob/7fc94d473b5f188693c6d9b4f5a11bc0ebda88a7/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift#L236) to ignore the error thrown by adding the following above `} catch {`:

```
        } catch WordPressApiError.unknown {
            // temporarily ignore this error for testing
```

1. Select the `WooCommerce IAP` scheme in Xcode, and build the app.
2. Open the `WooCommerceTestSynced` file in Xcode, and set an error using `Editor (menu) > Enable Ask to Buy`
3. In the app, select a Woo express store with a free trial active
4. Tap `Upgrade now`
5. Wait for the load to finish
6. Tap `Purchase Debug Essential Monthly`
7. Subscribe to the plan (observe that it's in `[Environment: Xcode]`)
8. Tap `Ask` when prompted to ask for consent in an alert
9. In Xcode, open `Debug (menu) > StoreKit > Manage Transactions`
10. Select the most recent transaction and click the `Approve` button
11. Observe that the success screen is shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/a4e99738-3759-4882-8a21-374e9bb17bd0



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
