### PR TITLE
Update the product type row to be editable in the product creation form

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.3
 -----
 - [*] Add URL route handler to open the `My Store` tab when a deeplink to `/mobile` is opened, instead of bouncing back to Safari [https://github.com/woocommerce/woocommerce-ios/pull/10077]
+- [*] Product creation: the product type row is now editable when creating a product. [https://github.com/woocommerce/woocommerce-ios/pull/10087]
 
 14.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -153,7 +153,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForSimpleProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
-        let canEditProductType = formType != .add && editable
+        let canEditProductType = editable
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
         let shouldShowDownloadableProduct = product.downloadable
         let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
@@ -180,7 +180,7 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowExternalURLRow = editable || product.product.externalURL?.isNotEmpty == true
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
-        let canEditProductType = formType != .add && editable
+        let canEditProductType = editable
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
@@ -202,7 +202,7 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForGroupedProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
-        let canEditProductType = formType != .add && editable
+        let canEditProductType = editable
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
@@ -222,7 +222,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
-        let canEditProductType = formType != .add && editable
+        let canEditProductType = editable
         let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
         let shouldShowAttributesRow = product.product.attributesForVariations.isNotEmpty
         let shouldShowNoPriceWarningRow: Bool = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */; };
 		02DE5CAB279F8754007CBEF3 /* Double+RoundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */; };
 		02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */; };
+		02DF174B2A4A134B008FD33B /* ProductFormActionsFactory+ProductCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF174A2A4A134B008FD33B /* ProductFormActionsFactory+ProductCreationTests.swift */; };
 		02DF980B2A15FD920009E2EA /* StoreCreationStatusChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF980A2A15FD920009E2EA /* StoreCreationStatusChecker.swift */; };
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9B284743A40010B254 /* ProductImageUploader.swift */; };
@@ -2819,6 +2820,7 @@
 		02DE5CA8279F857D007CBEF3 /* Double+Rounding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Rounding.swift"; sourceTree = "<group>"; };
 		02DE5CAA279F8754007CBEF3 /* Double+RoundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+RoundingTests.swift"; sourceTree = "<group>"; };
 		02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingScreen.swift; sourceTree = "<group>"; };
+		02DF174A2A4A134B008FD33B /* ProductFormActionsFactory+ProductCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+ProductCreationTests.swift"; sourceTree = "<group>"; };
 		02DF980A2A15FD920009E2EA /* StoreCreationStatusChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationStatusChecker.swift; sourceTree = "<group>"; };
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E19B9B284743A40010B254 /* ProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageUploader.swift; sourceTree = "<group>"; };
@@ -4790,6 +4792,7 @@
 				02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */,
 				02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */,
 				02503C622538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift */,
+				02DF174A2A4A134B008FD33B /* ProductFormActionsFactory+ProductCreationTests.swift */,
 			);
 			path = "Actions Factory";
 			sourceTree = "<group>";
@@ -12851,6 +12854,7 @@
 				5750BEE82764006F00388BE6 /* RefundFeesDetailsViewModelTests.swift in Sources */,
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				0331A7002A334982001D2C2C /* MockInAppPurchasesForWPComPlansManager.swift in Sources */,
+				02DF174B2A4A134B008FD33B /* ProductFormActionsFactory+ProductCreationTests.swift in Sources */,
 				02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
 				7E6A01A12725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import Fakes
+
+@testable import WooCommerce
+@testable import Yosemite
+
+final class ProductFormActionsFactory_ProductCreationTests: XCTestCase {
+    func test_product_type_is_editable_for_core_product_types() {
+        // Product types supported in core.
+        let coreProductTypes: [ProductType] = [.simple, .variable, .affiliate, .grouped]
+
+        coreProductTypes.forEach { coreProductType in
+            // Given
+            let product = Product.fake().copy(productTypeKey: coreProductType.rawValue)
+            let model = EditableProductModel(product: product)
+
+            // When
+            let actions = Fixtures.actionsFactory(product: model, formType: .add).settingsSectionActions()
+
+            // Then
+            XCTAssertTrue(actions.contains(.productType(editable: true)))
+        }
+    }
+
+    func test_product_type_is_not_editable_for_non_core_product_types() {
+        // Product types supported in Woo extensions.
+        let nonCoreProductTypes: [ProductType] = [.bundle, .composite, .subscription, .variableSubscription, .custom("sub")]
+
+        nonCoreProductTypes.forEach { nonCoreProductType in
+            // Given
+            let product = Product.fake().copy(productTypeKey: nonCoreProductType.rawValue)
+            let model = EditableProductModel(product: product)
+
+            // When
+            let actions = Fixtures.actionsFactory(product: model, formType: .add).settingsSectionActions()
+
+            // Then
+            XCTAssertTrue(actions.contains(.productType(editable: false)))
+        }
+    }
+}
+
+private extension ProductFormActionsFactory_ProductCreationTests {
+    enum Fixtures {
+        // Factory with default feature settings.
+        static func actionsFactory(product: EditableProductModel,
+                                   formType: ProductFormType,
+                                   addOnsFeatureEnabled: Bool = false,
+                                   isLinkedProductsPromoEnabled: Bool = false,
+                                   isBundledProductsEnabled: Bool = false,
+                                   isCompositeProductsEnabled: Bool = false,
+                                   isSubscriptionProductsEnabled: Bool = false,
+                                   isMinMaxQuantitiesEnabled: Bool = false,
+                                   variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
+            ProductFormActionsFactory(product: product,
+                                      formType: formType,
+                                      addOnsFeatureEnabled: addOnsFeatureEnabled,
+                                      isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
+                                      isBundledProductsEnabled: isBundledProductsEnabled,
+                                      isCompositeProductsEnabled: isCompositeProductsEnabled,
+                                      isSubscriptionProductsEnabled: isSubscriptionProductsEnabled,
+                                      isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
+                                      variationsPrice: variationsPrice)
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10021 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For the announcement of the product description AI feature, we plan to use the pre-existing What's New announcement modal for the i2 release. In pecCkj-Cr-p2#comment-367, Ann suggested skipping the step of the product type bottom sheet and showing the product creation form with the simple product type by default. Now that the user cannot select a product type at any time in the product creation flow, we can make the product type row editable. From my recollection, the product type row was read-only in the product creation form initially because we hadn't supported all the core product types. More than 2 years later, with the product type editable in the editing mode and many other iterations of the product editing experience, I believe we can make this change.

From the product creation events, it looks like `simple` produce type is the most common (more than 95% for the `woocommerceios_add_product_publish_tapped` event in the last 14 days). It makes sense to have the product type default to be `simple`.

<img width="324" alt="Screenshot 2023-06-26 at 3 03 11 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/4b1fe44c-ca23-469f-a219-5f9d47bdb044">


## How

In `ProductFormActionsFactory`, the `formType != .add` condition to exclude the product creation form from the product type being editable was removed for 4 core product types. Some test cases were added, we didn't have any tests on the product creation form before.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

🗒️ Please note that when creating a variable product, the product is saved as a draft when adding a new attribute or variation. This is a pre-existing behavior, and you can read more about it at https://github.com/woocommerce/woocommerce-ios/pull/3836.

- Go to the Products tab
- Tap `+` to create a product
- Select any product type (e.g. variable)
- Enter some name and description, and feel free to add any other fields like price and inventory details
- Tap on the product type row
- Select a different product type, and tap `Yes, change` in the alert --> some details like the product name and description should be preserved

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/e55a127c-2e2f-40a2-91b7-771f51138b13




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.