### PR TITLE
Store onboarding: Add missing Done button on launch store screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -5,6 +5,9 @@ import enum Yosemite.SiteLaunchError
 final class StoreOnboardingLaunchStoreHostingController: UIHostingController<StoreOnboardingLaunchStoreView> {
     init(viewModel: StoreOnboardingLaunchStoreViewModel) {
         super.init(rootView: StoreOnboardingLaunchStoreView(viewModel: viewModel))
+        rootView.onDismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
     }
 
     @available(*, unavailable)
@@ -21,6 +24,9 @@ final class StoreOnboardingLaunchStoreHostingController: UIHostingController<Sto
 
 /// Shows a preview of the site with a CTA to launch store if applicable.
 struct StoreOnboardingLaunchStoreView: View {
+    // Closure to be triggered when the Done button is tapped.
+    var onDismiss: () -> Void = {}
+
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1.0
 
@@ -79,6 +85,14 @@ struct StoreOnboardingLaunchStoreView: View {
         .task {
             await viewModel.checkEligibilityToPublishStore()
         }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(Localization.doneButton) {
+                    onDismiss()
+                }
+                .buttonStyle(TextButtonStyle())
+            }
+        }
     }
 }
 
@@ -120,6 +134,7 @@ private extension StoreOnboardingLaunchStoreView {
             "Publish My Store",
             comment: "Title of the primary button on the store onboarding > launch store screen to publish a store."
         )
+        static let doneButton = NSLocalizedString("Done", comment: "Button to dismiss the launch store screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -136,9 +136,9 @@ private extension StoreOnboardingLaunchStoreViewModel {
 private extension StoreOnboardingLaunchStoreViewModel {
     enum Localization {
         static let upgradePlanToLaunchStore = NSLocalizedString(
-            "To launch your store, you need to upgrade to your plan. %1$@",
+            "To launch your store, you need to upgrade to our plan. %1$@",
             comment: "Message to ask the user to upgrade free trial plan to launch store."
-            + "Reads - To launch your store, you need to upgrade to your plan. Upgrade"
+            + "Reads - To launch your store, you need to upgrade to our plan. Upgrade"
         )
         static let learnMore = NSLocalizedString("Learn More", comment: "Title on the button to upgrade a free trial plan.")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -136,9 +136,9 @@ private extension StoreOnboardingLaunchStoreViewModel {
 private extension StoreOnboardingLaunchStoreViewModel {
     enum Localization {
         static let upgradePlanToLaunchStore = NSLocalizedString(
-            "To launch your store, you need to upgrade to our plan. %1$@",
+            "To launch your store, you need to upgrade to your plan. %1$@",
             comment: "Message to ask the user to upgrade free trial plan to launch store."
-            + "Reads - To launch your store, you need to upgrade to our plan. Upgrade"
+            + "Reads - To launch your store, you need to upgrade to your plan. Upgrade"
         )
         static let learnMore = NSLocalizedString("Learn More", comment: "Title on the button to upgrade a free trial plan.")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -82,6 +82,7 @@ struct StoreOnboardingTaskView: View {
                     Divider().dividerStyle().renderedIf(showDivider)
                 }
             }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9949 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously the launch store screen did not have any button to dismiss the view in landscape mode. This PR adds that missing button on the top right.

Also:
- Improved the tap area for the onboarding task views by adding `contentShape` in the button label.
- Fixed typo on the free trial banner of the launch store screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store that hasn't been launched yet.
- Tap the Launch store onboarding task.
- Notice the Done button on the top right.
- Rotate the device to landscape mode and tap Done. The screen should be dismissed.
- Tap on any onboarding item in landscape mode, the relevant screen should be presented without tapping on the title of the item.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/5ee18119-8607-4684-b889-1996c8a08d38" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
