### PR TITLE
Domain Settings: Update the navigation bar button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -97,8 +97,8 @@ struct DomainSettingsView: View {
             isFetchingDataOnAppear = false
         }
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button(Localization.cancelButtonTitle) {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(Localization.doneButtonTitle) {
                     onClose()
                 }
                 .buttonStyle(TextButtonStyle())
@@ -123,8 +123,8 @@ private extension DomainSettingsView {
             "Learn more",
             comment: "Tappable text at the bottom of the domain settings screen that opens a webview."
         )
-        static let cancelButtonTitle = NSLocalizedString(
-            "Cancel",
+        static let doneButtonTitle = NSLocalizedString(
+            "Done",
             comment: "Navigation bar button on the domain settings screen to leave the flow."
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9951 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
During the user flow review [pdqJU4-2L0-p2] - it was commented that the navigation button on the domain settings screen should be Done instead of Cancel. This PR updates that button and move it to the right side of the screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom screen.
- Switch to Menu tap > Settings > Domains.
- Notice the navigation button is Done and is on the right.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/320739a7-0a12-48b4-8d1a-1398c4deb6a8" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.