### PR TITLE
[IAP] Refresh plan after upgrade completed

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -42,6 +42,7 @@ final class UpgradesViewModel: ObservableObject {
 
     private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol
     private let siteID: Int64
+    private let storePlanSynchronizer: StorePlanSynchronizer
     private let stores: StoresManager
 
     @Published var entitledWpcomPlanIDs: Set<String>
@@ -52,9 +53,11 @@ final class UpgradesViewModel: ObservableObject {
 
     init(siteID: Int64,
          inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager(),
+         storePlanSynchronizer: StorePlanSynchronizer = ServiceLocator.storePlanSynchronizer,
          stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.inAppPurchasesPlanManager = inAppPurchasesPlanManager
+        self.storePlanSynchronizer = storePlanSynchronizer
         self.stores = stores
 
         entitledWpcomPlanIDs = []
@@ -170,6 +173,8 @@ final class UpgradesViewModel: ObservableObject {
             case .userCancelled:
                 upgradeViewState = .loaded(wooWPComPlan)
             case .success(.verified(_)):
+                // refreshing the synchronizer removes the Upgrade Now banner by the time the flow is closed
+                storePlanSynchronizer.reloadPlan()
                 upgradeViewState = .completed(wooWPComPlan)
             default:
                 // TODO: handle `.success(.unverified(_))` here... somehow


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've added the ability to purchase Woo Express essential plans through In App Purchase.

The upgrade flow is accessed by tapping on an `Upgrade Now` button in the `FreeTrialBanner`, shown at the bottom of each tab while in a free trial.

Previously, this banner and the `Free Trial` tag on the store name in the Menu tab would stay around for a short time after upgrading – this could introduce some doubt in the user on whether their purchase was successful.

This PR refreshes the plan in storage once the upgrade is `.complete`, and so when the flow is dismissed, the banner is already gone and the Menu tag also updated to `Essential`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a new Woo Express store
2. Launch the app and switch to the store
3. Tap Upgrade Now
4. Follow the upgrade flow through to completion using a sandbox IAP user
5. Tap `Done` to dismiss the upgrade complete view
6. Observe that the Upgrade banner is gone
7. Go to the menu tab
8. Observe that the store is labeled `Essential` not `Free Trial`

Previously, the Upgrade banner would have continued to show for a short while, and the plan would be marked as Free Trial in the menu.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/19297959-c5b7-42ed-ad5a-2c2c2f4ddf0c


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
