### PR TITLE
[Free Trial - Local notification] Add feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -73,6 +73,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .freeTrialInAppPurchasesUpgradeM1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .twentyHourHoursAfterFreeTrialSubscribedNotification:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
         case .compositeProducts:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -73,7 +73,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .freeTrialInAppPurchasesUpgradeM1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .twentyHourHoursAfterFreeTrialSubscribedNotification:
+        case .twentyFourHoursAfterFreeTrialSubscribedNotification:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .manualErrorHandlingForSiteCredentialLogin:
             return true

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -160,6 +160,10 @@ public enum FeatureFlag: Int {
     ///
     case freeTrialInAppPurchasesUpgradeM1
 
+    /// Local notification asking to purchase plan 24 hrs after Free trial subscription
+    ///
+    case twentyHourHoursAfterFreeTrialSubscribedNotification
+
     /// Enables manual error handling for site credential login.
     ///
     case manualErrorHandlingForSiteCredentialLogin

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -162,7 +162,7 @@ public enum FeatureFlag: Int {
 
     /// Local notification asking to purchase plan 24 hrs after Free trial subscription
     ///
-    case twentyHourHoursAfterFreeTrialSubscribedNotification
+    case twentyFourHoursAfterFreeTrialSubscribedNotification
 
     /// Enables manual error handling for site credential login.
     ///

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -15,7 +15,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
     private let isFreeTrial: Bool
-    private let isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled: Bool
+    private let isTwentyFourHoursAfterFreeTrialSubscribedNotificationEnabled: Bool
     private let jetpackSetupWithApplicationPassword: Bool
     private let isTapToPayOnIPhoneMilestone2On: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
@@ -40,7 +40,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
          isFreeTrial: Bool = false,
-         isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled: Bool = false,
+         isTwentyFourHoursAfterFreeTrialSubscribedNotificationEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          isTapToPayOnIPhoneMilestone2On: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
@@ -64,7 +64,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
         self.isFreeTrial = isFreeTrial
-        self.isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled = isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled
+        self.isTwentyFourHoursAfterFreeTrialSubscribedNotificationEnabled = isTwentyFourHoursAfterFreeTrialSubscribedNotificationEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isTapToPayOnIPhoneMilestone2On = isTapToPayOnIPhoneMilestone2On
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
@@ -105,8 +105,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isDashboardStoreOnboardingEnabled
         case .freeTrial:
             return isFreeTrial
-        case .twentyHourHoursAfterFreeTrialSubscribedNotification:
-            return isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled
+        case .twentyFourHoursAfterFreeTrialSubscribedNotification:
+            return isTwentyFourHoursAfterFreeTrialSubscribedNotificationEnabled
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
         case .tapToPayOnIPhoneMilestone2:

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -15,6 +15,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
     private let isFreeTrial: Bool
+    private let isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled: Bool
     private let jetpackSetupWithApplicationPassword: Bool
     private let isTapToPayOnIPhoneMilestone2On: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
@@ -39,6 +40,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
          isFreeTrial: Bool = false,
+         isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          isTapToPayOnIPhoneMilestone2On: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
@@ -62,6 +64,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
         self.isFreeTrial = isFreeTrial
+        self.isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled = isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isTapToPayOnIPhoneMilestone2On = isTapToPayOnIPhoneMilestone2On
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
@@ -102,6 +105,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isDashboardStoreOnboardingEnabled
         case .freeTrial:
             return isFreeTrial
+        case .twentyHourHoursAfterFreeTrialSubscribedNotification:
+            return isTwentyHourHoursAfterFreeTrialSubscribedNotificationEnabled
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
         case .tapToPayOnIPhoneMilestone2:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10092 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
- Adds a new local feature flag to control the 24 hrs after Free Trial subscribed local notification. 
- This feature flag will be replaced with a remote feature flag in a future PR.

## Testing instructions
CI passing is enough.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
