### PR TITLE
[IAP] Ignore renewal errors, not all product purchase errors

### DIFF
--- a/Networking/Networking/Model/WordPressApiError.swift
+++ b/Networking/Networking/Model/WordPressApiError.swift
@@ -12,6 +12,10 @@ public enum WordPressApiError: Error, Decodable, Equatable {
     ///
     case productPurchased
 
+    /// The transaction type for this IAP receipt is expected to be processed
+    /// via the server-to-server notification method, not sent from the app
+    case transactionReasonInvalid(message: String)
+
     /// Decodable Initializer.
     ///
     public init(from decoder: Decoder) throws {
@@ -22,6 +26,8 @@ public enum WordPressApiError: Error, Decodable, Equatable {
         switch code {
         case Constants.productPurchased:
             self = .productPurchased
+        case Constants.transactionReasonInvalid:
+            self = .transactionReasonInvalid(message: message)
         default:
             self = .unknown(code: code, message: message)
         }
@@ -32,6 +38,7 @@ public enum WordPressApiError: Error, Decodable, Equatable {
     ///
     private enum Constants {
         static let productPurchased = "product_purchased"
+        static let transactionReasonInvalid = "transaction_reason_invalid"
     }
 
     /// Coding Keys
@@ -61,6 +68,13 @@ extension WordPressApiError: CustomStringConvertible {
             return NSLocalizedString(
                 "An order aready exists for this receipt",
                 comment: "Error message when an order already exists in the backend for a given receipt")
+
+        case .transactionReasonInvalid(let message):
+            let messageFormat = NSLocalizedString(
+                "This receipt's transaction type is not expected from the app [%1$@]",
+                comment: "Error message when an unsupported receipt type is sent - [%1$@] will be replaced with details")
+            return String.localizedStringWithFormat(messageFormat, message)
+
         case .unknown(let code, let message):
             let messageFormat = NSLocalizedString(
                 "WordPress API Error: [%1$@] %2$@",

--- a/Networking/Networking/Model/WordPressApiError.swift
+++ b/Networking/Networking/Model/WordPressApiError.swift
@@ -66,7 +66,7 @@ extension WordPressApiError: CustomStringConvertible {
         switch self {
         case .productPurchased:
             return NSLocalizedString(
-                "An order aready exists for this receipt",
+                "An order already exists for this receipt",
                 comment: "Error message when an order already exists in the backend for a given receipt")
 
         case .transactionReasonInvalid(let message):

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -170,11 +170,7 @@ private extension InAppPurchaseStore {
         } else {
             // Provide access to the product
             logInfo("Verified transaction \(transaction.id) (Original ID: \(transaction.originalID)) for product \(transaction.productID)")
-            /// We ignore 422 errors for product purchased because _usually_ from this method, these are renewals
-            /// that MobilePay already knows about, and when they're not, other client side checks should
-            /// prevent the purchase in the first place.
-            /// [See #10075 for details](https://github.com/woocommerce/woocommerce-ios/issues/10075)
-            try await submitTransaction(transaction, shouldIgnoreProductPurchasedErrors: true)
+            try await submitTransaction(transaction)
         }
         pendingTransactionCompletionHandler?(.success(.success(result)))
         pendingTransactionCompletionHandler = nil
@@ -204,8 +200,7 @@ private extension InAppPurchaseStore {
         }
     }
 
-    func submitTransaction(_ transaction: StoreKit.Transaction,
-                           shouldIgnoreProductPurchasedErrors: Bool = false) async throws {
+    func submitTransaction(_ transaction: StoreKit.Transaction) async throws {
         guard useBackend else {
             return
         }
@@ -236,11 +231,12 @@ private extension InAppPurchaseStore {
             )
             logInfo("Successfully registered purchase with Order ID \(orderID)")
         } catch WordPressApiError.productPurchased {
-            guard shouldIgnoreProductPurchasedErrors else {
-                throw Errors.transactionAlreadyAssociatedWithAnUpgrade
-            }
-            // Ignore errors for existing purchase
-            logInfo("Existing order found for transaction \(transaction.id) on site \(siteID), ignoring")
+            throw Errors.transactionAlreadyAssociatedWithAnUpgrade
+        } catch WordPressApiError.transactionReasonInvalid(let reasonMessage) {
+            /// We ignore transactionReasonInvalid errors, usually these are renewals that
+            /// MobilePay has already handled via Apple's server to server notifications
+            /// [See #10075 for details](https://github.com/woocommerce/woocommerce-ios/issues/10075)
+            logInfo("Unsupported transaction recieved: \(transaction.id) on site \(siteID), ignoring. \(reasonMessage)")
         } catch {
             // Rethrow any other error
             throw error

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -236,7 +236,7 @@ private extension InAppPurchaseStore {
             /// We ignore transactionReasonInvalid errors, usually these are renewals that
             /// MobilePay has already handled via Apple's server to server notifications
             /// [See #10075 for details](https://github.com/woocommerce/woocommerce-ios/issues/10075)
-            logInfo("Unsupported transaction recieved: \(transaction.id) on site \(siteID), ignoring. \(reasonMessage)")
+            logInfo("Unsupported transaction received: \(transaction.id) on site \(siteID), ignoring. \(reasonMessage)")
         } catch {
             // Rethrow any other error
             throw error


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10075 
Merge after #10093

~⛔️ Do not merge until **D114571** on MobilePay is landed~ ✅ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Initially, our IAP plan purchases only support upgrading a single site. Upgrading multiple sites is prevented by checking whether the merchant has already got an active entitlement to an In-App Purchase, and showing the Maximum sites upgraded error at the start of the Upgrade flow if they have.

Unfortunately, if the MobilePay server and Apple are out of sync, it's possible to make an In-App Purchase to upgrade a second site which will succeed with Apple (i.e. taking the merchants money), fail with MobilePay, but be announced as success in the app. The IAP Transaction will be marked as finished, (i.e. we're telling Apple that we've furnished the merchant with the upgrade they paid for) and the site will remain on the trial. We won't ever show the merchant an error.

Originally, we ignored all `productPurchased` errors because they were _usually_ renewals that had been processed on the server already, via server-to-server notifications.

This meant that we missed edge case errors where the merchant already had a live upgrade we knew about it, so we stopped ignoring these errors in the purchase flow – however, we still ignored them in the purchase recovery flow.

MobilePay now returns a distinct error message for renewals and other “unsupported” transactions that we submit. This means we can always ignore renewals, and avoid ever ignoring `productPurchased` errors, which can hide some rare edge cases.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Sandbox the API changes

If D114571 is not landed yet, on your WPCom sandbox apply that patch and sandbox `public-api.wordpress.com`, routing your device's traffic to it using Proxyman and your hosts file.

### Purchase flow

1. Using a sandbox App Store account, and a Woo Express free trial store,
2. Launch the app, and tap Upgrade Now
3. Upgrade the site and wait until the IAP expires (usually 1hr for sandbox users)
4. Edit the WC order in the backing store, change the status from `cancelled` to `completed`.
5. Launch the app and make a new free trial store
6. Upgrade the new store with IAP – observe that you can complete the payment
7. Observe that the `Error Activating Plan` screen is shown, saying that they should contact support.


### Renewal flow

Using a sandbox App Store account, and a Woo Express free trial store,
Launch the app, and tap Upgrade Now
Upgrade the site
Background the app and then open it again.
Wait for the renewals to come in
Observe that the `"Unsupported transaction recieved: \(transaction.id) on site \(siteID), ignoring.` message is logged to the console


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
