### PR TITLE
[IAP] Fix iPad upgrade flow display

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -109,6 +109,9 @@ struct UpgradesView: View {
             }
             .navigationBarHidden(true)
         }
+        // TODO: when we remove iOS 15 support, use NavigationStack instead.
+        // This is required to avoid a column layout on iPad, which looks strange.
+        .navigationViewStyle(.stack)
         .onDisappear {
             upgradesViewModel.onDisappear()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10090
Merge after: #10093
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With the new flow to upgrade a Woo Express site using In-App Purchase, on iPad the modal shows as a split view, or specifically a column-based NavigationView, with two thirds of the space empty waiting for a detail view.

This PR changes the view to use a `.stack` presentation style, which fixes the issue without breaking navigation to the feature details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a Woo Express site with a free trial active

### iPad
1. Open the app on an iPad
2. Tap `Upgrade now` 
3. Observe that the upgrade view is shown as the full content of the modal
4. Tap one of the features – observe that it's shown correctly and you can navigate back

### iPhone
Repeat the above, the behaviour is unchanged.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before

![upgrade in split view](https://user-images.githubusercontent.com/3812076/249071110-9a79dae2-4716-4256-bf9f-561fbcd26c74.png)

### After
https://github.com/woocommerce/woocommerce-ios/assets/2472348/06c05858-fe4b-4c8b-879b-f70e385a5eb3


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
