### PR TITLE
[Free Trial - Local notification] Schedule local notification after subscription

### DIFF
--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -184,5 +184,16 @@ extension LocalNotification {
                 "The placeholder is the name of the user."
             )
         }
+
+        enum TwentyFourHoursAfterFreeTrialSubscribed {
+            static let title = NSLocalizedString(
+                "🌟 Keep your business going!",
+                comment: "Title of the local notification to remind the user to purchase a plan."
+            )
+            static let body = NSLocalizedString(
+                "Discover advanced features and personalized recommendations for your store! Tap to pick a plan that suits you best.",
+                comment: "Message on the local notification to remind the user to purchase a plan."
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -22,6 +22,7 @@ struct LocalNotification {
         case oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: String)
         case oneDayBeforeFreeTrialExpires(siteID: Int64, expiryDate: Date)
         case oneDayAfterFreeTrialExpires(siteID: Int64)
+        case twentyFourHoursAfterFreeTrialSubscribed(siteID: Int64)
 
         var identifier: String {
             switch self {
@@ -33,6 +34,8 @@ struct LocalNotification {
                 return Identifier.Prefix.oneDayBeforeFreeTrialExpires + "\(siteID)"
             case .oneDayAfterFreeTrialExpires(let siteID):
                 return Identifier.Prefix.oneDayAfterFreeTrialExpires + "\(siteID)"
+            case let .twentyFourHoursAfterFreeTrialSubscribed(siteID):
+                return Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed + "\(siteID)"
             }
         }
 
@@ -40,6 +43,7 @@ struct LocalNotification {
             enum Prefix {
                 static let oneDayBeforeFreeTrialExpires = "one_day_before_free_trial_expires"
                 static let oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"
+                static let twentyFourHoursAfterFreeTrialSubscribed = "twenty_four_hours_after_free_trial_subscribed"
             }
             static let oneDayAfterStoreCreationNameWithoutFreeTrial = "one_day_after_store_creation_name_without_free_trial"
         }
@@ -50,6 +54,8 @@ struct LocalNotification {
                 return Identifier.Prefix.oneDayBeforeFreeTrialExpires
             } else if identifier.hasPrefix(Identifier.Prefix.oneDayAfterFreeTrialExpires) {
                 return Identifier.Prefix.oneDayAfterFreeTrialExpires
+            } else if identifier.hasPrefix(Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed) {
+                return Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed
             }
             return identifier
         }
@@ -121,6 +127,10 @@ extension LocalNotification {
         case .oneDayAfterFreeTrialExpires:
             title = Localization.OneDayAfterFreeTrialExpires.title
             body = String.localizedStringWithFormat(Localization.OneDayAfterFreeTrialExpires.body, name)
+
+        case .twentyFourHoursAfterFreeTrialSubscribed:
+            title = Localization.TwentyFourHoursAfterFreeTrialSubscribed.title
+            body = Localization.TwentyFourHoursAfterFreeTrialSubscribed.body
 
         }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -347,6 +347,7 @@ private extension AppCoordinator {
         let identifier = response.notification.request.identifier
         let oneDayBeforeFreeTrialExpiresIdentifier = LocalNotification.Scenario.Identifier.Prefix.oneDayBeforeFreeTrialExpires
         let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires
+        let twentyFourHoursAfterFreeTrialSubscribed = LocalNotification.Scenario.Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed
 
         guard response.actionIdentifier != UNNotificationDismissActionIdentifier else {
             analytics.track(.localNotificationDismissed, withProperties: [
@@ -369,6 +370,12 @@ private extension AppCoordinator {
         case let identifier where identifier.hasPrefix(oneDayAfterFreeTrialExpiresIdentifier):
             guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
                   let siteID = Int64(identifier.replacingOccurrences(of: oneDayAfterFreeTrialExpiresIdentifier, with: "")) else {
+                return
+            }
+            openPlansPage(siteID: siteID)
+        case let identifier where identifier.hasPrefix(twentyFourHoursAfterFreeTrialSubscribed):
+            guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+                  let siteID = Int64(identifier.replacingOccurrences(of: twentyFourHoursAfterFreeTrialSubscribed, with: "")) else {
                 return
             }
             openPlansPage(siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import Combine
+import Experiments
 
 /// Type that fetches and shares a `WPCom` store plan(subscription).
 /// The plan is stored on memory and not on the Storage Layer because this only relates to `WPCom` stores.
@@ -42,12 +43,16 @@ final class StorePlanSynchronizer: ObservableObject {
     ///
     private var subscriptions: Set<AnyCancellable> = []
 
+    private let featureFlagService: FeatureFlagService
+
     init(stores: StoresManager = ServiceLocator.stores,
          timeZone: TimeZone = .current,
-         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.stores = stores
         self.localNotificationScheduler = .init(pushNotesManager: pushNotesManager, stores: stores)
         self.timeZone = timeZone
+        self.featureFlagService = featureFlagService
 
         stores.site.sink { [weak self] site in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -130,6 +130,7 @@ private extension StorePlanSynchronizer {
         }
 
         if let subscribedDate = plan.subscribedDate,
+           // Schedule notification only if the Free trial is subscribed less than 24 hrs ago
            Date().timeIntervalSince(subscribedDate) < Constants.oneDayTimeInterval {
             schedule24HrsAfterSubscribedNotification(siteID: siteID, subcribedDate: subscribedDate)
         }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -131,7 +131,7 @@ private extension StorePlanSynchronizer {
 
         if let subscribedDate = plan.subscribedDate,
            Date().timeIntervalSince(subscribedDate) < Constants.oneDayTimeInterval {
-            schedule24HrsAfterSuscribedNotification(siteID: siteID, subcribedDate: subscribedDate)
+            schedule24HrsAfterSubscribedNotification(siteID: siteID, subcribedDate: subscribedDate)
         }
     }
 
@@ -144,7 +144,7 @@ private extension StorePlanSynchronizer {
         localNotificationScheduler.cancel(scenario: .twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID))
     }
 
-    func schedule24HrsAfterSuscribedNotification(siteID: Int64, subcribedDate: Date) {
+    func schedule24HrsAfterSubscribedNotification(siteID: Int64, subcribedDate: Date) {
         // TODO: #10094 Remove after adding remote feature flag
         guard featureFlagService.isFeatureFlagEnabled(.twentyFourHoursAfterFreeTrialSubscribedNotification) else {
             return

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -398,6 +398,26 @@ final class AppCoordinatorTests: XCTestCase {
         }
     }
 
+    func test_plans_page_is_displayed_when_tapping_on_twentyFourHoursAfterFreeTrialSubscribed_notification() throws {
+        // Given
+        let pushNotesManager = MockPushNotificationsManager()
+        let coordinator = makeCoordinator(window: window, pushNotesManager: pushNotesManager)
+        coordinator.start()
+        let siteID: Int64 = 123
+
+        // When
+        let response = try XCTUnwrap(MockNotificationResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            requestIdentifier: LocalNotification.Scenario.twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID).identifier)
+        )
+        pushNotesManager.sendLocalNotificationResponse(response)
+
+        // Then
+        waitUntil {
+            self.window.rootViewController?.topmostPresentedViewController is UpgradePlanCoordinatingController
+        }
+    }
+
     func test_local_notification_dismissal_is_tracked() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -115,6 +115,8 @@ extension LocalNotification.Scenario: Equatable {
             return lhsExpiryDate == rhsExpiryDate && lhsSiteID == rhsSiteID
         case let (.oneDayAfterFreeTrialExpires(lhsSiteID), .oneDayAfterFreeTrialExpires(rhsSiteID)):
             return lhsSiteID == rhsSiteID
+        case let (.twentyFourHoursAfterFreeTrialSubscribed(lhsSiteID), .twentyFourHoursAfterFreeTrialSubscribed(rhsSiteID)):
+            return lhsSiteID == rhsSiteID
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -76,4 +76,21 @@ final class LocalNotificationTests: XCTestCase {
         assertEqual(expectedBody, notification.body)
         XCTAssertNil(notification.actions)
     }
+
+    func test_twentyFourHoursAfterFreeTrialSubscribed_scenario_returns_correct_notification_contents() throws {
+        // Given
+        let scenario = LocalNotification.Scenario.twentyFourHoursAfterFreeTrialSubscribed(siteID: 123)
+        let testName = "Miffy"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
+
+        // When
+        let notification = LocalNotification(scenario: scenario, stores: stores)
+
+        // Then
+        let expectedTitle = LocalNotification.Localization.TwentyFourHoursAfterFreeTrialSubscribed.title
+        let expectedBody = LocalNotification.Localization.TwentyFourHoursAfterFreeTrialSubscribed.body
+        assertEqual(expectedTitle, notification.title)
+        assertEqual(expectedBody, notification.body)
+        XCTAssertNil(notification.actions)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10092

## Description
This PR schedules a local notification after 24 hrs from the free trial subscription time. 

Decisions in this thread - p1687855825234459/1687848121.991969-slack-C03L1NF1EA3

## Testing instructions

- For easier testing, please run the app on a physical device.
- Launch the app, log in, and create a new free trial site from the site picker.
- After successfully landing on the "My Store" page. Kill the app
- Kill the app, open Settings, and change the time of the device to 23 hr 58 mins from the current time ( which is the free trial subscription time). 
- Wait for 2 minutes, and then you should see a notification reminding to purchase a plan. Tap on the notification, the app should be open, and a web view should be presented to upgrade your plan.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

24 hrs notification from the notification center
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/98c8ac0e-8e53-4990-a262-7b9175a8e8af" width="320"/>

Upon tapping the notification
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/cc2bea3c-f647-4f19-9442-68487d5b0f30" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.