### PR TITLE
[IAP ] Use injected store in `UpgradesViewModel`

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum UpgradeViewState: Equatable {
+    case loading
+    case loaded(WooWPComPlan)
+    case purchasing(WooWPComPlan)
+    case waiting(WooWPComPlan)
+    case completed(WooWPComPlan)
+    case prePurchaseError(PrePurchaseError)
+    case purchaseUpgradeError(PurchaseUpgradeError)
+
+    var shouldShowPlanDetailsView: Bool {
+        switch self {
+        case .loading, .loaded, .purchasing, .prePurchaseError:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - Equatable conformance
+extension UpgradeViewState {
+    static func ==(lhs: UpgradeViewState, rhs: UpgradeViewState) -> Bool {
+        switch (lhs, rhs) {
+        case (.loading, .loading):
+            return true
+        case (.prePurchaseError(let lhsError), .prePurchaseError(let rhsError)):
+            return lhsError == rhsError
+        default:
+            // TODO: Needs conformance for the rest of cases
+            return false
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -88,7 +88,7 @@ final class UpgradesViewModel: ObservableObject {
 
         observeViewStateAndTrackAnalytics()
 
-        if let site = ServiceLocator.stores.sessionManager.defaultSite, !site.isSiteOwner {
+        if let site = stores.sessionManager.defaultSite, !site.isSiteOwner {
             self.upgradeViewState = .prePurchaseError(.userNotAllowedToUpgrade)
         } else {
             Task {

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -3,25 +3,6 @@ import SwiftUI
 import Yosemite
 import Combine
 
-enum UpgradeViewState {
-    case loading
-    case loaded(WooWPComPlan)
-    case purchasing(WooWPComPlan)
-    case waiting(WooWPComPlan)
-    case completed(WooWPComPlan)
-    case prePurchaseError(PrePurchaseError)
-    case purchaseUpgradeError(PurchaseUpgradeError)
-
-    var shouldShowPlanDetailsView: Bool {
-        switch self {
-        case .loading, .loaded, .purchasing, .prePurchaseError:
-            return true
-        default:
-            return false
-        }
-    }
-}
-
 enum PrePurchaseError: Error {
     case fetchError
     case entitlementsError

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1208,6 +1208,7 @@
 		57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */; };
 		57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */; };
 		581D5052274AA2480089B6AD /* View+AutofocusTextModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581D5051274AA2480089B6AD /* View+AutofocusTextModifier.swift */; };
+		680BA59A2A4C377900F5559D /* UpgradeViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680BA5992A4C377900F5559D /* UpgradeViewState.swift */; };
 		682210ED2909666600814E14 /* CustomerSearchUICommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682210EC2909666600814E14 /* CustomerSearchUICommandTests.swift */; };
 		6827140F28A3988300E6E3F6 /* DismissableNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */; };
 		6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */; };
@@ -3526,6 +3527,7 @@
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		581D5051274AA2480089B6AD /* View+AutofocusTextModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AutofocusTextModifier.swift"; sourceTree = "<group>"; };
+		680BA5992A4C377900F5559D /* UpgradeViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeViewState.swift; sourceTree = "<group>"; };
 		682210EC2909666600814E14 /* CustomerSearchUICommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommandTests.swift; sourceTree = "<group>"; };
 		6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableNoticeView.swift; sourceTree = "<group>"; };
 		6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledTextViewTableViewCell.swift; sourceTree = "<group>"; };
@@ -7462,6 +7464,7 @@
 			isa = PBXGroup;
 			children = (
 				68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */,
+				680BA5992A4C377900F5559D /* UpgradeViewState.swift */,
 			);
 			path = InAppPurchases;
 			sourceTree = "<group>";
@@ -11416,6 +11419,7 @@
 				0373A12D2A1D1E6000731236 /* BadgedLeftImageTableViewCell.swift in Sources */,
 				31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */,
 				02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */,
+				680BA59A2A4C377900F5559D /* UpgradeViewState.swift in Sources */,
 				E11228BE2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift in Sources */,
 				EEC5E01129A70CC300416CAC /* StoreSetupProgressView.swift in Sources */,
 				B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -76,4 +76,22 @@ final class UpgradesViewModelTests: XCTestCase {
         assertEqual("debug.woocommerce.express.essential.monthly", plan.wpComPlan.id)
         assertEqual("$1.50", plan.wpComPlan.displayPrice)
     }
+
+    func test_upgradeViewState_when_initialized_is_loading_state() {
+        // Given, When
+        // see `setUp`
+
+        // Then
+        XCTAssertEqual(sut.upgradeViewState, .loading)
+    }
+
+    func test_upgradeViewState_when_initialized_by_non_owner_then_state_is_prepurchaseError_userNotAllowedToUpgrade() {
+         // Given
+         let site = Site.fake().copy(isSiteOwner: false)
+         let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
+         let sut = UpgradesViewModel(siteID: sampleSiteID, stores: stores)
+
+         // Then
+         XCTAssertEqual(sut.upgradeViewState, .prePurchaseError(.userNotAllowedToUpgrade))
+     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -82,7 +82,7 @@ final class UpgradesViewModelTests: XCTestCase {
         // see `setUp`
 
         // Then
-        XCTAssertEqual(sut.upgradeViewState, .loading)
+        assertEqual(.loading, sut.upgradeViewState)
     }
 
     func test_upgradeViewState_when_initialized_by_non_owner_then_state_is_prepurchaseError_userNotAllowedToUpgrade() {
@@ -92,6 +92,6 @@ final class UpgradesViewModelTests: XCTestCase {
          let sut = UpgradesViewModel(siteID: sampleSiteID, stores: stores)
 
          // Then
-         XCTAssertEqual(sut.upgradeViewState, .prePurchaseError(.userNotAllowedToUpgrade))
+         assertEqual(.prePurchaseError(.userNotAllowedToUpgrade), sut.upgradeViewState)
      }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
This PR removes the ServiceLocator store reference from UpgradesViewModel, in favor of the injected store (which will default anyway to the shared instance if none is provided).

The change is done with the first commit at 5523bf04a4f87ec3c18463fc19b56b31384592f2, the rest of changes are added to make this testable and to start extracting components to their own files. If you prefer to just go ahead with the initial change for now, happy to revert the rest 👍 

## Changes

* Use injected store `UpgradesViewModel` for rather that the ServiceLocator shared instance
* Extracts `UpgradeViewState` to its own file
* Adds partial Equatable conformance for the UpgradeViewState `.loading` and `.prePurchaseError` cases. Since `WooWPComPlan` and `PurchaseUpgradeError` associated types are currently non-equatable and require more extensive changes, these can be left for future PRs when we add more tests.
* Adds basic Unit Tests to confirm the state changes if the user is site owner or not based on store injection.

## Testing instructions
There's no user-facing changes. Unit Tests should pass.
