### PR TITLE
[IAP] Send `transactionId` to create `/iap/order`

### DIFF
--- a/Networking/Networking/Remote/InAppPurchasesRemote.swift
+++ b/Networking/Networking/Remote/InAppPurchasesRemote.swift
@@ -30,13 +30,15 @@ public class InAppPurchasesRemote: Remote {
         productIdentifier: String,
         appStoreCountryCode: String,
         originalTransactionId: UInt64,
+        transactionId: UInt64,
         completion: @escaping (Swift.Result<Int, Error>) -> Void) {
             let parameters: [String: Any] = [
                 Constants.siteIDKey: siteID,
                 Constants.priceKey: price,
                 Constants.productIDKey: productIdentifier,
                 Constants.appStoreCountryCodeKey: appStoreCountryCode,
-                Constants.originalTransactionId: originalTransactionId
+                Constants.originalTransactionId: originalTransactionId,
+                Constants.transactionId: transactionId
             ]
             let request = DotcomRequest(
                 wordpressApiVersion: .wpcomMark2,
@@ -80,7 +82,8 @@ public extension InAppPurchasesRemote {
         price: Int,
         productIdentifier: String,
         appStoreCountryCode: String,
-        originalTransactionId: UInt64
+        originalTransactionId: UInt64,
+        transactionId: UInt64
     ) async throws -> Int {
         try await withCheckedThrowingContinuation { continuation in
             createOrder(
@@ -88,7 +91,8 @@ public extension InAppPurchasesRemote {
                 price: price,
                 productIdentifier: productIdentifier,
                 appStoreCountryCode: appStoreCountryCode,
-                originalTransactionId: originalTransactionId
+                originalTransactionId: originalTransactionId,
+                transactionId: transactionId
             ) { result in
                 continuation.resume(with: result)
             }
@@ -118,5 +122,6 @@ private extension InAppPurchasesRemote {
         static let productIDKey = "product_id"
         static let appStoreCountryCodeKey = "appstore_country"
         static let originalTransactionId = "original_transaction_id"
+        static let transactionId = "transaction_id"
     }
 }

--- a/Networking/NetworkingTests/Remote/InAppPurchasesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/InAppPurchasesRemoteTests.swift
@@ -61,7 +61,8 @@ class InAppPurchasesRemoteTests: XCTestCase {
                 price: 2499,
                 productIdentifier: "woocommerce_entry_monthly",
                 appStoreCountryCode: "us",
-                originalTransactionId: 1234) { aResult in
+                originalTransactionId: 1234,
+                transactionId: 12345) { aResult in
                     result = aResult
                     expectation.fulfill()
                 }

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -232,7 +232,8 @@ private extension InAppPurchaseStore {
                 price: priceInCents,
                 productIdentifier: product.id,
                 appStoreCountryCode: countryCode,
-                originalTransactionId: transaction.originalID
+                originalTransactionId: transaction.originalID,
+                transactionId: transaction.id
             )
             logInfo("Successfully registered purchase with Order ID \(orderID)")
         } catch WordPressApiError.productPurchased {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10108
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Attach Proxyman or Charles to observe API traffic, or check in WormHoly after the fact (`Menu > Settings > Launch Wormholy debug > Search iap/orders`

Using an App Store sandbox user:

Build the app and select a Woo Express store with a Free Trial active
Tap `Upgrade now` in the banner
Wait for the plan to load and tap `Purchase`
Complete the In-App Purchase and wait for the purchase to complete
Check the request to `/iap/orders`
Observe that it includes both `transaction_id` and `original_transaction_id`. These will be identical if this is the first purchase you've made using the sandbox user in question, or different if you've made other purchases before (i.e. this is a "renewal", even though it's for a different site)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![successful API Request for /iap/order/ with `transactionId`](https://github.com/woocommerce/woocommerce-ios/assets/2472348/a79b0892-1de7-4c55-8246-a045e47b5aa1)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
