### PR TITLE
[Performance] Add Networking model and mapper for WC Analytics products report

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -666,6 +666,8 @@
 		CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE92236E191005C79FB /* ProductType.swift */; };
 		CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6D666B2379E19D007835A1 /* Array+Woo.swift */; };
 		CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */; };
+		CE71E2292A4C35C900DB5376 /* reports-products.json in Resources */ = {isa = PBXBuildFile; fileRef = CE71E2282A4C35C900DB5376 /* reports-products.json */; };
+		CE71E2372A4C3F3900DB5376 /* reports-products-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */; };
 		CE831FE72A17FC1800E8BEFB /* order-with-composite-product.json in Resources */ = {isa = PBXBuildFile; fileRef = CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */; };
 		CE865A9D2A41E1480049B03C /* EntityDateModifiedMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */; };
 		CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */; };
@@ -1615,6 +1617,8 @@
 		CE6BFEE92236E191005C79FB /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		CE6D666B2379E19D007835A1 /* Array+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Woo.swift"; sourceTree = "<group>"; };
 		CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayWooTests.swift; sourceTree = "<group>"; };
+		CE71E2282A4C35C900DB5376 /* reports-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reports-products.json"; sourceTree = "<group>"; };
+		CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reports-products-without-data.json"; sourceTree = "<group>"; };
 		CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-composite-product.json"; sourceTree = "<group>"; };
 		CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapper.swift; sourceTree = "<group>"; };
 		CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt.json"; sourceTree = "<group>"; };
@@ -2663,6 +2667,8 @@
 				CEC4BF90234E40B5008D9195 /* refund-single.json */,
 				CEC4BF92234E7EE0008D9195 /* refunds-all.json */,
 				7412A8EF21B6E415005D182A /* report-orders.json */,
+				CE71E2282A4C35C900DB5376 /* reports-products.json */,
+				CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */,
 				D88D5A40230BC5DA007B6E01 /* reviews-all.json */,
 				57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */,
 				D88D5A42230BC668007B6E01 /* reviews-single.json */,
@@ -3664,10 +3670,12 @@
 				3158FE7826129DF300E566B9 /* wcpay-account-restricted.json in Resources */,
 				45A4B85625D2E75300776FB4 /* shipping-label-address-validation-success.json in Resources */,
 				457FC68C2382B2FD00B41B02 /* product-update.json in Resources */,
+				CE71E2292A4C35C900DB5376 /* reports-products.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,
 				EEA6584C2966CC4800112DF0 /* product-id-only-without-data.json in Resources */,
 				02F096C22406691100C0C1D5 /* media-library.json in Resources */,
 				028CB717290223CB00331C09 /* create-account-error-password.json in Resources */,
+				CE71E2372A4C3F3900DB5376 /* reports-products-without-data.json in Resources */,
 				D800DA0E25EFEC21001E13CE /* wcpay-connection-token.json in Resources */,
 				CE865AA32A4207A50049B03C /* date-modified-gmt-without-data.json in Resources */,
 				74159628224D63CE003C21CF /* settings-product-alt.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -668,6 +668,9 @@
 		CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */; };
 		CE71E2292A4C35C900DB5376 /* reports-products.json in Resources */ = {isa = PBXBuildFile; fileRef = CE71E2282A4C35C900DB5376 /* reports-products.json */; };
 		CE71E2372A4C3F3900DB5376 /* reports-products-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */; };
+		CE71E22F2A4C38C900DB5376 /* ProductsReportItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE71E22E2A4C38C900DB5376 /* ProductsReportItem.swift */; };
+		CE71E2312A4C3DDA00DB5376 /* ProductsReportMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE71E2302A4C3DDA00DB5376 /* ProductsReportMapper.swift */; };
+		CE71E2332A4C3EDD00DB5376 /* ProductsReportMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE71E2322A4C3EDD00DB5376 /* ProductsReportMapperTests.swift */; };
 		CE831FE72A17FC1800E8BEFB /* order-with-composite-product.json in Resources */ = {isa = PBXBuildFile; fileRef = CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */; };
 		CE865A9D2A41E1480049B03C /* EntityDateModifiedMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */; };
 		CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */; };
@@ -1619,6 +1622,9 @@
 		CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayWooTests.swift; sourceTree = "<group>"; };
 		CE71E2282A4C35C900DB5376 /* reports-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reports-products.json"; sourceTree = "<group>"; };
 		CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reports-products-without-data.json"; sourceTree = "<group>"; };
+		CE71E22E2A4C38C900DB5376 /* ProductsReportItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsReportItem.swift; sourceTree = "<group>"; };
+		CE71E2302A4C3DDA00DB5376 /* ProductsReportMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsReportMapper.swift; sourceTree = "<group>"; };
+		CE71E2322A4C3EDD00DB5376 /* ProductsReportMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsReportMapperTests.swift; sourceTree = "<group>"; };
 		CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-composite-product.json"; sourceTree = "<group>"; };
 		CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapper.swift; sourceTree = "<group>"; };
 		CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt.json"; sourceTree = "<group>"; };
@@ -2048,6 +2054,7 @@
 				26B2F74224C545D50065CCC8 /* Leaderboard.swift */,
 				26B2F74A24C696C00065CCC8 /* LeaderboardRow.swift */,
 				26B2F74C24C696E70065CCC8 /* LeaderboardRowContent.swift */,
+				CE71E22E2A4C38C900DB5376 /* ProductsReportItem.swift */,
 			);
 			path = Stats;
 			sourceTree = "<group>";
@@ -2848,6 +2855,7 @@
 				0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */,
 				025CA2C1238EBBAA00B05C81 /* ProductShippingClassListMapper.swift */,
 				45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */,
+				CE71E2302A4C3DDA00DB5376 /* ProductsReportMapper.swift */,
 				CE430673234BA6AD0073CBFF /* RefundMapper.swift */,
 				CE430675234BA7920073CBFF /* RefundListMapper.swift */,
 				7412A8EB21B6E286005D182A /* ReportOrderTotalsMapper.swift */,
@@ -3008,6 +3016,7 @@
 				45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */,
 				26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */,
 				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
+				CE71E2322A4C3EDD00DB5376 /* ProductsReportMapperTests.swift */,
 				4599FC5924A626B70056157A /* ProductTagListMapperTests.swift */,
 				CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */,
 				EE57C145297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift */,
@@ -3882,6 +3891,7 @@
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
 				57E8FED3246616AC0057CD68 /* Result+Extensions.swift in Sources */,
 				020D07BC23D856BF00FD9580 /* MediaRemote.swift in Sources */,
+				CE71E2312A4C3DDA00DB5376 /* ProductsReportMapper.swift in Sources */,
 				0286981429ED2D6400853B88 /* GenerativeContentRemote.swift in Sources */,
 				EE2C09C829AF6357009396F9 /* StoreOnboardingTask.swift in Sources */,
 				D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */,
@@ -4058,6 +4068,7 @@
 				B505F6EC20BEFDC200BB1B69 /* Loader.swift in Sources */,
 				74D3BD142114FE6900A6E85E /* MIContainer.swift in Sources */,
 				E1BAB2C72913FB5800C3982B /* WordPressApiError.swift in Sources */,
+				CE71E22F2A4C38C900DB5376 /* ProductsReportItem.swift in Sources */,
 				314703082670222500EF253A /* PaymentGatewayAccount.swift in Sources */,
 				CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */,
 				B5BB1D1220A255EC00112D92 /* OrderStatusEnum.swift in Sources */,
@@ -4211,6 +4222,7 @@
 				EEA658482966CBAD00112DF0 /* EntityIDMapperTests.swift in Sources */,
 				EE2C09C429AF5274009396F9 /* StoreOnboardingTaskListMapperTests.swift in Sources */,
 				DEC51AFB2769C66B009F3DF4 /* SystemStatusMapperTests.swift in Sources */,
+				CE71E2332A4C3EDD00DB5376 /* ProductsReportMapperTests.swift in Sources */,
 				DE34051F28BDFB0B00CF0D97 /* JetpackConnectionRemoteTests.swift in Sources */,
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,
 				68F48B0F28E3BB850045C15B /* WCAnalyticsCustomerRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductsReportMapper.swift
+++ b/Networking/Networking/Mapper/ProductsReportMapper.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Mapper: `[ProductsReportItem]`
+///
+struct ProductsReportMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into `[ProductsReportItem]`.
+    ///
+    func map(response: Data) throws -> [ProductsReportItem] {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(ProductsReportEnvelope.self, from: response).items
+        } else {
+            return try decoder.decode([ProductsReportItem].self, from: response)
+        }
+    }
+}
+
+
+/// ProductsReportEnvelope Disposable Entity:
+/// Load Products Report endpoint returns the coupon in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct ProductsReportEnvelope: Decodable {
+    let items: [ProductsReportItem]
+
+    private enum CodingKeys: String, CodingKey {
+        case items = "data"
+    }
+}

--- a/Networking/Networking/Model/Stats/ProductsReportItem.swift
+++ b/Networking/Networking/Model/Stats/ProductsReportItem.swift
@@ -4,7 +4,7 @@ import class Aztec.HTMLParser
 
 /// Represents a single product in a products analytics report over a specific period.
 ///
-public struct ProductsReportItem: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct ProductsReportItem: Decodable, Equatable {
 
     /// Product ID
     ///

--- a/Networking/Networking/Model/Stats/ProductsReportItem.swift
+++ b/Networking/Networking/Model/Stats/ProductsReportItem.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Codegen
+import class Aztec.HTMLParser
+
+/// Represents a single product in a products analytics report over a specific period.
+///
+public struct ProductsReportItem: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+
+    /// Product ID
+    ///
+    public let productID: Int64
+
+    /// Product name
+    ///
+    public let productName: String
+
+    /// Quantity sold
+    ///
+    public let quantity: Int
+
+    /// Price of item
+    ///
+    public let price: Double
+
+    /// Net revenue from product
+    ///
+    public let total: Double
+
+    /// Image URL for product
+    ///
+    public let imageUrl: String?
+
+
+    /// Designated Initializer.
+    ///
+    public init(productID: Int64, productName: String, quantity: Int, price: Double, total: Double, imageUrl: String?) {
+        self.productID = productID
+        self.productName = productName
+        self.quantity = quantity
+        self.price = price
+        self.total = total
+        self.imageUrl = imageUrl
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let productID = try container.decode(Int64.self, forKey: .productID)
+        let quantity = try container.decode(Int.self, forKey: .quantity)
+        let total = try container.decode(Double.self, forKey: .total)
+
+        let extendedInfo = try container.nestedContainer(keyedBy: ExtendedInfoCodingKeys.self, forKey: .extendedInfo)
+
+        let productName = try extendedInfo.decode(String.self, forKey: .productName)
+        let price = try extendedInfo.decode(Double.self, forKey: .price)
+
+        // Parse and extract the `src` string out of the image html using `Aztec parser`
+        let imageUrl: String? = {
+            guard let imageHTML = try? extendedInfo.decodeIfPresent(String.self, forKey: .imageHTML),
+            let img = HTMLParser().parse(imageHTML).firstChild(ofType: .img),
+            let src = img.attribute(ofType: .src)?.value.toString() else {
+                return nil
+            }
+            return src
+        }()
+
+        self.init(productID: productID, productName: productName, quantity: quantity, price: price, total: total, imageUrl: imageUrl)
+    }
+}
+
+
+/// Defines all of the ProductsReportItem CodingKeys.
+///
+private extension ProductsReportItem {
+    enum CodingKeys: String, CodingKey {
+        case productID      = "product_id"
+        case total          = "net_revenue"
+        case quantity       = "items_sold"
+        case extendedInfo   = "extended_info"
+    }
+
+    enum ExtendedInfoCodingKeys: String, CodingKey {
+        case productName    = "name"
+        case price          = "price"
+        case imageHTML      = "image"
+    }
+}
+
+
+// MARK: - Comparable Conformance
+//
+extension ProductsReportItem: Comparable {
+    public static func < (lhs: ProductsReportItem, rhs: ProductsReportItem) -> Bool {
+        return lhs.quantity < rhs.quantity ||
+            (lhs.quantity == rhs.quantity && lhs.total < rhs.total)
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductsReportMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductsReportMapperTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Networking
+
+final class ProductsReportMapperTests: XCTestCase {
+
+    /// Verifies that the whole list is parsed.
+    ///
+    func test_mapper_parses_all_products_in_response() throws {
+        // Given
+        let products = try mapLoadProductsReportResponseWithDataEnvelope()
+
+        // Then
+        XCTAssertEqual(products.count, 2)
+    }
+
+    /// Verifies that the whole list is parsed.
+    ///
+    func test_mapper_parses_all_products_in_response_without_data_envelope() throws {
+        // Given
+        let products = try mapLoadProductsReportResponseWithoutDataEnvelope()
+
+        // Then
+        XCTAssertEqual(products.count, 2)
+    }
+
+    /// Verifies that the fields are all parsed correctly
+    ///
+    func test_mapper_parses_all_fields_in_result() throws {
+        // Given
+        let products = try mapLoadProductsReportResponseWithDataEnvelope()
+        let product = products[0]
+        let expectedProduct = ProductsReportItem(productID: 233,
+                                                 productName: "Colorful Sunglasses Subscription",
+                                                 quantity: 5,
+                                                 price: 5,
+                                                 total: 177,
+                                                 imageUrl: "https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg")
+
+        // Then
+        XCTAssertEqual(product, expectedProduct)
+    }
+}
+
+// MARK: - Test Helpers
+///
+private extension ProductsReportMapperTests {
+
+    /// Returns the ProductsReportMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapReport(from filename: String) throws -> [ProductsReportItem] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try ProductsReportMapper().map(response: response)
+    }
+
+    /// Returns the ProductsReportItem list from `coupon-reports.json`
+    ///
+    func mapLoadProductsReportResponseWithDataEnvelope() throws -> [ProductsReportItem] {
+        return try mapReport(from: "reports-products")
+    }
+
+    /// Returns the ProductsReportItem list from `coupon-reports-without-data.json`
+    ///
+    func mapLoadProductsReportResponseWithoutDataEnvelope() throws -> [ProductsReportItem] {
+        return try mapReport(from: "reports-products-without-data")
+    }
+}

--- a/Networking/NetworkingTests/Responses/reports-products-without-data.json
+++ b/Networking/NetworkingTests/Responses/reports-products-without-data.json
@@ -1,0 +1,67 @@
+[
+    {
+        "product_id": 233,
+        "items_sold": 5,
+        "net_revenue": 177,
+        "orders_count": 5,
+        "extended_info": {
+            "name": "Colorful Sunglasses Subscription",
+            "price": 5,
+            "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg 600w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-768x768.jpg 768w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg 801w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"51\" data-permalink=\"https://example.com/?attachment_id=51\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg\" data-orig-size=\"801,801\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"sunglasses-2.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg\" />",
+            "permalink": "https://example.com/product/colorful-sunglasses-subscription/",
+            "stock_status": "instock",
+            "stock_quantity": 0,
+            "manage_stock": false,
+            "low_stock_amount": 2,
+            "category_ids": [],
+            "variations": [
+                241,
+                235,
+                236,
+                238,
+                500
+            ],
+            "sku": ""
+        },
+        "_links": {
+            "product": [
+                {
+                    "href": "https://example.com/wp-json/wc-analytics/products/233"
+                }
+            ]
+        }
+    },
+    {
+        "product_id": 16,
+        "items_sold": 1,
+        "net_revenue": 24,
+        "orders_count": 1,
+        "extended_info": {
+            "name": "Hoodie",
+            "price": 24,
+            "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/hoodie-2-600x600.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/hoodie-2-600x600.jpg 600w, https://example.com/wp-content/uploads/2023/01/hoodie-2-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/hoodie-2-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/hoodie-2-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/hoodie-2-768x768.jpg 768w, https://example.com/wp-content/uploads/2023/01/hoodie-2-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/hoodie-2-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/hoodie-2.jpg 801w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"43\" data-permalink=\"https://example.com/?attachment_id=43\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/hoodie-2.jpg\" data-orig-size=\"801,801\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"hoodie-2.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/hoodie-2-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/hoodie-2.jpg\" />",
+            "permalink": "https://example.com/product/hoodie/",
+            "stock_status": "instock",
+            "stock_quantity": 0,
+            "manage_stock": false,
+            "low_stock_amount": 2,
+            "category_ids": [
+                1362
+            ],
+            "variations": [
+                39,
+                32,
+                33,
+                34
+            ],
+            "sku": "woo-hoodie"
+        },
+        "_links": {
+            "product": [
+                {
+                    "href": "https://example.com/wp-json/wc-analytics/products/16"
+                }
+            ]
+        }
+    }
+]

--- a/Networking/NetworkingTests/Responses/reports-products.json
+++ b/Networking/NetworkingTests/Responses/reports-products.json
@@ -1,0 +1,64 @@
+{
+    "data": [
+        {
+            "product_id": 233,
+            "items_sold": 5,
+            "net_revenue": 177,
+            "orders_count": 5,
+            "extended_info": {
+                "name": "Colorful Sunglasses Subscription",
+                "price": 5,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg 600w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-768x768.jpg 768w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg 801w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"51\" data-permalink=\"https://example.com/?attachment_id=51\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg\" data-orig-size=\"801,801\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"sunglasses-2.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg\" />",
+                "permalink": "https://example.com/product/colorful-sunglasses-subscription/",
+                "stock_status": "instock",
+                "stock_quantity": 0,
+                "manage_stock": false,
+                "low_stock_amount": 2,
+                "category_ids": [],
+                "variations": [
+                    241,
+                    235,
+                    236,
+                    238,
+                    500
+                ],
+                "sku": ""
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/233"
+                    }
+                ]
+            }
+        },
+        {
+            "product_id": 27,
+            "items_sold": 1,
+            "net_revenue": 0,
+            "orders_count": 1,
+            "extended_info": {
+                "name": "Album",
+                "price": 15,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/album-1-600x600.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/album-1-600x600.jpg 600w, https://example.com/wp-content/uploads/2023/01/album-1-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/album-1-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/album-1-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/album-1-768x768.jpg 768w, https://example.com/wp-content/uploads/2023/01/album-1-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/album-1-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/album-1.jpg 800w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"56\" data-permalink=\"https://example.com/?attachment_id=56\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/album-1.jpg\" data-orig-size=\"800,800\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"album-1.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/album-1-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/album-1.jpg\" />",
+                "permalink": "https://example.com/product/album/",
+                "stock_status": "instock",
+                "stock_quantity": 0,
+                "manage_stock": false,
+                "low_stock_amount": 2,
+                "category_ids": [
+                    1364
+                ],
+                "sku": "woo-album"
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/27"
+                    }
+                ]
+            }
+        }
+    ]
+}
+


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10096
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We currently use the `/wc-analytics/leaderboards` endpoint (and a second request to the `products` endpoint) to populate the Top Performers section in My Store. To improve performance, we can switch to fetching this data from `/wc-analytics/reports/products` with a single request. This is the same data used for the WC Analytics Products report on the web.

This PR adds a model and mapper in the Networking layer to support that endpoint's response:

* Adds mock endpoint responses (with and without `data` wrapper)
* Adds a model `ProductsReportItem` to represent a product in a products report.
* Adds a mapper `ProductsReportMapper` for mapping the response to the model, and adds related unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Confirm unit tests pass. You can also use the testing instructions in #10113 to test the full set of changes.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
