### PR TITLE
[Performance] Use the products report endpoint to fetch top earner stats

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -673,6 +673,7 @@
 		CE71E2332A4C3EDD00DB5376 /* ProductsReportMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE71E2322A4C3EDD00DB5376 /* ProductsReportMapperTests.swift */; };
 		CE71E2372A4C3F3900DB5376 /* reports-products-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */; };
 		CE71E2392A4C594600DB5376 /* ProductsReportsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE71E2382A4C594600DB5376 /* ProductsReportsRemoteTests.swift */; };
+		CE71E23B2A4C666A00DB5376 /* reports-products-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE71E23A2A4C666A00DB5376 /* reports-products-alt.json */; };
 		CE831FE72A17FC1800E8BEFB /* order-with-composite-product.json in Resources */ = {isa = PBXBuildFile; fileRef = CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */; };
 		CE865A9D2A41E1480049B03C /* EntityDateModifiedMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */; };
 		CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */; };
@@ -1629,6 +1630,7 @@
 		CE71E2322A4C3EDD00DB5376 /* ProductsReportMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsReportMapperTests.swift; sourceTree = "<group>"; };
 		CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reports-products-without-data.json"; sourceTree = "<group>"; };
 		CE71E2382A4C594600DB5376 /* ProductsReportsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsReportsRemoteTests.swift; sourceTree = "<group>"; };
+		CE71E23A2A4C666A00DB5376 /* reports-products-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reports-products-alt.json"; sourceTree = "<group>"; };
 		CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-composite-product.json"; sourceTree = "<group>"; };
 		CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapper.swift; sourceTree = "<group>"; };
 		CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt.json"; sourceTree = "<group>"; };
@@ -2681,6 +2683,7 @@
 				CEC4BF92234E7EE0008D9195 /* refunds-all.json */,
 				7412A8EF21B6E415005D182A /* report-orders.json */,
 				CE71E2282A4C35C900DB5376 /* reports-products.json */,
+				CE71E23A2A4C666A00DB5376 /* reports-products-alt.json */,
 				CE71E2362A4C3F3900DB5376 /* reports-products-without-data.json */,
 				D88D5A40230BC5DA007B6E01 /* reviews-all.json */,
 				57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */,
@@ -3701,6 +3704,7 @@
 				451274A625276C82009911FF /* product-variation.json in Resources */,
 				CC80E3F92948C8BC00D5FF45 /* site-visits-quarter.json in Resources */,
 				020D07C223D858BB00FD9580 /* media-upload.json in Resources */,
+				CE71E23B2A4C666A00DB5376 /* reports-products-alt.json in Resources */,
 				31A451D127863A2E00FE81AA /* stripe-account-rejected-other.json in Resources */,
 				DEF13C5029629EEA0024A02B /* user-complete-without-data.json in Resources */,
 				EE57C123297EB04F00BC31E7 /* product-attribute-create-without-data.json in Resources */,

--- a/Networking/NetworkingTests/Responses/reports-products-alt.json
+++ b/Networking/NetworkingTests/Responses/reports-products-alt.json
@@ -1,0 +1,65 @@
+{
+    "data": [
+        {
+            "product_id": 233,
+            "items_sold": 8,
+            "net_revenue": 215,
+            "orders_count": 8,
+            "extended_info": {
+                "name": "Colorful Sunglasses Subscription",
+                "price": 5,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg 600w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-768x768.jpg 768w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/sunglasses-2-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg 801w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"51\" data-permalink=\"https://example.com/?attachment_id=51\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg\" data-orig-size=\"801,801\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"sunglasses-2.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/sunglasses-2.jpg\" />",
+                "permalink": "https://example.com/product/colorful-sunglasses-subscription/",
+                "stock_status": "instock",
+                "stock_quantity": 0,
+                "manage_stock": false,
+                "low_stock_amount": 2,
+                "category_ids": [],
+                "variations": [
+                    241,
+                    235,
+                    236,
+                    238,
+                    500
+                ],
+                "sku": ""
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/233"
+                    }
+                ]
+            }
+        },
+        {
+            "product_id": 27,
+            "items_sold": 4,
+            "net_revenue": 45,
+            "orders_count": 4,
+            "extended_info": {
+                "name": "Album",
+                "price": 15,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/album-1-600x600.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/album-1-600x600.jpg 600w, https://example.com/wp-content/uploads/2023/01/album-1-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/album-1-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/album-1-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/album-1-768x768.jpg 768w, https://example.com/wp-content/uploads/2023/01/album-1-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/album-1-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/album-1.jpg 800w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"56\" data-permalink=\"https://example.com/?attachment_id=56\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/album-1.jpg\" data-orig-size=\"800,800\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"album-1.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/album-1-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/album-1.jpg\" />",
+                "permalink": "https://example.com/product/album/",
+                "stock_status": "instock",
+                "stock_quantity": 0,
+                "manage_stock": false,
+                "low_stock_amount": 2,
+                "category_ids": [
+                    1364
+                ],
+                "sku": "woo-album"
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/27"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] SKU Scanner: Add the SKU to the error message after a failure. [https://github.com/woocommerce/woocommerce-ios/pull/10085]
 - [*] Add URL route handler to open the `My Store` tab when a deeplink to `/mobile` is opened, instead of bouncing back to Safari [https://github.com/woocommerce/woocommerce-ios/pull/10077]
+- [Internal] Performance: Replaces the endpoint used to load Top Performers on the My Store tab, for faster loading. [https://github.com/woocommerce/woocommerce-ios/pull/10113]
 
 14.2
 -----

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -7,14 +7,12 @@ import WooFoundation
 //
 public final class StatsStoreV4: Store {
     private let siteStatsRemote: SiteStatsRemote
-    private let leaderboardsRemote: LeaderboardsRemote
     private let orderStatsRemote: OrderStatsRemoteV4
     private let productsRemote: ProductsRemote
     private let productsReportsRemote: ProductsReportsRemote
 
     public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         self.siteStatsRemote = SiteStatsRemote(network: network)
-        self.leaderboardsRemote = LeaderboardsRemote(network: network)
         self.orderStatsRemote = OrderStatsRemoteV4(network: network)
         self.productsRemote = ProductsRemote(network: network)
         self.productsReportsRemote = ProductsReportsRemote(network: network)
@@ -293,43 +291,6 @@ private extension StatsStoreV4 {
                                                    productsReport: productsReport,
                                                    quantity: quantity)
     }
-
-    @MainActor
-    func loadTopEarnerStatsWithDeprecatedAPI(siteID: Int64,
-                                             timeRange: StatsTimeRangeV4,
-                                             earliestDateToInclude: Date,
-                                             latestDateToInclude: Date,
-                                             quantity: Int,
-                                             forceRefresh: Bool) async throws -> TopEarnerStats {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<TopEarnerStats, Error>) -> Void in
-            let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
-            let earliestDate = dateFormatter.string(from: earliestDateToInclude)
-            let latestDate = dateFormatter.string(from: latestDateToInclude)
-            leaderboardsRemote.loadLeaderboardsDeprecated(for: siteID,
-                                                          unit: timeRange.leaderboardsGranularity,
-                                                          earliestDateToInclude: earliestDate,
-                                                          latestDateToInclude: latestDate,
-                                                          quantity: quantity,
-                                                          forceRefresh: forceRefresh) { [weak self] result in
-                guard let self = self else {
-                    return
-                }
-
-                switch result {
-                case .success(let leaderboards):
-                    self.convertLeaderboardsIntoTopEarners(siteID: siteID,
-                                                           granularity: timeRange.topEarnerStatsGranularity,
-                                                           date: latestDateToInclude,
-                                                           leaderboards: leaderboards,
-                                                           quantity: quantity) { result in
-                        continuation.resume(with: result)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
 }
 
 
@@ -480,44 +441,9 @@ extension StatsStoreV4 {
     }
 }
 
-// MARK: Convert Leaderboard into TopEarnerStats
+// MARK: Convert Products Report into TopEarnerStats
 //
 private extension StatsStoreV4 {
-
-    /// Converts a top-product `leaderboard` into a `StatsTopEarner`
-    /// Since  a `leaderboard` does not contain the necessary product information, this method fetches the related product before starting the conversion.
-    ///
-    func convertLeaderboardsIntoTopEarners(siteID: Int64,
-                                           granularity: StatGranularity,
-                                           date: Date,
-                                           leaderboards: [Leaderboard],
-                                           quantity: Int,
-                                           onCompletion: @escaping (Result<TopEarnerStats, Error>) -> Void) {
-
-        // Find the top products leaderboard by its ID
-        guard let topProducts = leaderboards.first(where: { $0.id == Constants.topProductsID }) else {
-            onCompletion(.failure(StatsStoreV4Error.missingTopProducts))
-            return
-        }
-
-        // Make sure we have all the necessary product data before converting and storing top earners.
-        loadProducts(for: topProducts, siteID: siteID) { [weak self] topProductsResult in
-            guard let self = self else { return }
-
-            switch topProductsResult {
-            case .success(let products):
-                let topEarners = self.mergeTopProductsAndStoredProductsIntoTopEarners(siteID: siteID,
-                                                                                      granularity: granularity,
-                                                                                      date: date,
-                                                                                      topProducts: topProducts,
-                                                                                      storedProducts: products,
-                                                                                      quantityLimit: quantity)
-                onCompletion(.success((topEarners)))
-            case .failure(let error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
 
     /// Converts the `[ProductsReportItem]` list in a Products analytics report into `TopEarnerStats`
     ///
@@ -538,60 +464,6 @@ private extension StatsStoreV4 {
         }
         return TopEarnerStats(siteID: siteID, date: statsDate, granularity: granularity, limit: quantity.description, items: statsItems)
     }
-
-    /// Loads product objects that relates to the top products on a `leaderboard`
-    /// If product objects can't be found in the storage layer, they will be fetched from the remote layer.
-    ///
-    func loadProducts(for topProducts: Leaderboard, siteID: Int64, completion: @escaping (Result<[Product], Error>) -> Void) {
-
-        // Workout if we have stored all products that relate to the given leaderboard
-        let topProductIDs = LeaderboardStatsConverter.topProductsIDs(from: topProducts)
-        let topStoredProducts = loadStoredProducts(siteID: siteID, productIDs: topProductIDs)
-        let missingProductsIDs = LeaderboardStatsConverter.missingProductsIDs(from: topProducts, in: topStoredProducts)
-
-        // Return if we have all the products that we need
-        guard !missingProductsIDs.isEmpty else {
-            completion(.success(topStoredProducts))
-            return
-        }
-
-        // Fetch the products that we have not downloaded and stored yet
-        productsRemote.loadProducts(for: siteID, by: missingProductsIDs) { result in
-            switch result {
-            case .success(let products):
-                // Return the complete array of products that corresponds to a top product leaderboard
-                let completeTopProducts = products + topStoredProducts
-                completion(.success(completeTopProducts))
-
-            case .failure:
-                completion(result)
-            }
-        }
-    }
-
-    /// Returns all stored products for a given site ID
-    ///
-    func loadStoredProducts(siteID: Int64, productIDs: [Int64] ) -> [Networking.Product] {
-        let products = storageManager.viewStorage.loadProducts(siteID: siteID, productsIDs: productIDs)
-        return products.map { $0.toReadOnly() }
-    }
-
-    /// Merges a top-product leaderboard with an array of stored products into  a `TopEarnerStats` object
-    ///
-    func mergeTopProductsAndStoredProductsIntoTopEarners(siteID: Int64,
-                                                         granularity: StatGranularity,
-                                                         date: Date,
-                                                         topProducts: Leaderboard,
-                                                         storedProducts: [Product],
-                                                         quantityLimit: Int) -> TopEarnerStats {
-        let statsDate = Self.buildDateString(from: date, with: granularity)
-        let statsItems = LeaderboardStatsConverter.topEarnerStatsItems(from: topProducts, using: storedProducts)
-        return TopEarnerStats(siteID: siteID,
-                              date: statsDate,
-                              granularity: granularity,
-                              limit: String(quantityLimit),
-                              items: statsItems)
-    }
 }
 
 // MARK: - Public Helpers
@@ -611,17 +483,6 @@ public extension StatsStoreV4 {
         case .year:
             return DateFormatter.Stats.statsYearFormatter.string(from: date)
         }
-    }
-}
-
-// MARK: - Constants!
-//
-private extension StatsStoreV4 {
-
-    enum Constants {
-        /// ID of top products section in leaderboards API
-        ///
-        static let topProductsID = "products"
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10096
⚠️ Depends on #10112 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We currently use the `/wc-analytics/leaderboards` endpoint (and a second request to the `products` endpoint) to populate the Top Performers section in My Store. To improve performance, we can switch to fetching this data from `/wc-analytics/reports/products` with a single request. This is the same data used for the WC Analytics Products report on the web.

Across 5 test runs on the My Store tab, this change resulted in a 42% decrease in the average waiting time for Top Performer stats to load (measured with the `dashboard_top_performers_waiting_time_loaded` analytics event):

/|Average|Min|Max
-|-|-|-
Before|4.92|3.46|9.99
After|2.85|1.23|7.51

### Changes

This PR updates `StatsStoreV4` in the Yosemite layer to make this change:

* The `loadTopEarnerStats` method now uses the `reports/products` endpoint instead of `leaderboards` to fetch the top performers data. It converts the products report data into `TopEarnerStats` so we can store and use it for Top Performers.
* That method is used in `retrieveTopEarnerStats`, which can now be simplified because we don't need to handle two endpoints (the current and deprecated loadboards APIs).
* Other helper methods for leaderboards are also removed from `StatsStoreV4`, since they are no longer needed. (Additional cleanup will be done in another PR.)
* Updates the stats store unit tests to reflect the mock responses for the `reports/products` request.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Confirm the Top Performers list loads on the My Store tab, and shows the expected data.

You can also switch time periods on My Store or open the analytics hub to confirm the Top Performers list also loads correctly there.

## Screenshots

You'll notice a slight difference in the product images, since this endpoint returns placeholder images and slightly different thumbnails. (These match the thumbnails you see for these products on the web, in wp-admin.)

Before|After
-|-
![TopPerformers-Before](https://github.com/woocommerce/woocommerce-ios/assets/8658164/9bf3abd3-285c-4ed6-88d9-5d53f7f21b01)|![TopPerformers-After](https://github.com/woocommerce/woocommerce-ios/assets/8658164/5e992947-e8a2-43c1-8f73-1169a0973bda)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
