### PR TITLE
[IAP] Assorted UI fixes from testing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IndefiniteCircularProgressViewStyle.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IndefiniteCircularProgressViewStyle.swift
@@ -33,6 +33,7 @@ public struct IndefiniteCircularProgressViewStyle: ProgressViewStyle {
         .onDisappear() {
             arcTimer?.invalidate()
         }
+        .accessibilityLabel(Localization.inProgressAccessibilityLabel)
     }
 
     private func progressCircleView() -> some View {
@@ -85,5 +86,11 @@ private extension IndefiniteCircularProgressViewStyle {
 
         static let threeQuarterRotation: Angle = .radians((9 * Double.pi)/6)
         static let fullRotation: Angle = .radians(Double.pi * 2)
+    }
+
+    enum Localization {
+        static let inProgressAccessibilityLabel = NSLocalizedString(
+            "In progress",
+            comment: "Accessibility label for an indeterminate loading indicator")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -74,12 +74,10 @@ struct UpgradesView: View {
                         UpgradeWaitingView(planName: plan.wooPlan.shortName)
                     }
                 case .completed(let plan):
-                    ScrollView(.vertical) {
-                        CompletedUpgradeView(planName: plan.wooPlan.shortName,
-                                             doneAction: {
-                            dismiss()
-                        })
-                    }
+                    CompletedUpgradeView(planName: plan.wooPlan.shortName,
+                                         doneAction: {
+                        dismiss()
+                    })
                 case .prePurchaseError(let error):
                     ScrollView(.vertical) {
                         VStack {
@@ -515,28 +513,34 @@ struct CompletedUpgradeView: View {
     let doneAction: (() -> Void)
 
     var body: some View {
-        VStack(spacing: Layout.groupSpacing) {
-            Image("plan-upgrade-success-celebration")
-                .frame(maxWidth: .infinity, alignment: .center)
-                .accessibilityHidden(true)
+        VStack {
+            ScrollView(.vertical) {
+                VStack(spacing: Layout.groupSpacing) {
+                    Image("plan-upgrade-success-celebration")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .accessibilityHidden(true)
 
-            VStack(spacing: Layout.textSpacing) {
-                Text(Localization.title)
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-                Text(LocalizedString(format: Localization.subtitle, planName))
-                    .font(.title3)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
+                    VStack(spacing: Layout.textSpacing) {
+                        Text(Localization.title)
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Text(LocalizedString(format: Localization.subtitle, planName))
+                            .font(.title3)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Text(Localization.hint)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.top, Layout.completedUpgradeViewTopPadding)
+                .padding(.horizontal, Layout.padding)
             }
-
-            Text(Localization.hint)
-                .font(.footnote)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
 
             Spacer()
 
@@ -544,6 +548,7 @@ struct CompletedUpgradeView: View {
                 doneAction()
             }
             .buttonStyle(PrimaryButtonStyle())
+            .padding(.horizontal, Layout.padding)
         }
         .confettiCannon(counter: $confettiTrigger,
                         num: Constants.numberOfConfettiElements,
@@ -555,8 +560,7 @@ struct CompletedUpgradeView: View {
         .onAppear {
             confettiTrigger += 1
         }
-        .padding(.top, Layout.completedUpgradeViewTopPadding)
-        .padding([.bottom, .horizontal], Layout.padding)
+        .padding(.bottom, Layout.padding)
     }
 
     private struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -460,7 +460,9 @@ struct UpgradeWaitingView: View {
                     Text(Localization.title)
                         .font(.largeTitle)
                         .fontWeight(.bold)
+                        .fixedSize(horizontal: false, vertical: true)
                     Text(String(format: Localization.descriptionFormatString, planName))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .padding(.horizontal, Layout.horizontalPadding)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -146,6 +146,7 @@ struct PrePurchaseUpgradesErrorView: View {
         VStack(alignment: .center, spacing: Layout.spacingBetweenImageAndText) {
             Image("plan-upgrade-error")
                 .frame(maxWidth: .infinity, alignment: .center)
+                .accessibilityHidden(true)
 
             VStack(alignment: .center, spacing: Layout.textSpacing) {
                 switch error {
@@ -257,6 +258,7 @@ struct PurchaseUpgradeErrorView: View {
                 Image(systemName: "exclamationmark.circle")
                     .font(.system(size: Layout.exclamationImageSize))
                     .foregroundColor(.withColorStudio(name: .red, shade: .shade20))
+                    .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: Layout.textSpacing) {
                     Text(error.localizedTitle)
                         .font(.title)
@@ -513,6 +515,7 @@ struct CompletedUpgradeView: View {
         VStack(spacing: Layout.groupSpacing) {
             Image("plan-upgrade-success-celebration")
                 .frame(maxWidth: .infinity, alignment: .center)
+                .accessibilityHidden(true)
 
             VStack(spacing: Layout.textSpacing) {
                 Text(Localization.title)
@@ -594,6 +597,7 @@ struct OwnerUpgradesView: View {
                         .frame(maxWidth: .infinity, alignment: .center)
                         .listRowInsets(.zero)
                         .listRowBackground(upgradePlan.wooPlan.headerImageCardColor)
+                        .accessibilityHidden(true)
 
                     VStack(alignment: .leading) {
                         Text(upgradePlan.wooPlan.shortName)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -70,11 +70,13 @@ struct UpgradesView: View {
                     OwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
                 case .waiting(let plan):
                     UpgradeWaitingView(planName: plan.wooPlan.shortName)
+                        .scrollVerticallyIfNeeded()
                 case .completed(let plan):
                     CompletedUpgradeView(planName: plan.wooPlan.shortName,
                                          doneAction: {
                         dismiss()
                     })
+                    .scrollVerticallyIfNeeded()
                 case .prePurchaseError(let error):
                     VStack {
                         PrePurchaseUpgradesErrorView(error,
@@ -86,6 +88,7 @@ struct UpgradesView: View {
 
                         Spacer()
                     }
+                    .scrollVerticallyIfNeeded()
                     .background(Color(.systemGroupedBackground))
                 case .purchaseUpgradeError(.inAppPurchaseFailed(let plan, let iapStoreError)):
                     PurchaseUpgradeErrorView(error: .inAppPurchaseFailed(plan, iapStoreError)) {
@@ -97,6 +100,7 @@ struct UpgradesView: View {
                     } getSupportAction: {
                         supportHandler()
                     }
+                    .scrollVerticallyIfNeeded()
                 case .purchaseUpgradeError(let underlyingError):
                     // handles .planActivationFailed and .unknown underlyingErrors
                     PurchaseUpgradeErrorView(error: underlyingError,
@@ -105,6 +109,7 @@ struct UpgradesView: View {
                         dismiss()
                     },
                                              getSupportAction: supportHandler)
+                    .scrollVerticallyIfNeeded()
                 }
             }
             .navigationBarHidden(true)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -602,6 +602,7 @@ struct OwnerUpgradesView: View {
                     VStack(alignment: .leading) {
                         Text(upgradePlan.wooPlan.shortName)
                             .font(.largeTitle)
+                            .accessibilityAddTraits(.isHeader)
                         Text(upgradePlan.wooPlan.planDescription)
                             .font(.subheadline)
                     }
@@ -609,10 +610,12 @@ struct OwnerUpgradesView: View {
                     VStack(alignment: .leading) {
                         Text(upgradePlan.wpComPlan.displayPrice)
                             .font(.largeTitle)
+                            .accessibilityAddTraits(.isHeader)
                         Text(upgradePlan.wooPlan.planFrequency.localizedString)
                             .font(.footnote)
                     }
                 }
+                .accessibilityAddTraits(.isSummaryElement)
                 .listRowSeparator(.hidden)
 
                 if upgradePlan.hardcodedPlanDataIsValid {
@@ -763,6 +766,7 @@ private struct UpgradeTopBarView: View {
                 .fontWeight(.bold)
                 .padding()
                 .frame(maxWidth: .infinity, alignment: .center)
+                .accessibilityAddTraits(.isHeader)
 
             Spacer()
         }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -104,14 +104,12 @@ struct UpgradesView: View {
                     }
                 case .purchaseUpgradeError(let underlyingError):
                     // handles .planActivationFailed and .unknown underlyingErrors
-                    ScrollView(.vertical) {
-                        PurchaseUpgradeErrorView(error: underlyingError,
-                                                 primaryAction: nil,
-                                                 secondaryAction: {
-                            dismiss()
-                        },
-                                                 getSupportAction: supportHandler)
-                    }
+                    PurchaseUpgradeErrorView(error: underlyingError,
+                                             primaryAction: nil,
+                                             secondaryAction: {
+                        dismiss()
+                    },
+                                             getSupportAction: supportHandler)
                 }
             }
             .navigationBarHidden(true)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -95,16 +95,14 @@ struct UpgradesView: View {
                     }
                     .background(Color(.systemGroupedBackground))
                 case .purchaseUpgradeError(.inAppPurchaseFailed(let plan, let iapStoreError)):
-                    ScrollView(.vertical) {
-                        PurchaseUpgradeErrorView(error: .inAppPurchaseFailed(plan, iapStoreError)) {
-                            Task {
-                                await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
-                            }
-                        } secondaryAction: {
-                            dismiss()
-                        } getSupportAction: {
-                            supportHandler()
+                    PurchaseUpgradeErrorView(error: .inAppPurchaseFailed(plan, iapStoreError)) {
+                        Task {
+                            await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
                         }
+                    } secondaryAction: {
+                        dismiss()
+                    } getSupportAction: {
+                        supportHandler()
                     }
                 case .purchaseUpgradeError(let underlyingError):
                     // handles .planActivationFailed and .unknown underlyingErrors
@@ -255,58 +253,62 @@ struct PurchaseUpgradeErrorView: View {
 
     var body: some View {
         VStack {
-            VStack(alignment: .leading, spacing: Layout.spacing) {
-                Image(systemName: "exclamationmark.circle")
-                    .font(.system(size: Layout.exclamationImageSize))
-                    .foregroundColor(.withColorStudio(name: .red, shade: .shade20))
-                    .accessibilityHidden(true)
-                VStack(alignment: .leading, spacing: Layout.textSpacing) {
-                    Text(error.localizedTitle)
-                        .font(.title)
-                        .fontWeight(.bold)
-                    Text(error.localizedDescription)
-                    Text(error.localizedActionDirection)
-                        .font(.title3)
-                        .fontWeight(.bold)
-                    if let actionHint = error.localizedActionHint {
-                        Text(actionHint)
-                            .font(.footnote)
-                    }
-                    if let errorCode = error.localizedErrorCode {
-                        Text(String(format: Localization.errorCodeFormat, errorCode))
-                            .font(.footnote)
-                            .foregroundColor(.secondary)
-                    }
-                    Button(action: getSupportAction) {
-                        HStack {
-                            Image(systemName: "questionmark.circle")
-                                .font(.body.weight(.semibold))
-                                .foregroundColor(.withColorStudio(name: .blue, shade: .shade50))
-                            Text(Localization.getSupport)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.withColorStudio(name: .blue, shade: .shade50))
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: Layout.spacing) {
+                    Image(systemName: "exclamationmark.circle")
+                        .font(.system(size: Layout.exclamationImageSize))
+                        .foregroundColor(.withColorStudio(name: .red, shade: .shade20))
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: Layout.textSpacing) {
+                        Text(error.localizedTitle)
+                            .font(.title)
+                            .fontWeight(.bold)
+                        Text(error.localizedDescription)
+                        Text(error.localizedActionDirection)
+                            .font(.title3)
+                            .fontWeight(.bold)
+                        if let actionHint = error.localizedActionHint {
+                            Text(actionHint)
+                                .font(.footnote)
+                        }
+                        if let errorCode = error.localizedErrorCode {
+                            Text(String(format: Localization.errorCodeFormat, errorCode))
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                        }
+                        Button(action: getSupportAction) {
+                            HStack {
+                                Image(systemName: "questionmark.circle")
+                                    .font(.body.weight(.semibold))
+                                    .foregroundColor(.withColorStudio(name: .blue, shade: .shade50))
+                                Text(Localization.getSupport)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.withColorStudio(name: .blue, shade: .shade50))
+                            }
                         }
                     }
-
-                    Spacer()
-
-                    if let primaryButtonTitle = error.localizedPrimaryButtonLabel {
-                        Button(primaryButtonTitle) {
-                            primaryAction?()
-                        }
-                        .buttonStyle(PrimaryButtonStyle())
-                    }
-
-                    Button(error.localizedSecondaryButtonTitle) {
-                        secondaryAction()
-                    }
-                    .buttonStyle(SecondaryButtonStyle())
                 }
+                .padding(.top, Layout.topPadding)
+                .padding(.horizontal, Layout.horizontalPadding)
             }
+
+            Spacer()
+
+            if let primaryButtonTitle = error.localizedPrimaryButtonLabel {
+                Button(primaryButtonTitle) {
+                    primaryAction?()
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.horizontal, Layout.horizontalPadding)
+            }
+
+            Button(error.localizedSecondaryButtonTitle) {
+                secondaryAction()
+            }
+            .buttonStyle(SecondaryButtonStyle())
             .padding(.horizontal, Layout.horizontalPadding)
-            .padding(.top, Layout.topPadding)
-            .padding(.bottom)
         }
+        .padding(.bottom)
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -69,47 +69,52 @@ struct UpgradesView: View {
                 case .purchasing(let plan):
                     OwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
                 case .waiting(let plan):
-                    UpgradeWaitingView(planName: plan.wooPlan.shortName)
-                        .scrollVerticallyIfNeeded()
-                case .completed(let plan):
-                    CompletedUpgradeView(planName: plan.wooPlan.shortName,
-                                         doneAction: {
-                        dismiss()
-                    })
-                    .scrollVerticallyIfNeeded()
-                case .prePurchaseError(let error):
-                    VStack {
-                        PrePurchaseUpgradesErrorView(error,
-                                                     onRetryButtonTapped: {
-                            upgradesViewModel.retryFetch()
-                        })
-                        .padding(.top, Layout.errorViewTopPadding)
-                        .padding(.horizontal, Layout.errorViewHorizontalPadding)
-
-                        Spacer()
+                    ScrollView(.vertical) {
+                        UpgradeWaitingView(planName: plan.wooPlan.shortName)
                     }
-                    .scrollVerticallyIfNeeded()
+                case .completed(let plan):
+                    ScrollView(.vertical) {
+                        CompletedUpgradeView(planName: plan.wooPlan.shortName,
+                                             doneAction: {
+                            dismiss()
+                        })
+                    }
+                case .prePurchaseError(let error):
+                    ScrollView(.vertical) {
+                        VStack {
+                            PrePurchaseUpgradesErrorView(error,
+                                                         onRetryButtonTapped: {
+                                upgradesViewModel.retryFetch()
+                            })
+                            .padding(.top, Layout.errorViewTopPadding)
+                            .padding(.horizontal, Layout.errorViewHorizontalPadding)
+
+                            Spacer()
+                        }
+                    }
                     .background(Color(.systemGroupedBackground))
                 case .purchaseUpgradeError(.inAppPurchaseFailed(let plan, let iapStoreError)):
-                    PurchaseUpgradeErrorView(error: .inAppPurchaseFailed(plan, iapStoreError)) {
-                        Task {
-                            await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
+                    ScrollView(.vertical) {
+                        PurchaseUpgradeErrorView(error: .inAppPurchaseFailed(plan, iapStoreError)) {
+                            Task {
+                                await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
+                            }
+                        } secondaryAction: {
+                            dismiss()
+                        } getSupportAction: {
+                            supportHandler()
                         }
-                    } secondaryAction: {
-                        dismiss()
-                    } getSupportAction: {
-                        supportHandler()
                     }
-                    .scrollVerticallyIfNeeded()
                 case .purchaseUpgradeError(let underlyingError):
                     // handles .planActivationFailed and .unknown underlyingErrors
-                    PurchaseUpgradeErrorView(error: underlyingError,
-                                             primaryAction: nil,
-                                             secondaryAction: {
-                        dismiss()
-                    },
-                                             getSupportAction: supportHandler)
-                    .scrollVerticallyIfNeeded()
+                    ScrollView(.vertical) {
+                        PurchaseUpgradeErrorView(error: underlyingError,
+                                                 primaryAction: nil,
+                                                 secondaryAction: {
+                            dismiss()
+                        },
+                                                 getSupportAction: supportHandler)
+                    }
                 }
             }
             .navigationBarHidden(true)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -60,6 +60,7 @@ struct UpgradesView: View {
                 switch upgradesViewModel.upgradeViewState {
                 case .loading:
                     OwnerUpgradesView(upgradePlan: .skeletonPlan(), purchasePlanAction: {}, isLoading: true)
+                        .accessibilityLabel(Localization.plansLoadingAccessibilityLabel)
                 case .loaded(let plan):
                     OwnerUpgradesView(upgradePlan: plan, purchasePlanAction: {
                         Task {
@@ -820,5 +821,11 @@ private extension UpgradesView {
         static let padding: CGFloat = 16
         static let contentSpacing: CGFloat = 8
         static let smallPadding: CGFloat = 8
+    }
+
+    enum Localization {
+        static let plansLoadingAccessibilityLabel = NSLocalizedString(
+            "Loading plan details",
+            comment: "Accessibility label for the initial loading state of the Upgrades view")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
@@ -23,6 +23,7 @@ struct WooPlanFeatureBenefitsView: View {
                     .fontWeight(.semibold)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityAddTraits(.isHeader)
 
                 ForEach(wooPlanFeatureGroup.features, id: \.title) { feature in
                     WooPlanFeatureBenefitRow(feature: feature)
@@ -65,6 +66,7 @@ struct WooPlanFeatureBenefitRow: View {
             VStack(alignment: .leading, spacing: Layout.titleDescriptionVerticalSpacing) {
                 Text(feature.title)
                     .font(.body)
+                    .accessibilityAddTraits(.isHeader)
 
                 Text(feature.description)
                     .font(.footnote)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
@@ -16,6 +16,7 @@ struct WooPlanFeatureBenefitsView: View {
                             .aspectRatio(contentMode: .fit)
                             .padding(.vertical, Layout.imageCardImageVerticalPadding)
                     )
+                    .accessibilityHidden(true)
 
                 Text(wooPlanFeatureGroup.title)
                     .font(.subheadline)
@@ -59,6 +60,7 @@ struct WooPlanFeatureBenefitRow: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: Layout.checkmarkWidth)
                 .foregroundColor(.withColorStudio(name: .green, shade: .shade40))
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Layout.titleDescriptionVerticalSpacing) {
                 Text(feature.title)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureGroupRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureGroupRow.swift
@@ -16,6 +16,7 @@ struct WooPlanFeatureGroupRow: View {
                         .aspectRatio(contentMode: .fit)
                         .padding(8)
                 )
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(featureGroup.title)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

During testing, we identified various small issues with the UI of the upgrades flow, both visual and via accessibility tools, which this PR addresses

### Visual
- Longer error screens can truncate description at large sizes – fixed by using fixedSize and embedding content in a scrollview
- Waiting screen title truncates at larger sizes – fixed by using fixedSize

### Accessibility
- Decorative images announced by filename – fixed by omitting them
- Feature plan benefits screens need titles to be marked as headings – fixed
- Loading indicator shown but not announced – fixed by adding an accessibility label.
- Loading skeleton state was not announced – fixed by adding an accessibility label

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run through all screens in the upgrade flow at large type sizes, and using VoiceOver, particularly navigating by title. In some cases it can be useful to force a particular UI state for a longer time, e.g. the skeleton loading state.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
