### PR TITLE
Product description AI announcement modal: Storage and Yosemite layer changes

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		02C254F22563B12E00A04423 /* ShippingLabelAddress+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254EA2563B12E00A04423 /* ShippingLabelAddress+CoreDataProperties.swift */; };
 		02D200D8253FDEE500840173 /* WooCommerceModelV32toV33.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 02D200D7253FDEE500840173 /* WooCommerceModelV32toV33.xcmappingmodel */; };
 		02D45649231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */; };
+		02D7E7C52A4CB25D0003049A /* LocalAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D7E7C42A4CB25D0003049A /* LocalAnnouncement.swift */; };
 		02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64182313C2AA00284168 /* StatsVersion.swift */; };
 		03101EFF29DD7D1300769CF3 /* CardReaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03101EFE29DD7D1300769CF3 /* CardReaderType.swift */; };
 		031C1EA127AD3AFE00298699 /* WCPayCharge+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031C1E9927AD3AFE00298699 /* WCPayCharge+CoreDataClass.swift */; };
@@ -277,6 +278,7 @@
 		02C254EA2563B12E00A04423 /* ShippingLabelAddress+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAddress+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		02D200D7253FDEE500840173 /* WooCommerceModelV32toV33.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV32toV33.xcmappingmodel; sourceTree = "<group>"; };
 		02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBannerVisibility.swift; sourceTree = "<group>"; };
+		02D7E7C42A4CB25D0003049A /* LocalAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncement.swift; sourceTree = "<group>"; };
 		02DA64182313C2AA00284168 /* StatsVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersion.swift; sourceTree = "<group>"; };
 		0306C18227BAB09D0070B617 /* Model 65.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 65.xcdatamodel"; sourceTree = "<group>"; };
 		03101EFE29DD7D1300769CF3 /* CardReaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderType.swift; sourceTree = "<group>"; };
@@ -691,6 +693,7 @@
 				267439D524E5D45A0090696C /* FeedbackSettings.swift */,
 				26EA01D024EC3AEA00176A57 /* FeedbackType.swift */,
 				FEDD70AC26A5DBDD00194C3A /* EligibilityErrorInfo.swift */,
+				02D7E7C42A4CB25D0003049A /* LocalAnnouncement.swift */,
 			);
 			name = AppSettings;
 			sourceTree = "<group>";
@@ -1357,6 +1360,7 @@
 				452C23B627B4129300822986 /* InboxNote+CoreDataClass.swift in Sources */,
 				CE12FBE32220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel in Sources */,
 				747453A62242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataProperties.swift in Sources */,
+				02D7E7C52A4CB25D0003049A /* LocalAnnouncement.swift in Sources */,
 				028296F3237D404F00E84012 /* ProductVariation+CoreDataProperties.swift in Sources */,
 				5772842325BF465A0092FB2C /* NSPersistentStoreCoordinator+PersistentStoreCoordinatorProtocol.swift in Sources */,
 				077F39C4269F1F4600ABEADC /* SystemPlugin+CoreDataClass.swift in Sources */,

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -31,7 +31,8 @@ extension Storage.GeneralAppSettings {
         lastJetpackBenefitsBannerDismissedTime: NullableCopiableProp<Date> = .copy,
         featureAnnouncementCampaignSettings: CopiableProp<[FeatureAnnouncementCampaign: FeatureAnnouncementCampaignSettings]> = .copy,
         sitesWithAtLeastOneIPPTransactionFinished: CopiableProp<Set<Int64>> = .copy,
-        isEUShippingNoticeDismissed: CopiableProp<Bool> = .copy
+        isEUShippingNoticeDismissed: CopiableProp<Bool> = .copy,
+        localAnnouncementDismissed: CopiableProp<[LocalAnnouncement: Bool]> = .copy
     ) -> Storage.GeneralAppSettings {
         let installationDate = installationDate ?? self.installationDate
         let feedbacks = feedbacks ?? self.feedbacks
@@ -44,6 +45,7 @@ extension Storage.GeneralAppSettings {
         let featureAnnouncementCampaignSettings = featureAnnouncementCampaignSettings ?? self.featureAnnouncementCampaignSettings
         let sitesWithAtLeastOneIPPTransactionFinished = sitesWithAtLeastOneIPPTransactionFinished ?? self.sitesWithAtLeastOneIPPTransactionFinished
         let isEUShippingNoticeDismissed = isEUShippingNoticeDismissed ?? self.isEUShippingNoticeDismissed
+        let localAnnouncementDismissed = localAnnouncementDismissed ?? self.localAnnouncementDismissed
 
         return Storage.GeneralAppSettings(
             installationDate: installationDate,
@@ -56,7 +58,8 @@ extension Storage.GeneralAppSettings {
             lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime,
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
             sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+            localAnnouncementDismissed: localAnnouncementDismissed
         )
     }
 }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -156,7 +156,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
 
     /// Returns a new instance of `GeneralAppSettings` with the provided feature announcement campaign seetings updated.
     ///
-    public func replacingAsDismissed(localAnnouncement: LocalAnnouncement) -> GeneralAppSettings {
+    public func updatingAsDismissed(localAnnouncement: LocalAnnouncement) -> GeneralAppSettings {
         let updatedSettings = localAnnouncementDismissed.merging([localAnnouncement: true]) {
             _, new in new
         }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -56,6 +56,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var isEUShippingNoticeDismissed: Bool
 
+    /// The settings stored locally that indicate whether each local announcement's has been dismissed.
+    ///
+    public var localAnnouncementDismissed: [LocalAnnouncement: Bool]
+
     public init(installationDate: Date?,
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
@@ -66,7 +70,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
                 lastJetpackBenefitsBannerDismissedTime: Date? = nil,
                 featureAnnouncementCampaignSettings: [FeatureAnnouncementCampaign: FeatureAnnouncementCampaignSettings],
                 sitesWithAtLeastOneIPPTransactionFinished: Set<Int64>,
-                isEUShippingNoticeDismissed: Bool) {
+                isEUShippingNoticeDismissed: Bool,
+                localAnnouncementDismissed: [LocalAnnouncement: Bool]) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
@@ -78,6 +83,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         self.isTapToPayOnIPhoneSwitchEnabled = isTapToPayOnIPhoneSwitchEnabled
         self.sitesWithAtLeastOneIPPTransactionFinished = sitesWithAtLeastOneIPPTransactionFinished
         self.isEUShippingNoticeDismissed = isEUShippingNoticeDismissed
+        self.localAnnouncementDismissed = localAnnouncementDismissed
     }
 
     public static var `default`: Self {
@@ -90,7 +96,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
               lastEligibilityErrorInfo: nil,
               featureAnnouncementCampaignSettings: [:],
               sitesWithAtLeastOneIPPTransactionFinished: [],
-              isEUShippingNoticeDismissed: false)
+              isEUShippingNoticeDismissed: false,
+              localAnnouncementDismissed: [:])
     }
 
     /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
@@ -120,7 +127,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
             sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+            localAnnouncementDismissed: localAnnouncementDismissed
         )
     }
 
@@ -141,7 +149,30 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             featureAnnouncementCampaignSettings: updatedSettings,
             sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+            localAnnouncementDismissed: localAnnouncementDismissed
+        )
+    }
+
+    /// Returns a new instance of `GeneralAppSettings` with the provided feature announcement campaign seetings updated.
+    ///
+    public func replacingAsDismissed(localAnnouncement: LocalAnnouncement) -> GeneralAppSettings {
+        let updatedSettings = localAnnouncementDismissed.merging([localAnnouncement: true]) {
+            _, new in new
+        }
+
+        return GeneralAppSettings(
+            installationDate: installationDate,
+            feedbacks: feedbacks,
+            isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
+            isInAppPurchasesSwitchEnabled: isInAppPurchasesSwitchEnabled,
+            isTapToPayOnIPhoneSwitchEnabled: isTapToPayOnIPhoneSwitchEnabled,
+            knownCardReaders: knownCardReaders,
+            lastEligibilityErrorInfo: lastEligibilityErrorInfo,
+            featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
+            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+            localAnnouncementDismissed: updatedSettings
         )
     }
 }
@@ -167,6 +198,8 @@ extension GeneralAppSettings {
         self.sitesWithAtLeastOneIPPTransactionFinished = try container.decodeIfPresent(Set<Int64>.self,
                                                                                         forKey: .sitesWithAtLeastOneIPPTransactionFinished) ?? Set<Int64>([])
         self.isEUShippingNoticeDismissed = try container.decodeIfPresent(Bool.self, forKey: .isEUShippingNoticeDismissed) ?? false
+        self.localAnnouncementDismissed = try container.decodeIfPresent([LocalAnnouncement: Bool].self,
+                                                                        forKey: .localAnnouncementDismissed) ?? [:]
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Storage/Storage/Model/LocalAnnouncement.swift
+++ b/Storage/Storage/Model/LocalAnnouncement.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum LocalAnnouncement: Codable, Equatable {
+    case productDescriptionAI
+}

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -57,7 +57,7 @@ final class GeneralAppSettingsTests: XCTestCase {
         XCTAssertNil(settings.localAnnouncementDismissed[.productDescriptionAI])
 
         // When
-        let newSettings = settings.replacingAsDismissed(localAnnouncement: .productDescriptionAI)
+        let newSettings = settings.updatingAsDismissed(localAnnouncement: .productDescriptionAI)
 
         // Then
         XCTAssertEqual(newSettings.localAnnouncementDismissed[.productDescriptionAI], true)

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -51,6 +51,18 @@ final class GeneralAppSettingsTests: XCTestCase {
         XCTAssertEqual(newSettings.feedbacks[.general], newFeedback)
     }
 
+    func test_it_updates_localAnnouncementDismissed_when_replacing_an_announcement_as_dismissed() {
+        // Given
+        let settings = createGeneralAppSettings()
+        XCTAssertNil(settings.localAnnouncementDismissed[.productDescriptionAI])
+
+        // When
+        let newSettings = settings.replacingAsDismissed(localAnnouncement: .productDescriptionAI)
+
+        // Then
+        XCTAssertEqual(newSettings.localAnnouncementDismissed[.productDescriptionAI], true)
+    }
+
     func test_updating_properties_to_generalAppSettings_does_not_breaks_decoding() throws {
         // Given
         let installationDate = Date(timeIntervalSince1970: 1630314000) // Mon Aug 30 2021 09:00:00 UTC+0000
@@ -62,6 +74,7 @@ final class GeneralAppSettingsTests: XCTestCase {
             FeatureAnnouncementCampaign.linkedProductsPromo:
                 FeatureAnnouncementCampaignSettings(dismissedDate: Date(), remindAfter: nil)]
         let sitesWithAtLeastOneIPPTransactionFinished: Set<Int64> = [1234, 123, 12, 1]
+        let localAnnouncementDismissed = [LocalAnnouncement.productDescriptionAI: true]
         let previousSettings = GeneralAppSettings(installationDate: installationDate,
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
@@ -72,7 +85,8 @@ final class GeneralAppSettingsTests: XCTestCase {
                                                   lastJetpackBenefitsBannerDismissedTime: jetpackBannerDismissedDate,
                                                   featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
                                                   sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-                                                  isEUShippingNoticeDismissed: false)
+                                                  isEUShippingNoticeDismissed: false,
+                                                  localAnnouncementDismissed: localAnnouncementDismissed)
 
         let previousEncodedSettings = try JSONEncoder().encode(previousSettings)
         var previousSettingsJson = try JSONSerialization.jsonObject(with: previousEncodedSettings, options: .allowFragments) as? [String: Any]
@@ -91,6 +105,7 @@ final class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.lastJetpackBenefitsBannerDismissedTime, jetpackBannerDismissedDate)
         assertEqual(newSettings.featureAnnouncementCampaignSettings, featureAnnouncementCampaignSettings)
         assertEqual(newSettings.sitesWithAtLeastOneIPPTransactionFinished, sitesWithAtLeastOneIPPTransactionFinished)
+        assertEqual(newSettings.localAnnouncementDismissed, localAnnouncementDismissed)
     }
 }
 
@@ -108,7 +123,8 @@ private extension GeneralAppSettingsTests {
                                   lastJetpackBenefitsBannerDismissedTime: Date? = nil,
                                   featureAnnouncementCampaignSettings: [Campaign: CampaignSettings] = [:],
                                   sitesWithAtLeastOneIPPTransactionFinished: Set<Int64> = [],
-                                  isEUShippingNoticeDismissed: Bool = false
+                                  isEUShippingNoticeDismissed: Bool = false,
+                                  localAnnouncementDismissed: [LocalAnnouncement: Bool] = [:]
     ) -> GeneralAppSettings {
         GeneralAppSettings(installationDate: installationDate,
                            feedbacks: feedbacks,
@@ -120,6 +136,7 @@ private extension GeneralAppSettingsTests {
                            lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime,
                            featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
                            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-                           isEUShippingNoticeDismissed: isEUShippingNoticeDismissed)
+                           isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+                           localAnnouncementDismissed: localAnnouncementDismissed)
     }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -219,4 +219,9 @@ public enum AppSettingsAction: Action {
     ///
     case storeInPersonPaymentsTransactionIfFirst(siteID: Int64, cardReaderType: CardReaderType)
 
+    // MARK: - Local Announcement Visibility
+
+    case getLocalAnnouncementVisibility(announcement: LocalAnnouncement, onCompletion: (Bool) -> ())
+
+    case setLocalAnnouncementDismissed(announcement: LocalAnnouncement, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -260,6 +260,7 @@ public typealias StorageTaxClass = Storage.TaxClass
 public typealias StorageWCPayCharge = Storage.WCPayCharge
 public typealias FeatureAnnouncementCampaign = Storage.FeatureAnnouncementCampaign
 public typealias FeatureAnnouncementCampaignSettings = Storage.FeatureAnnouncementCampaignSettings
+public typealias LocalAnnouncement = Storage.LocalAnnouncement
 
 // MARK: - Internal ReadOnly Models
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -192,6 +192,10 @@ public class AppSettingsStore: Store {
             setEUShippingNoticeDismissState(isDismissed: true, onCompletion: onCompletion)
         case .loadEUShippingNoticeDismissState(let onCompletion):
             loadEUShippingNoticeDismissState(onCompletion: onCompletion)
+        case .getLocalAnnouncementVisibility(let announcement, let onCompletion):
+            getLocalAnnouncementVisibility(announcement: announcement, onCompletion: onCompletion)
+        case .setLocalAnnouncementDismissed(let announcement, let onCompletion):
+            setLocalAnnouncementDismissed(announcement: announcement, onCompletion: onCompletion)
         }
     }
 }
@@ -598,6 +602,29 @@ private extension AppSettingsStore {
         } catch {
             let error = AppSettingsStoreErrors.deletePreselectedProvider
             onCompletion?(error)
+        }
+    }
+}
+
+// MARK: - Local Announcement Visibility
+//
+private extension AppSettingsStore {
+    func getLocalAnnouncementVisibility(announcement: LocalAnnouncement, onCompletion: (Bool) -> Void) {
+        guard let isDismissed = generalAppSettings.value(for: \.localAnnouncementDismissed)[announcement] else {
+            // If the announcement hasn't been dismissed, it is visible.
+            return onCompletion(true)
+        }
+        onCompletion(isDismissed == false)
+    }
+
+    func setLocalAnnouncementDismissed(announcement: LocalAnnouncement, onCompletion: (Result<Void, Error>) -> ()) {
+        do {
+            let settings = generalAppSettings.settings
+            let settingsToSave = settings.replacingAsDismissed(localAnnouncement: announcement)
+            try generalAppSettings.saveSettings(settingsToSave)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -620,7 +620,7 @@ private extension AppSettingsStore {
     func setLocalAnnouncementDismissed(announcement: LocalAnnouncement, onCompletion: (Result<Void, Error>) -> ()) {
         do {
             let settings = generalAppSettings.settings
-            let settingsToSave = settings.replacingAsDismissed(localAnnouncement: announcement)
+            let settingsToSave = settings.updatingAsDismissed(localAnnouncement: announcement)
             try generalAppSettings.saveSettings(settingsToSave)
             onCompletion(.success(()))
         } catch {

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -164,7 +164,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
                                           knownCardReaders: [],
                                           featureAnnouncementCampaignSettings: [:],
                                           sitesWithAtLeastOneIPPTransactionFinished: [],
-                                          isEUShippingNoticeDismissed: false)
+                                          isEUShippingNoticeDismissed: false,
+                                          localAnnouncementDismissed: [:])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .ordersCreation)
 
         // When
@@ -233,7 +234,8 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             knownCardReaders: [],
             featureAnnouncementCampaignSettings: [:],
             sitesWithAtLeastOneIPPTransactionFinished: [],
-            isEUShippingNoticeDismissed: false)
+            isEUShippingNoticeDismissed: false,
+            localAnnouncementDismissed: [:])
         return settings
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10021 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We want to increase the visibility of the product description AI feature, and are showing a modal that has the same design as JITM NMncL2ViLjomfLhuyEhVM1-fi-236_84398. Originally, we wanted to reuse one of the two existing modals - JITM and What's New announcement modal. But each of the remote modal system has limitations, and we decided to implement a modal locally pecCkj-Cr-p2#comment-382 after syncing JITM and no modal is being shown.

## How

There are quite a lot of changes, I had to separate into multiple PRs. This is the first PR that includes the Storage and Yosemite layer changes, where it saves the modal dismissal state to the app settings (only cleared when reinstalling the app). `AppSettingsAction.getLocalAnnouncementVisibility(announcement:onCompletion:)` and `AppSettingsAction.setLocalAnnouncementDismissed(announcement:onCompletion:)` were added to get and set the local announcement visibility.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The Yosemite actions aren't used yet, just CI is sufficient.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.