### PR TITLE
[IAP] Use production ID for express essential plan

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -324,12 +324,6 @@ extension UpgradesViewModel {
     }
 }
 
-extension UpgradesViewModel {
-    enum AvailableInAppPurchasesWPComPlans: String {
-        case essentialMonthly = "debug.woocommerce.express.essential.monthly"
-    }
-}
-
 struct WooWPComPlan {
     let wpComPlan: WPComPlanProduct
     let wooPlan: WooPlan

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -249,10 +249,6 @@ private extension SubscriptionsViewModel {
 
 // MARK: Definitions
 private extension SubscriptionsViewModel {
-    enum AvailableInAppPurchasesWPComPlans: String {
-        case essentialMonthly = "debug.woocommerce.express.essential.monthly"
-    }
-
     enum Localization {
         static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
         static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. " +

--- a/WooCommerce/Resources/WooCommerceTestSynced.storekit
+++ b/WooCommerce/Resources/WooCommerceTestSynced.storekit
@@ -8,14 +8,50 @@
   ],
   "settings" : {
     "_applicationInternalID" : "1389130815",
-    "_compatibilityTimeRate" : 6,
+    "_compatibilityTimeRate" : {
+      "3" : 6
+    },
     "_developerTeamID" : "PZYM8XX95Q",
     "_failTransactionsEnabled" : false,
-    "_lastSynchronizedDate" : 709118083.66037405,
+    "_lastSynchronizedDate" : 709713857.71122098,
     "_storeKitError" : 0,
     "_timeRate" : 13
   },
   "subscriptionGroups" : [
+    {
+      "id" : "21032734",
+      "localizations" : [
+
+      ],
+      "name" : "Plans",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "39.0",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "6450767566",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Everything you need to launch an online store",
+              "displayName" : "Essential Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "woocommerce.express.essential.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Woo Express Essential Monthly",
+          "subscriptionGroupID" : "21032734",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    },
     {
       "id" : "21032762",
       "localizations" : [

--- a/WooCommerce/WooCommerceTests/Mocks/MockInAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockInAppPurchasesForWPComPlansManager.swift
@@ -62,10 +62,10 @@ extension MockInAppPurchasesForWPComPlansManager {
                  id: "debug.woocommerce.ecommerce.monthly",
                  displayPrice: "$69.99")
         ]
-        static let debugInAppPurchasesPlans: [WPComPlanProduct] = [
-            Plan(displayName: "Debug Essential Monthly",
-                 description: "1 Month of Debug Essential",
-                 id: "debug.woocommerce.express.essential.monthly",
+        static let essentialInAppPurchasesPlans: [WPComPlanProduct] = [
+            Plan(displayName: "Essential Monthly",
+                 description: "1 Month of Essential",
+                 id: "woocommerce.express.essential.monthly",
                  displayPrice: "$99.99")
         ]
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -48,7 +48,7 @@ final class UpgradesViewModelTests: XCTestCase {
         }
         assertEqual("Debug Essential Monthly", plan.wpComPlan.displayName)
         assertEqual("1 Month of Debug Essential", plan.wpComPlan.description)
-        assertEqual("debug.woocommerce.express.essential.monthly", plan.wpComPlan.id)
+        assertEqual("woocommerce.express.essential.monthly", plan.wpComPlan.id)
         assertEqual("$99.99", plan.wpComPlan.displayPrice)
     }
 
@@ -57,7 +57,7 @@ final class UpgradesViewModelTests: XCTestCase {
         let expectedPlan: WPComPlanProduct = MockInAppPurchasesForWPComPlansManager.Plan(
                 displayName: "Test awesome plan",
                 description: "All the Woo, all the time",
-                id: "debug.woocommerce.express.essential.monthly",
+                id: "woocommerce.express.essential.monthly",
                 displayPrice: "$1.50")
         let inAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: [expectedPlan])
         let sut = UpgradesViewModel(siteID: sampleSiteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -11,7 +11,7 @@ final class UpgradesViewModelTests: XCTestCase {
     private var sut: UpgradesViewModel!
 
     override func setUp() {
-        let plans = MockInAppPurchasesForWPComPlansManager.Defaults.debugInAppPurchasesPlans
+        let plans = MockInAppPurchasesForWPComPlansManager.Defaults.essentialInAppPurchasesPlans
         mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans)
         stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
@@ -46,8 +46,8 @@ final class UpgradesViewModelTests: XCTestCase {
         guard case .loaded(let plan) = sut.upgradeViewState else {
             return XCTFail("expected `.loaded` state not found")
         }
-        assertEqual("Debug Essential Monthly", plan.wpComPlan.displayName)
-        assertEqual("1 Month of Debug Essential", plan.wpComPlan.description)
+        assertEqual("Essential Monthly", plan.wpComPlan.displayName)
+        assertEqual("1 Month of Essential", plan.wpComPlan.description)
         assertEqual("woocommerce.express.essential.monthly", plan.wpComPlan.id)
         assertEqual("$99.99", plan.wpComPlan.displayPrice)
     }
@@ -73,7 +73,7 @@ final class UpgradesViewModelTests: XCTestCase {
         }
         assertEqual("Test awesome plan", plan.wpComPlan.displayName)
         assertEqual("All the Woo, all the time", plan.wpComPlan.description)
-        assertEqual("debug.woocommerce.express.essential.monthly", plan.wpComPlan.id)
+        assertEqual("woocommerce.express.essential.monthly", plan.wpComPlan.id)
         assertEqual("$1.50", plan.wpComPlan.displayPrice)
     }
 

--- a/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
@@ -30,7 +30,7 @@ public struct WooPlan: Decodable {
     }
 
     public static func loadHardcodedPlan() -> WooPlan {
-        WooPlan(id: "debug.woocommerce.express.essential.monthly",
+        WooPlan(id: AvailableInAppPurchasesWPComPlans.essentialMonthly.rawValue,
                 name: Localization.essentialPlanName,
                 shortName: Localization.essentialPlanShortName,
                 planFrequency: .month,
@@ -83,6 +83,10 @@ public struct WooPlan: Decodable {
             static let year = NSLocalizedString("per year", comment: "Description of the frequency of a yearly Woo plan")
         }
     }
+}
+
+public enum AvailableInAppPurchasesWPComPlans: String {
+    case essentialMonthly = "woocommerce.express.essential.monthly"
 }
 
 private extension WooPlan {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This switches us over to use the production ID for the essential plan.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N.B. There is a bug in MobilePay which means purchases using an IAP Sandbox user with previous debug purchases will always result in an error after purchase, and not upgrade the site. To test this, make a **new** IAP sandbox user in App Store Connect.


1. Open the app and switch to a Woo Express store with a free trial active
2. Tap Upgrade Now in the banner
3. Observe that the purchase button now reads `Purchase Essential Monthly`, without the word `Debug`
4. Follow the flow through
5. Observe that you are able to upgrade the site's plan

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![woo-express-plan-purchase-screen](https://github.com/woocommerce/woocommerce-ios/assets/2472348/76fdf998-0624-4cb7-9d4a-89c4afc4c89d)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
