### PR TITLE
Enable IAP for plan upgrades feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -72,7 +72,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .freeTrial:
             return true
         case .freeTrialInAppPurchasesUpgradeM1:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .twentyFourHoursAfterFreeTrialSubscribedNotification:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .manualErrorHandlingForSiteCredentialLogin:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Add URL route handler to open the `My Store` tab when a deeplink to `/mobile` is opened, instead of bouncing back to Safari [https://github.com/woocommerce/woocommerce-ios/pull/10077]
 - [*] A feedback banner is added for product description AI and product sharing AI sheets. [https://github.com/woocommerce/woocommerce-ios/pull/10102]
 - [*] Product creation: the product type row is now editable when creating a product. [https://github.com/woocommerce/woocommerce-ios/pull/10087]
+- [***] Store creation: US users can upgrade Woo Express free trial stores via In-App Purchase [https://github.com/woocommerce/woocommerce-ios/pull/10123]
 
 14.2
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
Merge after #10122 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have added the ability to purchase upgrades to the Woo Express Essential Monthly plan via In-App Purchase.

This PR turns the feature flag for M1 on, so that IAP upgrades will be available in the 14.3 build.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Edit your scheme, and select `Release`
2. Build and run on a simulator
3. Switch to a Woo Express store with a free trial active (or expired)
4. Tap `Upgrade now` in the banner
5. Observe that you're shown the native purchase flow, not a web view
6. Tap `Purchase Essential Monthly`
7. Observe that you are asked to log in with an Apple ID – this will not work because sandbox IAP purchases are not supported in the simulator.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
