### PR TITLE
Product description AI announcement modal: analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+LocalAnnouncement.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+LocalAnnouncement.swift
@@ -1,0 +1,38 @@
+import Foundation
+import enum Yosemite.LocalAnnouncement
+
+extension WooAnalyticsEvent {
+    enum LocalAnnouncementModal {
+        /// Event property keys.
+        private enum Key: String {
+            case announcement
+        }
+
+        /// Tracked when a local announcement modal is displayed.
+        static func localAnnouncementDisplayed(announcement: LocalAnnouncement) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localAnnouncementDisplayed,
+                              properties: [Key.announcement.rawValue: announcement.analyticsValue])
+        }
+
+        /// Tracked when the user taps the CTA of a local announcement modal.
+        static func localAnnouncementCallToActionTapped(announcement: LocalAnnouncement) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localAnnouncementCallToActionTapped,
+                              properties: [Key.announcement.rawValue: announcement.analyticsValue])
+        }
+
+        /// Tracked when the user taps to dismiss a local announcement modal.
+        static func localAnnouncementDismissTapped(announcement: LocalAnnouncement) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localAnnouncementDismissTapped,
+                              properties: [Key.announcement.rawValue: announcement.analyticsValue])
+        }
+    }
+}
+
+private extension LocalAnnouncement {
+    var analyticsValue: String {
+        switch self {
+            case .productDescriptionAI:
+                return "product_description_ai"
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -972,6 +972,11 @@ public enum WooAnalyticsStat: String {
     case privacyChoicesBannerPresented = "privacy_choices_banner_presented"
     case privacyChoicesSettingsButtonTapped = "privacy_choices_banner_settings_button_tapped"
     case privacyChoicesSaveButtonTapped = "privacy_choices_banner_save_button_tapped"
+
+    // MARK: Local Announcement
+    case localAnnouncementDisplayed = "local_announcement_displayed"
+    case localAnnouncementCallToActionTapped = "local_announcement_cta_tapped"
+    case localAnnouncementDismissTapped = "local_announcement_dismissed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/LocalAnnouncements/LocalAnnouncementViewModel.swift
+++ b/WooCommerce/Classes/LocalAnnouncements/LocalAnnouncementViewModel.swift
@@ -55,15 +55,15 @@ final class LocalAnnouncementViewModel {
 //
 private extension LocalAnnouncementViewModel {
     func trackAnnouncementDisplayed() {
-        // TODO: 10021 - analytics
+        analytics.track(event: .LocalAnnouncementModal.localAnnouncementDisplayed(announcement: announcement))
     }
 
     func trackCtaTapped() {
-        // TODO: 10021 - analytics
+        analytics.track(event: .LocalAnnouncementModal.localAnnouncementCallToActionTapped(announcement: announcement))
     }
 
     func trackDismissTapped() {
-        // TODO: 10021 - analytics
+        analytics.track(event: .LocalAnnouncementModal.localAnnouncementDismissTapped(announcement: announcement))
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		02393069291A065000B2632F /* DomainRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02393068291A065000B2632F /* DomainRowView.swift */; };
 		023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A059824135F2600E3FC99 /* ReviewsViewController.swift */; };
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
+		023B3EBA2A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
 		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
 		023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */; };
@@ -465,6 +466,7 @@
 		02D29A9029F7C2DA00473D6D /* AztecAIViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D29A8F29F7C2DA00473D6D /* AztecAIViewFactory.swift */; };
 		02D29A9229F7C39200473D6D /* UIImage+Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D29A9129F7C39200473D6D /* UIImage+Text.swift */; };
 		02D3B68529657061009BF0BC /* SupportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D3B68429657061009BF0BC /* SupportButton.swift */; };
+		02D4472C2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4472B2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
 		02D681A929C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D681A829C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift */; };
 		02D681AB29C3F8AC00348510 /* StoreOnboardingPaymentsSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D681AA29C3F8AC00348510 /* StoreOnboardingPaymentsSetupCoordinator.swift */; };
@@ -2511,6 +2513,7 @@
 		02393068291A065000B2632F /* DomainRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRowView.swift; sourceTree = "<group>"; };
 		023A059824135F2600E3FC99 /* ReviewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsViewController.swift; sourceTree = "<group>"; };
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
+		023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementViewModelTests.swift; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
 		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
 		023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -2813,6 +2816,7 @@
 		02D29A8F29F7C2DA00473D6D /* AztecAIViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecAIViewFactory.swift; sourceTree = "<group>"; };
 		02D29A9129F7C39200473D6D /* UIImage+Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Text.swift"; sourceTree = "<group>"; };
 		02D3B68429657061009BF0BC /* SupportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportButton.swift; sourceTree = "<group>"; };
+		02D4472B2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+LocalAnnouncement.swift"; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
 		02D681A829C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingPaymentsSetupView.swift; sourceTree = "<group>"; };
 		02D681AA29C3F8AC00348510 /* StoreOnboardingPaymentsSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingPaymentsSetupCoordinator.swift; sourceTree = "<group>"; };
@@ -5844,6 +5848,7 @@
 			isa = PBXGroup;
 			children = (
 				02D7E7CB2A4CE5060003049A /* LocalAnnouncementsProviderTests.swift */,
+				023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */,
 			);
 			path = LocalAnnouncements;
 			sourceTree = "<group>";
@@ -7638,6 +7643,7 @@
 				02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */,
 				DE96844A2A331AD2000FBF4E /* WooAnalyticsEvent+ProductSharingAI.swift */,
 				DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */,
+				02D4472B2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -12513,6 +12519,7 @@
 				B6F3796C293794A000718561 /* AnalyticsHubYearToDateRangeData.swift in Sources */,
 				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
 				AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */,
+				02D4472C2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,
 				26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */,
@@ -13108,6 +13115,7 @@
 				748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */,
 				02524A5D252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift in Sources */,
 				EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */,
+				023B3EBA2A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift in Sources */,
 				028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */,
 				0247F50E286E6CCD009C177E /* MockProductImageActionHandler.swift in Sources */,
 				AEA3F91527BEC96B00B9F555 /* PriceFieldFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/LocalAnnouncements/LocalAnnouncementViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/LocalAnnouncements/LocalAnnouncementViewModelTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class LocalAnnouncementViewModelTests: XCTestCase {
+    private var analytics: Analytics!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
+    func test_localAnnouncementDisplayed_is_tracked_when_the_view_appears() throws {
+        // Given
+        let viewModel = LocalAnnouncementViewModel(announcement: .productDescriptionAI, analytics: analytics)
+
+        // When
+        viewModel.onAppear()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["local_announcement_displayed"])
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(eventProperties["announcement"] as? String, "product_description_ai")
+    }
+
+    func test_localAnnouncementCallToActionTapped_is_tracked_when_the_cta_is_tapped() throws {
+        // Given
+        let viewModel = LocalAnnouncementViewModel(announcement: .productDescriptionAI, analytics: analytics)
+
+        // When
+        viewModel.ctaTapped()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["local_announcement_cta_tapped"])
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(eventProperties["announcement"] as? String, "product_description_ai")
+    }
+
+    func test_localAnnouncementDismissTapped_is_tracked_when_dismiss_is_tapped() throws {
+        // Given
+        let viewModel = LocalAnnouncementViewModel(announcement: .productDescriptionAI, analytics: analytics)
+
+        // When
+        viewModel.dismissTapped()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["local_announcement_dismissed"])
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(eventProperties["announcement"] as? String, "product_description_ai")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/LocalAnnouncements/LocalAnnouncementsProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/LocalAnnouncements/LocalAnnouncementsProviderTests.swift
@@ -4,21 +4,15 @@ import Yosemite
 
 @MainActor
 final class LocalAnnouncementsProviderTests: XCTestCase {
-    private var analytics: Analytics!
-    private var analyticsProvider: MockAnalyticsProvider!
     private var stores: MockStoresManager!
 
     override func setUp() {
         super.setUp()
-        analyticsProvider = MockAnalyticsProvider()
-        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         stores = MockStoresManager(sessionManager: .makeForTesting())
     }
 
     override func tearDown() {
         stores = nil
-        analytics = nil
-        analyticsProvider = nil
         super.tearDown()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10021 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We want to increase the visibility of the product description AI feature, and are showing a modal that has the same design as JITM NMncL2ViLjomfLhuyEhVM1-fi-236_84398. Originally, we wanted to reuse one of the two existing modals - JITM and What's New announcement modal. But each of the remote modal systems has limitations, and we decided to implement a modal locally pecCkj-Cr-p2#comment-382 after syncing JITM and no modal is being shown.

## How

Added 3 events when a local announcement modal is displayed/acted/dismissed (I'll p2 this for Android after the PR is approved):
- `local_announcement_displayed`
- `local_announcement_cta_tapped`
- `local_announcement_dismissed`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites: the store is hosted on WPCOM. for easier testing on two CTAs, I'd recommend hard-coding the announcement to be visible in `LocalAnnouncementsProvider.isVisible`. Alternatively, you can reinstall the app after testing a tap event

- Launch the app and log in to a store in the prerequisite if needed --> shortly, a announcement modal should be displayed with an event `🔵 Tracked local_announcement_displayed, properties: [AnyHashable("announcement"): "product_description_ai", ...]`
- Tap `Try it now` --> `🔵 Tracked local_announcement_cta_tapped, properties: [AnyHashable("announcement"): "product_description_ai", ...]` should be logged
- If the announcement isn't hard-coded to be visible, reinstall the app
- Relaunch the app --> shortly, a announcement modal should be displayed with an event `🔵 Tracked local_announcement_displayed, properties: [AnyHashable("announcement"): "product_description_ai", ...]`
- Tap `Maybe Later` --> `🔵 Tracked local_announcement_dismissed, properties: [AnyHashable("announcement"): "product_description_ai", ...]` should be logged


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
