### PR TITLE
[IAP] Show Subscriptions to users in non-IAP countries

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -40,6 +40,8 @@ final class FreeTrialBannerPresenter {
         inAppPurchasesUpgradeEnabled ? Localization.upgradeNow : Localization.learnMore
     }
 
+    private var inAppPurchasesManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()
+
     /// - Parameters:
     ///   - viewController: View controller used to present any action needed by the free trial banner.
     ///   - containerView: View that will contain the banner.
@@ -152,7 +154,7 @@ private extension FreeTrialBannerPresenter {
     func showUpgradesView() {
         guard let viewController else { return }
         Task { @MainActor in
-            if inAppPurchasesUpgradeEnabled {
+            if await inAppPurchasesManager.inAppPurchasesAreSupported() && inAppPurchasesUpgradeEnabled {
                 let upgradesController = UpgradesHostingController(siteID: siteID)
                 viewController.present(upgradesController, animated: true)
             } else {


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We are initially only offering IAP upgrades to users with US app store accounts.

Previously, they were shown an “In app purchases not supported” error.

This PR changes that to show them the Subscriptions view instead, as we did before releasing the IAP flow.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

In Xcode, open `WooCommerceTestSynced`
In the `Editor` menu, set `Default Storefront` to anything other than USA
Run the app with the WooCommerce IAP scheme
Switch to a Woo Express store in its free trial
Tap `Upgrade now` on the banner
Observe that you're taken to the subscriptions view, as before IAP was released. You're no longer shown "In-app purchases not supported"

Repeat the test with the US store front (rebuild the app)
Observe that you're shown the Upgrades IAP view as normal.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/f73030d0-50a2-4f43-93f4-f0f0eb34d83f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
