### PR TITLE
[IAP] Send subscriptionGroupId with IAP order POST request

### DIFF
--- a/Networking/Networking/Remote/InAppPurchasesRemote.swift
+++ b/Networking/Networking/Remote/InAppPurchasesRemote.swift
@@ -31,15 +31,19 @@ public class InAppPurchasesRemote: Remote {
         appStoreCountryCode: String,
         originalTransactionId: UInt64,
         transactionId: UInt64,
+        subscriptionGroupId: String?,
         completion: @escaping (Swift.Result<Int, Error>) -> Void) {
-            let parameters: [String: Any] = [
+            var parameters: [String: Any] = [
                 Constants.siteIDKey: siteID,
                 Constants.priceKey: price,
                 Constants.productIDKey: productIdentifier,
                 Constants.appStoreCountryCodeKey: appStoreCountryCode,
-                Constants.originalTransactionId: originalTransactionId,
-                Constants.transactionId: transactionId
+                Constants.originalTransactionIdKey: originalTransactionId,
+                Constants.transactionIdKey: transactionId
             ]
+            if let subscriptionGroupId {
+                parameters[Constants.subscriptionGroupIdKey] = subscriptionGroupId
+            }
             let request = DotcomRequest(
                 wordpressApiVersion: .wpcomMark2,
                 method: .post,
@@ -83,7 +87,8 @@ public extension InAppPurchasesRemote {
         productIdentifier: String,
         appStoreCountryCode: String,
         originalTransactionId: UInt64,
-        transactionId: UInt64
+        transactionId: UInt64,
+        subscriptionGroupId: String?
     ) async throws -> Int {
         try await withCheckedThrowingContinuation { continuation in
             createOrder(
@@ -92,7 +97,8 @@ public extension InAppPurchasesRemote {
                 productIdentifier: productIdentifier,
                 appStoreCountryCode: appStoreCountryCode,
                 originalTransactionId: originalTransactionId,
-                transactionId: transactionId
+                transactionId: transactionId,
+                subscriptionGroupId: subscriptionGroupId
             ) { result in
                 continuation.resume(with: result)
             }
@@ -121,7 +127,8 @@ private extension InAppPurchasesRemote {
         static let priceKey = "price"
         static let productIDKey = "product_id"
         static let appStoreCountryCodeKey = "appstore_country"
-        static let originalTransactionId = "original_transaction_id"
-        static let transactionId = "transaction_id"
+        static let originalTransactionIdKey = "original_transaction_id"
+        static let transactionIdKey = "transaction_id"
+        static let subscriptionGroupIdKey = "subscription_group_id"
     }
 }

--- a/Networking/NetworkingTests/Remote/InAppPurchasesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/InAppPurchasesRemoteTests.swift
@@ -62,7 +62,8 @@ class InAppPurchasesRemoteTests: XCTestCase {
                 productIdentifier: "woocommerce_entry_monthly",
                 appStoreCountryCode: "us",
                 originalTransactionId: 1234,
-                transactionId: 12345) { aResult in
+                transactionId: 12345,
+                subscriptionGroupId: "21032734") { aResult in
                     result = aResult
                     expectation.fulfill()
                 }

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -228,7 +228,8 @@ private extension InAppPurchaseStore {
                 productIdentifier: product.id,
                 appStoreCountryCode: countryCode,
                 originalTransactionId: transaction.originalID,
-                transactionId: transaction.id
+                transactionId: transaction.id,
+                subscriptionGroupId: transaction.subscriptionGroupID
             )
             logInfo("Successfully registered purchase with Order ID \(orderID)")
         } catch WordPressApiError.productPurchased {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

MobilePay finds the subscriptions we submit in a response from Apple, which it searches for the Original Transaction ID.

In future, we may want to use a more efficient approach, by identifying the correct group using its subscription_group_id

To avoid having to handle backwards compatibility in the API, we can start sending that now. This PR adds the subscription_group_id to our POST request, even though it's not actually used for anything.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Set up Proxyman or Charles to inspect your network traffic from your iOS device
Launch the app and select a Woo Express store in its free trial
Tap Upgrade now and go through the In-App Purchase
Observe that when it's complete, the request to `/iap/orders` includes the parameter `subscription_group_id`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
