### PR TITLE
[Tracking]Improve SKU search tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -542,10 +542,18 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductSearchViaSKUSuccess, properties: [Keys.source: source])
         }
 
-        static func barcodeScanningSearchViaSKUFailure(from source: BarcodeScanningSource, symbology: BarcodeSymbology, reason: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderProductSearchViaSKUFailure, properties: [Keys.source: source.rawValue,
-                                                                                       Keys.barcodeFormat: symbology.rawValue,
-                                                                                       Keys.reason: reason])
+        static func orderProductSearchViaSKUFailure(from source: String,
+                                                    symbology: BarcodeSymbology? = nil,
+                                                    reason: String) -> WooAnalyticsEvent {
+
+            var properties = [Keys.source: source,
+                              Keys.reason: reason]
+
+            if let symbology = symbology {
+                properties[Keys.barcodeFormat] = symbology.rawValue
+            }
+
+            return WooAnalyticsEvent(statName: .orderProductSearchViaSKUFailure, properties: properties)
         }
 
         static func orderEditButtonTapped(hasMultipleShippingLines: Bool, hasMultipleFeeLines: Bool) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -538,8 +538,8 @@ extension WooAnalyticsEvent {
                                                                               Keys.reason: reason.rawValue])
         }
 
-        static func barcodeScanningSearchViaSKUSuccess(from source: BarcodeScanningSource) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderProductSearchViaSKUSuccess, properties: [Keys.source: source.rawValue])
+        static func orderProductSearchViaSKUSuccess(from source: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderProductSearchViaSKUSuccess, properties: [Keys.source: source])
         }
 
         static func barcodeScanningSearchViaSKUFailure(from source: BarcodeScanningSource, symbology: BarcodeSymbology, reason: String) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -408,6 +408,7 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
                 tracker.trackSearchSuccessIfNecessary()
                 self.reloadData()
             case .failure(let error):
+                tracker.trackSearchFailureIfNecessary(with: error)
                 self.notice = NoticeFactory.productSearchNotice() { [weak self] in
                     self?.searchProducts(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -405,10 +405,10 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
 
             switch result {
             case .success:
-                tracker.trackSearchSuccessIfNecessary()
+                self.tracker.trackSearchSuccessIfNecessary()
                 self.reloadData()
             case .failure(let error):
-                tracker.trackSearchFailureIfNecessary(with: error)
+                self.tracker.trackSearchFailureIfNecessary(with: error)
                 self.notice = NoticeFactory.productSearchNotice() { [weak self] in
                     self?.searchProducts(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -405,6 +405,7 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
 
             switch result {
             case .success:
+                tracker.trackSearchSuccessIfNecessary()
                 self.reloadData()
             case .failure(let error):
                 self.notice = NoticeFactory.productSearchNotice() { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
@@ -44,6 +44,15 @@ final class ProductSelectorViewModelTracker {
         analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUSuccess(from: Constants.orderProductSearchViaSKUSuccessSource))
     }
 
+    func trackSearchFailureIfNecessary(with error: Error) {
+        guard viewModel?.productSearchFilter == .sku else {
+            return
+        }
+
+        analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUFailure(from: Constants.orderProductSearchViaSKUSuccessSource,
+                                                                                        reason: error.localizedDescription))
+    }
+
     func updateTrackingSourceAfterSelectionStateChangedForProduct(with productID: Int64) {
         guard productIDTrackingSources[productID] == nil else {
             productIDTrackingSources.removeValue(forKey: productID)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
@@ -36,6 +36,14 @@ final class ProductSelectorViewModelTracker {
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorSearchTriggered(searchFilter: productSearchFilter))
     }
 
+    func trackSearchSuccessIfNecessary() {
+        guard viewModel?.productSearchFilter == .sku else {
+            return
+        }
+
+        analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUSuccess(from: Constants.orderProductSearchViaSKUSuccessSource))
+    }
+
     func updateTrackingSourceAfterSelectionStateChangedForProduct(with productID: Int64) {
         guard productIDTrackingSources[productID] == nil else {
             productIDTrackingSources.removeValue(forKey: productID)
@@ -89,5 +97,11 @@ private extension ProductSelectorViewModelTracker {
         let section = viewModel.sections.first(where: { $0.type == sectionType })
 
         return section?.products.first(where: { $0.productID == productID}) != nil
+    }
+}
+
+extension ProductSelectorViewModelTracker {
+    enum Constants {
+        static let orderProductSearchViaSKUSuccessSource = "product_selector"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
@@ -20,12 +20,14 @@ struct BarcodeSKUScannerItemFinder {
 
             return result
         } catch {
+            let errorIsProductNotFound = (error as? ProductLoadError) == .notFound
+            let errorTrackignReason = errorIsProductNotFound ? Constants.productNotFoundErrorTrackingDescription : error.localizedDescription
             analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUFailure(from: source.rawValue,
-                                                                                               symbology: barcode.symbology,
-                                                                                               reason: error.localizedDescription))
+                                                                                            symbology: barcode.symbology,
+                                                                                            reason: errorTrackignReason))
 
             // If we couldn't find the product, let's keep trying by refining the SKU search
-            guard (error as? ProductLoadError) == .notFound else {
+            guard errorIsProductNotFound else {
                 throw error
             }
 
@@ -79,5 +81,11 @@ private extension ScannedBarcode {
         }
 
         return ScannedBarcode(payloadStringValue: String(payloadStringValue.dropFirst()), symbology: symbology)
+    }
+}
+
+private extension BarcodeSKUScannerItemFinder {
+    enum Constants {
+        static let productNotFoundErrorTrackingDescription = "Product not found"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
@@ -20,7 +20,7 @@ struct BarcodeSKUScannerItemFinder {
 
             return result
         } catch {
-            analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningSearchViaSKUFailure(from: source,
+            analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUFailure(from: source.rawValue,
                                                                                                symbology: barcode.symbology,
                                                                                                reason: error.localizedDescription))
 

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
@@ -16,7 +16,7 @@ struct BarcodeSKUScannerItemFinder {
     func searchBySKU(from barcode: ScannedBarcode, siteID: Int64, source: WooAnalyticsEvent.Orders.BarcodeScanningSource) async throws -> SKUSearchResult {
         do {
             let result = try await search(by: barcode.payloadStringValue, siteID: siteID)
-            analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningSearchViaSKUSuccess(from: source))
+            analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUSuccess(from: source.rawValue))
 
             return result
         } catch {

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -366,8 +366,8 @@ private extension ProductStore {
                         onCompletion(.success(.product(product)))
                     })
                 }
-            case .failure:
-                onCompletion(.failure(ProductLoadError.notFound))
+            case let .failure(error):
+                onCompletion(.failure(error))
             }
         })
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we improve the tracking via SKU Search by:
- Tracking also success or failure for SKU Search in the product selector. Make the functions generic to handle this case.
- Unify tracking values for the reason key after an error in SKU Scanner Search. Before we used localizedDescription, and that clutters Tracks with different values -one per language- for the same error.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Product Search via SKU in Product Selector

1. Go to Orders
2. Tap + to create a new one
3. Open the Product Selector
4. Search via SKU. When the search ends up successfully, see that it tracks the event with the right source value:

`🔵 Tracked product_search_via_sku_success, properties: [AnyHashable("blog_id"): 214354650, AnyHashable("source"): "product_selector", AnyHashable("is_wpcom_store"): true]`

4b. Make it fail, e.g with no internet:
`
🔵 Tracked product_search_via_sku_failure, properties: [AnyHashable("blog_id"): 214354650, AnyHashable("source"): "product_selector", AnyHashable("is_wpcom_store"): true, AnyHashable("reason"): "The Internet connection appears to be offline."]`

### Unified error reasons for the most common cases in the SKU Scanner Search
1. Go to Orders
2. Tap on the barcode scanner
3. Scan a code that doesn't match any product in your store. See that it tracks the right event with the right reason:

🔵 Tracked product_search_via_sku_failure, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("source"): "order_list", AnyHashable("reason"): "Product not found", AnyHashable("barcode_format"): "VNBarcodeSymbologyQR", AnyHashable("blog_id"): 214354650]

4. Change your device language. Make sure that the "reason" value is still the same ("Product not found"). Do the same for a code linking to a non-purchasable product (draft or without price). Please note that the code SKU should be the same as the SKU in your store, with the same digits, otherwise, it tracks it once as Product not found. It doesn't track the second try without digits.

`🔵 Tracked product_search_via_sku_failure, properties: [AnyHashable("source"): "order_list", AnyHashable("barcode_format"): "VNBarcodeSymbologyEAN13", AnyHashable("reason"): "Product not purchasable", AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 214354650]`

5. Try a different error, and see that we track the localized error string. E.g. without internet connection:

`🔵 Tracked product_search_via_sku_failure, properties: [AnyHashable("reason"): "The Internet connection appears to be offline.", AnyHashable("is_wpcom_store"): true, AnyHashable("barcode_format"): "VNBarcodeSymbologyQR", AnyHashable("source"): "order_list", AnyHashable("blog_id"): 214354650]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
