### PR TITLE
Fix typo on Coupon validation error notice

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
@@ -83,7 +83,7 @@ private extension CouponLineDetailsViewModel {
         static let couponNotFoundNoticeTitle = NSLocalizedString("We couldn't find a coupon with that code. Please try again",
                                                                  comment: "Title for the error notice when we couldn't find" +
                                                                  "a coupon with the given code to add to an order.")
-        static let couponNotValidatedNoticeTitle = NSLocalizedString("Something when wrong when validating your coupon code. Please try again",
+        static let couponNotValidatedNoticeTitle = NSLocalizedString("Something went wrong when validating your coupon code. Please try again",
                                                                      comment: "Notice title when validating a coupon code fails.")
     }
 }


### PR DESCRIPTION
## Description
Quick fix to address a typo found during testing

## Changes
Changed string from `Something when wrong when validating...` to `Something went wrong when validating...`