### PR TITLE
[IAP] Simplify check for existing Subscriptions, and improve unit test coverage

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -120,6 +120,9 @@ struct UpgradesView: View {
         .onDisappear {
             upgradesViewModel.onDisappear()
         }
+        .task {
+            await upgradesViewModel.prepareViewModel()
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -13,8 +13,12 @@ final class UpgradesViewModelTests: XCTestCase {
     @MainActor
     func createSut(alreadySubscribed: Bool = false,
                    isSiteOwner: Bool = true,
+                   isIAPSupported: Bool = true,
                    plans: [WPComPlanProduct] = MockInAppPurchasesForWPComPlansManager.Defaults.essentialInAppPurchasesPlans) {
-        mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans, userIsEntitledToPlan: alreadySubscribed)
+
+        mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(plans: plans,
+                                                                           userIsEntitledToPlan: alreadySubscribed,
+                                                                           isIAPSupported: isIAPSupported)
 
         let site = Site.fake().copy(isSiteOwner: isSiteOwner)
 
@@ -100,4 +104,26 @@ final class UpgradesViewModelTests: XCTestCase {
         // Then
         assertEqual(.prePurchaseError(.userNotAllowedToUpgrade), sut.upgradeViewState)
      }
+
+    func test_upgradeViewState_when_IAP_are_not_supported_and_prepareViewModel_then_state_is_inAppPurchasesNotSupported() async {
+        // Given
+        await createSut(isIAPSupported: false)
+
+        // When
+        await sut.prepareViewModel()
+
+        // Then
+        assertEqual(.prePurchaseError(.inAppPurchasesNotSupported), sut.upgradeViewState)
+    }
+
+    func test_upgradeViewState_when_retrievePlanDetailsIfAvailable_fails_and_prepareViewModel_then_state_is_fetchError() async {
+        // Given
+        await createSut(plans: [])
+
+        // When
+        await sut.prepareViewModel()
+
+        // Then
+        assertEqual(.prePurchaseError(.fetchError), sut.upgradeViewState)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -25,14 +25,17 @@ final class UpgradesViewModelTests: XCTestCase {
         sut = UpgradesViewModel(siteID: sampleSiteID, inAppPurchasesPlanManager: mockInAppPurchasesManager, stores: stores)
     }
 
-    func test_upgrades_are_initialized_with_empty_values() async {
-        // Given, When
+    func test_if_user_has_active_in_app_purchases_then_returns_maximum_sites_upgraded_error() async {
+        // Given
         let sut = UpgradesViewModel(siteID: sampleSiteID,
-                                    inAppPurchasesPlanManager: MockInAppPurchasesForWPComPlansManager(plans: []),
+                                    inAppPurchasesPlanManager: MockInAppPurchasesForWPComPlansManager(userIsEntitledToPlan: true),
                                     stores: stores)
 
+        // When
+        await sut.fetchPlans()
+
         // Then
-        XCTAssert(sut.entitledWpcomPlanIDs.isEmpty)
+        assertEqual(.prePurchaseError(.maximumSitesUpgraded), sut.upgradeViewState)
     }
 
     func test_upgrades_when_fetchPlans_is_invoked_then_fetch_mocked_wpcom_plan() async {


### PR DESCRIPTION
## Description
This PR simplifies the current IAP Upgrades flow by refactoring the "existing subscriptions" and "is site owner" checks, as well as returning early when necessary. 

We also refactored handling errors by throwing them when possible, rather than assigning the view model state specifically to that error.

We also add Unit Test coverage to the `UpgradesViewModel` state.

## Testing instructions
- The IAP flow should work normally.
- Unit tests should pass.
