### PR TITLE
[IAP] Replace IAP M1 feature flag with M2

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -71,8 +71,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .freeTrial:
             return true
-        case .freeTrialInAppPurchasesUpgradeM1:
-            return true
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
         case .compositeProducts:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,6 +95,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shareProductAI:
             return true
+        case .freeTrialInAppPurchasesUpgradeM2:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -203,4 +203,8 @@ public enum FeatureFlag: Int {
     /// Enables generating share product content using AI
     ///
     case shareProductAI
+
+    /// Shows multiple plans in the IAP Upgrade view
+    ///
+    case freeTrialInAppPurchasesUpgradeM2
 }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -156,10 +156,6 @@ public enum FeatureFlag: Int {
     ///
     case freeTrial
 
-    /// Enables free trial store upgrades via In-App Purchases
-    ///
-    case freeTrialInAppPurchasesUpgradeM1
-
     /// Enables manual error handling for site credential login.
     ///
     case manualErrorHandlingForSiteCredentialLogin

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/LegacyUpgradeViewState.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/LegacyUpgradeViewState.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum LegacyUpgradeViewState: Equatable {
+    case loading
+    case loaded(WooWPComPlan)
+    case purchasing(WooWPComPlan)
+    case waiting(WooWPComPlan)
+    case completed(WooWPComPlan)
+    case prePurchaseError(PrePurchaseError)
+    case purchaseUpgradeError(PurchaseUpgradeError)
+
+    var shouldShowPlanDetailsView: Bool {
+        switch self {
+        case .loading, .loaded, .purchasing, .prePurchaseError:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var analyticsStep: WooAnalyticsEvent.InAppPurchases.Step? {
+        switch self {
+        case .loading, .purchasing:
+            return nil
+        case .loaded:
+            return .planDetails
+        case .waiting:
+            return .processing
+        case .completed:
+            return .completed
+        case .prePurchaseError:
+            return .prePurchaseError
+        case .purchaseUpgradeError:
+            return .purchaseUpgradeError
+        }
+    }
+}
+
+// MARK: - Equatable conformance
+extension LegacyUpgradeViewState {
+    static func ==(lhs: LegacyUpgradeViewState, rhs: LegacyUpgradeViewState) -> Bool {
+        switch (lhs, rhs) {
+        case (.loading, .loading):
+            return true
+        case (.prePurchaseError(let lhsError), .prePurchaseError(let rhsError)):
+            return lhsError == rhsError
+        default:
+            // TODO: Needs conformance for the rest of cases
+            return false
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/LegacyUpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/LegacyUpgradesViewModel.swift
@@ -1,0 +1,299 @@
+import Foundation
+import SwiftUI
+import Yosemite
+import Combine
+
+/// ViewModel for the Upgrades View
+/// Drives the site's available In-App Purchases plan upgrades
+///
+final class LegacyUpgradesViewModel: ObservableObject {
+
+    @Published var entitledWpcomPlanIDs: Set<String>
+    @Published var upgradeViewState: LegacyUpgradeViewState = .loading
+
+    private let inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol
+    private let siteID: Int64
+    private let storePlanSynchronizer: StorePlanSynchronizer
+    private let stores: StoresManager
+    private let localPlans: [WooPlan] = [.loadHardcodedPlan()]
+    private let analytics: Analytics
+
+    private let notificationCenter: NotificationCenter = NotificationCenter.default
+    private var applicationDidBecomeActiveObservationToken: NSObjectProtocol?
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(siteID: Int64,
+         inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager(),
+         storePlanSynchronizer: StorePlanSynchronizer = ServiceLocator.storePlanSynchronizer,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.inAppPurchasesPlanManager = inAppPurchasesPlanManager
+        self.storePlanSynchronizer = storePlanSynchronizer
+        self.stores = stores
+        self.analytics = analytics
+
+        entitledWpcomPlanIDs = []
+
+        observeViewStateAndTrackAnalytics()
+        checkForSiteOwnership()
+    }
+
+    /// Sync wrapper for `fetchViewData`, so can be called directly from where this
+    /// ViewModel is referenced, outside of the initializer
+    ///
+    func retryFetch() {
+        Task {
+            await fetchViewData()
+        }
+    }
+
+    /// Retrieves all In-App Purchases WPCom plans
+    ///
+    @MainActor
+    func fetchPlans() async {
+        do {
+            guard await inAppPurchasesPlanManager.inAppPurchasesAreSupported() else {
+                upgradeViewState = .prePurchaseError(.inAppPurchasesNotSupported)
+                return
+            }
+
+            async let wpcomPlans = inAppPurchasesPlanManager.fetchPlans()
+            async let hardcodedPlanDataIsValid = checkHardcodedPlanDataValidity()
+
+            try await loadUserEntitlements(for: wpcomPlans)
+            guard entitledWpcomPlanIDs.isEmpty else {
+                upgradeViewState = .prePurchaseError(.maximumSitesUpgraded)
+                return
+            }
+
+            guard let plan = try await retrievePlanDetailsIfAvailable(.essentialMonthly,
+                                                                      from: wpcomPlans,
+                                                                      hardcodedPlanDataIsValid: hardcodedPlanDataIsValid)
+            else {
+                upgradeViewState = .prePurchaseError(.fetchError)
+                return
+            }
+            upgradeViewState = .loaded(plan)
+        } catch {
+            DDLogError("fetchPlans \(error)")
+            upgradeViewState = .prePurchaseError(.fetchError)
+        }
+    }
+
+    /// Triggers the purchase of the specified In-App Purchases WPCom plans by the passed plan ID
+    /// linked to the current site ID
+    ///
+    @MainActor
+    func purchasePlan(with planID: String) async {
+        analytics.track(event: .InAppPurchases.planUpgradePurchaseButtonTapped(planID))
+        guard let wooWPComPlan = planCanBePurchasedFromCurrentState() else {
+            return
+        }
+
+        upgradeViewState = .purchasing(wooWPComPlan)
+
+        observeInAppPurchaseDrawerDismissal { [weak self] in
+            /// The drawer gets dismissed when the IAP is cancelled too. That gets dealt with in the `do-catch`
+            /// below, but this is usually received before the `.userCancelled`, so we need to wait a little
+            /// before we try to advance to the waiting state.
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+                guard let self else { return }
+                /// If the user cancelled, the state will be `.loaded(_)` by now, so we don't advance to waiting.
+                /// Likewise, errors will have moved us to `.error(_)`, so we won't advance then either.
+                if case .purchasing(_) = self.upgradeViewState {
+                    self.upgradeViewState = .waiting(wooWPComPlan)
+                }
+            }
+        }
+
+        do {
+            let result = try await inAppPurchasesPlanManager.purchasePlan(with: planID,
+                                                                          for: siteID)
+            stopObservingInAppPurchaseDrawerDismissal()
+            switch result {
+            case .userCancelled:
+                upgradeViewState = .loaded(wooWPComPlan)
+            case .success(.verified(_)):
+                // refreshing the synchronizer removes the Upgrade Now banner by the time the flow is closed
+                storePlanSynchronizer.reloadPlan()
+                upgradeViewState = .completed(wooWPComPlan)
+            default:
+                // TODO: handle `.success(.unverified(_))` here... somehow
+                return
+            }
+        } catch {
+            DDLogError("purchasePlan \(error)")
+            stopObservingInAppPurchaseDrawerDismissal()
+            guard let recognisedError = error as? InAppPurchaseStore.Errors else {
+                upgradeViewState = .purchaseUpgradeError(.unknown)
+                return
+            }
+
+            switch recognisedError {
+            case .unverifiedTransaction,
+                    .transactionProductUnknown,
+                    .inAppPurchasesNotSupported,
+                    .inAppPurchaseProductPurchaseFailed,
+                    .inAppPurchaseStoreKitFailed:
+                upgradeViewState = .purchaseUpgradeError(.inAppPurchaseFailed(wooWPComPlan, recognisedError))
+            case .transactionMissingAppAccountToken,
+                    .appAccountTokenMissingSiteIdentifier,
+                    .storefrontUnknown,
+                    .transactionAlreadyAssociatedWithAnUpgrade:
+                upgradeViewState = .purchaseUpgradeError(.planActivationFailed(recognisedError))
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+//
+private extension LegacyUpgradesViewModel {
+    /// Iterates through all available WPCom plans and checks whether the merchant is entitled to purchase them
+    /// via In-App Purchases
+    ///
+    @MainActor
+    func loadUserEntitlements(for plans: [WPComPlanProduct]) async {
+        do {
+            for wpcomPlan in plans {
+                if try await inAppPurchasesPlanManager.userIsEntitledToPlan(with: wpcomPlan.id) {
+                    self.entitledWpcomPlanIDs.insert(wpcomPlan.id)
+                } else {
+                    self.entitledWpcomPlanIDs.remove(wpcomPlan.id)
+                }
+            }
+        } catch {
+            DDLogError("loadEntitlements \(error)")
+            upgradeViewState = .prePurchaseError(.entitlementsError)
+        }
+    }
+
+    @MainActor
+    /// Checks whether the current plan details being displayed to merchants are accurate
+    /// by reaching the remote feature flag
+    ///
+    func checkHardcodedPlanDataValidity() async -> Bool {
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(
+                .hardcodedPlanUpgradeDetailsMilestone1AreAccurate,
+                defaultValue: true) { isEnabled in
+                continuation.resume(returning: isEnabled)
+            })
+        }
+    }
+
+    @MainActor
+    func fetchViewData() async {
+        upgradeViewState = .loading
+        await fetchPlans()
+    }
+
+    /// Checks whether a plan can be purchased from the current view state,
+    /// in which case the `WooWPComPlan` object is returned
+    ///
+    func planCanBePurchasedFromCurrentState() -> WooWPComPlan? {
+        switch upgradeViewState {
+        case .loaded(let plan), .purchaseUpgradeError(.inAppPurchaseFailed(let plan, _)):
+            return plan
+        default:
+            return nil
+        }
+    }
+
+    /// Checks whether the current user is the site owner, as only the site owner can perform
+    /// In-App Purchases upgrades, despite their site role
+    ///
+    func checkForSiteOwnership() {
+        if let site = stores.sessionManager.defaultSite, !site.isSiteOwner {
+            self.upgradeViewState = .prePurchaseError(.userNotAllowedToUpgrade)
+        } else {
+            Task {
+                await fetchViewData()
+            }
+        }
+    }
+}
+
+// MARK: - Notification observers
+//
+private extension LegacyUpgradesViewModel {
+    /// Observes the `didBecomeActiveNotification` for one invocation of the notification.
+    /// Using this in the scope of `purchasePlan` tells us when Apple's IAP view has completed.
+    ///
+    /// However, it can also be triggered by other actions, e.g. a phone call ending.
+    ///
+    /// One good example test is to start an IAP, then background the app and foreground it again
+    /// before the IAP drawer is shown.  You'll see that this notification is received, even though the
+    /// IAP drawer is then shown on top. Dismissing or completing the IAP will not then trigger this
+    /// notification again.
+    ///
+    /// It's not perfect, but it's what we have.
+    func observeInAppPurchaseDrawerDismissal(whenFired action: @escaping (() -> Void)) {
+        applicationDidBecomeActiveObservationToken = notificationCenter.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main) { [weak self] notification in
+                action()
+                self?.stopObservingInAppPurchaseDrawerDismissal()
+            }
+    }
+
+    func stopObservingInAppPurchaseDrawerDismissal() {
+        if let token = applicationDidBecomeActiveObservationToken {
+            notificationCenter.removeObserver(token)
+        }
+    }
+
+    /// Retrieves a specific In-App Purchase WPCom plan from the available products
+    ///
+    func retrievePlanDetailsIfAvailable(_ type: AvailableInAppPurchasesWPComPlans,
+                                                from wpcomPlans: [WPComPlanProduct],
+                                                hardcodedPlanDataIsValid: Bool) -> WooWPComPlan? {
+        guard let wpcomPlanProduct = wpcomPlans.first(where: { $0.id == type.rawValue }),
+              let wooPlan = localPlans.first(where: { $0.id == wpcomPlanProduct.id }) else {
+            return nil
+        }
+        return WooWPComPlan(wpComPlan: wpcomPlanProduct,
+                            wooPlan: wooPlan,
+                            hardcodedPlanDataIsValid: hardcodedPlanDataIsValid)
+    }
+}
+
+// MARK: - Analytics observers, and track events
+//
+extension LegacyUpgradesViewModel {
+    /// Observes the view state and tracks events when this changes
+    ///
+    private func observeViewStateAndTrackAnalytics() {
+        $upgradeViewState.sink { [weak self] state in
+            switch state {
+            case .waiting:
+                self?.analytics.track(.planUpgradeProcessingScreenLoaded)
+            case .loaded:
+                self?.analytics.track(.planUpgradeScreenLoaded)
+            case .completed:
+                self?.analytics.track(.planUpgradeCompletedScreenLoaded)
+            case .prePurchaseError(let error):
+                self?.analytics.track(event: .InAppPurchases.planUpgradePrePurchaseFailed(error: error))
+            case .purchaseUpgradeError(let error):
+                self?.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: error.analyticErrorDetail))
+            default:
+                break
+            }
+        }
+        .store(in: &cancellables)
+    }
+
+    func track(_ stat: WooAnalyticsStat) {
+        analytics.track(stat)
+    }
+
+    func onDisappear() {
+        guard let stepTracked = upgradeViewState.analyticsStep else {
+            return
+        }
+        analytics.track(event: .InAppPurchases.planUpgradeScreenDismissed(step: stepTracked))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -404,7 +404,7 @@ private extension AppCoordinator {
             else {
                 return
             }
-            upgradesViewPresentationCoordinator.presentUpgrades(for: siteID, from: topViewController)
+            self.upgradesViewPresentationCoordinator.presentUpgrades(for: siteID, from: topViewController)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -25,7 +25,7 @@ final class AppCoordinator {
     private let featureFlagService: FeatureFlagService
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
     private let purchasesManager: InAppPurchasesForWPComPlansProtocol?
-    private let purchasesManagerForFreeTrialUpgrade: InAppPurchasesForWPComPlansProtocol
+    private let upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator
 
     private var storePickerCoordinator: StorePickerCoordinator?
     private var authStatesSubscription: AnyCancellable?
@@ -47,7 +47,7 @@ final class AppCoordinator {
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          purchasesManager: InAppPurchasesForWPComPlansProtocol? = nil,
-         purchasesManagerForFreeTrialUpgrade: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
+         upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator()) {
         self.window = window
         self.tabBarController = {
             let storyboard = UIStoryboard(name: "Main", bundle: nil) // Main is the name of storyboard
@@ -66,7 +66,7 @@ final class AppCoordinator {
         self.featureFlagService = featureFlagService
         self.purchasesManager = purchasesManager
         self.switchStoreUseCase = SwitchStoreUseCase(stores: stores, storageManager: storageManager)
-        self.purchasesManagerForFreeTrialUpgrade = purchasesManagerForFreeTrialUpgrade
+        self.upgradesViewPresentationCoordinator = upgradesViewPresentationCoordinator
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
 
         // Configures authenticator first in case `WordPressAuthenticator` is used in other `AppDelegate` launch events.
@@ -404,7 +404,7 @@ private extension AppCoordinator {
             else {
                 return
             }
-            UpgradesViewPresentationCoordinator().presentUpgrades(for: siteID, from: topViewController)
+            upgradesViewPresentationCoordinator.presentUpgrades(for: siteID, from: topViewController)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -399,17 +399,12 @@ private extension AppCoordinator {
 private extension AppCoordinator {
     func showUpgradesView(siteID: Int64) {
         switchStoreUseCase.switchStore(with: siteID) { [weak self] _ in
-            guard let self else { return }
-
-            Task { @MainActor in
-                if await self.purchasesManagerForFreeTrialUpgrade.inAppPurchasesAreSupported() {
-                    let upgradesController = UpgradesHostingController(siteID: siteID)
-                    self.window.rootViewController?.topmostPresentedViewController.present(upgradesController, animated: true)
-                } else {
-                    let subscriptionsController = SubscriptionsHostingController(siteID: siteID)
-                    self.window.rootViewController?.topmostPresentedViewController.present(subscriptionsController, animated: true)
-                }
+            guard let self,
+            let topViewController = self.window.rootViewController?.topmostPresentedViewController
+            else {
+                return
             }
+            UpgradesViewPresentationCoordinator().presentUpgrades(for: siteID, from: topViewController)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -402,8 +402,7 @@ private extension AppCoordinator {
             guard let self else { return }
 
             Task { @MainActor in
-                if await self.purchasesManagerForFreeTrialUpgrade.inAppPurchasesAreSupported() &&
-                    self.featureFlagService.isFeatureFlagEnabled(.freeTrialInAppPurchasesUpgradeM1) {
+                if await self.purchasesManagerForFreeTrialUpgrade.inAppPurchasesAreSupported() {
                     let upgradesController = UpgradesHostingController(siteID: siteID)
                     self.window.rootViewController?.topmostPresentedViewController.present(upgradesController, animated: true)
                 } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -158,15 +158,8 @@ private extension FreeTrialBannerPresenter {
     ///
     func showUpgradesView() {
         guard let viewController else { return }
-        Task { @MainActor in
-            if await inAppPurchasesManager.inAppPurchasesAreSupported() {
-                let upgradesController = UpgradesHostingController(siteID: siteID)
-                viewController.present(upgradesController, animated: true)
-            } else {
-                let subscriptionsController = SubscriptionsHostingController(siteID: siteID)
-                viewController.show(subscriptionsController, sender: self)
-            }
-        }
+
+        UpgradesViewPresentationCoordinator().presentUpgrades(for: siteID, from: viewController)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -30,10 +30,6 @@ final class FreeTrialBannerPresenter {
     ///
     private var subscriptions: Set<AnyCancellable> = []
 
-    /// Flag that indicates if a site can be upgraded via In-App Purchases
-    ///
-    private var inAppPurchasesUpgradeEnabled: Bool
-
     private var inAppPurchasesManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()
 
     /// - Parameters:
@@ -48,7 +44,6 @@ final class FreeTrialBannerPresenter {
         self.containerView = containerView
         self.siteID = siteID
         self.onLayoutUpdated = onLayoutUpdated
-        self.inAppPurchasesUpgradeEnabled = featureFlagService.isFeatureFlagEnabled(.freeTrialInAppPurchasesUpgradeM1)
         observeStorePlan()
         observeConnectivity()
     }
@@ -111,7 +106,7 @@ private extension FreeTrialBannerPresenter {
     /// Will display different CTA text depending if IAP is supported and is enabled
     ///
     private func setupBannerText() async -> String {
-        if await inAppPurchasesManager.inAppPurchasesAreSupported() && inAppPurchasesUpgradeEnabled {
+        if await inAppPurchasesManager.inAppPurchasesAreSupported() {
             return Localization.upgradeNow
         } else {
             return Localization.learnMore
@@ -164,7 +159,7 @@ private extension FreeTrialBannerPresenter {
     func showUpgradesView() {
         guard let viewController else { return }
         Task { @MainActor in
-            if await inAppPurchasesManager.inAppPurchasesAreSupported() && inAppPurchasesUpgradeEnabled {
+            if await inAppPurchasesManager.inAppPurchasesAreSupported() {
                 let upgradesController = UpgradesHostingController(siteID: siteID)
                 viewController.present(upgradesController, animated: true)
             } else {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/LegacyOwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/LegacyOwnerUpgradesView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct LegacyOwnerUpgradesView: View {
+    @State var upgradePlan: WooWPComPlan
+    @State var isPurchasing = false
+    let purchasePlanAction: () -> Void
+    @State var isLoading: Bool = false
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    Image(upgradePlan.wooPlan.headerImageFileName)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowInsets(.zero)
+                        .listRowBackground(upgradePlan.wooPlan.headerImageCardColor)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading) {
+                        Text(upgradePlan.wooPlan.shortName)
+                            .font(.largeTitle)
+                            .accessibilityAddTraits(.isHeader)
+                        Text(upgradePlan.wooPlan.planDescription)
+                            .font(.subheadline)
+                    }
+
+                    VStack(alignment: .leading) {
+                        Text(upgradePlan.wpComPlan.displayPrice)
+                            .font(.largeTitle)
+                            .accessibilityAddTraits(.isHeader)
+                        Text(upgradePlan.wooPlan.planFrequency.localizedString)
+                            .font(.footnote)
+                    }
+                }
+                .accessibilityAddTraits(.isSummaryElement)
+                .listRowSeparator(.hidden)
+
+                if upgradePlan.hardcodedPlanDataIsValid {
+                    Section {
+                        ForEach(upgradePlan.wooPlan.planFeatureGroups, id: \.title) { featureGroup in
+                            NavigationLink(destination: WooPlanFeatureBenefitsView(wooPlanFeatureGroup: featureGroup)) {
+                                WooPlanFeatureGroupRow(featureGroup: featureGroup)
+                            }
+                            .disabled(isLoading)
+                        }
+                    } header: {
+                        Text(String.localizedStringWithFormat(Localization.featuresHeaderTextFormat, upgradePlan.wooPlan.shortName))
+                    }
+                    .headerProminence(.increased)
+                } else {
+                    NavigationLink(destination: {
+                        /// Note that this is a fallback only, and we should remove it once we load feature details remotely.
+                        AuthenticatedWebView(isPresented: .constant(true),
+                                             url: WooConstants.URLs.fallbackWooExpressHome.asURL())
+                    }, label: {
+                        Text(Localization.featureDetailsUnavailableText)
+                    })
+                    .disabled(isLoading)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .redacted(reason: isLoading ? .placeholder : [])
+            .shimmering(active: isLoading)
+            VStack {
+                let buttonText = String.localizedStringWithFormat(Localization.purchaseCTAButtonText, upgradePlan.wpComPlan.displayName)
+                Button(buttonText) {
+                    purchasePlanAction()
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPurchasing))
+                .disabled(isLoading)
+                .redacted(reason: isLoading ? .placeholder : [])
+                .shimmering(active: isLoading)
+            }
+            .padding()
+        }
+    }
+}
+
+private extension LegacyOwnerUpgradesView {
+    struct Localization {
+        static let purchaseCTAButtonText = NSLocalizedString(
+            "Purchase %1$@",
+            comment: "The title of the button to purchase a Plan." +
+            "Reads as 'Purchase Essential Monthly'")
+
+        static let featuresHeaderTextFormat = NSLocalizedString(
+            "Get the most out of %1$@",
+            comment: "Title for the section header for the list of feature categories on the Upgrade plan screen. " +
+            "Reads as 'Get the most out of Essential'. %1$@ must be included in the string and will be replaced with " +
+            "the plan name.")
+
+        static let featureDetailsUnavailableText = NSLocalizedString(
+            "See plan details", comment: "Title for a link to view Woo Express plan details on the web, as a fallback.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Upgrades/LegacyUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/LegacyUpgradesView.swift
@@ -10,7 +10,7 @@ final class LegacyUpgradesHostingController: UIHostingController<LegacyUpgradesV
     private let authentication: Authentication = ServiceLocator.authenticationManager
 
     init(siteID: Int64) {
-        let upgradesViewModel = UpgradesViewModel(siteID: siteID)
+        let upgradesViewModel = LegacyUpgradesViewModel(siteID: siteID)
         let subscriptionsViewModel = SubscriptionsViewModel()
 
         super.init(rootView: LegacyUpgradesView(upgradesViewModel: upgradesViewModel, subscriptionsViewModel: subscriptionsViewModel))
@@ -32,12 +32,12 @@ final class LegacyUpgradesHostingController: UIHostingController<LegacyUpgradesV
 struct LegacyUpgradesView: View {
     @Environment(\.dismiss) var dismiss
 
-    @ObservedObject var upgradesViewModel: UpgradesViewModel
+    @ObservedObject var upgradesViewModel: LegacyUpgradesViewModel
     @ObservedObject var subscriptionsViewModel: SubscriptionsViewModel
 
     var supportHandler: () -> Void = {}
 
-    init(upgradesViewModel: UpgradesViewModel,
+    init(upgradesViewModel: LegacyUpgradesViewModel,
          subscriptionsViewModel: SubscriptionsViewModel) {
         self.upgradesViewModel = upgradesViewModel
         self.subscriptionsViewModel = subscriptionsViewModel
@@ -183,7 +183,7 @@ private extension WooWPComPlan {
 
 struct LegacyUpgradesView_Preview: PreviewProvider {
     static var previews: some View {
-        UpgradesView(upgradesViewModel: UpgradesViewModel(siteID: 0),
+        LegacyUpgradesView(upgradesViewModel: LegacyUpgradesViewModel(siteID: 0),
                      subscriptionsViewModel: SubscriptionsViewModel())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/LegacyUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/LegacyUpgradesView.swift
@@ -59,16 +59,16 @@ struct LegacyUpgradesView: View {
 
                 switch upgradesViewModel.upgradeViewState {
                 case .loading:
-                    OwnerUpgradesView(upgradePlan: .skeletonPlan(), purchasePlanAction: {}, isLoading: true)
+                    LegacyOwnerUpgradesView(upgradePlan: .skeletonPlan(), purchasePlanAction: {}, isLoading: true)
                         .accessibilityLabel(Localization.plansLoadingAccessibilityLabel)
                 case .loaded(let plan):
-                    OwnerUpgradesView(upgradePlan: plan, purchasePlanAction: {
+                    LegacyOwnerUpgradesView(upgradePlan: plan, purchasePlanAction: {
                         Task {
                             await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
                         }
                     })
                 case .purchasing(let plan):
-                    OwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
+                    LegacyOwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
                 case .waiting(let plan):
                     ScrollView(.vertical) {
                         UpgradeWaitingView(planName: plan.wooPlan.shortName)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/LegacyUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/LegacyUpgradesView.swift
@@ -1,42 +1,19 @@
 import Foundation
 import SwiftUI
 import Yosemite
-import Experiments
-
-final class UpgradesViewPresentationCoordinator {
-    private let featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService
-    private let inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()
-
-    func presentUpgrades(for siteID: Int64, from viewController: UIViewController) {
-        Task { @MainActor in
-            if await inAppPurchaseManager.inAppPurchasesAreSupported() {
-                if featureFlagService.isFeatureFlagEnabled(.freeTrialInAppPurchasesUpgradeM2) {
-                    let upgradesController = UpgradesHostingController(siteID: siteID)
-                    viewController.present(upgradesController, animated: true)
-                } else {
-                    let legacyUpgradesController = LegacyUpgradesHostingController(siteID: siteID)
-                    viewController.present(legacyUpgradesController, animated: true)
-                }
-            } else {
-                let subscriptionsController = SubscriptionsHostingController(siteID: siteID)
-                viewController.present(subscriptionsController, animated: true)
-            }
-        }
-    }
-}
 
 /// Hosting controller for `UpgradesView`
 /// To be used to display available current plan Subscriptions, available plan Upgrades,
 /// and the CTA to upgrade
 ///
-final class UpgradesHostingController: UIHostingController<UpgradesView> {
+final class LegacyUpgradesHostingController: UIHostingController<LegacyUpgradesView> {
     private let authentication: Authentication = ServiceLocator.authenticationManager
 
     init(siteID: Int64) {
         let upgradesViewModel = UpgradesViewModel(siteID: siteID)
         let subscriptionsViewModel = SubscriptionsViewModel()
 
-        super.init(rootView: UpgradesView(upgradesViewModel: upgradesViewModel, subscriptionsViewModel: subscriptionsViewModel))
+        super.init(rootView: LegacyUpgradesView(upgradesViewModel: upgradesViewModel, subscriptionsViewModel: subscriptionsViewModel))
 
         rootView.supportHandler = { [weak self] in
             self?.openSupport()
@@ -52,7 +29,7 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
     }
 }
 
-struct UpgradesView: View {
+struct LegacyUpgradesView: View {
     @Environment(\.dismiss) var dismiss
 
     @ObservedObject var upgradesViewModel: UpgradesViewModel
@@ -69,7 +46,6 @@ struct UpgradesView: View {
     var body: some View {
         NavigationView {
             VStack {
-                Text("M2 Upgrades")
                 VStack {
                     // TODO: Once we remove iOS 15 support, we can do this with .toolbar instead.
                     UpgradeTopBarView(dismiss: {
@@ -147,7 +123,7 @@ struct UpgradesView: View {
     }
 }
 
-private extension UpgradesView {
+private extension LegacyUpgradesView {
     struct Layout {
         static let errorViewHorizontalPadding: CGFloat = 20
         static let errorViewTopPadding: CGFloat = 36
@@ -205,7 +181,7 @@ private extension WooWPComPlan {
     }
 }
 
-struct UpgradesView_Preview: PreviewProvider {
+struct LegacyUpgradesView_Preview: PreviewProvider {
     static var previews: some View {
         UpgradesView(upgradesViewModel: UpgradesViewModel(siteID: 0),
                      subscriptionsViewModel: SubscriptionsViewModel())

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -4,8 +4,14 @@ import Yosemite
 import Experiments
 
 final class UpgradesViewPresentationCoordinator {
-    private let featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService
-    private let inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()
+    private let featureFlagService: FeatureFlagService
+    private let inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
+        self.featureFlagService = featureFlagService
+        self.inAppPurchaseManager = inAppPurchaseManager
+    }
 
     func presentUpgrades(for siteID: Int64, from viewController: UIViewController) {
         Task { @MainActor in

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -618,6 +618,7 @@
 		03B9E52F2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B9E52E2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift */; };
 		03BB9EA5292E2D0C00251E9E /* CardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */; };
 		03BB9EA7292E50B600251E9E /* CardPresentModalSelectSearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */; };
+		03C421122A54175400F851A1 /* LegacyUpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C421112A54175400F851A1 /* LegacyUpgradesView.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03E471BE29388787001A58AD /* BuiltInCardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471BD29388787001A58AD /* BuiltInCardReaderConnectionController.swift */; };
 		03E471C0293A158D001A58AD /* CardReaderConnectionAlertsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471BF293A158C001A58AD /* CardReaderConnectionAlertsProviding.swift */; };
@@ -2978,6 +2979,7 @@
 		03B9E52E2A150EED005C77F5 /* MockCardReaderSupportDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardReaderSupportDeterminer.swift; sourceTree = "<group>"; };
 		03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionController.swift; sourceTree = "<group>"; };
 		03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalSelectSearchType.swift; sourceTree = "<group>"; };
+		03C421112A54175400F851A1 /* LegacyUpgradesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyUpgradesView.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03E471BD29388787001A58AD /* BuiltInCardReaderConnectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuiltInCardReaderConnectionController.swift; sourceTree = "<group>"; };
 		03E471BF293A158C001A58AD /* CardReaderConnectionAlertsProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionAlertsProviding.swift; sourceTree = "<group>"; };
@@ -6338,6 +6340,7 @@
 				261E919F29C961EE00A5C118 /* SubscriptionsViewModel.swift */,
 				267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */,
 				DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */,
+				03C421112A54175400F851A1 /* LegacyUpgradesView.swift */,
 				68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */,
 				0331A7582A3A3D52001D2C2C /* WooPlanFeatureBenefitsView.swift */,
 				0331A7542A3A1A4C001D2C2C /* WooPlanFeatureGroupRow.swift */,
@@ -11876,6 +11879,7 @@
 				02D7E7C92A4CBEEC0003049A /* LocalAnnouncementModal.swift in Sources */,
 				0221121E288973C20028F0AF /* LocalNotification.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
+				03C421122A54175400F851A1 /* LegacyUpgradesView.swift in Sources */,
 				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -619,6 +619,7 @@
 		03BB9EA5292E2D0C00251E9E /* CardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */; };
 		03BB9EA7292E50B600251E9E /* CardPresentModalSelectSearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */; };
 		03C421122A54175400F851A1 /* LegacyUpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C421112A54175400F851A1 /* LegacyUpgradesView.swift */; };
+		03C421142A54214D00F851A1 /* LegacyOwnerUpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C421132A54214D00F851A1 /* LegacyOwnerUpgradesView.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03E471BE29388787001A58AD /* BuiltInCardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471BD29388787001A58AD /* BuiltInCardReaderConnectionController.swift */; };
 		03E471C0293A158D001A58AD /* CardReaderConnectionAlertsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471BF293A158C001A58AD /* CardReaderConnectionAlertsProviding.swift */; };
@@ -2980,6 +2981,7 @@
 		03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionController.swift; sourceTree = "<group>"; };
 		03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalSelectSearchType.swift; sourceTree = "<group>"; };
 		03C421112A54175400F851A1 /* LegacyUpgradesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyUpgradesView.swift; sourceTree = "<group>"; };
+		03C421132A54214D00F851A1 /* LegacyOwnerUpgradesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyOwnerUpgradesView.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03E471BD29388787001A58AD /* BuiltInCardReaderConnectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuiltInCardReaderConnectionController.swift; sourceTree = "<group>"; };
 		03E471BF293A158C001A58AD /* CardReaderConnectionAlertsProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionAlertsProviding.swift; sourceTree = "<group>"; };
@@ -6348,6 +6350,7 @@
 				68E674A42A4DA8510034BA1E /* PurchaseUpgradeErrorView.swift */,
 				68E674A62A4DAAA60034BA1E /* UpgradeWaitingView.swift */,
 				68E674A82A4DAB1A0034BA1E /* OwnerUpgradesView.swift */,
+				03C421132A54214D00F851A1 /* LegacyOwnerUpgradesView.swift */,
 				68E674AA2A4DAB8C0034BA1E /* CompletedUpgradeView.swift */,
 				68E674AC2A4DAC010034BA1E /* CurrentPlanDetailsView.swift */,
 				68E674AE2A4DACD50034BA1E /* UpgradeTopBarView.swift */,
@@ -11514,6 +11517,7 @@
 				02ACD25A2852E11700EC928E /* CloseAccountCoordinator.swift in Sources */,
 				036CA6F129229C9E00E4DF4F /* IndefiniteCircularProgressViewStyle.swift in Sources */,
 				451A9973260E39270059D135 /* ShippingLabelPackageNumberRow.swift in Sources */,
+				03C421142A54214D00F851A1 /* LegacyOwnerUpgradesView.swift in Sources */,
 				AEE2610F26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift in Sources */,
 				025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */,
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -561,6 +561,8 @@
 		0331A7002A334982001D2C2C /* MockInAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */; };
 		0331A7552A3A1A4C001D2C2C /* WooPlanFeatureGroupRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0331A7542A3A1A4C001D2C2C /* WooPlanFeatureGroupRow.swift */; };
 		0331A7592A3A3D52001D2C2C /* WooPlanFeatureBenefitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0331A7582A3A3D52001D2C2C /* WooPlanFeatureBenefitsView.swift */; };
+		0338454F2A54399500D50795 /* LegacyUpgradeViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0338454E2A54399400D50795 /* LegacyUpgradeViewState.swift */; };
+		033845512A5439D700D50795 /* LegacyUpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033845502A5439D700D50795 /* LegacyUpgradesViewModel.swift */; };
 		03582BE2299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03582BE1299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift */; };
 		035BA3A8291000E90056F0AD /* JustInTimeMessageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A7291000E90056F0AD /* JustInTimeMessageViewModelTests.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
@@ -2922,6 +2924,8 @@
 		032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailedNonRetryable.swift; sourceTree = "<group>"; };
 		0331A7542A3A1A4C001D2C2C /* WooPlanFeatureGroupRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPlanFeatureGroupRow.swift; sourceTree = "<group>"; };
 		0331A7582A3A3D52001D2C2C /* WooPlanFeatureBenefitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPlanFeatureBenefitsView.swift; sourceTree = "<group>"; };
+		0338454E2A54399400D50795 /* LegacyUpgradeViewState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyUpgradeViewState.swift; sourceTree = "<group>"; };
+		033845502A5439D700D50795 /* LegacyUpgradesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyUpgradesViewModel.swift; sourceTree = "<group>"; };
 		03582BE1299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentAnalytics.swift; sourceTree = "<group>"; };
 		035BA3A7291000E90056F0AD /* JustInTimeMessageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageViewModelTests.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
@@ -7531,6 +7535,8 @@
 			children = (
 				68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */,
 				680BA5992A4C377900F5559D /* UpgradeViewState.swift */,
+				033845502A5439D700D50795 /* LegacyUpgradesViewModel.swift */,
+				0338454E2A54399400D50795 /* LegacyUpgradeViewState.swift */,
 				68E6749E2A4DA01C0034BA1E /* WooWPComPlan.swift */,
 				68E674A02A4DA0B30034BA1E /* InAppPurchasesError.swift */,
 			);
@@ -11573,6 +11579,7 @@
 				26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,
 				03E471D62942222E001A58AD /* CardPresentModalBuiltInFollowReaderInstructions.swift in Sources */,
+				033845512A5439D700D50795 /* LegacyUpgradesViewModel.swift in Sources */,
 				B60B5026292D308A00178C26 /* AnalyticsTimeRangeCard.swift in Sources */,
 				E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */,
 				039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */,
@@ -11901,6 +11908,7 @@
 				4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */,
 				DE4B3B5626A68DD000EEF2D8 /* View+InsetPaddings.swift in Sources */,
 				B59D1EEC2190B08B009D1978 /* Age.swift in Sources */,
+				0338454F2A54399500D50795 /* LegacyUpgradeViewState.swift in Sources */,
 				CE27257C21924A8C002B22EB /* HelpAndSupportViewController.swift in Sources */,
 				025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */,
 				DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -363,10 +363,11 @@ final class AppCoordinatorTests: XCTestCase {
         let pushNotesManager = MockPushNotificationsManager()
         let featureFlagService = MockFeatureFlagService()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: false)
+        let upgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(inAppPurchaseManager: mockInAppPurchasesManager)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
                                           featureFlagService: featureFlagService,
-                                          purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
+                                          upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
         coordinator.start()
         let siteID: Int64 = 123
 
@@ -387,9 +388,10 @@ final class AppCoordinatorTests: XCTestCase {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
+        let upgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(inAppPurchaseManager: mockInAppPurchasesManager)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
+                                          upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
         coordinator.start()
         let siteID: Int64 = 123
 
@@ -410,9 +412,10 @@ final class AppCoordinatorTests: XCTestCase {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: false)
+        let upgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(inAppPurchaseManager: mockInAppPurchasesManager)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
+                                          upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
         coordinator.start()
         let siteID: Int64 = 123
 
@@ -433,9 +436,10 @@ final class AppCoordinatorTests: XCTestCase {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
+        let upgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(inAppPurchaseManager: mockInAppPurchasesManager)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
+                                          upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
         coordinator.start()
         let siteID: Int64 = 123
 
@@ -456,9 +460,10 @@ final class AppCoordinatorTests: XCTestCase {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: false)
+        let upgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(inAppPurchaseManager: mockInAppPurchasesManager)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
+                                          upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
         coordinator.start()
         let siteID: Int64 = 123
 
@@ -479,9 +484,10 @@ final class AppCoordinatorTests: XCTestCase {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
+        let upgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(inAppPurchaseManager: mockInAppPurchasesManager)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
+                                          upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
         coordinator.start()
         let siteID: Int64 = 123
 
@@ -651,7 +657,7 @@ private extension AppCoordinatorTests {
                          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
                          featureFlagService: FeatureFlagService = MockFeatureFlagService(),
                          purchasesManager: InAppPurchasesForWPComPlansProtocol? = nil,
-                         purchasesManagerForFreeTrialUpgrade: InAppPurchasesForWPComPlansProtocol = MockInAppPurchasesForWPComPlansManager()
+                         upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator()
     ) -> AppCoordinator {
         return AppCoordinator(window: window ?? self.window,
                               stores: stores ?? self.stores,
@@ -663,6 +669,6 @@ private extension AppCoordinatorTests {
                               pushNotesManager: pushNotesManager,
                               featureFlagService: featureFlagService,
                               purchasesManager: purchasesManager ?? nil,
-                              purchasesManagerForFreeTrialUpgrade: purchasesManagerForFreeTrialUpgrade)
+                              upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
     }
 }

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -361,7 +361,7 @@ final class AppCoordinatorTests: XCTestCase {
     func test_SubscriptionsHostingController_is_shown_when_tapping_oneDayBeforeFreeTrialExpires_notification_if_freeTrialIAP_not_available() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isFreeTrialInAppPurchasesUpgradeM1: false)
+        let featureFlagService = MockFeatureFlagService()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: false)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
@@ -386,11 +386,9 @@ final class AppCoordinatorTests: XCTestCase {
     func test_UpgradesHostingController_is_shown_when_tapping_oneDayBeforeFreeTrialExpires_notification_if_freeTrialIAP_available() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isFreeTrialInAppPurchasesUpgradeM1: true)
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService,
                                           purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
         coordinator.start()
         let siteID: Int64 = 123
@@ -411,11 +409,9 @@ final class AppCoordinatorTests: XCTestCase {
     func test_SubscriptionsHostingController_is_shown_when_tapping_oneDayAfterFreeTrialExpiresIdentifier_notification_if_freeTrialIAP_not_available() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isFreeTrialInAppPurchasesUpgradeM1: false)
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: false)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService,
                                           purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
         coordinator.start()
         let siteID: Int64 = 123
@@ -436,11 +432,9 @@ final class AppCoordinatorTests: XCTestCase {
     func test_UpgradesHostingController_is_shown_when_tapping_oneDayAfterFreeTrialExpiresIdentifier_notification_if_freeTrialIAP_available() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isFreeTrialInAppPurchasesUpgradeM1: true)
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService,
                                           purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
         coordinator.start()
         let siteID: Int64 = 123
@@ -461,11 +455,9 @@ final class AppCoordinatorTests: XCTestCase {
     func test_SubscriptionsHostingController_is_shown_when_tapping_twentyFourHoursAfterFreeTrialSubscribed_notification_if_freeTrialIAP_not_available() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isFreeTrialInAppPurchasesUpgradeM1: false)
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: false)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService,
                                           purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
         coordinator.start()
         let siteID: Int64 = 123
@@ -486,11 +478,9 @@ final class AppCoordinatorTests: XCTestCase {
     func test_UpgradesHostingController_is_shown_when_tapping_twentyFourHoursAfterFreeTrialSubscribed_notification_if_freeTrialIAP_available() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isFreeTrialInAppPurchasesUpgradeM1: true)
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
         let coordinator = makeCoordinator(window: window,
                                           pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService,
                                           purchasesManagerForFreeTrialUpgrade: mockInAppPurchasesManager)
         coordinator.start()
         let siteID: Int64 = 123

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -15,7 +15,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
     private let isFreeTrial: Bool
-    private let isFreeTrialInAppPurchasesUpgradeM1: Bool
     private let jetpackSetupWithApplicationPassword: Bool
     private let isTapToPayOnIPhoneMilestone2On: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
@@ -27,6 +26,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isBlazeEnabled: Bool
     private let isShareProductAIEnabled: Bool
     private let isJustInTimeMessagesOnDashboardEnabled: Bool
+    private let isFreeTrialInAppPurchasesUpgradeM2: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -41,7 +41,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
          isFreeTrial: Bool = false,
-         isFreeTrialInAppPurchasesUpgradeM1: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          isTapToPayOnIPhoneMilestone2On: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
@@ -52,7 +51,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isAddProductToOrderViaSKUScannerEnabled: Bool = false,
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
-         isJustInTimeMessagesOnDashboardEnabled: Bool = false) {
+         isJustInTimeMessagesOnDashboardEnabled: Bool = false,
+         isFreeTrialInAppPurchasesUpgradeM2: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -66,7 +66,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
         self.isFreeTrial = isFreeTrial
-        self.isFreeTrialInAppPurchasesUpgradeM1 = isFreeTrialInAppPurchasesUpgradeM1
+        self.isFreeTrialInAppPurchasesUpgradeM2 = isFreeTrialInAppPurchasesUpgradeM2
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isTapToPayOnIPhoneMilestone2On = isTapToPayOnIPhoneMilestone2On
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
@@ -108,8 +108,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isDashboardStoreOnboardingEnabled
         case .freeTrial:
             return isFreeTrial
-        case .freeTrialInAppPurchasesUpgradeM1:
-            return isFreeTrialInAppPurchasesUpgradeM1
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
         case .tapToPayOnIPhoneMilestone2:
@@ -130,6 +128,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isShareProductAIEnabled
         case .justInTimeMessagesOnDashboard:
             return isJustInTimeMessagesOnDashboardEnabled
+        case .freeTrialInAppPurchasesUpgradeM2:
+            return isFreeTrialInAppPurchasesUpgradeM2
         default:
             return false
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Now that M1 is turned on in the 14.3 release, we can replace the flag with an M2 version for the multiple-plans upgrade screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Feature flag off

Set the `isFreeTrialInAppPurchasesUpgradeM2` feature flag to `false` in `DefaultFeatureFlagService`

1. Using a US-based storefront (open WooCommerceTestSynced.storekit, `Editor Menu > Storefront > United States`) and the WooCommerce IAP scheme, run the app from Xcode.
2. Switch to a Woo Express store with a free trial active
3. Tap `Upgrade now`
4. Observe that the IAP upgrade flow is shown


Repeat the test using any other storefront
Observe that the subscriptions menu is shown.

### Feature flag on

Set the `isFreeTrialInAppPurchasesUpgradeM2` feature flag to `true` in `DefaultFeatureFlagService` (or leave as on this branch)

1. Using a US-based storefront (open WooCommerceTestSynced.storekit, `Editor Menu > Storefront > United States`) and the WooCommerce IAP scheme, run the app from Xcode.
2. Switch to a Woo Express store with a free trial active
3. Tap `Upgrade now`
4. Observe that the M2 IAP upgrade flow is shown (only difference is an identifying label at the top of the view)


Repeat the test using any other storefront
Observe that the subscriptions menu is shown.



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
