### PR TITLE
Blaze: Update entry point analytic name to align with Android

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -82,17 +82,17 @@ private extension WooAnalyticsEvent.Blaze.Step {
     }
 }
 
-private extension BlazeSource {
+extension BlazeSource {
     var analyticsValue: String {
         switch self {
         case .menu:
             return "menu"
         case .productMoreMenu:
             return "product_more_menu"
-        case .productList:
-            return "product_list"
-        case .myStore:
-            return "my_store"
+        case .productListBanner:
+            return "product_list_banner"
+        case .myStoreBanner:
+            return "my_store_banner"
         }
     }
 }

--- a/WooCommerce/Classes/Blaze/BlazeBanner.swift
+++ b/WooCommerce/Classes/Blaze/BlazeBanner.swift
@@ -197,9 +197,9 @@ extension BlazeBanner {
         var blazeSource: BlazeSource {
             switch self {
             case .myStore:
-                return .myStore
+                return .myStoreBanner
             case .products:
-                return .productList
+                return .productListBanner
             }
         }
     }

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -8,10 +8,10 @@ enum BlazeSource {
     case menu
     /// From the product more menu.
     case productMoreMenu
-    /// From the product list.
-    case productList
-    /// From the My Store tab.
-    case myStore
+    /// From the banner on product list.
+    case productListBanner
+    /// From the banner on My Store tab.
+    case myStoreBanner
 }
 
 /// View model for Blaze webview.
@@ -112,21 +112,6 @@ private extension BlazeWebViewModel {
             } else {
                 return .productList
             }
-        }
-    }
-}
-
-private extension BlazeSource {
-    var analyticsValue: String {
-        switch self {
-        case .menu:
-            return "menu"
-        case .productMoreMenu:
-            return "product_more_menu"
-        case .productList:
-            return "product_list"
-        case .myStore:
-            return "my_store"
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10098

⚠️  Please make sure that #10160 has been reviewed and merged.
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the analytic name for the Blaze entry point to align with Android: `my_store` to `my_store_banner` and `product_list` to `product_list_banner`.

Also removed a redundant extension of `BlazeSource` and make the other accessible internally.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in as an admin to a public WPCom site to be able to create a Blaze campaign. If you tested this feature before and dismissed the Blaze banner, reinstall the app if you don't have any other eligible stores to clear the saved user defaults value.
- Notice the Blaze banner on the My Store screen. Any related events to this banner: (display, dismiss, tap, etc.) should have the correct entry point: `my_store_banner`.
- Similarly, test with the banner on the product list, the source for the events should be `product_list_banner`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
