### PR TITLE
[IAP] Draft of new upgrades screen

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
@@ -2,8 +2,8 @@ import Foundation
 
 enum UpgradeViewState: Equatable {
     case loading
-    case loaded(WooWPComPlan)
-    case purchasing(WooWPComPlan)
+    case loaded([WooWPComPlan])
+    case purchasing(WooWPComPlan, [WooWPComPlan])
     case waiting(WooWPComPlan)
     case completed(WooWPComPlan)
     case prePurchaseError(PrePurchaseError)

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/WooWPComPlan.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/WooWPComPlan.swift
@@ -1,7 +1,11 @@
 import Yosemite
 
-public struct WooWPComPlan {
+public struct WooWPComPlan: Identifiable {
     let wpComPlan: WPComPlanProduct
     let wooPlan: WooPlan
     let hardcodedPlanDataIsValid: Bool
+
+    public var id: String {
+        return wpComPlan.id
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -1,15 +1,16 @@
 import SwiftUI
 import Yosemite
+import WooFoundation
 
 struct OwnerUpgradesView: View {
     @State var upgradePlans: [WooWPComPlan]
     @State var isPurchasing: Bool
-    let purchasePlanAction: () -> Void
+    let purchasePlanAction: (WooWPComPlan) -> Void
     @State var isLoading: Bool
 
     init(upgradePlans: [WooWPComPlan],
          isPurchasing: Bool = false,
-         purchasePlanAction: @escaping (() -> Void),
+         purchasePlanAction: @escaping ((WooWPComPlan) -> Void),
          isLoading: Bool = false) {
         _upgradePlans = .init(initialValue: upgradePlans)
         _isPurchasing = .init(initialValue: isPurchasing)
@@ -50,11 +51,11 @@ struct OwnerUpgradesView: View {
 
                                 if selectedPlan?.id == upgradePlan.id {
                                     Image(systemName: "checkmark.circle.fill")
-                                        .foregroundStyle(Color(.wooCommercePurple(.shade50)))
+                                        .foregroundStyle(Color.withColorStudio(name: .wooCommercePurple, shade: .shade50))
                                         .font(.system(size: 30))
                                 } else {
                                     Image(systemName: "circle")
-                                        .foregroundStyle(Color(.wooCommercePurple(.shade50)))
+                                        .foregroundStyle(Color(.systemGray4))
                                         .font(.system(size: 30))
                                 }
 
@@ -90,7 +91,7 @@ struct OwnerUpgradesView: View {
                 if let selectedPlan {
                     let buttonText = String.localizedStringWithFormat(Localization.purchaseCTAButtonText, selectedPlan.wpComPlan.displayName)
                     Button(buttonText) {
-                        purchasePlanAction()
+                        purchasePlanAction(selectedPlan)
                     }
                     .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPurchasing))
                     .disabled(isLoading)
@@ -98,7 +99,7 @@ struct OwnerUpgradesView: View {
                     .shimmering(active: isLoading)
                 } else {
                     Button("Choose a plan") {
-                        purchasePlanAction()
+                        // no-op
                     }
                     .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPurchasing))
                     .disabled(true)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -1,13 +1,40 @@
 import SwiftUI
+import Yosemite
 
 struct OwnerUpgradesView: View {
     @State var upgradePlan: WooWPComPlan
-    @State var isPurchasing = false
+    @State var isPurchasing: Bool
     let purchasePlanAction: () -> Void
-    @State var isLoading: Bool = false
+    @State var isLoading: Bool
+
+    init(upgradePlan: WooWPComPlan,
+         isPurchasing: Bool = false,
+         purchasePlanAction: @escaping (() -> Void),
+         isLoading: Bool = false) {
+        _upgradePlan = .init(initialValue: upgradePlan)
+        _isPurchasing = .init(initialValue: isPurchasing)
+        self.purchasePlanAction = purchasePlanAction
+        _isLoading = .init(initialValue: isLoading)
+    }
+
+    @State private var paymentFrequency: WooPlan.PlanFrequency = .year
+    private var paymentFrequencies: [WooPlan.PlanFrequency] = [.year, .month]
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
+            Section {
+                Picker("How frequently would you like to pay?", selection: $paymentFrequency) {
+                    ForEach(paymentFrequencies) {
+                        Text($0.paymentFrequencyLocalizedString)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .disabled(isLoading)
+            }
+            .padding()
+            .background(Color(.systemGroupedBackground))
+            .redacted(reason: isLoading ? .placeholder : [])
+            .shimmering(active: isLoading)
             List {
                 Section {
                     Image(upgradePlan.wooPlan.headerImageFileName)
@@ -91,5 +118,26 @@ private extension OwnerUpgradesView {
 
         static let featureDetailsUnavailableText = NSLocalizedString(
             "See plan details", comment: "Title for a link to view Woo Express plan details on the web, as a fallback.")
+    }
+}
+
+private extension WooPlan.PlanFrequency {
+    var paymentFrequencyLocalizedString: String {
+        switch self {
+        case .month:
+            return Localization.payMonthly
+        case .year:
+            return Localization.payAnnually
+        }
+    }
+
+    enum Localization {
+        static let payMonthly = NSLocalizedString(
+            "Pay Monthly",
+            comment: "Title of the selector option for paying monthly on the Upgrade view, when choosing a plan")
+
+        static let payAnnually = NSLocalizedString(
+            "Pay Annually",
+            comment: "Title of the selector option for paying annually on the Upgrade view, when choosing a plan")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -82,16 +82,16 @@ struct UpgradesView: View {
 
                 switch upgradesViewModel.upgradeViewState {
                 case .loading:
-                    OwnerUpgradesView(upgradePlans: [.skeletonPlan()], purchasePlanAction: {}, isLoading: true)
+                    OwnerUpgradesView(upgradePlans: [.skeletonPlan()], purchasePlanAction: { _ in }, isLoading: true)
                         .accessibilityLabel(Localization.plansLoadingAccessibilityLabel)
-                case .loaded(let plan):
-                    OwnerUpgradesView(upgradePlans: [plan], purchasePlanAction: {
+                case .loaded(let plans):
+                    OwnerUpgradesView(upgradePlans: plans, purchasePlanAction: { selectedPlan in
                         Task {
-                            await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
+                            await upgradesViewModel.purchasePlan(with: selectedPlan.wpComPlan.id)
                         }
                     })
-                case .purchasing(let plan):
-                    OwnerUpgradesView(upgradePlans: [plan], isPurchasing: true, purchasePlanAction: {})
+                case .purchasing(_, let plans):
+                    OwnerUpgradesView(upgradePlans: plans, isPurchasing: true, purchasePlanAction: { _ in })
                 case .waiting(let plan):
                     ScrollView(.vertical) {
                         UpgradeWaitingView(planName: plan.wooPlan.shortName)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -69,7 +69,6 @@ struct UpgradesView: View {
     var body: some View {
         NavigationView {
             VStack {
-                Text("M2 Upgrades")
                 VStack {
                     // TODO: Once we remove iOS 15 support, we can do this with .toolbar instead.
                     UpgradeTopBarView(dismiss: {
@@ -83,16 +82,16 @@ struct UpgradesView: View {
 
                 switch upgradesViewModel.upgradeViewState {
                 case .loading:
-                    OwnerUpgradesView(upgradePlan: .skeletonPlan(), purchasePlanAction: {}, isLoading: true)
+                    OwnerUpgradesView(upgradePlans: [.skeletonPlan()], purchasePlanAction: {}, isLoading: true)
                         .accessibilityLabel(Localization.plansLoadingAccessibilityLabel)
                 case .loaded(let plan):
-                    OwnerUpgradesView(upgradePlan: plan, purchasePlanAction: {
+                    OwnerUpgradesView(upgradePlans: [plan], purchasePlanAction: {
                         Task {
                             await upgradesViewModel.purchasePlan(with: plan.wpComPlan.id)
                         }
                     })
                 case .purchasing(let plan):
-                    OwnerUpgradesView(upgradePlan: plan, isPurchasing: true, purchasePlanAction: {})
+                    OwnerUpgradesView(upgradePlans: [plan], isPurchasing: true, purchasePlanAction: {})
                 case .waiting(let plan):
                     ScrollView(.vertical) {
                         UpgradeWaitingView(planName: plan.wooPlan.shortName)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -54,7 +54,8 @@ final class UpgradesViewModelTests: XCTestCase {
         await sut.prepareViewModel()
 
         // Then
-        guard case .loaded(let plan) = sut.upgradeViewState else {
+        guard case .loaded(let plans) = sut.upgradeViewState,
+              let plan = plans.first else {
             return XCTFail("expected `.loaded` state not found")
         }
         assertEqual("Essential Monthly", plan.wpComPlan.displayName)
@@ -77,7 +78,8 @@ final class UpgradesViewModelTests: XCTestCase {
         await sut.prepareViewModel()
 
         // Then
-        guard case .loaded(let plan) = sut.upgradeViewState else {
+        guard case .loaded(let plans) = sut.upgradeViewState,
+            let plan = plans.first else {
             return XCTFail("expected `.loaded` state not found")
         }
         assertEqual("Test awesome plan", plan.wpComPlan.displayName)

--- a/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
@@ -31,13 +31,48 @@ public struct WooPlan: Decodable {
 
     public static func loadHardcodedPlan() -> WooPlan {
         WooPlan(id: AvailableInAppPurchasesWPComPlans.essentialMonthly.rawValue,
-                name: Localization.essentialPlanName,
+                name: Localization.essentialPlanName(frequency: .month),
                 shortName: Localization.essentialPlanShortName,
                 planFrequency: .month,
                 planDescription: Localization.essentialPlanDescription,
                 headerImageFileName: "express-essential-header",
                 headerImageCardColor: (try? Color(rgbString: "rgba(238, 226, 211, 1)")) ?? .white,
                 planFeatureGroups: hardcodedFeatureGroups())
+    }
+
+    public static func loadM2HardcodedPlans() -> [WooPlan] {
+        [WooPlan(id: AvailableInAppPurchasesWPComPlans.essentialMonthly.rawValue,
+                 name: Localization.essentialPlanName(frequency: .month),
+                shortName: Localization.essentialPlanShortName,
+                planFrequency: .month,
+                planDescription: Localization.essentialPlanDescription,
+                headerImageFileName: "express-essential-header",
+                headerImageCardColor: (try? Color(rgbString: "rgba(238, 226, 211, 1)")) ?? .white,
+                planFeatureGroups: hardcodedFeatureGroups()),
+        WooPlan(id: AvailableInAppPurchasesWPComPlans.essentialYearly.rawValue,
+                name: Localization.essentialPlanName(frequency: .year),
+                shortName: Localization.essentialPlanShortName,
+                planFrequency: .year,
+                planDescription: Localization.essentialPlanDescription,
+                headerImageFileName: "express-essential-header",
+                headerImageCardColor: (try? Color(rgbString: "rgba(238, 226, 211, 1)")) ?? .white,
+                planFeatureGroups: hardcodedFeatureGroups()),
+        WooPlan(id: AvailableInAppPurchasesWPComPlans.performanceMonthly.rawValue,
+                name: Localization.performancePlanName(frequency: .month),
+                shortName: Localization.performancePlanShortName,
+                planFrequency: .month,
+                planDescription: Localization.performancePlanDescription,
+                headerImageFileName: "express-essential-header",
+                headerImageCardColor: (try? Color(rgbString: "rgba(238, 226, 211, 1)")) ?? .white,
+                planFeatureGroups: []),
+        WooPlan(id: AvailableInAppPurchasesWPComPlans.performanceYearly.rawValue,
+                name: Localization.performancePlanName(frequency: .year),
+                shortName: Localization.performancePlanShortName,
+                planFrequency: .year,
+                planDescription: Localization.performancePlanDescription,
+                headerImageFileName: "express-essential-header",
+                headerImageCardColor: (try? Color(rgbString: "rgba(238, 226, 211, 1)")) ?? .white,
+                planFeatureGroups: [])]
     }
 
     public init(from decoder: Decoder) throws {
@@ -85,12 +120,27 @@ public struct WooPlan: Decodable {
         private enum Localization {
             static let month = NSLocalizedString("per month", comment: "Description of the frequency of a monthly Woo plan")
             static let year = NSLocalizedString("per year", comment: "Description of the frequency of a yearly Woo plan")
+
+            static let monthPlanName = NSLocalizedString("Monthly", comment: "Description of the frequency of a monthly Woo plan for use in the plan name")
+            static let yearPlanName = NSLocalizedString("Yearly", comment: "Description of the frequency of a yearly Woo plan for use in the plan name")
+        }
+
+        public var localizedPlanName: String {
+            switch self {
+            case .month:
+                return Localization.monthPlanName
+            case .year:
+                return Localization.yearPlanName
+            }
         }
     }
 }
 
 public enum AvailableInAppPurchasesWPComPlans: String {
     case essentialMonthly = "woocommerce.express.essential.monthly"
+    case essentialYearly = "debug.woocommerce.express.essential.yearly"
+    case performanceMonthly = "debug.woocommerce.express.performance.monthly"
+    case performanceYearly = "debug.woocommerce.express.performance.yearly"
 }
 
 private extension WooPlan {
@@ -280,15 +330,35 @@ private extension WooPlan {
     }
 
     enum Localization {
-        static let essentialPlanName = NSLocalizedString(
-            "Woo Express Essential Monthly",
-            comment: "Title for the plan on a screen showing the Woo Express Essential Monthly plan upgrade benefits")
+        static let essentialPlanNameFormat = NSLocalizedString(
+            "Woo Express Essential %1$@",
+            comment: "Title for the plan on a screen showing the Woo Express Essential plan upgrade benefits. " +
+            "%1$@ will be replaced with Monthly or Yearly, and should be included in translations.")
+        static func essentialPlanName(frequency: PlanFrequency) -> String {
+            String.localizedStringWithFormat(essentialPlanNameFormat, frequency.localizedPlanName)
+        }
+
         static let essentialPlanShortName = NSLocalizedString(
             "Essential",
-            comment: "Short name for the plan on a screen showing the Woo Express Essential Monthly plan upgrade benefits")
+            comment: "Short name for the plan on a screen showing the Woo Express Essential plan upgrade benefits")
         static let essentialPlanDescription = NSLocalizedString(
             "Everything you need to launch an online store.",
-            comment: "Description of the plan on a screen showing the Woo Express Essential Monthly plan upgrade benefits")
+            comment: "Description of the plan on a screen showing the Woo Express Essential plan upgrade benefits")
+
+        static let performancePlanNameFormat = NSLocalizedString(
+            "Woo Express Performance %1$@",
+            comment: "Title for the plan on a screen showing the Woo Express Performance plan upgrade benefits " +
+            "%1$@ will be replaced with Monthly or Yearly, and should be included in translations")
+        static func performancePlanName(frequency: PlanFrequency) -> String {
+            String.localizedStringWithFormat(performancePlanNameFormat, frequency.localizedPlanName)
+        }
+        static let performancePlanShortName = NSLocalizedString(
+            "Performance",
+            comment: "Short name for the plan on a screen showing the Woo Express Performance plan upgrade benefits")
+        static let performancePlanDescription = NSLocalizedString(
+            "Activate your growth with advanced features.",
+            comment: "Description of the plan on a screen showing the Woo Express Performance plan upgrade benefits")
+
 
         /// General features
         static let generalFeaturesTitle = NSLocalizedString(

--- a/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
@@ -65,9 +65,13 @@ public struct WooPlan: Decodable {
         case planFeatureGroups = "feature_categories"
     }
 
-    public enum PlanFrequency: String, Decodable {
+    public enum PlanFrequency: String, Decodable, Identifiable, CaseIterable {
         case month
         case year
+
+        public var id: Self {
+            return self
+        }
 
         public var localizedString: String {
             switch self {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after: #10165 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This needs some polish before merging, if we do want to merge it at all. I think we should move away from List in favour of a scrollable VStack, because of some strange UI glitches.

Also we might consider a custom picker control for the cards – at the moment the tap gesture only works if you tap on some text in the section, not the white space. However, a picker may not work well with the design direction, which may have an expandable features part of each section.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/0579de09-c946-4253-9db5-e8455e3dc96b



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
