### PR TITLE
Identify language using a separate AI prompt

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -911,6 +911,8 @@
 		EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */ = {isa = PBXBuildFile; fileRef = EECB7EE7286555180028C888 /* media-update-product-id.json */; };
 		EECDBEDE296845F400293C4E /* RESTRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDBEDD296845F400293C4E /* RESTRequestConvertible.swift */; };
 		EECDBEE029684AC500293C4E /* WordPressAPIVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDBEDF29684AC500293C4E /* WordPressAPIVersionTests.swift */; };
+		EEE846A22A54745F005239B6 /* identify-language-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EEE846A02A54745F005239B6 /* identify-language-success.json */; };
+		EEE846A32A54745F005239B6 /* identify-language-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = EEE846A12A54745F005239B6 /* identify-language-failure.json */; };
 		EEFAA579295D2FC7003583BE /* RESTRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA578295D2FC7003583BE /* RESTRequestTests.swift */; };
 		EEFAA57B295D7793003583BE /* AuthenticatedDotcomRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA57A295D7793003583BE /* AuthenticatedDotcomRequest.swift */; };
 		EEFAA57D295D77F0003583BE /* AuthenticatedRESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA57C295D77F0003583BE /* AuthenticatedRESTRequest.swift */; };
@@ -1857,6 +1859,8 @@
 		EECB7EE7286555180028C888 /* media-update-product-id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id.json"; sourceTree = "<group>"; };
 		EECDBEDD296845F400293C4E /* RESTRequestConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequestConvertible.swift; sourceTree = "<group>"; };
 		EECDBEDF29684AC500293C4E /* WordPressAPIVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAPIVersionTests.swift; sourceTree = "<group>"; };
+		EEE846A02A54745F005239B6 /* identify-language-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "identify-language-success.json"; sourceTree = "<group>"; };
+		EEE846A12A54745F005239B6 /* identify-language-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "identify-language-failure.json"; sourceTree = "<group>"; };
 		EEFAA578295D2FC7003583BE /* RESTRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequestTests.swift; sourceTree = "<group>"; };
 		EEFAA57A295D7793003583BE /* AuthenticatedDotcomRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedDotcomRequest.swift; sourceTree = "<group>"; };
 		EEFAA57C295D77F0003583BE /* AuthenticatedRESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedRESTRequest.swift; sourceTree = "<group>"; };
@@ -2415,6 +2419,8 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				EEE846A12A54745F005239B6 /* identify-language-failure.json */,
+				EEE846A02A54745F005239B6 /* identify-language-success.json */,
 				DE4D23BD29B6E10F003A4B5D /* announcements.json */,
 				021D741B2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json */,
 				DEC2B092297AA60D003923FB /* category-without-data.json */,
@@ -3462,6 +3468,7 @@
 				DE66C559297799D000DAA978 /* add-on-groups-without-data.json in Resources */,
 				265BCA02243056E3004E53EE /* categories-all.json in Resources */,
 				D8FBFF2422D52815006E3336 /* order-stats-v4-daily.json in Resources */,
+				EEE846A22A54745F005239B6 /* identify-language-success.json in Resources */,
 				CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */,
 				2683D70E24456DB8002A1589 /* categories-empty.json in Resources */,
 				D865CE67278CA225002C8520 /* stripe-payment-intent-succeeded.json in Resources */,
@@ -3553,6 +3560,7 @@
 				EE57C127297F8E5E00BC31E7 /* product-attribute-terms-without-data.json in Resources */,
 				CCEC5E9129E9BF1400912D6B /* product-variation-subscription.json in Resources */,
 				027EB57429C07524003CE551 /* site-launch-error-unauthorized.json in Resources */,
+				EEE846A32A54745F005239B6 /* identify-language-failure.json in Resources */,
 				B53EF53621813681003E146F /* generic_success.json in Resources */,
 				31054718262E2F5E00C5C02B /* wcpay-payment-intent-requires-confirmation.json in Resources */,
 				DE66C5672977CEB800DAA978 /* shipping-label-status-success-without-data.json in Resources */,

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -49,4 +49,37 @@ final class GenerativeContentRemoteTests: XCTestCase {
             error as? WordPressApiError == .unknown(code: "inactive", message: "OpenAI features have been disabled")
         }
     }
+
+
+    // MARK: - `identifyLanguage`
+
+    func test_identifyLanguage_with_success_returns_generated_text() async throws {
+        // Given
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-ai/completions", filename: "identify-language-success")
+
+        // When
+        let language = try await remote.identifyLanguage(siteID: sampleSiteID,
+                                                              string: "Woo is awesome.",
+                                                              feature: .productDescription)
+
+        // Then
+        XCTAssertEqual(language, "English")
+    }
+
+    func test_identifyLanguage_with_failure_returns_error() async throws {
+        // Given
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-ai/completions", filename: "identify-language-failure")
+
+        // When
+        await assertThrowsError {
+            _ = try await remote.identifyLanguage(siteID: sampleSiteID,
+                                                  string: "Woo is awesome.",
+                                                  feature: .productDescription)
+        } errorAssert: { error in
+            // Then
+            error as? WordPressApiError == .unknown(code: "inactive", message: "OpenAI features have been disabled")
+        }
+    }
 }

--- a/Networking/NetworkingTests/Responses/identify-language-failure.json
+++ b/Networking/NetworkingTests/Responses/identify-language-failure.json
@@ -1,0 +1,5 @@
+{
+    "code": "inactive",
+    "message": "OpenAI features have been disabled",
+    "data": null
+}

--- a/Networking/NetworkingTests/Responses/identify-language-success.json
+++ b/Networking/NetworkingTests/Responses/identify-language-success.json
@@ -1,0 +1,1 @@
+"English"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [*] Shipping Labels: Fixed a bug preventing label printing in orders viewed from search [https://github.com/woocommerce/woocommerce-ios/pull/10161]
 - [*] Blaze: Disable the entry point in the product creation form. [https://github.com/woocommerce/woocommerce-ios/pull/10173]
- 
+- [*] Product description and sharing message AI: Fixed incorrect language issue by using a separate prompt for identifying language. [https://github.com/woocommerce/woocommerce-ios/pull/10169]
 
 14.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -234,7 +234,7 @@ final class ProductDescriptionGenerationPreviewStores: DefaultStoresManager {
 
     override func dispatch(_ action: Action) {
         if let action = action as? ProductAction {
-            if case let .generateProductDescription(_, _, _, completion) = action {
+            if case let .generateProductDescription(_, _, _, _, completion) = action {
                 completion(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -91,7 +91,7 @@ private extension ProductDescriptionGenerationViewModel {
     @MainActor
     func generateProductDescription() async -> Result<String, Error> {
         do {
-            let language = try await detectLaunguage()
+            let language = try await identifyLanguage()
             return await withCheckedContinuation { continuation in
                 stores.dispatch(ProductAction.generateProductDescription(siteID: siteID,
                                                                          name: name,
@@ -106,7 +106,7 @@ private extension ProductDescriptionGenerationViewModel {
     }
 
     @MainActor
-    func detectLaunguage() async throws -> String {
+    func identifyLanguage() async throws -> String {
         if let languageIdentifiedUsingAI,
            languageIdentifiedUsingAI.isNotEmpty {
             return languageIdentifiedUsingAI

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -36,6 +36,10 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
 
     private var task: Task<Void, Error>?
 
+    /// Language used in product identified by AI
+    ///
+    private var languageIdentifiedUsingAI: String?
+
     init(siteID: Int64,
          name: String,
          description: String,
@@ -86,13 +90,38 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
 private extension ProductDescriptionGenerationViewModel {
     @MainActor
     func generateProductDescription() async -> Result<String, Error> {
-        await withCheckedContinuation { continuation in
-            stores.dispatch(ProductAction.generateProductDescription(siteID: siteID,
-                                                                     name: name,
-                                                                     features: features) { result in
-                continuation.resume(returning: result)
-            })
+        do {
+            let language = try await detectLaunguage()
+            return await withCheckedContinuation { continuation in
+                stores.dispatch(ProductAction.generateProductDescription(siteID: siteID,
+                                                                         name: name,
+                                                                         features: features,
+                                                                         language: language) { result in
+                    continuation.resume(returning: result)
+                })
+            }
+        } catch {
+            return .failure(error)
         }
+    }
+
+    @MainActor
+    func detectLaunguage() async throws -> String {
+        if let languageIdentifiedUsingAI,
+           languageIdentifiedUsingAI.isNotEmpty {
+            return languageIdentifiedUsingAI
+        }
+
+        let language = try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
+                                                           string: name + " " + features,
+                                                           feature: .productSharing,
+                                                           completion: { result in
+                continuation.resume(with: result)
+            }))
+        }
+        self.languageIdentifiedUsingAI = language
+        return language
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -112,7 +112,7 @@ private extension ProductSharingMessageGenerationViewModel {
 
     @MainActor
     func requestMessageFromAI() async throws -> String {
-        let language = try await detectLaunguage()
+        let language = try await identifyLanguage()
         return try await withCheckedThrowingContinuation { continuation in
 
             stores.dispatch(ProductAction.generateProductSharingMessage(siteID: siteID,
@@ -127,7 +127,7 @@ private extension ProductSharingMessageGenerationViewModel {
     }
 
     @MainActor
-    func detectLaunguage() async throws -> String {
+    func identifyLanguage() async throws -> String {
         if let languageIdentifiedUsingAI,
            languageIdentifiedUsingAI.isNotEmpty {
             return languageIdentifiedUsingAI

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -46,6 +46,10 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
     /// This is needed to identify whether the next request is a retry.
     private var hasGeneratedMessage = false
 
+    /// Language used in product identified by AI
+    ///
+    private var languageIdentifiedUsingAI: String?
+
     init(siteID: Int64,
          url: String,
          productName: String,
@@ -108,15 +112,37 @@ private extension ProductSharingMessageGenerationViewModel {
 
     @MainActor
     func requestMessageFromAI() async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
+        let language = try await detectLaunguage()
+        return try await withCheckedThrowingContinuation { continuation in
+
             stores.dispatch(ProductAction.generateProductSharingMessage(siteID: siteID,
                                                                         url: url,
                                                                         name: productName,
                                                                         description: productDescription,
+                                                                        language: language,
                                                                         completion: { result in
                 continuation.resume(with: result)
             }))
         }
+    }
+
+    @MainActor
+    func detectLaunguage() async throws -> String {
+        if let languageIdentifiedUsingAI,
+           languageIdentifiedUsingAI.isNotEmpty {
+            return languageIdentifiedUsingAI
+        }
+
+        let language = try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
+                                                           string: productName + " " + productDescription,
+                                                           feature: .productSharing,
+                                                           completion: { result in
+                continuation.resume(with: result)
+            }))
+        }
+        self.languageIdentifiedUsingAI = language
+        return language
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -44,9 +44,11 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.generationInProgress)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 XCTAssertTrue(viewModel.generationInProgress)
                 completion(.success("Check this out!"))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
             default:
                 return
             }
@@ -70,8 +72,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
             default:
                 return
             }
@@ -95,7 +99,34 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+                completion(.failure(NSError(domain: "Test", code: 500)))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
+            default:
+                return
+            }
+        }
+        XCTAssertNil(viewModel.errorMessage)
+
+        // When
+        await viewModel.generateShareMessage()
+
+        // Then
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    func test_generateShareMessage_updates_errorMessage_on_identifyLanguage_failure() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
+                                                                 url: "https://example.com",
+                                                                 productName: "Test",
+                                                                 productDescription: "Test description",
+                                                                 stores: stores)
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .identifyLanguage(_, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
             default:
                 return
@@ -122,8 +153,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  analytics: analytics)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success("Test"))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
             default:
                 return
             }
@@ -164,8 +197,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  analytics: analytics)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
             default:
                 return
             }
@@ -213,8 +248,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
             default:
                 return
             }
@@ -310,8 +347,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
             default:
                 return
             }
@@ -338,8 +377,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("English"))
             default:
                 return
             }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -125,7 +125,11 @@ public enum ProductAction: Action {
 
     /// Generates a product description with Jetpack AI given the name and features.
     ///
-    case generateProductDescription(siteID: Int64, name: String, features: String, completion: (Result<String, Error>) -> Void)
+    case generateProductDescription(siteID: Int64,
+                                    name: String,
+                                    features: String,
+                                    language: String,
+                                    completion: (Result<String, Error>) -> Void)
 
     /// Generates a product sharing message with Jetpack AI given the URL, name, and description
     ///
@@ -133,5 +137,6 @@ public enum ProductAction: Action {
                                        url: String,
                                        name: String,
                                        description: String,
+                                       language: String,
                                        completion: (Result<String, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -116,6 +116,13 @@ public enum ProductAction: Action {
     ///
     case createTemplateProduct(siteID: Int64, template: ProductsRemote.TemplateType, onCompletion: (Result<Product, Error>) -> Void)
 
+    /// Identifies the language from the given string
+    ///
+    case identifyLanguage(siteID: Int64,
+                          string: String,
+                          feature: GenerativeContentRemoteFeature,
+                          completion: (Result<String, Error>) -> Void)
+
     /// Generates a product description with Jetpack AI given the name and features.
     ///
     case generateProductDescription(siteID: Int64, name: String, features: String, completion: (Result<String, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -124,10 +124,10 @@ public class ProductStore: Store {
             identifyLanguage(siteID: siteID,
                              string: string, feature: feature,
                              completion: completion)
-        case let .generateProductDescription(siteID, name, features, completion):
-            generateProductDescription(siteID: siteID, name: name, features: features, completion: completion)
-        case let .generateProductSharingMessage(siteID, url, name, description, completion):
-            generateProductSharingMessage(siteID: siteID, url: url, name: name, description: description, completion: completion)
+        case let .generateProductDescription(siteID, name, features, language, completion):
+            generateProductDescription(siteID: siteID, name: name, features: features, language: language, completion: completion)
+        case let .generateProductSharingMessage(siteID, url, name, description, language, completion):
+            generateProductSharingMessage(siteID: siteID, url: url, name: name, description: description, language: language, completion: completion)
         }
     }
 }
@@ -554,13 +554,10 @@ private extension ProductStore {
     func generateProductDescription(siteID: Int64,
                                     name: String,
                                     features: String,
+                                    language: String,
                                     completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             let result = await Result {
-                let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
-                                                                                  string: name + " " + features,
-                                                                                  feature: .productDescription)
-
                 let prompt = [
                     "Write a description for a product with title ```\(name)``` and features: ```\(features)```.",
                     "Your response should be in language \(language).",
@@ -583,13 +580,10 @@ private extension ProductStore {
                                        url: String,
                                        name: String,
                                        description: String,
+                                       language: String,
                                        completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             let result = await Result {
-                let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
-                                                                                  string: name + " " + description,
-                                                                                  feature: .productSharing)
-
                 let prompt = [
                     // swiftlint:disable:next line_length
                     "Your task is to help a merchant create a message to share with their customers a product named ```\(name)```. More information about the product:",

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -556,17 +556,17 @@ private extension ProductStore {
                                     features: String,
                                     language: String,
                                     completion: @escaping (Result<String, Error>) -> Void) {
+        let prompt = [
+            "Write a description for a product with title ```\(name)``` and features: ```\(features)```.",
+            "Your response should be in language \(language).",
+            "Make the description 50-60 words or less.",
+            "Use a 9th grade reading level.",
+            "Perform in-depth keyword research relating to the product in the same language of the product title, " +
+            "and use them in your sentences without listing them out."
+        ].joined(separator: "\n")
+
         Task {
             let result = await Result {
-                let prompt = [
-                    "Write a description for a product with title ```\(name)``` and features: ```\(features)```.",
-                    "Your response should be in language \(language).",
-                    "Make the description 50-60 words or less.",
-                    "Use a 9th grade reading level.",
-                    "Perform in-depth keyword research relating to the product in the same language of the product title, " +
-                    "and use them in your sentences without listing them out."
-                ].joined(separator: "\n")
-
                 let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription)
                 return description
             }
@@ -582,20 +582,20 @@ private extension ProductStore {
                                        description: String,
                                        language: String,
                                        completion: @escaping (Result<String, Error>) -> Void) {
+        let prompt = [
+            // swiftlint:disable:next line_length
+            "Your task is to help a merchant create a message to share with their customers a product named ```\(name)```. More information about the product:",
+            "- Product description: ```\(description)```",
+            "- Product URL: \(url).",
+            "Your response should be in language \(language).",
+            "The length should be up to 3 sentences.",
+            "Use a 9th grade reading level.",
+            "Add related hashtags at the end of the message.",
+            "Do not include the URL in the message.",
+        ].joined(separator: "\n")
+
         Task {
             let result = await Result {
-                let prompt = [
-                    // swiftlint:disable:next line_length
-                    "Your task is to help a merchant create a message to share with their customers a product named ```\(name)```. More information about the product:",
-                    "- Product description: ```\(description)```",
-                    "- Product URL: \(url).",
-                    "Your response should be in language \(language).",
-                    "The length should be up to 3 sentences.",
-                    "Use a 9th grade reading level.",
-                    "Add related hashtags at the end of the message.",
-                    "Do not include the URL in the message.",
-                ].joined(separator: "\n")
-
                 let message = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing)
                     .trimmingCharacters(in: CharacterSet(["\""]))  // Trims quotation mark
                 return message

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -539,15 +539,13 @@ private extension ProductStore {
                           string: String,
                           feature: GenerativeContentRemoteFeature,
                           completion: @escaping (Result<String, Error>) -> Void) {
-        Task {
+        Task { @MainActor in
             let result = await Result {
                 try await generativeContentRemote.identifyLanguage(siteID: siteID,
                                                                    string: string,
                                                                    feature: feature)
             }
-            await MainActor.run {
-                completion(result)
-            }
+            completion(result)
         }
     }
 
@@ -565,14 +563,12 @@ private extension ProductStore {
             "and use them in your sentences without listing them out."
         ].joined(separator: "\n")
 
-        Task {
+        Task { @MainActor in
             let result = await Result {
                 let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription)
                 return description
             }
-            await MainActor.run {
-                completion(result)
-            }
+            completion(result)
         }
     }
 
@@ -594,15 +590,13 @@ private extension ProductStore {
             "Do not include the URL in the message.",
         ].joined(separator: "\n")
 
-        Task {
+        Task { @MainActor in
             let result = await Result {
                 let message = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing)
                     .trimmingCharacters(in: CharacterSet(["\""]))  // Trims quotation mark
                 return message
             }
-            await MainActor.run {
-                completion(result)
-            }
+            completion(result)
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -120,6 +120,10 @@ public class ProductStore: Store {
             checkIfStoreHasProducts(siteID: siteID, onCompletion: onCompletion)
         case let .createTemplateProduct(siteID, template, onCompletion):
             createTemplateProduct(siteID: siteID, template: template, onCompletion: onCompletion)
+        case let .identifyLanguage(siteID, string, feature, completion):
+            identifyLanguage(siteID: siteID,
+                             string: string, feature: feature,
+                             completion: completion)
         case let .generateProductDescription(siteID, name, features, completion):
             generateProductDescription(siteID: siteID, name: name, features: features, completion: completion)
         case let .generateProductSharingMessage(siteID, url, name, description, completion):
@@ -527,6 +531,22 @@ private extension ProductStore {
 
             case .failure(let error):
                 onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func identifyLanguage(siteID: Int64,
+                          string: String,
+                          feature: GenerativeContentRemoteFeature,
+                          completion: @escaping (Result<String, Error>) -> Void) {
+        Task {
+            let result = await Result {
+                try await generativeContentRemote.identifyLanguage(siteID: siteID,
+                                                                   string: string,
+                                                                   feature: feature)
+            }
+            await MainActor.run {
+                completion(result)
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -561,17 +561,23 @@ private extension ProductStore {
                                        name: String,
                                        description: String,
                                        completion: @escaping (Result<String, Error>) -> Void) {
-        let prompt = [
-            "Your task is to help a merchant create a message to share with their customers a product named ```\(name)```. More information about the product:",
-            "- Product description: ```\(description)```",
-            "- Product URL: \(url).",
-            "Identify the language used in the product name and product description to use in your response.",
-            "The length should be up to 3 sentences.",
-            "Use a 9th grade reading level.",
-            "Add related hashtags at the end of the message.",
-            "Do not include the URL in the message.",
-        ].joined(separator: "\n")
         Task {
+            let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
+                                                                              string: name + " " + description,
+                                                                              feature: .productSharing)
+
+            let prompt = [
+                // swiftlint:disable:next line_length
+                "Your task is to help a merchant create a message to share with their customers a product named ```\(name)```. More information about the product:",
+                "- Product description: ```\(description)```",
+                "- Product URL: \(url).",
+                "Your response should be in language \(language).",
+                "The length should be up to 3 sentences.",
+                "Use a 9th grade reading level.",
+                "Add related hashtags at the end of the message.",
+                "Do not include the URL in the message.",
+            ].joined(separator: "\n")
+
             let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing)
                     .trimmingCharacters(in: CharacterSet(["\""]))  // Trims quotation mark
             }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -535,15 +535,20 @@ private extension ProductStore {
                                     name: String,
                                     features: String,
                                     completion: @escaping (Result<String, Error>) -> Void) {
-        let prompt = [
-            "Write a description for a product with title ```\(name)``` and features: ```\(features)```.",
-            "Identify the language used in the product title and features and use the same language in your response.",
-            "Make the description 50-60 words or less.",
-            "Use a 9th grade reading level.",
-            "Perform in-depth keyword research relating to the product in the same language of the product title, " +
-            "and use them in your sentences without listing them out."
-        ].joined(separator: "\n")
         Task {
+            let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
+                                                                              string: name + " " + features,
+                                                                              feature: .productDescription)
+
+            let prompt = [
+                "Write a description for a product with title ```\(name)``` and features: ```\(features)```.",
+                "Your response should be in language \(language).",
+                "Make the description 50-60 words or less.",
+                "Use a 9th grade reading level.",
+                "Perform in-depth keyword research relating to the product in the same language of the product title, " +
+                "and use them in your sentences without listing them out."
+            ].joined(separator: "\n")
+
             let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription) }
             await MainActor.run {
                 completion(result)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -536,20 +536,23 @@ private extension ProductStore {
                                     features: String,
                                     completion: @escaping (Result<String, Error>) -> Void) {
         Task {
-            let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
-                                                                              string: name + " " + features,
-                                                                              feature: .productDescription)
+            let result = await Result {
+                let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
+                                                                                  string: name + " " + features,
+                                                                                  feature: .productDescription)
 
-            let prompt = [
-                "Write a description for a product with title ```\(name)``` and features: ```\(features)```.",
-                "Your response should be in language \(language).",
-                "Make the description 50-60 words or less.",
-                "Use a 9th grade reading level.",
-                "Perform in-depth keyword research relating to the product in the same language of the product title, " +
-                "and use them in your sentences without listing them out."
-            ].joined(separator: "\n")
+                let prompt = [
+                    "Write a description for a product with title ```\(name)``` and features: ```\(features)```.",
+                    "Your response should be in language \(language).",
+                    "Make the description 50-60 words or less.",
+                    "Use a 9th grade reading level.",
+                    "Perform in-depth keyword research relating to the product in the same language of the product title, " +
+                    "and use them in your sentences without listing them out."
+                ].joined(separator: "\n")
 
-            let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription) }
+                let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription)
+                return description
+            }
             await MainActor.run {
                 completion(result)
             }
@@ -562,24 +565,26 @@ private extension ProductStore {
                                        description: String,
                                        completion: @escaping (Result<String, Error>) -> Void) {
         Task {
-            let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
-                                                                              string: name + " " + description,
-                                                                              feature: .productSharing)
+            let result = await Result {
+                let language = try await generativeContentRemote.identifyLanguage(siteID: siteID,
+                                                                                  string: name + " " + description,
+                                                                                  feature: .productSharing)
 
-            let prompt = [
-                // swiftlint:disable:next line_length
-                "Your task is to help a merchant create a message to share with their customers a product named ```\(name)```. More information about the product:",
-                "- Product description: ```\(description)```",
-                "- Product URL: \(url).",
-                "Your response should be in language \(language).",
-                "The length should be up to 3 sentences.",
-                "Use a 9th grade reading level.",
-                "Add related hashtags at the end of the message.",
-                "Do not include the URL in the message.",
-            ].joined(separator: "\n")
+                let prompt = [
+                    // swiftlint:disable:next line_length
+                    "Your task is to help a merchant create a message to share with their customers a product named ```\(name)```. More information about the product:",
+                    "- Product description: ```\(description)```",
+                    "- Product URL: \(url).",
+                    "Your response should be in language \(language).",
+                    "The length should be up to 3 sentences.",
+                    "Use a 9th grade reading level.",
+                    "Add related hashtags at the end of the message.",
+                    "Do not include the URL in the message.",
+                ].joined(separator: "\n")
 
-            let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing)
+                let message = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing)
                     .trimmingCharacters(in: CharacterSet(["\""]))  // Trims quotation mark
+                return message
             }
             await MainActor.run {
                 completion(result)

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
@@ -14,6 +14,17 @@ final class MockGenerativeContentRemote {
     func whenGeneratingText(thenReturn result: Result<String, Error>) {
         generateTextResult = result
     }
+
+    private(set) var identifyLanguageString: String?
+    private(set) var identifyLanguageFeature: GenerativeContentRemoteFeature?
+
+    /// The results to return in `identifyLanguage`.
+    private var identifyLanguageResult: Result<String, Error>?
+
+    /// Returns the value when `identifyLanguage` is called.
+    func whenIdentifyingLanguage(thenReturn result: Result<String, Error>) {
+        identifyLanguageResult = result
+    }
 }
 
 extension MockGenerativeContentRemote: GenerativeContentRemoteProtocol {
@@ -23,6 +34,18 @@ extension MockGenerativeContentRemote: GenerativeContentRemoteProtocol {
         generateTextBase = base
         generateTextFeature = feature
         guard let result = generateTextResult else {
+            XCTFail("Could not find result for generating text.")
+            throw NetworkError.notFound
+        }
+        return try result.get()
+    }
+
+    func identifyLanguage(siteID: Int64,
+                          string: String,
+                          feature: GenerativeContentRemoteFeature) async throws -> String {
+        identifyLanguageString = string
+        identifyLanguageFeature = feature
+        guard let result = identifyLanguageResult else {
             XCTFail("Could not find result for generating text.")
             throw NetworkError.notFound
         }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1740,7 +1740,6 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductDescription_returns_text_on_success() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success("Trendy product"))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1752,7 +1751,8 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product",
-                                                                           features: "Trendy") { result in
+                                                                           features: "Trendy",
+                                                                           language: "English") { result in
                 promise(result)
             })
         }
@@ -1766,7 +1766,6 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductDescription_returns_error_on_failure() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .failure(NetworkError.timeout))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1778,31 +1777,8 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product",
-                                                                           features: "Trendy") { result in
-                promise(result)
-            })
-        }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertEqual(result.failure as? NetworkError, .timeout)
-    }
-
-    func test_generateProductDescription_returns_error_on_identify_language_failure() throws {
-        // Given
-        let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .failure(NetworkError.timeout))
-        let productStore = ProductStore(dispatcher: dispatcher,
-                                        storageManager: storageManager,
-                                        network: network,
-                                        remote: MockProductsRemote(),
-                                        generativeContentRemote: generativeContentRemote)
-
-        // When
-        let result = waitFor { promise in
-            productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
-                                                                           name: "A product",
-                                                                           features: "Trendy") { result in
+                                                                           features: "Trendy",
+                                                                           language: "English") { result in
                 promise(result)
             })
         }
@@ -1815,7 +1791,6 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductDescription_includes_parameters_in_remote_base_parameter() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1827,7 +1802,8 @@ final class ProductStoreTests: XCTestCase {
         waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product name",
-                                                                           features: "Trendy, cool, fun") { _ in
+                                                                           features: "Trendy, cool, fun",
+                                                                           language: "English") { _ in
                 promise(())
             })
         }
@@ -1836,12 +1812,12 @@ final class ProductStoreTests: XCTestCase {
         let base = try XCTUnwrap(generativeContentRemote.generateTextBase)
         XCTAssertTrue(base.contains("```A product name```"))
         XCTAssertTrue(base.contains("```Trendy, cool, fun```"))
+        XCTAssertTrue(base.contains("English"))
     }
 
     func test_generateProductDescription_uses_correct_feature() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1853,7 +1829,8 @@ final class ProductStoreTests: XCTestCase {
         waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product name",
-                                                                           features: "Trendy, cool, fun") { _ in
+                                                                           features: "Trendy, cool, fun",
+                                                                           language: "English") { _ in
                 promise(())
             })
         }
@@ -1869,7 +1846,6 @@ final class ProductStoreTests: XCTestCase {
         // Given
         let expectedText = "Check out this cool product"
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(expectedText))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1883,7 +1859,8 @@ final class ProductStoreTests: XCTestCase {
                 siteID: self.sampleSiteID,
                 url: "https://example.com",
                 name: "Sample product",
-                description: "Sample description"
+                description: "Sample description",
+                language: "English"
             ) { result in
                 promise(result)
             })
@@ -1898,7 +1875,6 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductSharingMessage_returns_text_after_trimming_quotation_marks() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success("\"This is \"AI\" generated message.\""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1912,7 +1888,8 @@ final class ProductStoreTests: XCTestCase {
                 siteID: self.sampleSiteID,
                 url: "https://example.com",
                 name: "Sample product",
-                description: "Sample description"
+                description: "Sample description",
+                language: "English"
             ) { result in
                 promise(result)
             })
@@ -1927,7 +1904,6 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductSharingMessage_returns_error_on_failure() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .failure(NetworkError.timeout))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1941,34 +1917,8 @@ final class ProductStoreTests: XCTestCase {
                 siteID: self.sampleSiteID,
                 url: "https://example.com",
                 name: "Sample product",
-                description: "Sample description"
-            ) { result in
-                promise(result)
-            })
-        }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertEqual(result.failure as? NetworkError, .timeout)
-    }
-
-    func test_generateProductSharingMessage_returns_error_on_identify_language_failure() throws {
-        // Given
-        let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .failure(NetworkError.timeout))
-        let productStore = ProductStore(dispatcher: dispatcher,
-                                        storageManager: storageManager,
-                                        network: network,
-                                        remote: MockProductsRemote(),
-                                        generativeContentRemote: generativeContentRemote)
-
-        // When
-        let result = waitFor { promise in
-            productStore.onAction(ProductAction.generateProductSharingMessage(
-                siteID: self.sampleSiteID,
-                url: "https://example.com",
-                name: "Sample product",
-                description: "Sample description"
+                description: "Sample description",
+                language: "English"
             ) { result in
                 promise(result)
             })
@@ -1984,6 +1934,7 @@ final class ProductStoreTests: XCTestCase {
         let expectedURL = "https://example.com"
         let expectedName = "Sample product"
         let expectedDescription = "Sample description"
+        let expectedLangugae = "English"
         let generativeContentRemote = MockGenerativeContentRemote()
         generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
@@ -1999,7 +1950,8 @@ final class ProductStoreTests: XCTestCase {
                 siteID: self.sampleSiteID,
                 url: expectedURL,
                 name: expectedName,
-                description: expectedDescription
+                description: expectedDescription,
+                language: expectedLangugae
             ) { result in
                 promise(())
             })
@@ -2010,12 +1962,12 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertTrue(base.contains(expectedURL))
         XCTAssertTrue(base.contains(expectedName))
         XCTAssertTrue(base.contains(expectedDescription))
+        XCTAssertTrue(base.contains(expectedLangugae))
     }
 
     func test_generateProductSharingMessage_uses_correct_feature() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
-        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -2029,7 +1981,8 @@ final class ProductStoreTests: XCTestCase {
                 siteID: self.sampleSiteID,
                 url: "https://example.com",
                 name: "Sample product",
-                description: "Sample description"
+                description: "Sample description",
+                language: "English"
             ) { result in
                 promise(())
             })
@@ -2039,6 +1992,59 @@ final class ProductStoreTests: XCTestCase {
         let feature = try XCTUnwrap(generativeContentRemote.generateTextFeature)
         XCTAssertEqual(feature, GenerativeContentRemoteFeature.productSharing)
     }
+
+    // MARK: - ProductAction.identifyLanguage
+
+    func test_identifyLanguage_returns_language_on_success() throws {
+        // Given
+        let expectedLanguage = "English"
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(expectedLanguage))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        let result = waitFor { promise in
+            productStore.onAction(ProductAction.identifyLanguage(siteID: self.sampleSiteID,
+                                                                 string: "Woo is awesome",
+                                                                 feature: .productSharing) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let generatedText = try XCTUnwrap(result.get())
+        XCTAssertEqual(generatedText, expectedLanguage)
+    }
+
+    func test_identifyLanguage_returns_error_on_identify_language_failure() throws {
+        // Given
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .failure(NetworkError.timeout))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        let result = waitFor { promise in
+            productStore.onAction(ProductAction.identifyLanguage(siteID: self.sampleSiteID,
+                                                                 string: "Woo is awesome",
+                                                                 feature: .productSharing) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout)
+    }
+
 
     // MARK: - ProductAction.retrieveFirstPurchasableItemMatchFromSKU
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1740,6 +1740,7 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductDescription_returns_text_on_success() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success("Trendy product"))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1765,7 +1766,32 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductDescription_returns_error_on_failure() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .failure(NetworkError.timeout))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        let result = waitFor { promise in
+            productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
+                                                                           name: "A product",
+                                                                           features: "Trendy") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout)
+    }
+
+    func test_generateProductDescription_returns_error_on_identify_language_failure() throws {
+        // Given
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .failure(NetworkError.timeout))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
                                         network: network,
@@ -1789,6 +1815,7 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductDescription_includes_parameters_in_remote_base_parameter() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1814,6 +1841,7 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductDescription_uses_correct_feature() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1841,6 +1869,7 @@ final class ProductStoreTests: XCTestCase {
         // Given
         let expectedText = "Check out this cool product"
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(expectedText))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1869,6 +1898,7 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductSharingMessage_returns_text_after_trimming_quotation_marks() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success("\"This is \"AI\" generated message.\""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1897,7 +1927,35 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductSharingMessage_returns_error_on_failure() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .failure(NetworkError.timeout))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        let result = waitFor { promise in
+            productStore.onAction(ProductAction.generateProductSharingMessage(
+                siteID: self.sampleSiteID,
+                url: "https://example.com",
+                name: "Sample product",
+                description: "Sample description"
+            ) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout)
+    }
+
+    func test_generateProductSharingMessage_returns_error_on_identify_language_failure() throws {
+        // Given
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .failure(NetworkError.timeout))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
                                         network: network,
@@ -1927,6 +1985,7 @@ final class ProductStoreTests: XCTestCase {
         let expectedName = "Sample product"
         let expectedDescription = "Sample description"
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
@@ -1956,6 +2015,7 @@ final class ProductStoreTests: XCTestCase {
     func test_generateProductSharingMessage_uses_correct_feature() throws {
         // Given
         let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
                                         storageManager: storageManager,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10103
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Tries to identify the language using a separate prompt. Inputs the identified language to the text generation prompt.

### Notes
I think we should skip storing the identified language due to the following reasons.
1. A store might have products in different languages.
2. If incorrect language is identified for a product the first time, we will keep generating text in the wrong language for all other products. (which will be a pretty bad user experience)

Should we cache the language information to reduce network requests?

## Testing instructions

- Log in to a published WPCom site.
- Select an existing product or create a new one.
- Select Write with AI in the description row.
- On the description AI sheet, select Write with AI. The response should be in the same language as the product title and features.
- Tap Regenerate and make sure that new responses are still good.
- Tap the `...` button from the top right and tap Share to open the share sheet
- Tap "Write with AI" to generate a "share message".
- The generated share message should be in the same language as the product title and description.


## Screenshots
| Product description | Product sharing |
|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-05 at 10 28 26](https://github.com/woocommerce/woocommerce-ios/assets/524475/92c8129a-a6e0-445d-9cf1-0478778b8169) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-05 at 10 28 15](https://github.com/woocommerce/woocommerce-ios/assets/524475/fd538127-befe-42cf-9c88-62fb9fd16da6) |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
