### PR TITLE
Blaze: Only show entry point if store has at least 1 published product

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -42,7 +42,11 @@ public protocol ProductsRemoteProtocol {
     func updateProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void)
     func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void)
     func updateProducts(siteID: Int64, products: [Product], completion: @escaping (Result<[Product], Error>) -> Void)
-    func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Int64], Error>) -> Void)
+    func loadProductIDs(for siteID: Int64,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        productStatus: ProductStatus?,
+                        completion: @escaping (Result<[Int64], Error>) -> Void)
     func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void)
 }
 
@@ -365,11 +369,13 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func loadProductIDs(for siteID: Int64,
                                pageNumber: Int = Default.pageNumber,
                                pageSize: Int = Default.pageSize,
+                               productStatus: ProductStatus? = nil,
                                completion: @escaping (Result<[Int64], Error>) -> Void) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
-            ParameterKey.fields: ParameterKey.id
+            ParameterKey.fields: ParameterKey.id,
+            ParameterKey.productStatus: productStatus?.rawValue ?? ""
         ]
 
         let path = Path.products

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 14.4
 -----
+- [*] Blaze: New banner on the My Store and Products screens. [https://github.com/woocommerce/woocommerce-ios/pull/10135, https://github.com/woocommerce/woocommerce-ios/pull/10160,  https://github.com/woocommerce/woocommerce-ios/pull/10172]
 - [*] Shipping Labels: Fixed a bug preventing label printing in orders viewed from search [https://github.com/woocommerce/woocommerce-ios/pull/10161]
 
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 14.4
 -----
-- [*] Blaze: New banner on the My Store and Products screens. [https://github.com/woocommerce/woocommerce-ios/pull/10135, https://github.com/woocommerce/woocommerce-ios/pull/10160, https://github.com/woocommerce/woocommerce-ios/pull/10172]
+- [*] Blaze: New banner on the My Store and Products screens for admins of eligible stores. [https://github.com/woocommerce/woocommerce-ios/pull/10135, https://github.com/woocommerce/woocommerce-ios/pull/10160, https://github.com/woocommerce/woocommerce-ios/pull/10172]
 - [*] Shipping Labels: Fixed a bug preventing label printing in orders viewed from search [https://github.com/woocommerce/woocommerce-ios/pull/10161]
 - [*] Blaze: Disable the entry point in the product creation form. [https://github.com/woocommerce/woocommerce-ios/pull/10173]
  

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 14.4
 -----
-- [*] Blaze: New banner on the My Store and Products screens. [https://github.com/woocommerce/woocommerce-ios/pull/10135, https://github.com/woocommerce/woocommerce-ios/pull/10160,  https://github.com/woocommerce/woocommerce-ios/pull/10172]
+- [*] Blaze: New banner on the My Store and Products screens. [https://github.com/woocommerce/woocommerce-ios/pull/10135, https://github.com/woocommerce/woocommerce-ios/pull/10160, https://github.com/woocommerce/woocommerce-ios/pull/10172]
 - [*] Shipping Labels: Fixed a bug preventing label printing in orders viewed from search [https://github.com/woocommerce/woocommerce-ios/pull/10161]
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -295,7 +295,7 @@ extension DashboardViewModel {
 
     private func isBlazeBannerVisible() async -> Bool {
         async let isSiteEligible = blazeEligibilityChecker.isSiteEligible()
-        async let storeHasProducts = (try? checkIfStoreHasProducts(siteID: siteID)) ?? false
+        async let storeHasProducts = (try? checkIfStoreHasProducts(siteID: siteID, status: .published)) ?? false
         guard (await isSiteEligible, await storeHasProducts) == (true, true) else {
             return false
         }
@@ -303,9 +303,9 @@ extension DashboardViewModel {
     }
 
     @MainActor
-    private func checkIfStoreHasProducts(siteID: Int64) async throws -> Bool {
+    private func checkIfStoreHasProducts(siteID: Int64, status: ProductStatus? = nil) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(ProductAction.checkIfStoreHasProducts(siteID: siteID, onCompletion: { result in
+            stores.dispatch(ProductAction.checkIfStoreHasProducts(siteID: siteID, status: status, onCompletion: { result in
                 switch result {
                 case .success(let hasProducts):
                     continuation.resume(returning: hasProducts)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -295,8 +295,8 @@ extension DashboardViewModel {
 
     private func isBlazeBannerVisible() async -> Bool {
         async let isSiteEligible = blazeEligibilityChecker.isSiteEligible()
-        async let storeHasProducts = (try? checkIfStoreHasProducts(siteID: siteID, status: .published)) ?? false
-        guard (await isSiteEligible, await storeHasProducts) == (true, true) else {
+        async let storeHasPublishedProducts = (try? checkIfStoreHasProducts(siteID: siteID, status: .published)) ?? false
+        guard (await isSiteEligible, await storeHasPublishedProducts) == (true, true) else {
             return false
         }
         return !userDefaults.hasDismissedBlazeBanner(for: siteID)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -692,6 +692,10 @@ private extension ProductFormViewModel {
 
 private extension ProductFormViewModel {
     func updateBlazeEligibility() {
+        guard formType == .edit else {
+            isEligibleForBlaze = false
+            return
+        }
         Task { @MainActor in
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -692,10 +692,6 @@ private extension ProductFormViewModel {
 
 private extension ProductFormViewModel {
     func updateBlazeEligibility() {
-        guard formType == .edit else {
-            isEligibleForBlaze = false
-            return
-        }
         Task { @MainActor in
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -106,7 +106,6 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         configureResultsController(resultsController, onReload: { [weak self] in
             guard let self else { return }
             self.reloadTableAndView()
-            self.isEmpty = resultsController.isEmpty
         })
         return resultsController
     }()
@@ -132,7 +131,9 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     /// Indicates if there are no results onscreen.
     ///
-    @Published private var isEmpty: Bool = true
+    private var isEmpty: Bool {
+        resultsController.isEmpty
+    }
 
     /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
     ///
@@ -864,10 +865,9 @@ private extension ProductsViewController {
     func checkBlazeBannerVisibility() {
         viewModel.$shouldShowBlazeBanner
             .removeDuplicates()
-            .combineLatest($isEmpty.removeDuplicates())
-            .sink { [weak self] shouldShow, isEmpty in
+            .sink { [weak self] shouldShow in
                 guard let self else { return }
-                guard !self.hasErrorLoadingData, !isEmpty else {
+                guard !self.hasErrorLoadingData else {
                     return self.hideBlazeBanner()
                 }
                 if shouldShow {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1326,6 +1326,7 @@ private extension ProductsViewController {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
+            hideBlazeBanner()
         case .syncing(let pageNumber):
             let isFirstPage = pageNumber == SyncingCoordinator.Defaults.pageFirstIndex
             if isFirstPage && resultsController.isEmpty {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -834,6 +834,7 @@ private extension ProductsViewController {
     func reloadTableAndView() {
         showOrHideToolbar()
         addOrRemoveOverlay()
+        updateBlazeBannerVisibility()
         tableView.reloadData()
     }
 
@@ -878,6 +879,10 @@ private extension ProductsViewController {
             }
             .store(in: &subscriptions)
 
+        updateBlazeBannerVisibility()
+    }
+
+    func updateBlazeBannerVisibility() {
         Task { @MainActor in
             await viewModel.updateBlazeBannerVisibility()
         }
@@ -1326,7 +1331,6 @@ private extension ProductsViewController {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
-            hideBlazeBanner()
         case .syncing(let pageNumber):
             let isFirstPage = pageNumber == SyncingCoordinator.Defaults.pageFirstIndex
             if isFirstPage && resultsController.isEmpty {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -7,6 +7,7 @@ import enum Yosemite.JustInTimeMessageAction
 import struct Yosemite.JustInTimeMessage
 import struct Yosemite.StoreOnboardingTask
 import enum Yosemite.StoreOnboardingTasksAction
+import enum Yosemite.ProductStatus
 import struct Yosemite.Site
 @testable import WooCommerce
 
@@ -102,7 +103,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .checkIfStoreHasProducts(_, completion):
+            case let .checkIfStoreHasProducts(_, _, completion):
                 completion(.success(false))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -138,7 +139,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .checkIfStoreHasProducts(_, completion):
+            case let .checkIfStoreHasProducts(_, _, completion):
                 completion(.success(false))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -180,7 +181,7 @@ final class DashboardViewModelTests: XCTestCase {
     func prepareStoresToShowJustInTimeMessage(_ response: Result<[Yosemite.JustInTimeMessage], Error>) {
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .checkIfStoreHasProducts(_, completion):
+            case let .checkIfStoreHasProducts(_, _, completion):
                 completion(.success(true))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -200,7 +201,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .checkIfStoreHasProducts(_, completion):
+            case let .checkIfStoreHasProducts(_, _, completion):
                 completion(.success(true))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -611,6 +612,33 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     // MARK: Blaze banner
+    func test_updateBlazeBannerVisibility_triggers_loading_product_ids_with_published_status() async throws {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           userDefaults: userDefaults,
+                                           blazeEligibilityChecker: checker)
+        var productStatusToCheck: ProductStatus?
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case .checkIfStoreHasProducts(_, let productStatus, let completion):
+                productStatusToCheck = productStatus
+                completion(.success(false))
+            default:
+                break
+            }
+        }
+        await viewModel.updateBlazeBannerVisibility()
+
+        //  Then
+        XCTAssertEqual(productStatusToCheck?.rawValue, "publish")
+    }
+
     // swiftlint:disable:next line_length
     func test_updateBlazeBannerVisibility_updates_showBlazeBanner_to_true_if_site_is_eligible_for_blaze_and_banner_is_not_dismissed_yet_and_store_has_products() async throws {
         // Given
@@ -626,7 +654,7 @@ final class DashboardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case .checkIfStoreHasProducts(_, let onCompletion):
+            case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
             default:
                 break
@@ -652,7 +680,7 @@ final class DashboardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case .checkIfStoreHasProducts(_, let onCompletion):
+            case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
             default:
                 break
@@ -679,7 +707,7 @@ final class DashboardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case .checkIfStoreHasProducts(_, let onCompletion):
+            case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
             default:
                 break
@@ -705,7 +733,7 @@ final class DashboardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case .checkIfStoreHasProducts(_, let onCompletion):
+            case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(false))
             default:
                 break
@@ -728,7 +756,7 @@ final class DashboardViewModelTests: XCTestCase {
                                            blazeEligibilityChecker: checker)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case .checkIfStoreHasProducts(_, let onCompletion):
+            case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
             default:
                 break

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -640,7 +640,7 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     // swiftlint:disable:next line_length
-    func test_updateBlazeBannerVisibility_updates_showBlazeBanner_to_true_if_site_is_eligible_for_blaze_and_banner_is_not_dismissed_yet_and_store_has_products() async throws {
+    func test_updateBlazeBannerVisibility_updates_showBlazeBanner_to_true_if_site_is_eligible_for_blaze_and_banner_is_not_dismissed_yet_and_store_has_published_products() async throws {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let uuid = UUID().uuidString

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -107,10 +107,12 @@ public enum ProductAction: Action {
     ///
     case replaceProductLocally(product: Product, onCompletion: () -> Void)
 
-    /// Checks if the store already has any products.
+    /// Checks if the store already has any products with the given status.
     /// Returns `false` if the store has no products.
     ///
-    case checkIfStoreHasProducts(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void)
+    case checkIfStoreHasProducts(siteID: Int64,
+                                 status: ProductStatus? = nil,
+                                 onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Creates a product using the provided template type.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -501,10 +501,10 @@ private extension ProductStore {
     func checkIfStoreHasProducts(siteID: Int64, status: ProductStatus?, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         // Check for locally stored products first.
         let storage = storageManager.viewStorage
-        if let products = storage.loadProducts(siteID: siteID) {
+        if let products = storage.loadProducts(siteID: siteID), !products.isEmpty {
             if let status, (products.filter { $0.statusKey == status.rawValue }.isEmpty) == false {
                 return onCompletion(.success(true))
-            } else if status == nil, !products.isEmpty {
+            } else if status == nil {
                 return onCompletion(.success(true))
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -200,7 +200,11 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         // no-op
     }
 
-    func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, productStatus: ProductStatus?, completion: @escaping (Result<[Int64], Error>) -> Void) {
+    func loadProductIDs(for siteID: Int64,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        productStatus: ProductStatus?,
+                        completion: @escaping (Result<[Int64], Error>) -> Void) {
         // no-op
     }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -200,7 +200,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         // no-op
     }
 
-    func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Int64], Error>) -> Void) {
+    func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, productStatus: ProductStatus?, completion: @escaping (Result<[Int64], Error>) -> Void) {
         // no-op
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10098 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the previous PRs we are checking to show the Blaze banner only if the store has at least one product. But only published products should be promoted, so this PR aims to check for products with published status. Changes include:
- `ProductsRemote`, `ProductAction` and `ProductStore`: include an optional parameter for product status when loading product IDs.
- `DashboardViewModel`: send status `published` when checking products in the store.
- `ProductListViewModel`: update the check to fetch product IDs with status, and remove the observing of the fetched data in `ProductsViewController`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in as an admin to a public WPCom store with no product.
- Notice that the Blaze banner is unavailable on both the my store and product list screens.
- Add a new product and publish it. Refresh the my store and product list screens to see the Blaze banner appear.
- Update the created product status to private or draft. Refresh the my store and product list screens to see the Blaze banner disappear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/f967791e-8ccb-4e18-8987-74d849483ea8



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
