### PR TITLE
Blaze: Disable Blaze in product creation form

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,8 @@
 14.4
 -----
 - [*] Shipping Labels: Fixed a bug preventing label printing in orders viewed from search [https://github.com/woocommerce/woocommerce-ios/pull/10161]
-
+- [*] Blaze: Disable the entry point in the product creation form. [https://github.com/woocommerce/woocommerce-ios/pull/10173]
+ 
 
 14.3
 -----

--- a/WooCommerce/Classes/Blaze/BlazeBanner.swift
+++ b/WooCommerce/Classes/Blaze/BlazeBanner.swift
@@ -110,6 +110,7 @@ struct BlazeBanner: View {
                         Image(systemName: "xmark")
                     }
                     .buttonStyle(.plain)
+                    .foregroundColor(Color(.textSubtle))
                 }
 
                 // Blaze icon
@@ -142,6 +143,7 @@ struct BlazeBanner: View {
                 .frame(height: Layout.spacing)
                 .renderedIf(showsBottomSpacer)
         }
+        .background(Color(.listForeground(modal: false)))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -692,6 +692,10 @@ private extension ProductFormViewModel {
 
 private extension ProductFormViewModel {
     func updateBlazeEligibility() {
+        guard formType == .edit else {
+            isEligibleForBlaze = false
+            return
+        }
         Task { @MainActor in
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -204,6 +204,24 @@ final class ProductFormViewModelTests: XCTestCase {
         }
     }
 
+    func test_canPromoteWithBlaze_is_false_for_product_creation_when_product_is_eligible_for_blaze() {
+            // Given
+            let product = Product.fake()
+            let blazeEligibilityChecker = MockBlazeEligibilityChecker(isProductEligible: true)
+            let nonEditableFormTypes: [ProductFormType] = [.add, .readonly]
+
+            // When
+            nonEditableFormTypes.forEach { nonEditableFormType in
+                // When
+                let viewModel = createViewModel(product: product, formType: nonEditableFormType, blazeEligibilityChecker: blazeEligibilityChecker)
+
+                waitUntil {
+                    // Then
+                    viewModel.canPromoteWithBlaze() == false
+                }
+            }
+        }
+
     // MARK: `canDeleteProduct`
 
     func test_edit_product_form_with_published_status_can_delete_product() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10168 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR hides the Blaze entry point in product form if the user is creating a new product.
No unit test was added because the check was added in a class conforming to a protocol, so it was not very testable unless we refactor how the product form works. Please feel free to share any suggestions for testing this.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in as an admin to a public WPCom site to ensure you have permission to create Blaze campaigns.
- Switch to the Products tab and select "+" to add a new product with a template or manually.
- Notice that the Blaze entry point is not available when tapping the ellipsis menu.
- Publish the product, the entry point should be available.
- Save the product as draft, the entry point should be hidden again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/65651074-39d1-43d3-b024-53b235a197fb



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
