### PR TITLE
Free trial banner: Reload visibility after plan upgrade

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -23,12 +23,16 @@ final class UpgradesViewModel: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
 
+    private let onPlanUpgradeCompleted: (() -> Void)?
+
     init(siteID: Int64,
+         onPlanUpgradeCompleted: (() -> Void)? = nil,
          inAppPurchasesPlanManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager(),
          storePlanSynchronizer: StorePlanSynchronizer = ServiceLocator.storePlanSynchronizer,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
+        self.onPlanUpgradeCompleted = onPlanUpgradeCompleted
         self.inAppPurchasesPlanManager = inAppPurchasesPlanManager
         self.storePlanSynchronizer = storePlanSynchronizer
         self.stores = stores

--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradesViewModel.swift
@@ -41,6 +41,7 @@ final class UpgradesViewModel: ObservableObject {
         entitledWpcomPlanIDs = []
 
         observeViewStateAndTrackAnalytics()
+        observeViewStateAndFireCompletionHandler()
         checkForSiteOwnership()
     }
 
@@ -283,6 +284,18 @@ extension UpgradesViewModel {
                 self?.analytics.track(event: .InAppPurchases.planUpgradePrePurchaseFailed(error: error))
             case .purchaseUpgradeError(let error):
                 self?.analytics.track(event: .InAppPurchases.planUpgradePurchaseFailed(error: error.analyticErrorDetail))
+            default:
+                break
+            }
+        }
+        .store(in: &cancellables)
+    }
+
+    private func observeViewStateAndFireCompletionHandler() {
+        $upgradeViewState.sink { [weak self] state in
+            switch state {
+            case .completed:
+                self?.onPlanUpgradeCompleted?()
             default:
                 break
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerPresenter.swift
@@ -165,7 +165,9 @@ private extension FreeTrialBannerPresenter {
         guard let viewController else { return }
         Task { @MainActor in
             if await inAppPurchasesManager.inAppPurchasesAreSupported() && inAppPurchasesUpgradeEnabled {
-                let upgradesController = UpgradesHostingController(siteID: siteID)
+                let upgradesController = UpgradesHostingController(siteID: siteID) { [weak self] in
+                    self?.reloadBannerVisibility()
+                }
                 viewController.present(upgradesController, animated: true)
             } else {
                 let subscriptionsController = SubscriptionsHostingController(siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -9,8 +9,10 @@ import Yosemite
 final class UpgradesHostingController: UIHostingController<UpgradesView> {
     private let authentication: Authentication = ServiceLocator.authenticationManager
 
-    init(siteID: Int64) {
-        let upgradesViewModel = UpgradesViewModel(siteID: siteID)
+    init(siteID: Int64,
+         onPlanUpgradeCompleted: (() -> Void)? = nil) {
+        let upgradesViewModel = UpgradesViewModel(siteID: siteID,
+                                                  onPlanUpgradeCompleted: onPlanUpgradeCompleted)
         let subscriptionsViewModel = SubscriptionsViewModel()
 
         super.init(rootView: UpgradesView(upgradesViewModel: upgradesViewModel, subscriptionsViewModel: subscriptionsViewModel))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10127
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Reloads the Free trial banner after the plan upgrade is completed. 

### Notes

⚠️ I haven't tested this because I couldn't get IAP working after following the instructions.

> In Xcode, open the WoocommerceTestSynced file, and in the Editor menu, select Default Storefront - USA. Then run the app with the WooCommerce IAP scheme.

I am adding @joshheald, and @iamgabrielma add reviewers as they will know of a way to test this. Thank you Josh and Gabriel!

## Testing instructions

This needs IAP setup for testing. It is currently enabled only for USA.

- Login into a Free trial store
- You should see a Free trial banner in the "My store" tab
- If you are eligible for IAP, the banner will have an "Upgrade Now" button. Tap on it.
- Follow the steps and complete the plan purchase 
- Validate that the free trial banner is not visible after you have successfully purchased a plan

## Screenshots
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/d2acc7ff-6c01-4b14-8eba-6a5e14af162e" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
