### PR TITLE
[IAP] Fix: Apply lower-case to product_id prop

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2426,7 +2426,7 @@ extension WooAnalyticsEvent {
 extension WooAnalyticsEvent {
     enum InAppPurchases {
         enum Keys: String {
-            case productID = "product_ID"
+            case productID = "product_id"
             case source
             case step
             case featureGroup = "feature_group"


### PR DESCRIPTION
## Description
This PR changes the prop `product_ID` to `product_id` (lowercase), which is tracked when the `plan_upgrade_purchase_button_tapped` event is triggered.

This is necessary since we can't validate event properties with uppercase letters in Track Events.

## Testing instructions
- Run the app, on an IAP-upgrade-eligible store
- Tap "Upgrade Now" > Tap "Purchase Essentials Monthly" > See in the the console that `product_id` is tracked (id lower-case):
```
2023-07-05 16:27:48.646620+0800 WooCommerce[39920:2652611] 🔵 Tracked plan_upgrade_purchase_button_tapped, properties: [AnyHashable("product_id"): "woocommerce.express.essential.monthly", AnyHashable("blog_id"): 220865014, AnyHashable("is_wpcom_store"): true]
```
