### PR TITLE
[AI generation] Reset identified language if user downvotes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -80,6 +80,10 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
     func handleFeedback(_ vote: FeedbackView.Vote) {
         analytics.track(event: .AIFeedback.feedbackSent(source: .productDescription,
                                                         isUseful: vote == .up))
+        if vote == .down {
+            languageIdentifiedUsingAI = nil
+        }
+
         // Delay the disappearance of the banner for a better UX.
         DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeDismissingFeedbackBanner) { [weak self] in
             self?.shouldShowFeedbackView = false

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -81,6 +81,9 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
         analytics.track(event: .AIFeedback.feedbackSent(source: .productDescription,
                                                         isUseful: vote == .up))
         if vote == .down {
+            // User down voting could be because the identified language is incorrect.
+            // Setting it as `nil` to identify language again during next generation attempt.
+            // pe5sF9-1GF-p2
             languageIdentifiedUsingAI = nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -102,6 +102,9 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         analytics.track(event: .AIFeedback.feedbackSent(source: .productSharingMessage,
                                                         isUseful: vote == .up))
         if vote == .down {
+            // User down voting could be because the identified language is incorrect.
+            // Setting it as `nil` to identify language again during next generation attempt.
+            // pe5sF9-1GF-p2
             languageIdentifiedUsingAI = nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -101,6 +101,10 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
     func handleFeedback(_ vote: FeedbackView.Vote) {
         analytics.track(event: .AIFeedback.feedbackSent(source: .productSharingMessage,
                                                         isUseful: vote == .up))
+        if vote == .down {
+            languageIdentifiedUsingAI = nil
+        }
+
         // Delay the disappearance of the banner for a better UX.
         DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeDismissingFeedbackBanner) { [weak self] in
             self?.shouldShowFeedbackView = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10103
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Resets the identified language when the user downvotes the generated content. 

pe5sF9-1GF-p2#comment-2430

> We just added the feedback banner – do you think it’s worth triggering the language detection again if they downvote the response? Just to avoid the worst-case scenario when the subsequent response are bad due to the incorrect language in the first try?

## Testing instructions

We need [proxyman](https://proxyman.io/) or a similar proxy setup to check the network requests.

**Product Description**
- Log in to a published WPCom site.
- Select an existing product or create a new one.
- Select Write with AI in the description row.
- On the description AI sheet, select Write with AI. The response should be in the same language as the product title and features.
- Clear requests in proxyman 
- Tap Regenerate and wait for new text to generate.
- Check proxy man and validate that the `jetpack-ai/completions` request is sent only once. (To generate text)
- Tap the thumbs-down button from the feedback banner. This should clear the locally saved identified language information.
- Clear requests in proxyman 
- Tap Regenerate and wait for new text to generate.
- Check proxy man and validate that the `jetpack-ai/completions` request is sent twice. (One to identify language and another to generate text)

**Product Sharing message**
- Log in to a published WPCom site.
- Select an existing product or create a new one.
- Tap the `...` button from the top right and tap Share to open the share sheet
- Tap "Write with AI" to generate a "share message".
- The generated share message should be in the same language as the product title and description.
- Clear requests in proxyman 
- Tap Regenerate and wait for new text to generate.
- Check proxy man and validate that the `jetpack-ai/completions` request is sent only once.  (To generate text)
- Tap the thumbs-down button from the feedback banner. This should clear the locally saved identified language information.
- Clear requests in proxyman 
- Tap Regenerate and wait for new text to generate.
- Check proxy man and validate that the `jetpack-ai/completions` request is sent twice. (One to identify language and another to generate text)

## Screenshots
| Product description | Product sharing |
|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-06 at 12 10 30](https://github.com/woocommerce/woocommerce-ios/assets/524475/5d38aeaa-df1c-4d16-bbcb-a22be2f0a8b8) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-06 at 12 10 18](https://github.com/woocommerce/woocommerce-ios/assets/524475/865ce2e0-0af7-4354-9c89-cf7cd482fa40) |




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.