### PR TITLE
[AI generation] Identify ISO language code and track it

### DIFF
--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -24,7 +24,7 @@ public protocol GenerativeContentRemoteProtocol {
     ///   - siteID: WPCOM ID of the site.
     ///   - string: String from which we should identify the language
     ///   - feature: Used by backend to track AI-generation usage and measure costs
-    /// - Returns: Name of the language
+    /// - Returns: ISO code of the language
     func identifyLanguage(siteID: Int64,
                           string: String,
                           feature: GenerativeContentRemoteFeature) async throws -> String
@@ -50,7 +50,8 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                  feature: GenerativeContentRemoteFeature) async throws -> String {
         let path = "sites/\(siteID)/\(Path.text)"
         let prompt = [
-            "What is the name of the language used in the following text? Just give me only the language name in your response.",
+            "What is the ISO language code of the language used in the below text?" +
+            "Do not include any explanations and only provide the ISO language code in your response.",
             "Text: ```\(string)```"
         ].joined(separator: "\n")
 

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -53,7 +53,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
 
     // MARK: - `identifyLanguage`
 
-    func test_identifyLanguage_with_success_returns_generated_text() async throws {
+    func test_identifyLanguage_with_success_returns_language_code() async throws {
         // Given
         let remote = GenerativeContentRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-ai/completions", filename: "identify-language-success")
@@ -64,7 +64,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                               feature: .productDescription)
 
         // Then
-        XCTAssertEqual(language, "English")
+        XCTAssertEqual(language, "en")
     }
 
     func test_identifyLanguage_with_failure_returns_error() async throws {

--- a/Networking/NetworkingTests/Responses/identify-language-success.json
+++ b/Networking/NetworkingTests/Responses/identify-language-success.json
@@ -1,1 +1,1 @@
-"English"
+"en"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [*] Blaze: New banner on the My Store and Products screens for admins of eligible stores. [https://github.com/woocommerce/woocommerce-ios/pull/10135, https://github.com/woocommerce/woocommerce-ios/pull/10160, https://github.com/woocommerce/woocommerce-ios/pull/10172]
 - [*] Shipping Labels: Fixed a bug preventing label printing in orders viewed from search [https://github.com/woocommerce/woocommerce-ios/pull/10161]
 - [*] Blaze: Disable the entry point in the product creation form. [https://github.com/woocommerce/woocommerce-ios/pull/10173]
-- [*] Product description and sharing message AI: Fixed incorrect language issue by using a separate prompt for identifying language. [https://github.com/woocommerce/woocommerce-ios/pull/10169]
+- [*] Product description and sharing message AI: Fixed incorrect language issue by using a separate prompt for identifying language. [https://github.com/woocommerce/woocommerce-ios/pull/10169, https://github.com/woocommerce/woocommerce-ios/pull/10177, https://github.com/woocommerce/woocommerce-ios/pull/10179]
 
 14.3
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
@@ -4,6 +4,7 @@ extension WooAnalyticsEvent {
         private enum Key {
             static let source = "source"
             static let isRetry = "is_retry"
+            static let identifiedLanguage = "identified_language"
         }
 
         /// Tracked when the user taps on the button to start the product description AI flow.
@@ -35,8 +36,9 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when the product description AI generation succeeds.
-        static func productDescriptionAIGenerationSuccess() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productDescriptionAIGenerationSuccess, properties: [:])
+        static func productDescriptionAIGenerationSuccess(identifiedLanguage: String?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIGenerationSuccess,
+                              properties: [Key.identifiedLanguage: identifiedLanguage].compactMapValues { $0 })
         }
 
         /// Tracked when the product description AI generation fails.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
@@ -35,14 +35,14 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDescriptionAICopyButtonTapped, properties: [:])
         }
 
-        /// Tracked when the product description AI identifies language
+        /// Tracked when AI identifies language
         static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .identifyLanguageSuccess,
                               properties: [Key.language: identifiedLanguage,
                                            Key.source: Constants.productDescriptionSource])
         }
 
-        /// Tracked when the product description AI fails to identify language
+        /// Tracked when AI fails to identify language
         static func identifyLanguageFailed(error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .identifyLanguageFailed,
                               properties: [Key.source: Constants.productDescriptionSource],

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
@@ -4,7 +4,7 @@ extension WooAnalyticsEvent {
         private enum Key {
             static let source = "source"
             static let isRetry = "is_retry"
-            static let identifiedLanguage = "identified_language"
+            static let language = "language"
         }
 
         /// Tracked when the user taps on the button to start the product description AI flow.
@@ -35,10 +35,20 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDescriptionAICopyButtonTapped, properties: [:])
         }
 
+        /// Tracked when the product description AI identifies language
+        static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionIdentifyLanguageSuccess,
+                              properties: [Key.language: identifiedLanguage])
+        }
+
+        /// Tracked when the product description AI fails to identify language
+        static func identifyLanguageFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionIdentifyLanguageFailed, properties: [:], error: error)
+        }
+
         /// Tracked when the product description AI generation succeeds.
-        static func productDescriptionAIGenerationSuccess(identifiedLanguage: String?) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productDescriptionAIGenerationSuccess,
-                              properties: [Key.identifiedLanguage: identifiedLanguage].compactMapValues { $0 })
+        static func productDescriptionAIGenerationSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIGenerationSuccess, properties: [:])
         }
 
         /// Tracked when the product description AI generation fails.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
@@ -37,13 +37,16 @@ extension WooAnalyticsEvent {
 
         /// Tracked when the product description AI identifies language
         static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productDescriptionIdentifyLanguageSuccess,
-                              properties: [Key.language: identifiedLanguage])
+            WooAnalyticsEvent(statName: .identifyLanguageSuccess,
+                              properties: [Key.language: identifiedLanguage,
+                                           Key.source: Constants.productDescriptionSource])
         }
 
         /// Tracked when the product description AI fails to identify language
         static func identifyLanguageFailed(error: Error) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productDescriptionIdentifyLanguageFailed, properties: [:], error: error)
+            WooAnalyticsEvent(statName: .identifyLanguageFailed,
+                              properties: [Key.source: Constants.productDescriptionSource],
+                              error: error)
         }
 
         /// Tracked when the product description AI generation succeeds.
@@ -65,5 +68,11 @@ extension WooAnalyticsEvent.ProductFormAI {
         case aztecEditor = "aztec_editor"
         /// From the product form below the description row.
         case productForm = "product_form"
+    }
+}
+
+private extension WooAnalyticsEvent.ProductFormAI {
+    enum Constants {
+        static let productDescriptionSource = "product_description"
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductSharingAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductSharingAI.swift
@@ -5,6 +5,7 @@ extension WooAnalyticsEvent {
         private enum Key: String {
             case isRetry = "is_retry"
             case withMessage = "with_message"
+            case identifiedLanguage = "identified_language"
         }
 
         static func sheetDisplayed() -> WooAnalyticsEvent {
@@ -27,9 +28,9 @@ extension WooAnalyticsEvent {
                               properties: [:])
         }
 
-        static func messageGenerated() -> WooAnalyticsEvent {
+        static func messageGenerated(identifiedLanguage: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productSharingAIMessageGenerated,
-                              properties: [:])
+                              properties: [Key.identifiedLanguage.rawValue: identifiedLanguage].compactMapValues { $0 })
         }
 
         static func messageGenerationFailed(error: Error) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductSharingAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductSharingAI.swift
@@ -3,6 +3,7 @@ import Foundation
 extension WooAnalyticsEvent {
     enum ProductSharingAI {
         private enum Key: String {
+            case source = "source"
             case isRetry = "is_retry"
             case withMessage = "with_message"
             case language = "language"
@@ -29,13 +30,14 @@ extension WooAnalyticsEvent {
         }
 
         static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productSharingAIIdentifyLanguageSuccess,
-                              properties: [Key.language.rawValue: identifiedLanguage])
+            WooAnalyticsEvent(statName: .identifyLanguageSuccess,
+                              properties: [Key.language.rawValue: identifiedLanguage,
+                                           Key.source.rawValue: Constants.productSharingSource])
         }
 
         static func identifyLanguageFailed(error: Error) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productSharingAIIdentifyLanguageFailed,
-                              properties: [:],
+            WooAnalyticsEvent(statName: .identifyLanguageFailed,
+                              properties: [Key.source.rawValue: Constants.productSharingSource],
                               error: error)
         }
 
@@ -49,5 +51,11 @@ extension WooAnalyticsEvent {
                               properties: [:],
                               error: error)
         }
+    }
+}
+
+private extension WooAnalyticsEvent.ProductSharingAI {
+    enum Constants {
+        static let productSharingSource = "product_sharing"
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductSharingAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductSharingAI.swift
@@ -5,7 +5,7 @@ extension WooAnalyticsEvent {
         private enum Key: String {
             case isRetry = "is_retry"
             case withMessage = "with_message"
-            case identifiedLanguage = "identified_language"
+            case language = "language"
         }
 
         static func sheetDisplayed() -> WooAnalyticsEvent {
@@ -28,9 +28,20 @@ extension WooAnalyticsEvent {
                               properties: [:])
         }
 
-        static func messageGenerated(identifiedLanguage: String?) -> WooAnalyticsEvent {
+        static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productSharingAIIdentifyLanguageSuccess,
+                              properties: [Key.language.rawValue: identifiedLanguage])
+        }
+
+        static func identifyLanguageFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productSharingAIIdentifyLanguageFailed,
+                              properties: [:],
+                              error: error)
+        }
+
+        static func messageGenerated() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productSharingAIMessageGenerated,
-                              properties: [Key.identifiedLanguage.rawValue: identifiedLanguage].compactMapValues { $0 })
+                              properties: [:])
         }
 
         static func messageGenerationFailed(error: Error) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -750,7 +750,7 @@ public enum WooAnalyticsStat: String {
     case productSharingAIMessageGenerated = "product_sharing_ai_message_generated"
     case productSharingAIMessageGenerationFailed = "product_sharing_ai_message_generation_failed"
 
-    // MARK: AI Language detection
+    // MARK: AI Identify Language
     //
     case identifyLanguageSuccess = "ai_identify_language_success"
     case identifyLanguageFailed = "ai_identify_language_failed"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -734,8 +734,6 @@ public enum WooAnalyticsStat: String {
     case productDescriptionAIPauseButtonTapped = "product_description_ai_pause_button_tapped"
     case productDescriptionAIApplyButtonTapped = "product_description_ai_apply_button_tapped"
     case productDescriptionAICopyButtonTapped = "product_description_ai_copy_button_tapped"
-    case productDescriptionIdentifyLanguageSuccess = "product_description_ai_identify_language_success"
-    case productDescriptionIdentifyLanguageFailed = "product_description_ai_identify_language_failed"
     case productDescriptionAIGenerationSuccess = "product_description_ai_generation_success"
     case productDescriptionAIGenerationFailed = "product_description_ai_generation_failed"
 
@@ -749,8 +747,6 @@ public enum WooAnalyticsStat: String {
     case productSharingAIGenerateTapped = "product_sharing_ai_generate_tapped"
     case productSharingAIShareTapped = "product_sharing_ai_share_tapped"
     case productSharingAIDismissed = "product_sharing_ai_dismissed"
-    case productSharingAIIdentifyLanguageSuccess = "product_sharing_ai_identify_language_success"
-    case productSharingAIIdentifyLanguageFailed = "product_sharing_ai_identify_language_failed"
     case productSharingAIMessageGenerated = "product_sharing_ai_message_generated"
     case productSharingAIMessageGenerationFailed = "product_sharing_ai_message_generation_failed"
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -754,6 +754,11 @@ public enum WooAnalyticsStat: String {
     case productSharingAIMessageGenerated = "product_sharing_ai_message_generated"
     case productSharingAIMessageGenerationFailed = "product_sharing_ai_message_generation_failed"
 
+    // MARK: AI Language detection
+    //
+    case identifyLanguageSuccess = "ai_identify_language_success"
+    case identifyLanguageFailed = "ai_identify_language_failed"
+
     // MARK: Product AI Feedback
     //
     case productAIFeedback = "product_ai_feedback"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -734,6 +734,8 @@ public enum WooAnalyticsStat: String {
     case productDescriptionAIPauseButtonTapped = "product_description_ai_pause_button_tapped"
     case productDescriptionAIApplyButtonTapped = "product_description_ai_apply_button_tapped"
     case productDescriptionAICopyButtonTapped = "product_description_ai_copy_button_tapped"
+    case productDescriptionIdentifyLanguageSuccess = "product_description_ai_identify_language_success"
+    case productDescriptionIdentifyLanguageFailed = "product_description_ai_identify_language_failed"
     case productDescriptionAIGenerationSuccess = "product_description_ai_generation_success"
     case productDescriptionAIGenerationFailed = "product_description_ai_generation_failed"
 
@@ -747,6 +749,8 @@ public enum WooAnalyticsStat: String {
     case productSharingAIGenerateTapped = "product_sharing_ai_generate_tapped"
     case productSharingAIShareTapped = "product_sharing_ai_share_tapped"
     case productSharingAIDismissed = "product_sharing_ai_dismissed"
+    case productSharingAIIdentifyLanguageSuccess = "product_sharing_ai_identify_language_success"
+    case productSharingAIIdentifyLanguageFailed = "product_sharing_ai_identify_language_failed"
     case productSharingAIMessageGenerated = "product_sharing_ai_message_generated"
     case productSharingAIMessageGenerationFailed = "product_sharing_ai_message_generation_failed"
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -145,7 +145,7 @@ private extension ProductDescriptionGenerationViewModel {
             shouldShowFeedbackView = true
         case let .failure(error):
             if case let IdentifyLanguageError.failedToIdentifyLanguage(underlyingError: underlyingError) = error {
-                DDLogError("⛔️ Error identifing language: \(error)")
+                DDLogError("⛔️ Error identifying language: \(error)")
                 errorMessage = underlyingError.localizedDescription
                 analytics.track(event: .ProductFormAI.identifyLanguageFailed(error: underlyingError))
             } else {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -136,7 +136,7 @@ private extension ProductDescriptionGenerationViewModel {
         switch result {
         case let .success(text):
             suggestedText = text
-            analytics.track(event: .ProductFormAI.productDescriptionAIGenerationSuccess())
+            analytics.track(event: .ProductFormAI.productDescriptionAIGenerationSuccess(identifiedLanguage: languageIdentifiedUsingAI))
             shouldShowFeedbackView = true
         case let .failure(error):
             errorMessage = error.localizedDescription

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -119,16 +119,21 @@ private extension ProductDescriptionGenerationViewModel {
             return languageIdentifiedUsingAI
         }
 
-        let language = try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
-                                                           string: name + " " + features,
-                                                           feature: .productSharing,
-                                                           completion: { result in
-                continuation.resume(with: result)
-            }))
+        do {
+            let language = try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
+                                                               string: name + " " + features,
+                                                               feature: .productSharing,
+                                                               completion: { result in
+                    continuation.resume(with: result)
+                }))
+            }
+            analytics.track(event: .ProductFormAI.identifiedLanguage(language))
+            self.languageIdentifiedUsingAI = language
+            return language
+        } catch {
+            throw IdentifyLanguageError.failedToIdentifyLanguage(underlyingError: error)
         }
-        self.languageIdentifiedUsingAI = language
-        return language
     }
 
     @MainActor
@@ -136,13 +141,23 @@ private extension ProductDescriptionGenerationViewModel {
         switch result {
         case let .success(text):
             suggestedText = text
-            analytics.track(event: .ProductFormAI.productDescriptionAIGenerationSuccess(identifiedLanguage: languageIdentifiedUsingAI))
+            analytics.track(event: .ProductFormAI.productDescriptionAIGenerationSuccess())
             shouldShowFeedbackView = true
         case let .failure(error):
-            errorMessage = error.localizedDescription
-            DDLogError("Error generating product description: \(error)")
-            analytics.track(event: .ProductFormAI.productDescriptionAIGenerationFailed(error: error))
+            if case let IdentifyLanguageError.failedToIdentifyLanguage(underlyingError: underlyingError) = error {
+                DDLogError("⛔️ Error identifing language: \(error)")
+                errorMessage = underlyingError.localizedDescription
+                analytics.track(event: .ProductFormAI.identifyLanguageFailed(error: underlyingError))
+            } else {
+                DDLogError("⛔️ Error generating product description: \(error)")
+                errorMessage = error.localizedDescription
+                analytics.track(event: .ProductFormAI.productDescriptionAIGenerationFailed(error: error))
+            }
         }
         isGenerationInProgress = false
     }
+}
+
+private enum IdentifyLanguageError: Error {
+    case failedToIdentifyLanguage(underlyingError: Error)
 }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -82,7 +82,7 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
             shouldShowFeedbackView = true
         } catch {
             if case let IdentifyLanguageError.failedToIdentifyLanguage(underlyingError: underlyingError) = error {
-                DDLogError("⛔️ Error identifing language: \(error)")
+                DDLogError("⛔️ Error identifying language: \(error)")
                 errorMessage = underlyingError.localizedDescription
                 analytics.track(event: .ProductSharingAI.identifyLanguageFailed(error: underlyingError))
             } else {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -78,7 +78,7 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         do {
             messageContent = try await requestMessageFromAI()
             hasGeneratedMessage = true
-            analytics.track(event: .ProductSharingAI.messageGenerated())
+            analytics.track(event: .ProductSharingAI.messageGenerated(identifiedLanguage: languageIdentifiedUsingAI))
             shouldShowFeedbackView = true
         } catch {
             DDLogError("⛔️ Error generating product sharing message: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -78,12 +78,18 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         do {
             messageContent = try await requestMessageFromAI()
             hasGeneratedMessage = true
-            analytics.track(event: .ProductSharingAI.messageGenerated(identifiedLanguage: languageIdentifiedUsingAI))
+            analytics.track(event: .ProductSharingAI.messageGenerated())
             shouldShowFeedbackView = true
         } catch {
-            DDLogError("⛔️ Error generating product sharing message: \(error)")
-            errorMessage = error.localizedDescription
-            analytics.track(event: .ProductSharingAI.messageGenerationFailed(error: error))
+            if case let IdentifyLanguageError.failedToIdentifyLanguage(underlyingError: underlyingError) = error {
+                DDLogError("⛔️ Error identifing language: \(error)")
+                errorMessage = underlyingError.localizedDescription
+                analytics.track(event: .ProductSharingAI.identifyLanguageFailed(error: underlyingError))
+            } else {
+                DDLogError("⛔️ Error generating product sharing message: \(error)")
+                errorMessage = error.localizedDescription
+                analytics.track(event: .ProductSharingAI.messageGenerationFailed(error: error))
+            }
         }
         generationInProgress = false
     }
@@ -140,17 +146,26 @@ private extension ProductSharingMessageGenerationViewModel {
             return languageIdentifiedUsingAI
         }
 
-        let language = try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
-                                                           string: productName + " " + productDescription,
-                                                           feature: .productSharing,
-                                                           completion: { result in
-                continuation.resume(with: result)
-            }))
+        do {
+            let language = try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
+                                                               string: productName + " " + productDescription,
+                                                               feature: .productSharing,
+                                                               completion: { result in
+                    continuation.resume(with: result)
+                }))
+            }
+            analytics.track(event: .ProductSharingAI.identifiedLanguage(language))
+            self.languageIdentifiedUsingAI = language
+            return language
+        } catch {
+            throw IdentifyLanguageError.failedToIdentifyLanguage(underlyingError: error)
         }
-        self.languageIdentifiedUsingAI = language
-        return language
     }
+}
+
+private enum IdentifyLanguageError: Error {
+    case failedToIdentifyLanguage(underlyingError: Error)
 }
 
 extension ProductSharingMessageGenerationViewModel {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
@@ -230,7 +230,7 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
             case let .generateProductDescription(_, _, _, _, completion):
                 completion(.success("Must buy"))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:
                 return XCTFail("Unexpected action: \(action)")
@@ -272,7 +272,7 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
             case let .generateProductDescription(_, _, _, _, completion):
                 completion(.success("Must buy"))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:
                 return XCTFail("Unexpected action: \(action)")
@@ -323,7 +323,7 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
 
 private extension ProductDescriptionGenerationViewModelTests {
     func mock(generatedDescription: Result<String, Error>,
-              identifyLaunguage: Result<String, Error> = .success("English")) {
+              identifyLaunguage: Result<String, Error> = .success("en")) {
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateProductDescription(_, _, _, _, completion):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
@@ -343,11 +343,12 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["product_description_ai_generate_button_tapped",
-                                                          "product_description_ai_identify_language_success",
+                                                          "ai_identify_language_success",
                                                           "product_description_ai_generation_success"])
-        let identifyEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_description_ai_identify_language_success"}))
+        let identifyEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "ai_identify_language_success"}))
         let identifyEventProperties = analyticsProvider.receivedProperties[identifyEventIndex]
         XCTAssertEqual(identifyEventProperties["language"] as? String, expectedLanguage)
+        XCTAssertEqual(identifyEventProperties["source"] as? String, "product_description")
     }
 
     func test_generateDescription_tracks_events_correctly_when_identify_language_fails() throws {
@@ -372,11 +373,12 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["product_description_ai_generate_button_tapped",
-                                                          "product_description_ai_identify_language_failed"])
-        let failureEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "product_description_ai_identify_language_failed"}))
+                                                          "ai_identify_language_failed"])
+        let failureEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "ai_identify_language_failed"}))
         let failureEventProperties = analyticsProvider.receivedProperties[failureEventIndex]
         XCTAssertEqual(failureEventProperties["error_code"] as? String, "500")
         XCTAssertEqual(failureEventProperties["error_domain"] as? String, "Test")
+        XCTAssertEqual(failureEventProperties["source"] as? String, "product_description")
     }
 
     func test_generateDescription_tracks_events_correctly_when_text_generation_fails() throws {
@@ -401,7 +403,7 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["product_description_ai_generate_button_tapped",
-                                                          "product_description_ai_identify_language_success",
+                                                          "ai_identify_language_success",
                                                           "product_description_ai_generation_failed"])
         let failureEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "product_description_ai_generation_failed"}))
         let failureEventProperties = analyticsProvider.receivedProperties[failureEventIndex]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -48,7 +48,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                 XCTAssertTrue(viewModel.generationInProgress)
                 completion(.success("Check this out!"))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -75,7 +75,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -102,7 +102,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -156,7 +156,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success("Test"))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -200,7 +200,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -251,7 +251,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -350,7 +350,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -380,7 +380,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success(expectedString))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
             default:
                 return
             }
@@ -415,7 +415,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success("Must buy"))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:
                 return XCTFail("Unexpected action: \(action)")
@@ -453,7 +453,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success("Must buy"))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("English"))
+                completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:
                 return XCTFail("Unexpected action: \(action)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -144,6 +144,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
     // MARK: - Analytics
     func test_generate_button_tapped_is_tracked_correctly() async throws {
         // Given
+        let expectedLanguage = "en"
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductSharingMessageGenerationViewModel(siteID: 123,
                                                                  url: "https://example.com",
@@ -156,7 +157,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
             case let .generateProductSharingMessage(_, _, _, _, _, completion):
                 completion(.success("Test"))
             case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
+                completion(.success(expectedLanguage))
             default:
                 return
             }
@@ -167,6 +168,11 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["product_sharing_ai_generate_tapped", "product_sharing_ai_message_generated"])
+
+        let generatedEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_sharing_ai_message_generated"}))
+        let generatedEventProperties = analyticsProvider.receivedProperties[generatedEventIndex]
+        XCTAssertEqual(generatedEventProperties["identified_language"] as? String, expectedLanguage)
+
         let firstEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_sharing_ai_generate_tapped"}))
         let firstEventProperties = analyticsProvider.receivedProperties[firstEventIndex]
         XCTAssertEqual(firstEventProperties["is_retry"] as? Bool, false)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -168,12 +168,13 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["product_sharing_ai_generate_tapped",
-                                                          "product_sharing_ai_identify_language_success",
+                                                          "ai_identify_language_success",
                                                           "product_sharing_ai_message_generated"])
 
-        let identifyEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_sharing_ai_identify_language_success"}))
+        let identifyEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "ai_identify_language_success"}))
         let identifyEventProperties = analyticsProvider.receivedProperties[identifyEventIndex]
         XCTAssertEqual(identifyEventProperties["language"] as? String, expectedLanguage)
+        XCTAssertEqual(identifyEventProperties["source"] as? String, "product_sharing")
 
         let firstEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_sharing_ai_generate_tapped"}))
         let firstEventProperties = analyticsProvider.receivedProperties[firstEventIndex]
@@ -185,7 +186,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, [
             "product_sharing_ai_generate_tapped",
-            "product_sharing_ai_identify_language_success",
+            "ai_identify_language_success",
             "product_sharing_ai_message_generated",
             "product_sharing_ai_generate_tapped",
             "product_sharing_ai_message_generated"
@@ -220,7 +221,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["product_sharing_ai_generate_tapped",
-                                                          "product_sharing_ai_identify_language_success",
+                                                          "ai_identify_language_success",
                                                           "product_sharing_ai_message_generation_failed"])
         let failureEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "product_sharing_ai_message_generation_failed"}))
         let failureEventProperties = analyticsProvider.receivedProperties[failureEventIndex]
@@ -253,11 +254,12 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["product_sharing_ai_generate_tapped",
-                                                          "product_sharing_ai_identify_language_failed"])
-        let failureEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "product_sharing_ai_identify_language_failed"}))
+                                                          "ai_identify_language_failed"])
+        let failureEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "ai_identify_language_failed"}))
         let failureEventProperties = analyticsProvider.receivedProperties[failureEventIndex]
         XCTAssertEqual(failureEventProperties["error_code"] as? String, "500")
         XCTAssertEqual(failureEventProperties["error_domain"] as? String, "Test")
+        XCTAssertEqual(failureEventProperties["source"] as? String, "product_sharing")
     }
 
     func test_handleFeedback_tracks_feedback_received() async throws {

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1772,7 +1772,7 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product",
                                                                            features: "Trendy",
-                                                                           language: "English") { result in
+                                                                           language: "en") { result in
                 promise(result)
             })
         }
@@ -1798,7 +1798,7 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product",
                                                                            features: "Trendy",
-                                                                           language: "English") { result in
+                                                                           language: "en") { result in
                 promise(result)
             })
         }
@@ -1823,7 +1823,7 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product name",
                                                                            features: "Trendy, cool, fun",
-                                                                           language: "English") { _ in
+                                                                           language: "en") { _ in
                 promise(())
             })
         }
@@ -1832,7 +1832,7 @@ final class ProductStoreTests: XCTestCase {
         let base = try XCTUnwrap(generativeContentRemote.generateTextBase)
         XCTAssertTrue(base.contains("```A product name```"))
         XCTAssertTrue(base.contains("```Trendy, cool, fun```"))
-        XCTAssertTrue(base.contains("English"))
+        XCTAssertTrue(base.contains("en"))
     }
 
     func test_generateProductDescription_uses_correct_feature() throws {
@@ -1850,7 +1850,7 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product name",
                                                                            features: "Trendy, cool, fun",
-                                                                           language: "English") { _ in
+                                                                           language: "en") { _ in
                 promise(())
             })
         }
@@ -1880,7 +1880,7 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "English"
+                language: "en"
             ) { result in
                 promise(result)
             })
@@ -1909,7 +1909,7 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "English"
+                language: "en"
             ) { result in
                 promise(result)
             })
@@ -1938,7 +1938,7 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "English"
+                language: "en"
             ) { result in
                 promise(result)
             })
@@ -1954,7 +1954,7 @@ final class ProductStoreTests: XCTestCase {
         let expectedURL = "https://example.com"
         let expectedName = "Sample product"
         let expectedDescription = "Sample description"
-        let expectedLangugae = "English"
+        let expectedLangugae = "en"
         let generativeContentRemote = MockGenerativeContentRemote()
         generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
@@ -2002,7 +2002,7 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "English"
+                language: "en"
             ) { result in
                 promise(())
             })
@@ -2017,7 +2017,7 @@ final class ProductStoreTests: XCTestCase {
 
     func test_identifyLanguage_returns_language_on_success() throws {
         // Given
-        let expectedLanguage = "English"
+        let expectedLanguage = "en"
         let generativeContentRemote = MockGenerativeContentRemote()
         generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(expectedLanguage))
         let productStore = ProductStore(dispatcher: dispatcher,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10103 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Identifies the ISO language code instead of name and tracks that upon successful AI generation.

- The prompt is updated to identify the language code instead of the name.
- The language code is tracked when the product description or product sharing message is generated.

## Testing instructions

**Product Description**
- Log in to a published WPCom site.
- Select an existing product or create a new one.
- Select Write with AI in the description row.
- On the description AI sheet, select Write with AI. The response should be in the same language as the product title and features.
- Check Xcode logs and ensure that the following event is tracked with the `language` and `source` properties
```
Tracked ai_identify_language_success, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("language"): "en", AnyHashable("blog_id"): 12345, AnyHashable("source"): "product_description"]
```
- Tap Regenerate and ensure that the generated description is still good.
- Dismiss the sheet. Turn off the internet.
- Select Write with AI in the description row.
- On the description AI sheet, select Write with AI.
- Check Xcode logs and ensure that the following event is tracked with the `language` and `source` properties
```
Tracked ai_identify_language_failed, properties: [AnyHashable("error_description"): "<long error description here>", AnyHashable("source"): "product_description", AnyHashable("error_domain"): "NSURLErrorDomain", AnyHashable("error_code"): "-1009", AnyHashable("blog_id"): 12345, AnyHashable("is_wpcom_store"): true]
```

**Product Sharing message**
- Log in to a published WPCom site.
- Select an existing product or create a new one.
- Tap the `...` button from the top right and tap Share to open the share sheet
- Tap "Write with AI" to generate a "share message".
- Check Xcode logs and ensure that the following event is tracked with the language code as the value for `language` property
```
Tracked ai_identify_language_success, properties: [AnyHashable("language"): "en", AnyHashable("is_wpcom_store"): true, AnyHashable("source"): "product_sharing", AnyHashable("blog_id"): 12345]
```
- The generated share message should be in the same language as the product title and description.
- Tap Regenerate and ensure that the message is still good.
- Dismiss the sheet. Turn off the internet.
- Tap the `...` button from the top right and tap Share to open the share sheet
- Tap "Write with AI" to generate a "share message".
- Check Xcode logs and ensure that the following event is tracked with the `language` and `source` properties
```
Tracked ai_identify_language_failed, properties: [AnyHashable("error_domain"): "NSURLErrorDomain", AnyHashable("error_code"): "-1009", AnyHashable("error_description"): "<Long error description here>", AnyHashable("blog_id"): 12345, AnyHashable("source"): "product_sharing", AnyHashable("is_wpcom_store"): true]
```

## Screenshots
| Product description | Product sharing |
|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-05 at 10 28 26](https://github.com/woocommerce/woocommerce-ios/assets/524475/92c8129a-a6e0-445d-9cf1-0478778b8169) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-05 at 10 28 15](https://github.com/woocommerce/woocommerce-ios/assets/524475/fd538127-befe-42cf-9c88-62fb9fd16da6) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
