### PR TITLE
Add unit tests for `LocalAnnouncementViewModel` actions

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/LocalAnnouncements/LocalAnnouncementViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/LocalAnnouncements/LocalAnnouncementViewModelTests.swift
@@ -21,6 +21,8 @@ final class LocalAnnouncementViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: Analytics
+
     func test_localAnnouncementDisplayed_is_tracked_when_the_view_appears() throws {
         // Given
         let viewModel = LocalAnnouncementViewModel(announcement: .productDescriptionAI, analytics: analytics)
@@ -58,5 +60,41 @@ final class LocalAnnouncementViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents, ["local_announcement_dismissed"])
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
         XCTAssertEqual(eventProperties["announcement"] as? String, "product_description_ai")
+    }
+
+    // MARK: Store actions
+
+    func test_ctaTapped_dispatches_setLocalAnnouncementDismissed_action() throws {
+        // Given
+        let viewModel = LocalAnnouncementViewModel(announcement: .productDescriptionAI, stores: stores, analytics: analytics)
+
+        // When
+        waitFor { promise in
+            self.stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+                guard case .setLocalAnnouncementDismissed(_, _) = action else {
+                    return XCTFail("Unexpected action: \(action)")
+                }
+                // Then
+                promise(())
+            }
+            viewModel.ctaTapped()
+        }
+    }
+
+    func test_dismissTapped_dispatches_setLocalAnnouncementDismissed_action() throws {
+        // Given
+        let viewModel = LocalAnnouncementViewModel(announcement: .productDescriptionAI, stores: stores, analytics: analytics)
+
+        // When
+        waitFor { promise in
+            self.stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+                guard case .setLocalAnnouncementDismissed(_, _) = action else {
+                    return XCTFail("Unexpected action: \(action)")
+                }
+                // Then
+                promise(())
+            }
+            viewModel.dismissTapped()
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10021 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR added unit tests that I didn't have time to work on last week for the code freeze. The tests verified that `LocalAnnouncementViewModel` actions (CTA and dismiss button) dispatch `AppSettingsAction.setLocalAnnouncementDismissed` action.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There are no app layer changes, just CI passing is sufficient.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
