### PR TITLE
Add product from image: barebone flow

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -97,6 +97,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .freeTrialInAppPurchasesUpgradeM2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .addProductFromImage:
+            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -207,4 +207,8 @@ public enum FeatureFlag: Int {
     /// Shows multiple plans in the IAP Upgrade view
     ///
     case freeTrialInAppPurchasesUpgradeM2
+
+    /// A new flow to add product from an image.
+    ///
+    case addProductFromImage
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -46,6 +46,8 @@ final class AddProductCoordinator: Coordinator {
     ///
     var onProductCreated: (Product) -> Void = { _ in }
 
+    private var addProductFromImageCoordinator: AddProductFromImageCoordinator?
+
     init(siteID: Int64,
          source: Source,
          sourceBarButtonItem: UIBarButtonItem,
@@ -90,6 +92,19 @@ final class AddProductCoordinator: Coordinator {
             ServiceLocator.analytics.track(event: .ProductsOnboarding.productListAddProductButtonTapped(templateEligible: isTemplateOptionsEligible()))
         default:
             break
+        }
+
+        // TODO-JC: eligibility check
+        if ServiceLocator.stores.sessionManager.defaultSite?.isWordPressComStore == true {
+            // TODO: 10180 - A/B experiment exposure event
+            let coordinator = AddProductFromImageCoordinator(siteID: siteID,
+                                                             sourceNavigationController: navigationController,
+                                                             onProductCreated: { [weak self] product in
+                self?.onProductCreated(product)
+            })
+            self.addProductFromImageCoordinator = coordinator
+            coordinator.start()
+            return
         }
 
         if shouldSkipBottomSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -87,10 +87,6 @@ final class AddProductCoordinator: Coordinator {
         self.isFirstProduct = isFirstProduct
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     func start() {
         switch source {
         case .productsTab, .productOnboarding:

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -29,10 +29,6 @@ final class AddProductFromImageCoordinator: Coordinator {
         self.onProductCreated = onProductCreated
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     func start() {
         let addProductFromImage = AddProductFromImageHostingController(siteID: siteID,
                                                                        completion: { [weak self] data in

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -1,0 +1,91 @@
+import Photos
+import UIKit
+import Yosemite
+import WooFoundation
+
+/// Controls navigation for the flow to add a product from an image.
+final class AddProductFromImageCoordinator: Coordinator {
+    let navigationController: UINavigationController
+
+    /// Navigation controller for the product creation form.
+    private var formNavigationController: UINavigationController?
+
+    private let siteID: Int64
+    private let productImageUploader: ProductImageUploaderProtocol
+    private let productImageLoader: ProductUIImageLoader
+
+    /// Invoked when a new product is saved remotely.
+    private let onProductCreated: (Product) -> Void
+
+    init(siteID: Int64,
+         sourceNavigationController: UINavigationController,
+         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+         productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
+         onProductCreated: @escaping (Product) -> Void) {
+        self.siteID = siteID
+        self.navigationController = sourceNavigationController
+        self.productImageUploader = productImageUploader
+        self.productImageLoader = productImageLoader
+        self.onProductCreated = onProductCreated
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func start() {
+        let addProductFromImage = AddProductFromImageHostingController(siteID: siteID,
+                                                                       completion: { [weak self] data in
+            self?.navigationController.dismiss(animated: true) { [weak self] in
+                guard let self else { return }
+                guard let product = self.createProduct(name: data.name, description: data.description) else {
+                    return
+                }
+                self.showProduct(product)
+            }
+        })
+        let formNavigationController = UINavigationController(rootViewController: addProductFromImage)
+        self.formNavigationController = formNavigationController
+        navigationController.present(formNavigationController, animated: true)
+    }
+}
+
+private extension AddProductFromImageCoordinator {
+    func createProduct(name: String, description: String?) -> Product? {
+        guard let product = ProductFactory().createNewProduct(type: .simple,
+                                                              isVirtual: false,
+                                                              siteID: siteID)?
+            .copy(name: name,
+                  fullDescription: description) else {
+            return nil
+        }
+        return product
+    }
+
+    /// Shows a product in the current navigation stack.
+    func showProduct(_ product: Product) {
+        let model = EditableProductModel(product: product)
+        let currencyCode = ServiceLocator.currencySettings.currencyCode
+        let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
+        let productImageActionHandler = productImageUploader
+            .actionHandler(key: .init(siteID: product.siteID,
+                                      productOrVariationID: .product(id: model.productID),
+                                      isLocalID: true),
+                           originalStatuses: [])
+        let viewModel = ProductFormViewModel(product: model,
+                                             formType: .add,
+                                             productImageActionHandler: productImageActionHandler)
+        viewModel.onProductCreated = { [weak self] product in
+            guard let self else { return }
+            self.onProductCreated(product)
+        }
+        let viewController = ProductFormViewController(viewModel: viewModel,
+                                                       eventLogger: ProductFormEventLogger(),
+                                                       productImageActionHandler: productImageActionHandler,
+                                                       currency: currency,
+                                                       presentationStyle: .navigationStack)
+        // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
+        viewController.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Yosemite
+
+/// Protocol for checking "add product from image" eligibility for easier unit testing.
+protocol AddProductFromImageEligibilityCheckerProtocol {
+    /// Checks if the user is eligible to participate in the A/B experiment.
+    func isEligibleToParticipateInABTest() -> Bool
+
+    /// Checks if the user is eligible for the "add product from image" feature.
+    func isEligible() -> Bool
+}
+
+/// Checks the eligibility for the "add product from image" feature.
+final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol {
+    private let stores: StoresManager
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+    }
+
+    func isEligibleToParticipateInABTest() -> Bool {
+        stores.sessionManager.defaultSite?.isWordPressComStore == true
+    }
+
+    func isEligible() -> Bool {
+        // TODO: 10180 - A/B experiment check
+        true
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import protocol Experiments.FeatureFlagService
 
 /// Protocol for checking "add product from image" eligibility for easier unit testing.
 protocol AddProductFromImageEligibilityCheckerProtocol {
@@ -13,9 +14,12 @@ protocol AddProductFromImageEligibilityCheckerProtocol {
 /// Checks the eligibility for the "add product from image" feature.
 final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol {
     private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
 
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.stores = stores
+        self.featureFlagService = featureFlagService
     }
 
     func isEligibleToParticipateInABTest() -> Bool {
@@ -23,7 +27,11 @@ final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilit
     }
 
     func isEligible() -> Bool {
+        guard isEligibleToParticipateInABTest() else {
+            return false
+        }
+
         // TODO: 10180 - A/B experiment check
-        true
+        return featureFlagService.isFeatureFlagEnabled(.addProductFromImage)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -46,7 +46,7 @@ struct AddProductFromImageView: View {
         }
         .navigationTitle(Localization.title)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .confirmationAction) {
                 Button(Localization.continueButtonTitle) {
                     // TODO: 10180 - pass the image from media picker
                     completion(.init(name: viewModel.name, description: viewModel.description))

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import Yosemite
+
+/// Product data from the "add product from image" form.
+struct AddProductFromImageData {
+    let name: String
+    let description: String
+    // TODO: 10180 - image from media picker
+}
+
+/// Hosting controller for `AddProductFromImageView`.
+final class AddProductFromImageHostingController: UIHostingController<AddProductFromImageView> {
+    init(siteID: Int64,
+         completion: @escaping (AddProductFromImageData) -> Void) {
+        super.init(rootView: AddProductFromImageView(siteID: siteID, completion: completion))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// A form to create a product from an image, where any texts in the image can be scanned to generate product details with Jetpack AI.
+struct AddProductFromImageView: View {
+    private let completion: (AddProductFromImageData) -> Void
+    @StateObject private var viewModel: AddProductFromImageViewModel
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         completion: @escaping (AddProductFromImageData) -> Void) {
+        self.completion = completion
+        self._viewModel = .init(wrappedValue: AddProductFromImageViewModel(siteID: siteID, stores: stores))
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                // TODO: 10180 - use `TextEditor` with a placeholder overlay
+                TextField(Localization.nameFieldPlaceholder, text: $viewModel.name)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                TextField(Localization.descriptionFieldPlaceholder, text: $viewModel.description)
+                    .lineLimit(5)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .navigationTitle(Localization.title)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(Localization.continueButtonTitle) {
+                    // TODO: 10180 - pass the image from media picker
+                    completion(.init(name: viewModel.name, description: viewModel.description))
+                }
+                .buttonStyle(LinkButtonStyle())
+            }
+        }
+    }
+}
+
+private extension AddProductFromImageView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Add product",
+            comment: "Navigation bar title of the add product from image form."
+        )
+        static let nameFieldPlaceholder = NSLocalizedString(
+            "Name",
+            comment: "Product name placeholder on the add product from image form."
+        )
+        static let descriptionFieldPlaceholder = NSLocalizedString(
+            "Description",
+            comment: "Product description placeholder on the add product from image form."
+        )
+        static let continueButtonTitle = NSLocalizedString(
+            "Continue",
+            comment: "Continue button on the add product from image form."
+        )
+    }
+}
+
+struct AddProductFromImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddProductFromImageView(siteID: 134, completion: { _ in })
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -29,7 +29,7 @@ struct AddProductFromImageView: View {
          stores: StoresManager = ServiceLocator.stores,
          completion: @escaping (AddProductFromImageData) -> Void) {
         self.completion = completion
-        self._viewModel = .init(wrappedValue: AddProductFromImageViewModel(siteID: siteID, stores: stores))
+        self._viewModel = .init(wrappedValue: AddProductFromImageViewModel())
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import Yosemite
+
+/// View model for `AddProductFromImageView` to handle user actions from the view and provide data for the view.
+@MainActor
+final class AddProductFromImageViewModel: ObservableObject {
+    // MARK: - Product Details
+
+    @Published var name: String = ""
+    @Published var description: String = ""
+
+    private let siteID: Int64
+    private let stores: StoresManager
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Yosemite
 
 /// View model for `AddProductFromImageView` to handle user actions from the view and provide data for the view.
 @MainActor
@@ -8,13 +7,4 @@ final class AddProductFromImageViewModel: ObservableObject {
 
     @Published var name: String = ""
     @Published var description: String = ""
-
-    private let siteID: Int64
-    private let stores: StoresManager
-
-    init(siteID: Int64,
-         stores: StoresManager = ServiceLocator.stores) {
-        self.siteID = siteID
-        self.stores = stores
-    }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -344,6 +344,9 @@
 		028A4659295BCFFC001CF6CE /* StoreCreationSellingStatusQuestionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028A4658295BCFFC001CF6CE /* StoreCreationSellingStatusQuestionContainerView.swift */; };
 		028AFFB32484ED2800693C09 /* Dictionary+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028AFFB22484ED2800693C09 /* Dictionary+Logging.swift */; };
 		028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028AFFB52484EDA000693C09 /* Dictionary+LoggingTests.swift */; };
+		028B68B82A573FF400FE03A8 /* AddProductFromImageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68B72A573FF400FE03A8 /* AddProductFromImageCoordinator.swift */; };
+		028B68BA2A57410500FE03A8 /* AddProductFromImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */; };
+		028B68BC2A57419700FE03A8 /* AddProductFromImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
 		028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */; };
@@ -2707,6 +2710,9 @@
 		028A4658295BCFFC001CF6CE /* StoreCreationSellingStatusQuestionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationSellingStatusQuestionContainerView.swift; sourceTree = "<group>"; };
 		028AFFB22484ED2800693C09 /* Dictionary+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Logging.swift"; sourceTree = "<group>"; };
 		028AFFB52484EDA000693C09 /* Dictionary+LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+LoggingTests.swift"; sourceTree = "<group>"; };
+		028B68B72A573FF400FE03A8 /* AddProductFromImageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageCoordinator.swift; sourceTree = "<group>"; };
+		028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageView.swift; sourceTree = "<group>"; };
+		028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModel.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
 		028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
@@ -5617,6 +5623,16 @@
 			path = Logging;
 			sourceTree = "<group>";
 		};
+		028B68B62A573F9500FE03A8 /* AddProductFromImage */ = {
+			isa = PBXGroup;
+			children = (
+				028B68B72A573FF400FE03A8 /* AddProductFromImageCoordinator.swift */,
+				028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */,
+				028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */,
+			);
+			path = AddProductFromImage;
+			sourceTree = "<group>";
+		};
 		028BAC4322F3AE3B008BB4AF /* Stats v4 */ = {
 			isa = PBXGroup;
 			children = (
@@ -5986,6 +6002,7 @@
 		02ECD1E224FF5DDD00735BE5 /* Add Product */ = {
 			isa = PBXGroup;
 			children = (
+				028B68B62A573F9500FE03A8 /* AddProductFromImage */,
 				EEBDF7E32A317BBB00EFEF47 /* FirstProductCreated */,
 				02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */,
 				02ECD1E524FFB4E900735BE5 /* ProductFactory.swift */,
@@ -11996,6 +12013,7 @@
 				03E471C4293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift in Sources */,
 				D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */,
 				B5F8B7E02194759100DAB7E2 /* ReviewDetailsViewController.swift in Sources */,
+				028B68BA2A57410500FE03A8 /* AddProductFromImageView.swift in Sources */,
 				262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */,
 				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
 				D8EE9692264D328A0033B2F9 /* ReceiptViewController.swift in Sources */,
@@ -12362,6 +12380,7 @@
 				45455EFA26580B5D00BBB0C4 /* ShippingLabelCarrierRowViewModel.swift in Sources */,
 				025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */,
 				451B1740258B7EFB00836277 /* AddAttributeOptionsViewController.swift in Sources */,
+				028B68B82A573FF400FE03A8 /* AddProductFromImageCoordinator.swift in Sources */,
 				AE6C4FDF28A15BFE00EAC00D /* FeatureAnnouncementCardCell.swift in Sources */,
 				02562AD0296D1FD100980404 /* View+DividerStyle.swift in Sources */,
 				CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */,
@@ -12640,6 +12659,7 @@
 				CE13681729FBD94300EBF43C /* QuantityRulesViewModel.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */,
+				028B68BC2A57419700FE03A8 /* AddProductFromImageViewModel.swift in Sources */,
 				0388E1A829E04687007DF84D /* DeepLinkForwarder.swift in Sources */,
 				B6A10E9C292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 		028B68BA2A57410500FE03A8 /* AddProductFromImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */; };
 		028B68BC2A57419700FE03A8 /* AddProductFromImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */; };
 		028B68BE2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */; };
+		028B68C02A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
 		028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */; };
@@ -2715,6 +2716,7 @@
 		028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageView.swift; sourceTree = "<group>"; };
 		028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModel.swift; sourceTree = "<group>"; };
 		028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageEligibilityChecker.swift; sourceTree = "<group>"; };
+		028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAddProductFromImageEligibilityChecker.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
 		028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
@@ -7670,6 +7672,7 @@
 				B9DC770629F2D4910013B191 /* MockProductSelectorTopProductsProvider.swift */,
 				026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */,
 				02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */,
+				028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -12980,6 +12983,7 @@
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
 				7E6A01A12725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift in Sources */,
 				02BF9BAF2851E7EA008CE2DD /* MockAppleIDCredentialChecker.swift in Sources */,
+				028B68C02A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift in Sources */,
 				E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */,
 				CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */,
 				EEB221A729B9B5B300662A12 /* CouponLineDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 		028B68BC2A57419700FE03A8 /* AddProductFromImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */; };
 		028B68BE2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */; };
 		028B68C02A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */; };
+		028B68C32A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
 		028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */; };
@@ -2717,6 +2718,7 @@
 		028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModel.swift; sourceTree = "<group>"; };
 		028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageEligibilityChecker.swift; sourceTree = "<group>"; };
 		028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAddProductFromImageEligibilityChecker.swift; sourceTree = "<group>"; };
+		028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModelTests.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
 		028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
@@ -5287,6 +5289,7 @@
 		024F1450250B658F0003030A /* Add Product */ = {
 			isa = PBXGroup;
 			children = (
+				028B68C12A574DA100FE03A8 /* AddProductFromImage */,
 				024F1451250B65A40003030A /* AddProductCoordinatorTests.swift */,
 				02C3FDE9251091CE009569EE /* ProductFactoryTests.swift */,
 				EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */,
@@ -5634,6 +5637,14 @@
 				028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */,
 				028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */,
 				028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */,
+			);
+			path = AddProductFromImage;
+			sourceTree = "<group>";
+		};
+		028B68C12A574DA100FE03A8 /* AddProductFromImage */ = {
+			isa = PBXGroup;
+			children = (
+				028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -13074,6 +13085,7 @@
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,
 				0277AEA5256CAA4200F45C4A /* MockShippingLabel.swift in Sources */,
 				02BAB02324D0250300F8B06E /* ProductVariation+ProductFormTests.swift in Sources */,
+				028B68C32A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift in Sources */,
 				B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */,
 				AE4CCCEB29365CFD00B47EE8 /* AnalyticsHubViewModelTests.swift in Sources */,
 				025C00CC2551524300FAC222 /* BarcodeScannerFrameScalerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 		028B68BE2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */; };
 		028B68C02A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */; };
 		028B68C32A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */; };
+		028B68C52A57566300FE03A8 /* AddProductFromImageEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68C42A57566300FE03A8 /* AddProductFromImageEligibilityCheckerTests.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
 		028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */; };
@@ -2719,6 +2720,7 @@
 		028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageEligibilityChecker.swift; sourceTree = "<group>"; };
 		028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAddProductFromImageEligibilityChecker.swift; sourceTree = "<group>"; };
 		028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModelTests.swift; sourceTree = "<group>"; };
+		028B68C42A57566300FE03A8 /* AddProductFromImageEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
 		028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
@@ -5645,6 +5647,7 @@
 			isa = PBXGroup;
 			children = (
 				028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */,
+				028B68C42A57566300FE03A8 /* AddProductFromImageEligibilityCheckerTests.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -12865,6 +12868,7 @@
 				EEB221A529B97F8400662A12 /* CouponInputTransformerTests.swift in Sources */,
 				45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */,
 				CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */,
+				028B68C52A57566300FE03A8 /* AddProductFromImageEligibilityCheckerTests.swift in Sources */,
 				DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */,
 				455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */,
 				0215C6FC2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -347,6 +347,7 @@
 		028B68B82A573FF400FE03A8 /* AddProductFromImageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68B72A573FF400FE03A8 /* AddProductFromImageCoordinator.swift */; };
 		028B68BA2A57410500FE03A8 /* AddProductFromImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */; };
 		028B68BC2A57419700FE03A8 /* AddProductFromImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */; };
+		028B68BE2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
 		028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */; };
@@ -2713,6 +2714,7 @@
 		028B68B72A573FF400FE03A8 /* AddProductFromImageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageCoordinator.swift; sourceTree = "<group>"; };
 		028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageView.swift; sourceTree = "<group>"; };
 		028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModel.swift; sourceTree = "<group>"; };
+		028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageEligibilityChecker.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
 		028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
@@ -5629,6 +5631,7 @@
 				028B68B72A573FF400FE03A8 /* AddProductFromImageCoordinator.swift */,
 				028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */,
 				028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */,
+				028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -12564,6 +12567,7 @@
 				77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */,
 				3F50FE4328CAEBA800C89201 /* AppLocalizedString.swift in Sources */,
 				0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */,
+				028B68BE2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockAddProductFromImageEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAddProductFromImageEligibilityChecker.swift
@@ -1,0 +1,21 @@
+@testable import WooCommerce
+import Foundation
+
+/// Mock version of `AddProductFromImageEligibilityChecker` for easier unit testing.
+final class MockAddProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol {
+    private let eligibleToParticipateInABTest: Bool
+    private let eligible: Bool
+
+    init(isEligibleToParticipateInABTest: Bool = false, isEligible: Bool = false) {
+        self.eligibleToParticipateInABTest = isEligibleToParticipateInABTest
+        self.eligible = isEligible
+    }
+
+    func isEligibleToParticipateInABTest() -> Bool {
+        eligibleToParticipateInABTest
+    }
+
+    func isEligible() -> Bool {
+        eligible
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -27,6 +27,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShareProductAIEnabled: Bool
     private let isJustInTimeMessagesOnDashboardEnabled: Bool
     private let isFreeTrialInAppPurchasesUpgradeM2: Bool
+    private let isAddProductFromImageEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -52,7 +53,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
          isJustInTimeMessagesOnDashboardEnabled: Bool = false,
-         isFreeTrialInAppPurchasesUpgradeM2: Bool = false) {
+         isFreeTrialInAppPurchasesUpgradeM2: Bool = false,
+         isAddProductFromImageEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -78,6 +80,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isBlazeEnabled = isBlazeEnabled
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.isJustInTimeMessagesOnDashboardEnabled = isJustInTimeMessagesOnDashboardEnabled
+        self.isAddProductFromImageEnabled = isAddProductFromImageEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -130,6 +133,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isJustInTimeMessagesOnDashboardEnabled
         case .freeTrialInAppPurchasesUpgradeM2:
             return isFreeTrialInAppPurchasesUpgradeM2
+        case .addProductFromImage:
+            return isAddProductFromImageEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
@@ -36,15 +36,34 @@ final class AddProductCoordinatorTests: XCTestCase {
         // Assert
         assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
     }
+
+    func test_it_presents_AddProductFromImageHostingController_on_start_when_eligible() throws {
+        // Given
+        let coordinator = makeAddProductCoordinator(
+            addProductFromImageEligibilityChecker: MockAddProductFromImageEligibilityChecker(isEligibleToParticipateInABTest: true, isEligible: true)
+        )
+
+        // When
+        coordinator.start()
+        waitUntil {
+            coordinator.navigationController.presentedViewController != nil
+        }
+
+        // Then
+        let navigationController = try XCTUnwrap(coordinator.navigationController.presentedViewController as? UINavigationController)
+        assertThat(navigationController.topViewController, isAnInstanceOf: AddProductFromImageHostingController.self)
+    }
 }
 
 private extension AddProductCoordinatorTests {
-    func makeAddProductCoordinator() -> AddProductCoordinator {
+    func makeAddProductCoordinator(addProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol =
+                                   MockAddProductFromImageEligibilityChecker()) -> AddProductCoordinator {
         let view = UIView()
         return AddProductCoordinator(siteID: 100,
                                      source: .productsTab,
                                      sourceView: view,
                                      sourceNavigationController: navigationController,
+                                     addProductFromImageEligibilityChecker: addProductFromImageEligibilityChecker,
                                      isFirstProduct: false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityCheckerTests.swift
@@ -1,0 +1,92 @@
+import TestKit
+import XCTest
+
+@testable import WooCommerce
+
+final class AddProductFromImageEligibilityCheckerTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
+
+    // MARK: - `isEligibleToParticipateInABTest`
+
+    func test_isEligibleToParticipateInABTest_is_true_for_wpcom_store() throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: true)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores)
+
+        // When
+        let isEligibleToParticipateInABTest = checker.isEligibleToParticipateInABTest()
+
+        // Then
+        XCTAssertTrue(isEligibleToParticipateInABTest)
+    }
+
+    func test_isEligibleToParticipateInABTest_is_false_for_non_wpcom_store() throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: false)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores)
+
+        // When
+        let isEligibleToParticipateInABTest = checker.isEligibleToParticipateInABTest()
+
+        // Then
+        XCTAssertFalse(isEligibleToParticipateInABTest)
+    }
+
+    // MARK: - `isEligible`
+
+    func test_isEligible_is_true_for_wpcom_store() throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: true)
+        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+
+        // When
+        let isEligible = checker.isEligible()
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_isEligible_is_false_for_non_wpcom_store() throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: false)
+        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+
+        // When
+        let isEligible = checker.isEligible()
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligible_is_false_for_wpcom_store_when_feature_flag_is_disabled() throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: true)
+        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: false)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+
+        // When
+        let isEligible = checker.isEligible()
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+}
+
+private extension AddProductFromImageEligibilityCheckerTests {
+    func updateDefaultStore(isWPCOMStore: Bool) {
+        stores.updateDefaultStore(storeID: 134)
+        stores.updateDefaultStore(.fake().copy(siteID: 134, isWordPressComStore: isWPCOMStore))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -1,0 +1,24 @@
+import TestKit
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+@MainActor
+final class AddProductFromImageViewModelTests: XCTestCase {
+    func test_initial_name_is_empty() throws {
+        // Given
+        let viewModel = AddProductFromImageViewModel()
+
+        // Then
+        XCTAssertEqual(viewModel.name, "")
+    }
+
+    func test_initial_description_is_empty() throws {
+        // Given
+        let viewModel = AddProductFromImageViewModel()
+
+        // Then
+        XCTAssertEqual(viewModel.description, "")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -1,6 +1,5 @@
 import TestKit
 import XCTest
-import Yosemite
 
 @testable import WooCommerce
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're running an A/B experiment for a new starting screen for the product creation flow. This new screen just contains 3 fields: image, name, and description. When selecting a packaging image, the texts can be scanned and used to generate product details (name and description for now). The latest POC looks like pe5sF9-1Es-p2#comment-2427.

This PR includes a barebone screen for this "add product from image form" flow with just name and description text fields.

## How

- Before the A/B experiment is ready for release, we're using a local feature flag `addProductFromImage` to only show this in debug builds
- The new screen is `AddProductFromImageView` with a barebone view model `AddProductFromImageViewModel`
- A new coordinator `AddProductFromImageCoordinator` was created to show the new screen, and then show the fully-featured product form with the name/description values from the new screen. Please note that the `showProduct` function might look the same as `AddProductCoordinator`, but will have some modifications to pass the image
- In the existing `AddProductCoordinator`, it calls a new `AddProductFromImageEligibilityChecker`'s functions to determine whether to show the new screen with `AddProductFromImageCoordinator`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### WPCOM store

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product --> a new screen as in the screenshot should be presented
- Enter some value to the name and description fields
- Tap `Continue` --> the new screen should be dismissed and then it navigates to the pre-existing product form
- Tap `Publish` to publish the product --> the product should be saved remotely

### Self-hosted store

- Log in to a self-hosted store
- Go to the Products tab
- Tap + to add a product --> the flow should be the same as before

---
- [x] @jaclync tests that when the feature flag is off, adding a product is the production flow

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


WPCOM store | self-hosted store
-- | --
![Simulator Screenshot - iPhone 14 Pro - 2023-07-06 at 16 31 39](https://github.com/woocommerce/woocommerce-ios/assets/1945542/3a1bf898-db71-4bda-af2c-59f8b4f71ea5) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-06 at 16 33 53](https://github.com/woocommerce/woocommerce-ios/assets/1945542/1809f478-8b98-484a-9c68-ca050479fb1c)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.