### PR TITLE
[IAP] Update event when tracking plan details

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2437,7 +2437,6 @@ extension WooAnalyticsEvent {
             case productID = "product_id"
             case source
             case step
-            case featureGroup = "feature_group"
             case error
         }
 
@@ -2466,11 +2465,6 @@ extension WooAnalyticsEvent {
         static func planUpgradeScreenDismissed(step: Step) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .planUpgradeScreenDismissed,
                               properties: [Keys.step.rawValue: step.rawValue])
-        }
-
-        static func planUpgradeFeatureScreenLoaded(featureGroup: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .planUpgradeFeatureScreenLoaded,
-                              properties: [Keys.featureGroup.rawValue: featureGroup])
         }
 
         static func planUpgradePrePurchaseFailed(error: Error) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -946,6 +946,7 @@ public enum WooAnalyticsStat: String {
     case planUpgradeScreenLoaded = "plan_upgrade_screen_loaded"
     case planUpgradeScreenDismissed = "plan_upgrade_screen_dismissed"
     case planUpgradeFeatureScreenLoaded = "plan_upgrade_feature_screen_loaded"
+    case planUpgradeDetailsScreenLoaded = "plan_upgrade_details_screen_loaded"
     case planUpgradeProcessingScreenLoaded = "plan_upgrade_processing_screen_loaded"
     case planUpgradeCompletedScreenLoaded = "plan_upgrade_completed_screen_loaded"
     case planUpgradePurchaseFailed = "plan_upgrade_purchase_failed"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -945,7 +945,6 @@ public enum WooAnalyticsStat: String {
     case planUpgradePurchaseButtonTapped = "plan_upgrade_purchase_button_tapped"
     case planUpgradeScreenLoaded = "plan_upgrade_screen_loaded"
     case planUpgradeScreenDismissed = "plan_upgrade_screen_dismissed"
-    case planUpgradeFeatureScreenLoaded = "plan_upgrade_feature_screen_loaded"
     case planUpgradeDetailsScreenLoaded = "plan_upgrade_details_screen_loaded"
     case planUpgradeProcessingScreenLoaded = "plan_upgrade_processing_screen_loaded"
     case planUpgradeCompletedScreenLoaded = "plan_upgrade_completed_screen_loaded"

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanFeatureBenefitsView.swift
@@ -38,8 +38,7 @@ struct WooPlanFeatureBenefitsView: View {
         .navigationTitle(wooPlanFeatureGroup.title)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            ServiceLocator.analytics.track(event:
-                    .InAppPurchases.planUpgradeFeatureScreenLoaded(featureGroup: wooPlanFeatureGroup.title))
+            ServiceLocator.analytics.track(.planUpgradeDetailsScreenLoaded)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10178 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR deletes the current `*_plan_upgrade_feature_screen_loaded` event along its `feature_group` property, and adds a more generic `plan_upgrade_details_screen_loaded` instead.

## Why?

We're currently passing the locate to the `feature_group` property, which increases the dataset unnecessarily since these will be passed to tracks in the user language. This is very prone to change as well since any translation could be updated at any time. 

While we could pass some sort of internal identifier, the current designs for M2 will not work with this sort of per-feature event granularity, so we lose the `feature_group` event anyway, so we'll be changing the event to make it simpler.

## Testing instructions
- Switch the `freeTrialInAppPurchasesUpgradeM2` flag to false, since we haven't implemented yet the details screen in M2.
- On a Woo Hosted Free Trial store, eligible for IAP, tap on "Upgrade Now" > Scroll a bit down to the different plan features > Tap in any of these.

<img width="414" alt="Screenshot 2023-07-09 at 19 23 51" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/58e675b3-c3b2-4d8f-b734-014cea6af52f">


- See the event `plan_upgrade_details_screen_loaded` being logged in the console:

```
2023-07-07 11:12:24.604520+0800 WooCommerce[84940:3475121] 🔵 Tracked plan_upgrade_details_screen_loaded, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 220865014]
```
