### PR TITLE
Add product from image: media picker in SwiftUI

### DIFF
--- a/WooCommerce/Classes/Extensions/UIViewController+Navigation.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Navigation.swift
@@ -8,4 +8,15 @@ extension UIViewController {
     var isBeingDismissedInAnyWay: Bool {
         isMovingFromParent || isBeingDismissed || navigationController?.isBeingDismissed == true
     }
+
+    /// Async/await version of the UIKit `dismiss(animated:)`.
+    /// - Parameter animated: Whether the dismissal is animated.
+    @MainActor
+    func dismiss(animated: Bool) async {
+        await withCheckedContinuation { continuation in
+            dismiss(animated: animated) {
+                continuation.resume()
+            }
+        }
+    }
 }

--- a/WooCommerce/Classes/View Modifiers/View+MediaSourceActionSheet.swift
+++ b/WooCommerce/Classes/View Modifiers/View+MediaSourceActionSheet.swift
@@ -63,7 +63,7 @@ extension View {
     func mediaSourceActionSheet(showsActionSheet: Binding<Bool>,
                                 selectMedia: @escaping (MediaPickingSource) -> Void) -> some View {
         self.modifier(MediaSourceActionSheet(showsActionSheet: showsActionSheet,
-                                                   selectMedia: selectMedia))
+                                             selectMedia: selectMedia))
     }
 }
 

--- a/WooCommerce/Classes/View Modifiers/View+MediaSourceActionSheet.swift
+++ b/WooCommerce/Classes/View Modifiers/View+MediaSourceActionSheet.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Shows an action sheet to pick a media source from the content view.
+struct MediaSourceActionSheet: ViewModifier {
+    private let showsActionSheet: Binding<Bool>
+    private let selectMedia: (MediaPickingSource) -> Void
+
+    init(showsActionSheet: Binding<Bool>,
+         selectMedia: @escaping (MediaPickingSource) -> Void) {
+        self.showsActionSheet = showsActionSheet
+        self.selectMedia = selectMedia
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .actionSheet(isPresented: showsActionSheet) {
+                ActionSheet(title: Text(Localization.title),
+                            message: nil,
+                            buttons: [
+                                (UIImagePickerController.isSourceTypeAvailable(.camera) ?
+                                    .default(Text(Localization.camera)) {
+                                        selectMedia(.camera)
+                                    } : nil),
+                                .default(Text(Localization.photoLibrary)) {
+                                    selectMedia(.photoLibrary)
+                                },
+                                .default(Text(Localization.siteMediaLibrary)) {
+                                    selectMedia(.siteMediaLibrary)
+                                },
+                                .cancel()
+                            ].compactMap { $0 })
+            }
+    }
+}
+
+private extension MediaSourceActionSheet {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Select Media Source",
+            comment: "Title of the media picker action sheet to select a source."
+        )
+        static let camera = NSLocalizedString(
+            "Take a photo",
+            comment: "Menu option for taking an image or video with the device's camera."
+        )
+        static let photoLibrary = NSLocalizedString(
+            "Choose from device",
+            comment: "Menu option for selecting media from the device's photo library."
+        )
+        static let siteMediaLibrary = NSLocalizedString(
+            "WordPress Media Library",
+            comment: "Menu option for selecting media from the device's photo library."
+        )
+    }
+}
+
+extension View {
+    /// Shows an action sheet to pick a media source from the content view.
+    /// - Parameters:
+    ///   - showsActionSheet: Whether the action sheet is shown.
+    ///   - selectMedia: Invoked when the user selects a media source.
+    /// - Returns: The view of the action sheet.
+    func mediaSourceActionSheet(showsActionSheet: Binding<Bool>,
+                                selectMedia: @escaping (MediaPickingSource) -> Void) -> some View {
+        self.modifier(MediaSourceActionSheet(showsActionSheet: showsActionSheet,
+                                                   selectMedia: selectMedia))
+    }
+}
+
+struct MediaPickerSourceActionSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            Text("Content")
+                .mediaSourceActionSheet(showsActionSheet: .constant(true),
+                                        selectMedia: { _ in })
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -10,6 +10,8 @@ final class AddProductFromImageCoordinator: Coordinator {
     /// Navigation controller for the product creation form.
     private var formNavigationController: UINavigationController?
 
+    private var mediaPickingCoordinator: MediaPickingCoordinator?
+
     private let siteID: Int64
     private let productImageUploader: ProductImageUploaderProtocol
     private let productImageLoader: ProductUIImageLoader
@@ -31,13 +33,15 @@ final class AddProductFromImageCoordinator: Coordinator {
 
     func start() {
         let addProductFromImage = AddProductFromImageHostingController(siteID: siteID,
-                                                                       completion: { [weak self] data in
+                                                                       addImage: { [weak self] source in
+            await self?.showImagePicker(source: source)
+        }, completion: { [weak self] data in
             self?.navigationController.dismiss(animated: true) { [weak self] in
                 guard let self else { return }
                 guard let product = self.createProduct(name: data.name, description: data.description) else {
                     return
                 }
-                self.showProduct(product)
+                self.showProduct(product, image: data.image)
             }
         })
         let formNavigationController = UINavigationController(rootViewController: addProductFromImage)
@@ -59,7 +63,7 @@ private extension AddProductFromImageCoordinator {
     }
 
     /// Shows a product in the current navigation stack.
-    func showProduct(_ product: Product) {
+    func showProduct(_ product: Product, image: MediaPickerImage?) {
         let model = EditableProductModel(product: product)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
@@ -68,6 +72,14 @@ private extension AddProductFromImageCoordinator {
                                       productOrVariationID: .product(id: model.productID),
                                       isLocalID: true),
                            originalStatuses: [])
+        if let image {
+            switch image.source {
+                case let .asset(asset):
+                    productImageActionHandler.uploadMediaAssetToSiteMediaLibrary(asset: asset)
+                case let .media(media):
+                    productImageActionHandler.addSiteMediaLibraryImagesToProduct(mediaItems: [media])
+            }
+        }
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler)
@@ -83,5 +95,118 @@ private extension AddProductFromImageCoordinator {
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(viewController, animated: true)
+    }
+}
+
+// MARK: - Action handling for camera capture
+//
+private extension AddProductFromImageCoordinator {
+    @MainActor
+    func showImagePicker(source: MediaPickingSource) async -> MediaPickerImage? {
+        guard let formNavigationController else {
+            return nil
+        }
+        return await withCheckedContinuation { continuation in
+            let mediaPickingCoordinator = MediaPickingCoordinator(siteID: siteID,
+                                                                  allowsMultipleImages: false,
+                                                                  onCameraCaptureCompletion: { [weak self] asset, error in
+                guard let self else {
+                    return continuation.resume(returning: nil)
+                }
+                Task { @MainActor in
+                    let image = await self.onCameraCaptureCompletion(asset: asset, error: error)
+                    continuation.resume(returning: image)
+                }
+            }, onDeviceMediaLibraryPickerCompletion: { [weak self] assets in
+                guard let self else {
+                    return continuation.resume(returning: nil)
+                }
+                Task { @MainActor in
+                    let image = await self.onDeviceMediaLibraryPickerCompletion(assets: assets, navigationController: formNavigationController)
+                    continuation.resume(returning: image)
+                }
+            }, onWPMediaPickerCompletion: { [weak self] mediaItems in
+                guard let self else {
+                    return continuation.resume(returning: nil)
+                }
+                Task { @MainActor in
+                    let image = await self.onWPMediaPickerCompletion(mediaItems: mediaItems, navigationController: formNavigationController)
+                    continuation.resume(returning: image)
+                }
+            })
+            self.mediaPickingCoordinator = mediaPickingCoordinator
+            mediaPickingCoordinator.showMediaPicker(source: source, from: formNavigationController)
+        }
+    }
+}
+
+// MARK: - Action handling for camera capture
+//
+private extension AddProductFromImageCoordinator {
+    @MainActor
+    func onCameraCaptureCompletion(asset: PHAsset?, error: Error?) async -> MediaPickerImage? {
+        guard let asset else {
+            return nil
+        }
+        return await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                continuation.resume(returning: await requestImage(from: asset))
+            }
+        }
+    }
+}
+
+// MARK: Action handling for device media library picker
+//
+private extension AddProductFromImageCoordinator {
+    @MainActor
+    func onDeviceMediaLibraryPickerCompletion(assets: [PHAsset], navigationController: UINavigationController) async -> MediaPickerImage? {
+        await withCheckedContinuation { continuation in
+            let shouldAnimateMediaLibraryDismissal = assets.isEmpty
+            navigationController.dismiss(animated: shouldAnimateMediaLibraryDismissal) { [weak self] in
+                guard let self, let asset = assets.first else {
+                    return continuation.resume(returning: nil)
+                }
+                Task { @MainActor in
+                    continuation.resume(returning: await self.requestImage(from: asset))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Action handling for WordPress Media Library
+//
+private extension AddProductFromImageCoordinator {
+    @MainActor
+    func onWPMediaPickerCompletion(mediaItems: [Media], navigationController: UINavigationController) async -> MediaPickerImage? {
+        await withCheckedContinuation { continuation in
+            let shouldAnimateMediaLibraryDismissal = mediaItems.isEmpty
+            navigationController.dismiss(animated: shouldAnimateMediaLibraryDismissal) { [weak self] in
+                guard let self, let media = mediaItems.first else {
+                    return continuation.resume(returning: nil)
+                }
+                let productImage = media.toProductImage
+                _ = self.productImageLoader.requestImage(productImage: productImage) { image in
+                    continuation.resume(returning: .init(image: image, source: .media(media: media)))
+                }
+            }
+        }
+    }
+}
+
+private extension AddProductFromImageCoordinator {
+    func requestImage(from asset: PHAsset) async -> MediaPickerImage? {
+        await withCheckedContinuation { continuation in
+            // PHImageManager.requestImageForAsset can be called more than once.
+            var hasReceivedImage = false
+            productImageLoader.requestImage(asset: asset, targetSize: PHImageManagerMaximumSize, skipsDegradedImage: true) { image in
+                guard hasReceivedImage == false else {
+                    return
+                }
+                continuation.resume(returning: .init(image: image, source: .asset(asset: asset)))
+                hasReceivedImage = true
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -148,11 +148,7 @@ private extension AddProductFromImageCoordinator {
         guard let asset else {
             return nil
         }
-        return await withCheckedContinuation { continuation in
-            Task { @MainActor in
-                continuation.resume(returning: await requestImage(from: asset))
-            }
-        }
+        return await requestImage(from: asset)
     }
 }
 
@@ -196,6 +192,7 @@ private extension AddProductFromImageCoordinator {
 }
 
 private extension AddProductFromImageCoordinator {
+    @MainActor
     func requestImage(from asset: PHAsset) async -> MediaPickerImage? {
         await withCheckedContinuation { continuation in
             // PHImageManager.requestImageForAsset can be called more than once.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -36,8 +36,9 @@ final class AddProductFromImageCoordinator: Coordinator {
                                                                        addImage: { [weak self] source in
             await self?.showImagePicker(source: source)
         }, completion: { [weak self] data in
-            self?.navigationController.dismiss(animated: true) { [weak self] in
-                guard let self else { return }
+            guard let self else { return }
+            Task { @MainActor in
+                await self.navigationController.dismiss(animated: true)
                 guard let product = self.createProduct(name: data.name, description: data.description) else {
                     return
                 }
@@ -157,17 +158,12 @@ private extension AddProductFromImageCoordinator {
 private extension AddProductFromImageCoordinator {
     @MainActor
     func onDeviceMediaLibraryPickerCompletion(assets: [PHAsset], navigationController: UINavigationController) async -> MediaPickerImage? {
-        await withCheckedContinuation { continuation in
-            let shouldAnimateMediaLibraryDismissal = assets.isEmpty
-            navigationController.dismiss(animated: shouldAnimateMediaLibraryDismissal) { [weak self] in
-                guard let self, let asset = assets.first else {
-                    return continuation.resume(returning: nil)
-                }
-                Task { @MainActor in
-                    continuation.resume(returning: await self.requestImage(from: asset))
-                }
-            }
+        let shouldAnimateMediaLibraryDismissal = assets.isEmpty
+        await navigationController.dismiss(animated: shouldAnimateMediaLibraryDismissal)
+        guard let asset = assets.first else {
+            return nil
         }
+        return await requestImage(from: asset)
     }
 }
 
@@ -176,16 +172,15 @@ private extension AddProductFromImageCoordinator {
 private extension AddProductFromImageCoordinator {
     @MainActor
     func onWPMediaPickerCompletion(mediaItems: [Media], navigationController: UINavigationController) async -> MediaPickerImage? {
-        await withCheckedContinuation { continuation in
-            let shouldAnimateMediaLibraryDismissal = mediaItems.isEmpty
-            navigationController.dismiss(animated: shouldAnimateMediaLibraryDismissal) { [weak self] in
-                guard let self, let media = mediaItems.first else {
-                    return continuation.resume(returning: nil)
-                }
-                let productImage = media.toProductImage
-                _ = self.productImageLoader.requestImage(productImage: productImage) { image in
-                    continuation.resume(returning: .init(image: image, source: .media(media: media)))
-                }
+        let shouldAnimateMediaLibraryDismissal = mediaItems.isEmpty
+        await navigationController.dismiss(animated: shouldAnimateMediaLibraryDismissal)
+        guard let media = mediaItems.first else {
+            return nil
+        }
+        return await withCheckedContinuation { continuation in
+            let productImage = media.toProductImage
+            _ = productImageLoader.requestImage(productImage: productImage) { image in
+                continuation.resume(returning: .init(image: image, source: .media(media: media)))
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Image header view in the add product from image form.
+struct AddProductFromImageFormImageView: View {
+    @ObservedObject private var viewModel: AddProductFromImageViewModel
+    @State private var isShowingActionSheet: Bool = false
+
+    init(viewModel: AddProductFromImageViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        EditableImageView(imageState: viewModel.imageState,
+                          emptyContent: {
+            VStack(spacing: 16) {
+                Image(systemName: "photo")
+                    .font(.system(size: Layout.emptyStateImageSize))
+                Label {
+                    Text(Localization.packagingImageTip)
+                } icon: {
+                    Image(uiImage: .sparklesImage)
+                }
+                .foregroundColor(.init(uiColor: .accent))
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        })
+        .overlay(alignment: .topTrailing) {
+            Button {
+                isShowingActionSheet = true
+            } label: {
+                Image(systemName: "pencil.circle.fill")
+                    .symbolRenderingMode(.multicolor)
+                    .font(.system(size: Layout.editImageSize))
+                    .foregroundColor(.init(uiColor: .accent))
+                    .renderedIf(viewModel.imageState.image != nil)
+            }
+        }
+        .mediaSourceActionSheet(showsActionSheet: $isShowingActionSheet, selectMedia: { source in
+            viewModel.addImage(from: source)
+        })
+    }
+}
+
+private extension AddProductFromImageFormImageView {
+    enum Layout {
+        static let emptyStateImageSize: CGFloat = 40
+        static let editImageSize: CGFloat = 30
+    }
+
+    enum Localization {
+        static let packagingImageTip = NSLocalizedString(
+            "Take a packaging photo to create product details with AI",
+            comment: "Tip in the add product from image form to add a packaging image for AI-generated product details."
+        )
+    }
+}
+
+struct AddProductFromImageFormImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddProductFromImageFormImageView(viewModel: .init(onAddImage: { _ in nil }))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
@@ -12,7 +12,7 @@ struct AddProductFromImageFormImageView: View {
     var body: some View {
         EditableImageView(imageState: viewModel.imageState,
                           emptyContent: {
-            VStack(spacing: 16) {
+            VStack(spacing: Layout.verticalSpacing) {
                 Image(systemName: "photo")
                     .font(.system(size: Layout.emptyStateImageSize))
                 Label {
@@ -24,6 +24,7 @@ struct AddProductFromImageFormImageView: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
         })
+        .padding(Layout.padding)
         .overlay(alignment: .topTrailing) {
             Button {
                 isShowingActionSheet = true
@@ -45,6 +46,8 @@ private extension AddProductFromImageFormImageView {
     enum Layout {
         static let emptyStateImageSize: CGFloat = 40
         static let editImageSize: CGFloat = 30
+        static let verticalSpacing: CGFloat = 16
+        static let padding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -5,14 +5,15 @@ import Yosemite
 struct AddProductFromImageData {
     let name: String
     let description: String
-    // TODO: 10180 - image from media picker
+    let image: MediaPickerImage?
 }
 
 /// Hosting controller for `AddProductFromImageView`.
 final class AddProductFromImageHostingController: UIHostingController<AddProductFromImageView> {
     init(siteID: Int64,
+         addImage: @escaping (MediaPickingSource) async -> MediaPickerImage?,
          completion: @escaping (AddProductFromImageData) -> Void) {
-        super.init(rootView: AddProductFromImageView(siteID: siteID, completion: completion))
+        super.init(rootView: AddProductFromImageView(siteID: siteID, addImage: addImage, completion: completion))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -26,14 +27,23 @@ struct AddProductFromImageView: View {
     @StateObject private var viewModel: AddProductFromImageViewModel
 
     init(siteID: Int64,
+         addImage: @escaping (MediaPickingSource) async -> MediaPickerImage?,
          stores: StoresManager = ServiceLocator.stores,
          completion: @escaping (AddProductFromImageData) -> Void) {
         self.completion = completion
-        self._viewModel = .init(wrappedValue: AddProductFromImageViewModel())
+        self._viewModel = .init(wrappedValue: AddProductFromImageViewModel(onAddImage: addImage))
     }
 
     var body: some View {
         Form {
+            Section {
+                HStack {
+                    Spacer()
+                    AddProductFromImageFormImageView(viewModel: viewModel)
+                    Spacer()
+                }
+            }
+
             Section {
                 // TODO: 10180 - use `TextEditor` with a placeholder overlay
                 TextField(Localization.nameFieldPlaceholder, text: $viewModel.name)
@@ -48,8 +58,7 @@ struct AddProductFromImageView: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(Localization.continueButtonTitle) {
-                    // TODO: 10180 - pass the image from media picker
-                    completion(.init(name: viewModel.name, description: viewModel.description))
+                    completion(.init(name: viewModel.name, description: viewModel.description, image: viewModel.image))
                 }
                 .buttonStyle(LinkButtonStyle())
             }
@@ -80,6 +89,6 @@ private extension AddProductFromImageView {
 
 struct AddProductFromImageView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductFromImageView(siteID: 134, completion: { _ in })
+        AddProductFromImageView(siteID: 134, addImage: { _ in nil }, completion: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -35,6 +35,7 @@ final class AddProductFromImageViewModel: ObservableObject {
     /// - Parameter source: Source of the image.
     func addImage(from source: MediaPickingSource) {
         Task { @MainActor in
+            imageState = .loading
             guard let image = await onAddImage(source) else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -34,10 +34,11 @@ final class AddProductFromImageViewModel: ObservableObject {
     /// Invoked after the user selects a media source to add an image.
     /// - Parameter source: Source of the image.
     func addImage(from source: MediaPickingSource) {
+        let previousState = imageState
+        imageState = .loading
         Task { @MainActor in
-            imageState = .loading
             guard let image = await onAddImage(source) else {
-                return
+                return imageState = previousState
             }
             imageState = .success(image)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -1,10 +1,50 @@
+import Combine
 import SwiftUI
+import Yosemite
 
 /// View model for `AddProductFromImageView` to handle user actions from the view and provide data for the view.
 @MainActor
 final class AddProductFromImageViewModel: ObservableObject {
+    typealias ImageState = EditableImageViewState
+
     // MARK: - Product Details
 
     @Published var name: String = ""
     @Published var description: String = ""
+
+    // MARK: - Product Image
+
+    @Published private(set) var imageState: ImageState = .empty
+    var image: MediaPickerImage? {
+        imageState.image
+    }
+
+    private let onAddImage: (MediaPickingSource) async -> MediaPickerImage?
+    private var selectedImageSubscription: AnyCancellable?
+
+    init(onAddImage: @escaping (MediaPickingSource) async -> MediaPickerImage?) {
+        self.onAddImage = onAddImage
+
+        selectedImageSubscription = $imageState.compactMap { $0.image?.image }
+        .sink { [weak self] image in
+            self?.onSelectedImage(image)
+        }
+    }
+
+    /// Invoked after the user selects a media source to add an image.
+    /// - Parameter source: Source of the image.
+    func addImage(from source: MediaPickingSource) {
+        Task { @MainActor in
+            guard let image = await onAddImage(source) else {
+                return
+            }
+            imageState = .success(image)
+        }
+    }
+}
+
+private extension AddProductFromImageViewModel {
+    func onSelectedImage(_ image: UIImage) {
+        // TODO: 10180 - scan texts from the image
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/CameraCaptureCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/CameraCaptureCoordinator.swift
@@ -35,6 +35,8 @@ final class CameraCaptureCoordinator {
         capturePresenter.completionBlock = { [weak self] mediaInfo in
             if let mediaInfo = mediaInfo as NSDictionary? {
                 self?.processMediaCaptured(mediaInfo)
+            } else {
+                self?.onCompletion(nil, nil)
             }
             self?.capturePresenter = nil
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -79,8 +79,15 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
     }
 
     func requestImage(asset: PHAsset, targetSize: CGSize, completion: @escaping (UIImage) -> Void) {
+        requestImage(asset: asset, targetSize: targetSize, skipsDegradedImage: false, completion: completion)
+    }
+
+    func requestImage(asset: PHAsset, targetSize: CGSize, skipsDegradedImage: Bool, completion: @escaping (UIImage) -> Void) {
         phAssetImageLoader.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFit, options: nil) { (image, info) in
-            guard let image = image else {
+            guard let image else {
+                return
+            }
+            if let isDegraded = info?[PHImageResultIsDegradedKey] as? Bool, isDegraded && skipsDegradedImage {
                 return
             }
             completion(image)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
@@ -12,4 +12,13 @@ protocol ProductUIImageLoader {
     /// Requests an image given a `PHAsset` asynchronously, with a target size for optimization.
     ///
     func requestImage(asset: PHAsset, targetSize: CGSize, completion: @escaping (UIImage) -> Void)
+
+    /// Requests an image given a `PHAsset` asynchronously, with a target size for optimization.
+    ///
+    /// - Parameters:
+    ///   - asset: The asset to generate a `UIImage` from.
+    ///   - targetSize: The target size of the image.
+    ///   - skipsDegradedImage: Whether to skip the degraded image while loading image from an asset.
+    ///   - completion: Invoked when an image is available. Can be called more than once.
+    func requestImage(asset: PHAsset, targetSize: CGSize, skipsDegradedImage: Bool, completion: @escaping (UIImage) -> Void)
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
@@ -7,7 +7,6 @@ enum EditableImageViewState {
     case empty
     case loading
     case success(MediaPickerImage)
-    case failure(Error)
 }
 
 /// Image selected from the media picker.
@@ -49,11 +48,6 @@ struct EditableImageView<Content: View>: View {
                 ProgressView()
             case .empty:
                 emptyContent()
-            case .failure(let error):
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                    Text(error.localizedDescription)
-                }
         }
     }
 }
@@ -81,9 +75,6 @@ struct EditableImageView_Previews: PreviewProvider {
                 Text("Empty")
             })
             .previewDisplayName("Empty state")
-
-            EditableImageView(imageState: .failure(ProductDownloadFileError.emptyFileName), emptyContent: {})
-                .previewDisplayName("Error state")
 
             EditableImageView(imageState: .loading, emptyContent: {})
                 .previewDisplayName("Loading state")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
@@ -1,0 +1,92 @@
+import Photos
+import SwiftUI
+import Yosemite
+
+/// State of the `EditableImageView`.
+enum EditableImageViewState {
+    case empty
+    case loading
+    case success(MediaPickerImage)
+    case failure(Error)
+}
+
+/// Image selected from the media picker.
+struct MediaPickerImage {
+    enum Source {
+        /// From device camera or photo library.
+        case asset(asset: PHAsset)
+        /// From site media library.
+        case media(media: Media)
+    }
+
+    let image: UIImage
+    let source: Source
+
+    init(image: UIImage, source: Source) {
+        self.image = image
+        self.source = source
+    }
+}
+
+/// A view that hosts a mutable image in different states.
+struct EditableImageView<Content: View>: View {
+    private let imageState: EditableImageViewState
+    private let emptyContent: () -> Content
+
+    init(imageState: EditableImageViewState,
+         @ViewBuilder emptyContent: @escaping () -> Content) {
+        self.imageState = imageState
+        self.emptyContent = emptyContent
+    }
+
+    var body: some View {
+        switch imageState {
+            case .success(let image):
+                Image(uiImage: image.image)
+                    .resizable()
+                    .scaledToFit()
+            case .loading:
+                ProgressView()
+            case .empty:
+                emptyContent()
+            case .failure(let error):
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                    Text(error.localizedDescription)
+                }
+        }
+    }
+}
+
+extension EditableImageViewState {
+    var image: MediaPickerImage? {
+        guard case let .success(image) = self else {
+            return nil
+        }
+        return image
+    }
+}
+
+struct EditableImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            EditableImageView(imageState: .success(
+                .init(image: .prologueWooMobileImage,
+                      source: .asset(asset: .init()))),
+                              emptyContent: {})
+            .previewDisplayName("Image state")
+
+            EditableImageView(imageState: .empty,
+                              emptyContent: {
+                Text("Empty")
+            })
+            .previewDisplayName("Empty state")
+
+            EditableImageView(imageState: .failure(ProductDownloadFileError.emptyFileName), emptyContent: {})
+                .previewDisplayName("Error state")
+
+            EditableImageView(imageState: .loading, emptyContent: {})
+                .previewDisplayName("Loading state")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
@@ -3,15 +3,15 @@ import SwiftUI
 import Yosemite
 
 /// State of the `EditableImageView`.
-enum EditableImageViewState {
+enum EditableImageViewState: Equatable {
     case empty
     case loading
     case success(MediaPickerImage)
 }
 
 /// Image selected from the media picker.
-struct MediaPickerImage {
-    enum Source {
+struct MediaPickerImage: Equatable {
+    enum Source: Equatable {
         /// From device camera or photo library.
         case asset(asset: PHAsset)
         /// From site media library.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		02490D1E284F3226002096EF /* ProductImagesSaverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02490D1D284F3226002096EF /* ProductImagesSaverTests.swift */; };
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
+		024A8F1F2A588FA500ABF3EB /* EditableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A8F1E2A588FA500ABF3EB /* EditableImageView.swift */; };
 		024D4E842A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */; };
 		024D4E942A2E1E240090E0E6 /* BlazeWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */; };
 		024D4E972A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */; };
@@ -415,6 +416,7 @@
 		02B2829227C4808D004A332A /* InfiniteScrollIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */; };
 		02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */; };
 		02B41A96296D09D100FE3311 /* DomainSettingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */; };
+		02B60DF72A586C7F004C47FF /* AddProductFromImageFormImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */; };
 		02B60DFB2A58809F004C47FF /* View+MediaSourceActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */; };
 		02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B653AB2429F7BF00A9C839 /* MockTaxClassStoresManager.swift */; };
 		02B8650F24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B8650E24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift */; };
@@ -2563,6 +2565,7 @@
 		02490D1D284F3226002096EF /* ProductImagesSaverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesSaverTests.swift; sourceTree = "<group>"; };
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
+		024A8F1E2A588FA500ABF3EB /* EditableImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditableImageView.swift; sourceTree = "<group>"; };
 		024D4E832A1B4B630090E0E6 /* WooAnalyticsEvent+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductForm.swift"; sourceTree = "<group>"; };
 		024D4E932A2E1E240090E0E6 /* BlazeWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeWebViewModel.swift; sourceTree = "<group>"; };
 		024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeWebViewModelTests.swift; sourceTree = "<group>"; };
@@ -2785,6 +2788,7 @@
 		02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollIndicator.swift; sourceTree = "<group>"; };
 		02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignmentTests.swift; sourceTree = "<group>"; };
 		02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsListView.swift; sourceTree = "<group>"; };
+		02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageFormImageView.swift; sourceTree = "<group>"; };
 		02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+MediaSourceActionSheet.swift"; sourceTree = "<group>"; };
 		02B653AB2429F7BF00A9C839 /* MockTaxClassStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTaxClassStoresManager.swift; sourceTree = "<group>"; };
 		02B8650E24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+SwiftUIPreviewHelpers.swift"; sourceTree = "<group>"; };
@@ -5641,6 +5645,7 @@
 				028B68B92A57410500FE03A8 /* AddProductFromImageView.swift */,
 				028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */,
 				028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */,
+				02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -7292,6 +7297,7 @@
 				03F5CB002A0BA3D40026877A /* ModalOverlay.swift */,
 				02D7E7C82A4CBEEC0003049A /* LocalAnnouncementModal.swift */,
 				DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */,
+				024A8F1E2A588FA500ABF3EB /* EditableImageView.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -11573,6 +11579,7 @@
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				EE45E2B92A409BA40085F227 /* ProductDescriptionAITooltipUseCase.swift in Sources */,
 				456AB0E7283E610500019CFF /* WCShipInstallTableViewCell.swift in Sources */,
+				024A8F1F2A588FA500ABF3EB /* EditableImageView.swift in Sources */,
 				02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */,
 				E15F163126C5117300D3059B /* InPersonPaymentsNoConnectionView.swift in Sources */,
 				CC41E70C29310C1F008B3FB9 /* AnalyticsLineChart.swift in Sources */,
@@ -12687,6 +12694,7 @@
 				028B68BC2A57419700FE03A8 /* AddProductFromImageViewModel.swift in Sources */,
 				0388E1A829E04687007DF84D /* DeepLinkForwarder.swift in Sources */,
 				B6A10E9C292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift in Sources */,
+				02B60DF72A586C7F004C47FF /* AddProductFromImageFormImageView.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
 				0229ED00258767BC00C336F8 /* ShippingLabelPrintingStepContentView.swift in Sources */,
 				D8EE9698264D3CCB0033B2F9 /* ReceiptViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		02B2829227C4808D004A332A /* InfiniteScrollIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */; };
 		02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */; };
 		02B41A96296D09D100FE3311 /* DomainSettingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */; };
+		02B60DFB2A58809F004C47FF /* View+MediaSourceActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */; };
 		02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B653AB2429F7BF00A9C839 /* MockTaxClassStoresManager.swift */; };
 		02B8650F24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B8650E24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift */; };
 		02BA12852461674B008D8325 /* Optional+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA12842461674B008D8325 /* Optional+String.swift */; };
@@ -2784,6 +2785,7 @@
 		02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollIndicator.swift; sourceTree = "<group>"; };
 		02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignmentTests.swift; sourceTree = "<group>"; };
 		02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsListView.swift; sourceTree = "<group>"; };
+		02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+MediaSourceActionSheet.swift"; sourceTree = "<group>"; };
 		02B653AB2429F7BF00A9C839 /* MockTaxClassStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTaxClassStoresManager.swift; sourceTree = "<group>"; };
 		02B8650E24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+SwiftUIPreviewHelpers.swift"; sourceTree = "<group>"; };
 		02BA12842461674B008D8325 /* Optional+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+String.swift"; sourceTree = "<group>"; };
@@ -6313,6 +6315,7 @@
 				CC666F2327F329DC0045AF1E /* View+DiscardChanges.swift */,
 				02562ACF296D1FD100980404 /* View+DividerStyle.swift */,
 				B649BC7D2A1C295B007AB988 /* View+HighlightModifier.swift */,
+				02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -11478,6 +11481,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DEEF8E6629C833C600D47411 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */,
+				02B60DFB2A58809F004C47FF /* View+MediaSourceActionSheet.swift in Sources */,
 				B5F571A421BEC90D0010D1B8 /* NoteDetailsHeaderPlainTableViewCell.swift in Sources */,
 				EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */,
 				AEA3F91127BEC08800B9F555 /* PriceFieldFormatter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class AddProductFromImageViewModelTests: XCTestCase {
     func test_initial_name_is_empty() throws {
         // Given
-        let viewModel = AddProductFromImageViewModel()
+        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in nil })
 
         // Then
         XCTAssertEqual(viewModel.name, "")
@@ -15,7 +15,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
 
     func test_initial_description_is_empty() throws {
         // Given
-        let viewModel = AddProductFromImageViewModel()
+        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in nil })
 
         // Then
         XCTAssertEqual(viewModel.description, "")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -20,4 +20,53 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.description, "")
     }
+
+    // MARK: - `addImage`
+
+    func test_imageState_is_reverted_to_empty_when_addImage_returns_nil() {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in
+            nil
+        })
+        XCTAssertEqual(viewModel.imageState, .empty)
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        XCTAssertEqual(viewModel.imageState, .loading)
+
+        // Then
+        waitUntil {
+            viewModel.imageState == .empty
+        }
+    }
+
+    func test_imageState_is_reverted_to_success_when_addImage_returns_image_then_nil() {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        var imageToReturn: MediaPickerImage? = image
+        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in
+            imageToReturn
+        })
+        XCTAssertEqual(viewModel.imageState, .empty)
+
+        // When adding an image returns an image
+        viewModel.addImage(from: .siteMediaLibrary)
+        XCTAssertEqual(viewModel.imageState, .loading)
+
+        // Then imageState becomes success
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // When adding an image returns nil
+        imageToReturn = nil
+        viewModel.addImage(from: .siteMediaLibrary)
+        XCTAssertEqual(viewModel.imageState, .loading)
+
+        // Then imageState stays success
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're running an A/B experiment for a new starting screen for the product creation flow. This new screen just contains 3 fields: image, name, and description. When selecting a packaging image, the texts can be scanned and used to generate product details (name and description for now). The latest POC looks like pe5sF9-1Es-p2#comment-2427.

This PR focuses on integrating a media picker with an editable image view in the form.

## How

🗒️  I struggled with a few constraints in the media picking process, please feel free to suggest any changes to the implementation:

- The pre-existing `MediaPickingCoordinator` is block-based, and the action sheet doesn't work with SwiftUI. I decided to create a SwiftUI view modifier `mediaSourceActionSheet` to show the action sheet for picking a media source. This makes the iPad popover origin handling much easier, since UIKit expects a source origin/rect for the action sheet.
- After the user picks a media source from the action sheet, `AddProductFromImageCoordinator` shows the media picker using a new navigation function `MediaPickingCoordinator.showMediaPicker`. The selected media is passed to the completion block in the initializer (I tried converting it to async/await, but it involves too many changes).
- The selected media (either `PHAsset` from the device or `Media` from the site media library) needs to be converted to `UIImage` async:
  - When requesting `UIImage` from a `PHAsset` from camera/photo library, the image can be returned multiple times at different resolutions. This makes using `async/await` challenging because it's expecting one image, plus we want to scan the texts only once. That's why I had to change `DefaultProductUIImageLoader.requestImage` to add a parameter to skip the degraded version to only return the one with full resolution.
- When the user taps to continue from the new "add product from image" form, it passes the image source to the full product form in `MediaPickingCoordinator`. It either uploads the asset or adds the media to the new product.

On the UI side:

- A generic view `EditableImageView` was created to host a mutable image with empty/loading/success states.
- `AddProductFromImageFormImageView` was created that contains `EditableImageView` with an overlay to show the media source action sheet, then triggers the view model `AddProductFromImageViewModel` to add an image.
- `AddProductFromImageData` was updated to show `AddProductFromImageFormImageView` in the header.

🗒️ Due to the PR size, I will add unit tests in a future PR.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please test on a physical device for the camera.

### Camera

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- Tap the image header, then tap `Take a photo`
- Take a photo with the camera and then use the photo --> the photo should be loaded in the form header
- Optionally enter a name or description
- Tap `Continue` --> it should navigate to the main product form with the image being uploaded
- Tap `Publish` --> the product should be created remotely with the newly taken photo

### Device photo library

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- Tap the image header, then tap `Choose from device`
- Choose photo --> the photo should be loaded in the form header
- Optionally enter a name or description
- Tap `Continue` --> it should navigate to the main product form with the image being uploaded
- Tap `Publish` --> the product should be created remotely with the selected photo

### WP media library

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- Tap the image header, then tap `WordPress Media Library`
- Choose photo --> the photo should be loaded in the form header
- Optionally enter a name or description
- Tap `Continue` --> it should navigate to the main product form with the image preloaded
- Tap `Publish` --> the product should be created remotely with the selected photo

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

iPad | iPhone - main form | iPhone - action sheet
-- | -- | --
![Simulator Screenshot - iPad (10th generation) - 2023-07-07 at 16 51 10](https://github.com/woocommerce/woocommerce-ios/assets/1945542/ec6f08df-2fe9-448c-bbd2-8bb0c37804d6) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-07 at 16 49 51](https://github.com/woocommerce/woocommerce-ios/assets/1945542/553225b2-9fab-45c7-8f5d-d5e81ae3ca27) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-07 at 17 04 54](https://github.com/woocommerce/woocommerce-ios/assets/1945542/e494ad32-d4e4-46be-b44f-94773e9a6085)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
