### PR TITLE
[IAP] Update plan selection UI to M2

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -25,7 +25,7 @@ struct OwnerUpgradesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Picker("How frequently would you like to pay?", selection: $paymentFrequency) {
+            Picker(selection: $paymentFrequency, label: EmptyView()) {
                 ForEach(paymentFrequencies) {
                     Text($0.paymentFrequencyLocalizedString)
                 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -100,7 +100,7 @@ private struct WooPlanCardView: View {
             VStack(alignment: .leading, spacing: Layout.spacing) {
                 HStack {
                     Text(upgradePlan.wooPlan.shortName)
-                        .font(.title)
+                        .font(.title2)
                         .bold()
                         .accessibilityAddTraits(.isHeader)
 
@@ -118,7 +118,8 @@ private struct WooPlanCardView: View {
 
             VStack(alignment: .leading, spacing: Layout.textSpacing) {
                 Text(upgradePlan.wpComPlan.displayPrice)
-                    .font(.largeTitle)
+                    .font(.title)
+                    .bold()
                     .accessibilityAddTraits(.isHeader)
                 Text(upgradePlan.wooPlan.planFrequency.localizedString)
                     .font(.footnote)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -63,7 +63,7 @@ struct OwnerUpgradesView: View {
                     .redacted(reason: isLoading ? .placeholder : [])
                     .shimmering(active: isLoading)
                 } else {
-                    Button("Choose a plan") {
+                    Button(Localization.selectPlanButtonText) {
                         // no-op
                     }
                     .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPurchasing))
@@ -116,8 +116,9 @@ private struct WooPlanCardView: View {
 
             let buttonText = String.localizedStringWithFormat(Localization.viewPlanFeaturesFormat, upgradePlan.wooPlan.shortName)
             Button("\(buttonText) \(Image(systemName: isExpanded ? "chevron.up" : "chevron.down"))") {
-                isExpanded.toggle() // needs using to actually expand!
+                isExpanded.toggle()
             }
+            Text("Expanded").renderedIf(isExpanded)
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal)
@@ -172,6 +173,9 @@ private extension OwnerUpgradesView {
 
         static let featureDetailsUnavailableText = NSLocalizedString(
             "See plan details", comment: "Title for a link to view Woo Express plan details on the web, as a fallback.")
+
+        static let selectPlanButtonText = NSLocalizedString(
+            "Select a plan", comment: "The title of the button to purchase a Plan when no plan is selected yet.")
     }
 }
 
@@ -191,7 +195,7 @@ private extension WooPlan.PlanFrequency {
             comment: "Title of the selector option for paying monthly on the Upgrade view, when choosing a plan")
 
         static let payAnnually = NSLocalizedString(
-            "Pay Annually",
+            "Pay Annually (Save 35%)",
             comment: "Title of the selector option for paying annually on the Upgrade view, when choosing a plan")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -85,6 +85,14 @@ private struct WooPlanCardView: View {
         selectedPlan?.id == upgradePlan.id
     }
 
+    private var isPopular: Bool {
+        let popularPlans =  [
+            AvailableInAppPurchasesWPComPlans.performanceMonthly.rawValue,
+            AvailableInAppPurchasesWPComPlans.performanceYearly.rawValue
+        ]
+
+        return popularPlans.contains(where: {$0 == upgradePlan.id})
+    }
     @State private var isExpanded = false
 
     var body: some View {
@@ -97,6 +105,7 @@ private struct WooPlanCardView: View {
 
                     Spacer()
 
+                    BadgeView(text: Localization.isPopularBadgeText.uppercased()).renderedIf(isPopular)
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .foregroundStyle(isSelected ? Color.withColorStudio(name: .wooCommercePurple, shade: .shade50) : Color(.systemGray4))
                         .font(.system(size: Layout.checkImageSize))
@@ -155,6 +164,10 @@ private extension WooPlanCardView {
             comment: "Title for the button to expand plan details on the Upgrade plan screen. " +
             "Reads as 'View Essential features'. %1$@ must be included in the string and will be replaced with " +
             "the plan name.")
+
+        static let isPopularBadgeText = NSLocalizedString(
+            "Popular",
+            comment: "The text of the badge that indicates the most popular choice when purchasing a Plan")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -132,7 +132,7 @@ private struct WooPlanCardView: View {
         .frame(maxWidth: .infinity)
         .padding(.horizontal)
         .padding(.vertical)
-        .background(Color.white)
+        .background(Color(.systemGroupedBackground))
         .cornerRadius(Layout.cornerRadius)
         .overlay(
             RoundedRectangle(cornerRadius: Layout.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -100,7 +100,8 @@ private struct WooPlanCardView: View {
             VStack(alignment: .leading, spacing: Layout.spacing) {
                 HStack {
                     Text(upgradePlan.wooPlan.shortName)
-                        .font(.largeTitle)
+                        .font(.title)
+                        .bold()
                         .accessibilityAddTraits(.isHeader)
 
                     Spacer()
@@ -204,11 +205,11 @@ private extension WooPlan.PlanFrequency {
 
     enum Localization {
         static let payMonthly = NSLocalizedString(
-            "Pay Monthly",
+            "Monthly",
             comment: "Title of the selector option for paying monthly on the Upgrade view, when choosing a plan")
 
         static let payAnnually = NSLocalizedString(
-            "Pay Annually (Save 35%)",
+            "Annually (Save 35%)",
             comment: "Title of the selector option for paying annually on the Upgrade view, when choosing a plan")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -25,68 +25,33 @@ struct OwnerUpgradesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Section {
-                Picker("How frequently would you like to pay?", selection: $paymentFrequency) {
-                    ForEach(paymentFrequencies) {
-                        Text($0.paymentFrequencyLocalizedString)
-                    }
+            Picker("How frequently would you like to pay?", selection: $paymentFrequency) {
+                ForEach(paymentFrequencies) {
+                    Text($0.paymentFrequencyLocalizedString)
                 }
-                .pickerStyle(.segmented)
-                .disabled(isLoading)
             }
+            .pickerStyle(.segmented)
+            .disabled(isLoading)
             .padding()
             .background(Color(.systemGroupedBackground))
             .redacted(reason: isLoading ? .placeholder : [])
             .shimmering(active: isLoading)
-            List {
-                ForEach(upgradePlans.filter { $0.wooPlan.planFrequency == paymentFrequency }) { upgradePlan in
-                    Section {
-                        VStack(alignment: .leading) {
-                            HStack {
-                                Text(upgradePlan.wooPlan.shortName)
-                                    .font(.largeTitle)
-                                    .accessibilityAddTraits(.isHeader)
 
-                                Spacer()
-
-                                if selectedPlan?.id == upgradePlan.id {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundStyle(Color.withColorStudio(name: .wooCommercePurple, shade: .shade50))
-                                        .font(.system(size: 30))
-                                } else {
-                                    Image(systemName: "circle")
-                                        .foregroundStyle(Color(.systemGray4))
-                                        .font(.system(size: 30))
-                                }
-
-                            }
-                            Text(upgradePlan.wooPlan.planDescription)
-                                .font(.subheadline)
-                        }
-                        .padding(.top)
-
-                        VStack(alignment: .leading) {
-                            Text(upgradePlan.wpComPlan.displayPrice)
-                                .font(.largeTitle)
-                                .accessibilityAddTraits(.isHeader)
-                            Text(upgradePlan.wooPlan.planFrequency.localizedString)
-                                .font(.footnote)
-                        }
-                        .padding(.bottom)
+            ScrollView {
+                VStack {
+                    ForEach(upgradePlans.filter { $0.wooPlan.planFrequency == paymentFrequency }) { upgradePlan in
+                        WooPlanCardView(upgradePlan: upgradePlan, selectedPlan: $selectedPlan)
+                        .accessibilityAddTraits(.isSummaryElement)
+                        .listRowSeparator(.hidden)
+                        .redacted(reason: isLoading ? .placeholder : [])
+                        .shimmering(active: isLoading)
+                        .padding(.bottom, 8)
                     }
-                    .accessibilityAddTraits(.isSummaryElement)
-                    .listRowSeparator(.hidden)
-                    .gesture(TapGesture()
-                        .onEnded({ _ in
-                            if selectedPlan?.id != upgradePlan.id {
-                                selectedPlan = upgradePlan
-                            }
-                        }))
                 }
+                .padding()
             }
-            .listStyle(.insetGrouped)
-            .redacted(reason: isLoading ? .placeholder : [])
-            .shimmering(active: isLoading)
+            .background(Color(.systemGroupedBackground))
+
             VStack {
                 if let selectedPlan {
                     let buttonText = String.localizedStringWithFormat(Localization.purchaseCTAButtonText, selectedPlan.wpComPlan.displayName)
@@ -109,6 +74,86 @@ struct OwnerUpgradesView: View {
             }
             .padding()
         }
+    }
+}
+
+private struct WooPlanCardView: View {
+    let upgradePlan: WooWPComPlan
+    @Binding var selectedPlan: WooWPComPlan?
+
+    private var isSelected: Bool {
+        selectedPlan?.id == upgradePlan.id
+    }
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.spacing) {
+            VStack(alignment: .leading, spacing: Layout.spacing) {
+                HStack {
+                    Text(upgradePlan.wooPlan.shortName)
+                        .font(.largeTitle)
+                        .accessibilityAddTraits(.isHeader)
+
+                    Spacer()
+
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(isSelected ? Color.withColorStudio(name: .wooCommercePurple, shade: .shade50) : Color(.systemGray4))
+                        .font(.system(size: Layout.checkImageSize))
+
+                }
+                Text(upgradePlan.wooPlan.planDescription)
+                    .font(.subheadline)
+            }
+
+            VStack(alignment: .leading, spacing: Layout.textSpacing) {
+                Text(upgradePlan.wpComPlan.displayPrice)
+                    .font(.largeTitle)
+                    .accessibilityAddTraits(.isHeader)
+                Text(upgradePlan.wooPlan.planFrequency.localizedString)
+                    .font(.footnote)
+            }
+
+            let buttonText = String.localizedStringWithFormat(Localization.viewPlanFeaturesFormat, upgradePlan.wooPlan.shortName)
+            Button("\(buttonText) \(Image(systemName: isExpanded ? "chevron.up" : "chevron.down"))") {
+                isExpanded.toggle() // needs using to actually expand!
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal)
+        .padding(.vertical)
+        .background(Color.white)
+        .cornerRadius(Layout.cornerRadius)
+        .overlay(
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(isSelected ? .withColorStudio(name: .wooCommercePurple, shade: .shade50) : Color(.systemGray4),
+                        lineWidth: isSelected ? Layout.selectedBorder : Layout.unselectedBorder)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if selectedPlan?.id != upgradePlan.id {
+                selectedPlan = upgradePlan
+            }
+        }
+    }
+}
+
+private extension WooPlanCardView {
+    enum Layout {
+        static let cornerRadius: CGFloat = 8.0
+        static let selectedBorder: CGFloat = 2
+        static let unselectedBorder: CGFloat = 0.5
+        static let checkImageSize: CGFloat = 24
+        static let spacing: CGFloat = 16
+        static let textSpacing: CGFloat = 4
+    }
+
+    enum Localization {
+        static let viewPlanFeaturesFormat = NSLocalizedString(
+            "View %1$@ features",
+            comment: "Title for the button to expand plan details on the Upgrade plan screen. " +
+            "Reads as 'View Essential features'. %1$@ must be included in the string and will be replaced with " +
+            "the plan name.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -88,7 +88,12 @@ struct UpgradesView: View {
 
                 switch upgradesViewModel.upgradeViewState {
                 case .loading:
-                    OwnerUpgradesView(upgradePlans: [.skeletonPlan()], purchasePlanAction: { _ in }, isLoading: true)
+                    OwnerUpgradesView(upgradePlans: [
+                        .skeletonPlan(frequency: .year, shortName: "Essential"),
+                        .skeletonPlan(frequency: .year, shortName: "Performance"),
+                        .skeletonPlan(frequency: .month, shortName: "Essential"),
+                        .skeletonPlan(frequency: .month, shortName: "Performance")],
+                                      purchasePlanAction: { _ in }, isLoading: true)
                         .accessibilityLabel(Localization.plansLoadingAccessibilityLabel)
                 case .loaded(let plans):
                     OwnerUpgradesView(upgradePlans: plans, purchasePlanAction: { selectedPlan in
@@ -172,44 +177,38 @@ private extension UpgradesView {
 }
 
 private extension WooWPComPlan {
-    static func skeletonPlan() -> WooWPComPlan {
+    static func skeletonPlan(frequency: WooPlan.PlanFrequency, shortName: String) -> WooWPComPlan {
+        let planProduct = SkeletonWPComPlanProduct(displayName: "\(frequency.localizedPlanName) \(shortName) Plan",
+                                                   id: "skeleton.wpcom.plan.product.monthly",
+                                                   price: "$100")
         return WooWPComPlan(
-            wpComPlan: SkeletonWPComPlanProduct(),
-            wooPlan: WooPlan(id: "skeleton.plan.monthly",
-                             name: "Skeleton Plan Monthly",
+            wpComPlan: planProduct,
+            wooPlan: WooPlan(id: "skeleton.plan.\(shortName).\(frequency.rawValue)",
+                             name: "Skeleton \(shortName) Plan \(frequency.localizedPlanName)",
                              shortName: "Skeleton",
-                             planFrequency: .month,
+                             planFrequency: frequency,
                              planDescription: "A skeleton plan to show (redacted) while we're loading",
                              headerImageFileName: "express-essential-header",
                              headerImageCardColor: .withColorStudio(name: .orange, shade: .shade5),
-                             planFeatureGroups: [
-                                WooPlanFeatureGroup(title: "Feature group 1",
-                                                    description: "A feature description with a realistic length to " +
-                                                    "ensure the cell looks correct when redacted",
-                                                    imageFilename: "",
-                                                    imageCardColor: .withColorStudio(name: .blue, shade: .shade5),
-                                                    features: []),
-                                WooPlanFeatureGroup(title: "Feature group 2",
-                                                    description: "A feature description with a realistic length to " +
-                                                    "ensure the cell looks correct when redacted",
-                                                    imageFilename: "",
-                                                    imageCardColor: .withColorStudio(name: .green, shade: .shade5),
-                                                    features: []),
-                                WooPlanFeatureGroup(title: "Feature group 3",
-                                                    description: "A feature description with a realistic length to " +
-                                                    "ensure the cell looks correct when redacted",
-                                                    imageFilename: "",
-                                                    imageCardColor: .withColorStudio(name: .pink, shade: .shade5),
-                                                    features: []),
-                             ]),
+                             planFeatureGroups: []),
             hardcodedPlanDataIsValid: true)
     }
 
     private struct SkeletonWPComPlanProduct: WPComPlanProduct {
-        let displayName: String = "Skeleton Plan Monthly"
+        let displayName: String
         let description: String = "A skeleton plan to show (redacted) while we're loading"
-        let id: String = "skeleton.wpcom.plan.product"
-        let displayPrice: String = "$39"
+        let id: String
+        let displayPrice: String
+
+        init(displayName: String,
+             id: String,
+             price: String) {
+            self.displayName = displayName
+            self.id = id
+            self.displayPrice = price
+        }
+
+
     }
 }
 

--- a/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
@@ -342,7 +342,7 @@ private extension WooPlan {
             "Essential",
             comment: "Short name for the plan on a screen showing the Woo Express Essential plan upgrade benefits")
         static let essentialPlanDescription = NSLocalizedString(
-            "Everything you need to launch an online store.",
+            "Everything you need to set up your store and start selling your products.",
             comment: "Description of the plan on a screen showing the Woo Express Essential plan upgrade benefits")
 
         static let performancePlanNameFormat = NSLocalizedString(
@@ -356,7 +356,7 @@ private extension WooPlan {
             "Performance",
             comment: "Short name for the plan on a screen showing the Woo Express Performance plan upgrade benefits")
         static let performancePlanDescription = NSLocalizedString(
-            "Activate your growth with advanced features.",
+            "Accelerate your growth with advanced features.",
             comment: "Description of the plan on a screen showing the Woo Express Performance plan upgrade benefits")
 
 


### PR DESCRIPTION
Closes: #10189 

## Description
With this PR we start the implementation of the updated UI for In-App Purchases plan selection (M2). We mainly move to a card-based layout, with one selectable card for each plan:

Since the UI updates are pretty extensive (and are still ongoing), there are some items we have left out of this PR and we'll work on it separately, like so:
- The `View Full Feature List` button has not been added yet.
- The contents of `View PlanName Features` when the view is expanded have not been added yet.
- The text for "Billed annually/25 per month" while we confirm this won't be a problem, for the moment only shows "per month" or "per year" for each case.
- The button text is currently dynamic and appends Monthly or Yearly depending on which plan is chosen. We're discussing if this needs to be changed here p1688979147117499-slack-C0354HSNUJH and show only the plan name without the frequency.

For clarity, I marked here the part we're working with in this PR:

<img width="597" alt="Screenshot 2023-07-10 at 16 35 13" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/4191aaf3-df99-4d6a-9e9b-31a1b9eab69f">| 

## Changes
* Updated the UI to a card-based layout, moving from `List` and `Section` to use `ScrollView` and `VStack`
* Added segmented control (monthly, yearly)
* Added a checkbox to reflect selected/unselected plans
* Cards are expandable upon tapping `View PlanName Features` (details to be implemented on a different PR)
* Updated plan description to fit the latest design update
* Added a badge that shows `POPULAR` in Performance plans

## Testing instructions

* On a Free Trial site, eligible for IAP (a new site can be created in Menu > Switch Sites > Add New Site) tap on `Purchase Now` and observe that:
  * No plan is selected when the screen is loaded
  * The primary purchase button should be disabled and read Select a plan
  * When a plan is selected, the primary button changes to "Purchase Essential Monthly" (or the selected plan)
  * Checkbox is visible when a plan is selected
  * The yearly option reads as "Annually (Save 35%)"
  * Performance plans have the "POPULAR" badge
  * Tapping on "View Essential Features" expands and collapses a new section.

## Screenshots

| Screen loaded | Plan selected | Plan details expanded |
|--------|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-07-10 at 16 58 05](https://github.com/woocommerce/woocommerce-ios/assets/3812076/0a0bd67a-aa1c-4a20-bc1e-77ab8112ecd2) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-07-10 at 16 58 13](https://github.com/woocommerce/woocommerce-ios/assets/3812076/2544bed6-0109-4c74-99d4-c21b6e4e0587) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-07-10 at 16 58 20](https://github.com/woocommerce/woocommerce-ios/assets/3812076/01f88537-56c0-463e-997a-b5f9de89747d) |

