### PR TITLE
Add product from image: update entry point

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreation.swift
@@ -1,0 +1,59 @@
+extension WooAnalyticsEvent {
+    enum ProductCreation {
+        /// Event property keys.
+        private enum Key {
+            static let source = "source"
+            static let storeHasProducts = "has_products"
+            static let productType = "product_type"
+            static let isVirtual = "is_virtual"
+            static let creationType = "creation_type"
+        }
+
+        /// Tracked when the user taps to start adding a product.
+        /// - Parameters:
+        ///   - source: Entry point to product creation.
+        ///   - storeHasProducts: Whether the store has any products when adding a product.
+        static func addProductStarted(source: AddProductCoordinator.Source, storeHasProducts: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .addProductStarted,
+                              properties: [Key.source: source.analyticsValue,
+                                           Key.storeHasProducts: storeHasProducts])
+        }
+
+        /// Tracked when the user selects a product type during the product creation flow.
+        /// - Parameters:
+        ///   - bottomSheetProductType: User selected product type from the bottom sheet.
+        ///   - creationType: Product creation type.
+        static func addProductTypeSelected(bottomSheetProductType: BottomSheetProductType, creationType: ProductCreationType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .addProductTypeSelected,
+                              properties: [Key.productType: bottomSheetProductType.productType.rawValue,
+                                           Key.isVirtual: bottomSheetProductType.isVirtual,
+                                           Key.creationType: creationType.analyticsType.rawValue])
+        }
+    }
+}
+
+private extension AddProductCoordinator.Source {
+    var analyticsValue: String {
+        switch self {
+            case .productsTab:
+                return "products_tab"
+            case .productOnboarding:
+                return "product_onboarding"
+            case .storeOnboarding:
+                return "store_onboarding"
+            case .productDescriptionAIAnnouncementModal:
+                return "product_description_ai_announcement"
+        }
+    }
+}
+
+private extension ProductCreationType {
+    var analyticsType: WooAnalyticsEvent.ProductsOnboarding.CreationType {
+        switch self {
+        case .template:
+            return .template
+        case .manual:
+            return .manual
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -565,12 +565,15 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Add Product Events
     //
+    case addProductStarted = "add_product_started"
     case addProductCreationTypeSelected = "add_product_creation_type_selected"
     case addProductTypeSelected = "add_product_product_type_selected"
     case addProductPublishTapped = "add_product_publish_tapped"
     case addProductSaveAsDraftTapped = "add_product_save_as_draft_tapped"
     case addProductSuccess = "add_product_success"
     case addProductFailed = "add_product_failed"
+    // Exposure event for the A/B experiment.
+    case addProductFromImageEligible = "add_product_from_image_eligible"
 
     // MARK: Duplicate Product events
     case duplicateProductSuccess = "duplicate_product_success"

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -95,21 +95,6 @@ final class AddProductCoordinator: Coordinator {
             break
         }
 
-        if addProductFromImageEligibilityChecker.isEligibleToParticipateInABTest() {
-            // TODO: 10180 - A/B experiment exposure event
-
-            if addProductFromImageEligibilityChecker.isEligible() {
-                let coordinator = AddProductFromImageCoordinator(siteID: siteID,
-                                                                 sourceNavigationController: navigationController,
-                                                                 onProductCreated: { [weak self] product in
-                    self?.onProductCreated(product)
-                })
-                self.addProductFromImageCoordinator = coordinator
-                coordinator.start()
-                return
-            }
-        }
-
         if shouldSkipBottomSheet() {
             presentProductForm(bottomSheetProductType: .simple(isVirtual: false))
         } else if shouldPresentProductCreationBottomSheet() {
@@ -246,6 +231,23 @@ private extension AddProductCoordinator {
     /// Presents a new product based on the provided bottom sheet type.
     ///
     func presentProductForm(bottomSheetProductType: BottomSheetProductType) {
+        if bottomSheetProductType.productType == .simple,
+           bottomSheetProductType.isVirtual == false,
+           addProductFromImageEligibilityChecker.isEligibleToParticipateInABTest() {
+            // TODO: 10180 - track A/B experiment exposure event for all variants
+
+            if addProductFromImageEligibilityChecker.isEligible() {
+                let coordinator = AddProductFromImageCoordinator(siteID: siteID,
+                                                                 sourceNavigationController: navigationController,
+                                                                 onProductCreated: { [weak self] product in
+                    self?.onProductCreated(product)
+                })
+                self.addProductFromImageCoordinator = coordinator
+                coordinator.start()
+                return
+            }
+        }
+
         guard let product = ProductFactory().createNewProduct(type: bottomSheetProductType.productType,
                                                               isVirtual: bottomSheetProductType.isVirtual,
                                                               siteID: siteID) else {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -164,7 +164,8 @@ private extension AddProductCoordinator {
             ServiceLocator.analytics.track(.addProductTypeSelected,
                                            withProperties: [
                                             "product_type": selectedBottomSheetProductType.productType.rawValue,
-                                            "is_virtual": selectedBottomSheetProductType.isVirtual])
+                                            "is_virtual": selectedBottomSheetProductType.isVirtual
+                                           ])
             self.navigationController.dismiss(animated: true) {
                 switch creationType {
                 case .manual:

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -161,7 +161,10 @@ private extension AddProductCoordinator {
                                          comment: "Message subtitle of bottom sheet for selecting a product type to create a product")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title, subtitle: subtitle)
         let command = ProductTypeBottomSheetListSelectorCommand(selected: nil) { selectedBottomSheetProductType in
-            ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedBottomSheetProductType.productType.rawValue])
+            ServiceLocator.analytics.track(.addProductTypeSelected,
+                                           withProperties: [
+                                            "product_type": selectedBottomSheetProductType.productType.rawValue,
+                                            "is_virtual": selectedBottomSheetProductType.isVirtual])
             self.navigationController.dismiss(animated: true) {
                 switch creationType {
                 case .manual:

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -233,6 +233,7 @@ private extension AddProductCoordinator {
     func presentProductForm(bottomSheetProductType: BottomSheetProductType) {
         if bottomSheetProductType.productType == .simple,
            bottomSheetProductType.isVirtual == false,
+           shouldSkipBottomSheet() == false,
            addProductFromImageEligibilityChecker.isEligibleToParticipateInABTest() {
             // TODO: 10180 - track A/B experiment exposure event for all variants
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -46,6 +46,10 @@ final class AddProductCoordinator: Coordinator {
     ///
     var onProductCreated: (Product) -> Void = { _ in }
 
+    private var storeHasProducts: Bool {
+        !productsResultsController.isEmpty
+    }
+
     private let addProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol
     private var addProductFromImageCoordinator: AddProductFromImageCoordinator?
 
@@ -96,7 +100,7 @@ final class AddProductCoordinator: Coordinator {
         }
 
         ServiceLocator.analytics.track(event: .ProductCreation.addProductStarted(source: source,
-                                                                                 storeHasProducts: storeHasProducts()))
+                                                                                 storeHasProducts: storeHasProducts))
 
         if shouldSkipBottomSheet() {
             presentProductForm(bottomSheetProductType: .simple(isVirtual: false))
@@ -134,11 +138,7 @@ private extension AddProductCoordinator {
     /// Returns `true` when there are existing products.
     ///
     func shouldShowGroupedProductType() -> Bool {
-        storeHasProducts()
-    }
-
-    func storeHasProducts() -> Bool {
-        !productsResultsController.isEmpty
+        storeHasProducts
     }
 
     /// Presents a bottom sheet for users to choose if they want a create a product manually or via a template.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
@@ -27,6 +27,9 @@ final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilit
     }
 
     func isEligible() -> Bool {
+        // `isEligibleToParticipateInABTest` isn't necessary here since `isEligibleToParticipateInABTest` is
+        // checked before this in its use case, but it's still included here so that it remains a condition when
+        // removing the A/B experiment.
         guard isEligibleToParticipateInABTest() else {
             return false
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		021EBB382A3076F4003634CA /* BlazeEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */; };
 		021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */; };
 		0221121E288973C20028F0AF /* LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0221121D288973C20028F0AF /* LocalNotification.swift */; };
+		0225091D2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225091C2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift */; };
 		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
 		0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */; };
 		0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */; };
@@ -2489,6 +2490,7 @@
 		021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommand.swift; sourceTree = "<group>"; };
 		0221121D288973C20028F0AF /* LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotification.swift; sourceTree = "<group>"; };
+		0225091C2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductCreation.swift"; sourceTree = "<group>"; };
 		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
 		0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelProductListFilterTests.swift; sourceTree = "<group>"; };
 		0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModel.swift; sourceTree = "<group>"; };
@@ -7728,6 +7730,7 @@
 				DE96844A2A331AD2000FBF4E /* WooAnalyticsEvent+ProductSharingAI.swift */,
 				DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */,
 				02D4472B2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift */,
+				0225091C2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -12684,6 +12687,7 @@
 				02E3B62F2906322B007E0F13 /* AuthenticationFormFieldView.swift in Sources */,
 				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
+				0225091D2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				B649BC7E2A1C295B007AB988 /* View+HighlightModifier.swift in Sources */,
 				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
@@ -37,7 +37,7 @@ final class AddProductCoordinatorTests: XCTestCase {
         assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
     }
 
-    func test_it_presents_AddProductFromImageHostingController_on_start_when_eligible() throws {
+    func test_it_presents_bottom_sheet_on_start_when_eligible_for_AddProductFromImage() throws {
         // Given
         let coordinator = makeAddProductCoordinator(
             addProductFromImageEligibilityChecker: MockAddProductFromImageEligibilityChecker(isEligibleToParticipateInABTest: true, isEligible: true)
@@ -50,8 +50,7 @@ final class AddProductCoordinatorTests: XCTestCase {
         }
 
         // Then
-        let navigationController = try XCTUnwrap(coordinator.navigationController.presentedViewController as? UINavigationController)
-        assertThat(navigationController.topViewController, isAnInstanceOf: AddProductFromImageHostingController.self)
+        assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're running an A/B experiment for a new starting screen for the product creation flow. This new screen just contains 3 fields: image, name, and description. When selecting a packaging image, the texts can be scanned and used to generate product details (name and description for now). The latest POC looks like pe5sF9-1Es-p2#comment-2427.

This PR updates the entry point from the beginning of the product creation flow to after the user selects a physical product, based on the discussion p1688726507910159/1688653635.239979-slack-C03L1NF1EA3. It also updated the analytics for us to understand more about product creation for future projects.

## How

The block of code for the A/B experiment was moved from the coordinator's `start` to `presentProductForm(bottomSheetProductType:)` to only allow the new "add product from image" feature after the user selects a physical (simple+non-virtual) product from the bottom sheet.

Some updates on the analytics in product creation, based on pe5sF9-1H4-p2#metrics:
- Track exposure event `add_product_from_image_eligible` for the A/B experiment
- Track a new event `add_product_started` when the user starts product creation from any entry point
- Update `add_product_product_type_selected` event to track 2 additional event properties: `is_virtual` and `creation_type`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### WPCOM store

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product --> an event should be tracked `🔵 Tracked add_product_started, properties: [AnyHashable("source"): "products_tab", AnyHashable("has_products"): true, ...]` where `has_products` indicates whether the store has any products
- If the store has 0-2 products, tap `Add manually`
- Tap on `Simple physical product` --> the new "add product from image" flow should be shown, with two events `add_product_from_image_eligible` and `add_product_product_type_selected` with `product_type=simple, is_virtual=false, creation_type=manual`
- Dismiss the form to go back to the Products tab
- Tap + to add a product
- If the store has 0-2 products, tap `Add manually`
- Tap on any other product type that's not a physical product --> the original product form should be shown, with just `add_product_product_type_selected` tracked

### Self-hosted store

- Log in to a self-hosted store
- Go to the Products tab
- Tap + to add a product
- If the store has 0-2 products, tap `Add manually`
- Tap on `Simple physical product` --> the original product form should be shown, with just `add_product_product_type_selected` tracked

---

- [ ] @jaclync tests other entry points for the `add_product_started` event

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.