### PR TITLE
[Orders with Coupons M4] Add discount to product business logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -736,7 +736,7 @@ extension EditableOrderViewModel {
                                                                       didSelectSave: saveShippingLineClosure)
             self.feeLineViewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: shouldShowFees,
                                                                       baseAmountForPercentage: feesBaseAmountForPercentage,
-                                                                      total: feeLineTotal,
+                                                                      initialTotal: feeLineTotal,
                                                                       lineType: .fee,
                                                             didSelectSave: saveFeeLineClosure)
             self.addCouponLineViewModel = CouponLineDetailsViewModel(isExistingCouponLine: false,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1199,14 +1199,15 @@ private extension EditableOrderViewModel {
     func createSelectedProductViewModel(itemID: Int64) -> ProductInOrderViewModel? {
         // Find order item based on the provided id.
         // Creates the product row view model needed for `ProductInOrderViewModel`.
-        guard
-            let orderItem = orderSynchronizer.order.items.first(where: { $0.itemID == itemID }),
-            let rowViewModel = createProductRowViewModel(for: orderItem, canChangeQuantity: false)
-        else {
+        guard let orderItem = orderSynchronizer.order.items.first(where: { $0.itemID == itemID }),
+              let subTotalDecimal = currencyFormatter.convertToDecimal(orderItem.subtotal),
+              let rowViewModel = createProductRowViewModel(for: orderItem, canChangeQuantity: false) else {
             return nil
         }
 
-        return ProductInOrderViewModel(productRowViewModel: rowViewModel, onRemoveProduct: { [weak self] in
+        return ProductInOrderViewModel(productRowViewModel: rowViewModel,
+                                       baseAmountForDiscountPercentage: subTotalDecimal as Decimal,
+                                       onRemoveProduct: { [weak self] in
             self?.removeItemFromOrder(orderItem)
         }, onSaveFormattedDiscount: { [weak self] formattedDiscount in
             guard let formattedDiscount = formattedDiscount else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -842,14 +842,14 @@ private extension EditableOrderViewModel {
         for product in products {
             // Only perform the operation if the product has not been already added to the existing Order
             if !itemsInOrder.contains(where: { $0.productID == product.productID }) {
-                productInputs.append(OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0))
+                productInputs.append(OrderSyncProductInput(product: .product(product), quantity: 1))
             }
         }
 
         for variation in variations {
             // Only perform the operation if the variation has not been already added to the existing Order
             if !itemsInOrder.contains(where: { $0.productOrVariationID == variation.productVariationID }) {
-                productVariationInputs.append(OrderSyncProductInput(product: .variation(variation), quantity: 1, discount: 0))
+                productVariationInputs.append(OrderSyncProductInput(product: .variation(variation), quantity: 1))
             }
         }
 
@@ -980,11 +980,11 @@ private extension EditableOrderViewModel {
             case let .product(product):
                 allProducts.insert(product)
                 selectedProducts.append(product)
-                orderSynchronizer.setProduct.send(.init(product: .product(product), quantity: 1, discount: 0))
+                orderSynchronizer.setProduct.send(.init(product: .product(product), quantity: 1))
             case let .variation(productVariation):
                 allProductVariations.insert(productVariation)
                 selectedProductVariations.append(productVariation)
-                orderSynchronizer.setProduct.send(.init(product: .variation(productVariation), quantity: 1, discount: 0))
+                orderSynchronizer.setProduct.send(.init(product: .variation(productVariation), quantity: 1))
             }
 
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -444,6 +444,10 @@ final class EditableOrderViewModel: ObservableObject {
         analytics.track(event: WooAnalyticsEvent.Orders.orderProductRemove(flow: flow.analyticsFlow))
     }
 
+    func addDiscountToOrderItem(item: OrderItem, formattedDiscount: String) {
+        debugPrint("Add discount \(formattedDiscount) to item \(item)")
+    }
+
     /// Creates a view model for the `ProductRow` corresponding to an order item.
     ///
     func createProductRowViewModel(for item: OrderItem, canChangeQuantity: Bool) -> ProductRowViewModel? {
@@ -1202,9 +1206,14 @@ private extension EditableOrderViewModel {
             return nil
         }
 
-        return ProductInOrderViewModel(productRowViewModel: rowViewModel) { [weak self] in
+        return ProductInOrderViewModel(productRowViewModel: rowViewModel, onRemoveProduct: { [weak self] in
             self?.removeItemFromOrder(orderItem)
-        }
+        }, onSaveFormattedDiscount: { [weak self] formattedDiscount in
+            guard let formattedDiscount = formattedDiscount else {
+                return
+            }
+            self?.addDiscountToOrderItem(item: orderItem, formattedDiscount: formattedDiscount)
+        })
     }
 
     /// Creates `ProductRowViewModels` ready to be used as product rows.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeOrDiscountLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeOrDiscountLineDetails.swift
@@ -178,7 +178,7 @@ struct FeeOrDiscountLineDetails_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: true,
                                                           baseAmountForPercentage: 200,
-                                                          total: "10",
+                                                          initialTotal: "10",
                                                           lineType: .fee,
                                                           didSelectSave: { _ in })
         FeeOrDiscountLineDetails(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeOrDiscountLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/FeeOrDiscountLineDetailsViewModel.swift
@@ -189,7 +189,7 @@ class FeeOrDiscountLineDetailsViewModel: ObservableObject {
 
     init(isExistingLine: Bool,
          baseAmountForPercentage: Decimal,
-         total: String,
+         initialTotal: String,
          lineType: LineType,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
@@ -204,7 +204,7 @@ class FeeOrDiscountLineDetailsViewModel: ObservableObject {
         self.isExistingLine = isExistingLine
         self.baseAmountForPercentage = baseAmountForPercentage
 
-        if let initialAmount = currencyFormatter.convertToDecimal(total) {
+        if let initialAmount = currencyFormatter.convertToDecimal(initialTotal) {
             self.initialAmount = initialAmount as Decimal
         } else {
             self.initialAmount = .zero

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -37,11 +37,7 @@ struct ProductInOrder: View {
                     }
                     .background(Color(.listForeground(modal: false)))
                     .sheet(isPresented: $shouldShowDiscountLineDetails) {
-                        FeeOrDiscountLineDetails(viewModel: FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
-                                                                                              baseAmountForPercentage: 50,
-                                                                                              total: "0.00",
-                                                                                              lineType: .discount,
-                                                                                              didSelectSave: { _ in }))
+                        FeeOrDiscountLineDetails(viewModel: viewModel.discountDetailsViewModel)
                     }
                     Spacer(minLength: Layout.sectionSpacing)
                     Section {
@@ -103,7 +99,8 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             canChangeQuantity: false,
                                             imageURL: nil)
         let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
-                                                onRemoveProduct: {})
+                                                onRemoveProduct: {},
+                                                onSaveFormattedDiscount: {_ in })
         ProductInOrder(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -101,7 +101,7 @@ struct ProductInOrder_Previews: PreviewProvider {
         let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
                                                 baseAmountForDiscountPercentage: 0,
                                                 onRemoveProduct: {},
-                                                onSaveFormattedDiscount: {_ in })
+                                                onSaveFormattedDiscount: { _ in })
         ProductInOrder(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -99,6 +99,7 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             canChangeQuantity: false,
                                             imageURL: nil)
         let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
+                                                baseAmountForDiscountPercentage: 0,
                                                 onRemoveProduct: {},
                                                 onSaveFormattedDiscount: {_ in })
         ProductInOrder(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -28,7 +28,7 @@ final class ProductInOrderViewModel: Identifiable {
     lazy var discountDetailsViewModel: FeeOrDiscountLineDetailsViewModel = {
         FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                           baseAmountForPercentage: 50,
-                                          total: "0.00",
+                                          initialTotal: "0.00",
                                           lineType: .discount,
                                           didSelectSave: onSaveFormattedDiscount)
     }()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -13,11 +13,23 @@ final class ProductInOrderViewModel: Identifiable {
 
     let isAddingDiscountToProductEnabled: Bool
 
+    let onSaveFormattedDiscount: (String?) -> Void
+
     init(productRowViewModel: ProductRowViewModel,
          onRemoveProduct: @escaping () -> Void,
+         onSaveFormattedDiscount: @escaping (String?) -> Void,
          isAddingDiscountToProductEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4)) {
         self.productRowViewModel = productRowViewModel
         self.onRemoveProduct = onRemoveProduct
+        self.onSaveFormattedDiscount = onSaveFormattedDiscount
         self.isAddingDiscountToProductEnabled = isAddingDiscountToProductEnabled
     }
+
+    lazy var discountDetailsViewModel: FeeOrDiscountLineDetailsViewModel = {
+        FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
+                                          baseAmountForPercentage: 50,
+                                          total: "0.00",
+                                          lineType: .discount,
+                                          didSelectSave: onSaveFormattedDiscount)
+    }()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -7,6 +7,8 @@ final class ProductInOrderViewModel: Identifiable {
     ///
     let productRowViewModel: ProductRowViewModel
 
+    let baseAmountForDiscountPercentage: Decimal
+
     /// Closure invoked when the product is removed.
     ///
     let onRemoveProduct: () -> Void
@@ -16,10 +18,12 @@ final class ProductInOrderViewModel: Identifiable {
     let onSaveFormattedDiscount: (String?) -> Void
 
     init(productRowViewModel: ProductRowViewModel,
+         baseAmountForDiscountPercentage: Decimal,
          onRemoveProduct: @escaping () -> Void,
          onSaveFormattedDiscount: @escaping (String?) -> Void,
          isAddingDiscountToProductEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4)) {
         self.productRowViewModel = productRowViewModel
+        self.baseAmountForDiscountPercentage = baseAmountForDiscountPercentage
         self.onRemoveProduct = onRemoveProduct
         self.onSaveFormattedDiscount = onSaveFormattedDiscount
         self.isAddingDiscountToProductEnabled = isAddingDiscountToProductEnabled
@@ -27,7 +31,7 @@ final class ProductInOrderViewModel: Identifiable {
 
     lazy var discountDetailsViewModel: FeeOrDiscountLineDetailsViewModel = {
         FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
-                                          baseAmountForPercentage: 50,
+                                          baseAmountForPercentage: baseAmountForDiscountPercentage,
                                           initialTotal: "0.00",
                                           lineType: .discount,
                                           didSelectSave: onSaveFormattedDiscount)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -23,9 +23,10 @@ struct OrderSyncProductInput {
     var id: Int64 = .zero
     let product: ProductType
     let quantity: Decimal
+    let discount: Decimal
 
     func updating(id: Int64) -> OrderSyncProductInput {
-        .init(id: id, product: self.product, quantity: self.quantity)
+        .init(id: id, product: self.product, quantity: self.quantity, discount: discount)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -23,7 +23,7 @@ struct OrderSyncProductInput {
     var id: Int64 = .zero
     let product: ProductType
     let quantity: Decimal
-    let discount: Decimal
+    var discount: Decimal = .zero
 
     func updating(id: Int64) -> OrderSyncProductInput {
         .init(id: id, product: self.product, quantity: self.quantity, discount: discount)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -9,13 +9,18 @@ struct ProductInputTransformer {
     struct OrderItemParameters {
         let quantity: Decimal
         let price: Decimal
+        let discount: Decimal
         let productID: Int64
         let variationID: Int64?
+        private var subTotalDecimal: Decimal {
+            price * quantity
+        }
+
         var subtotal: String {
-            "\(price * quantity)"
+            "\(subTotalDecimal)"
         }
         var total: String {
-            subtotal
+            "\(subTotalDecimal - discount)"
         }
     }
 
@@ -128,13 +133,17 @@ private extension ProductInputTransformer {
             switch input.product {
             case .product(let product):
                 let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: product.price) ?? .zero
-                return OrderItemParameters(quantity: input.quantity, price: price, productID: product.productID, variationID: nil)
+                return OrderItemParameters(quantity: input.quantity, price: price, discount: input.discount, productID: product.productID, variationID: nil)
             case .productID(let productID):
                 let price: Decimal = existingItem?.price.decimalValue ?? .zero
-                return OrderItemParameters(quantity: input.quantity, price: price, productID: productID, variationID: nil)
+                return OrderItemParameters(quantity: input.quantity, price: price, discount: input.discount, productID: productID, variationID: nil)
             case .variation(let variation):
                 let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: variation.price) ?? .zero
-                return OrderItemParameters(quantity: input.quantity, price: price, productID: variation.productID, variationID: variation.productVariationID)
+                return OrderItemParameters(quantity: input.quantity,
+                                           price: price,
+                                           discount: input.discount,
+                                           productID: variation.productID,
+                                           variationID: variation.productVariationID)
             }
         }()
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeOrDiscountLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/FeeOrDiscountLineDetailsViewModelTests.swift
@@ -14,7 +14,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 0,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -33,7 +33,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 0,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -59,7 +59,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
 
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 0,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: customSettings,
@@ -79,7 +79,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 100,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -99,7 +99,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 100,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -118,7 +118,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: true,
                                                 baseAmountForPercentage: 200,
-                                                total: "10",
+                                                initialTotal: "10",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -136,7 +136,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: true,
                                                 baseAmountForPercentage: 200,
-                                                total: "-10",
+                                                initialTotal: "-10",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -154,7 +154,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 200,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -190,7 +190,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: true,
                                                 baseAmountForPercentage: 100,
-                                                total: "11.30",
+                                                initialTotal: "11.30",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -215,7 +215,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Initial fee is $10/5%
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: true,
                                                 baseAmountForPercentage: 200,
-                                                total: "10",
+                                                initialTotal: "10",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -239,7 +239,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         var savedFeeLine: String?
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 0,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -260,7 +260,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         var savedFeeLine: String?
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 200,
-                                                total: "0",
+                                                initialTotal: "0",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -282,7 +282,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         var savedFeeLine: String?
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 0,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -302,7 +302,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 0,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,
@@ -316,7 +316,7 @@ final class FeeOrDiscountLineDetailsViewModelTests: XCTestCase {
         // Given
         let viewModel = FeeOrDiscountLineDetailsViewModel(isExistingLine: false,
                                                 baseAmountForPercentage: 0,
-                                                total: "",
+                                                initialTotal: "",
                                                 lineType: .fee,
                                                 locale: usLocale,
                                                 storeCurrencySettings: usStoreSettings,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -16,7 +16,7 @@ class ProductInputTransformerTests: XCTestCase {
     func test_sending_a_new_product_input_adds_an_item_to_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
-        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
@@ -38,8 +38,8 @@ class ProductInputTransformerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
         let anotherProduct = Product.fake().copy(productID: anotherSampleProductID, price: "9.99")
         let input = [
-            OrderSyncProductInput(product: .product(product), quantity: 1),
-            OrderSyncProductInput(product: .product(anotherProduct), quantity: 1)
+            OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0),
+            OrderSyncProductInput(product: .product(anotherProduct), quantity: 1, discount: 0)
         ]
         let originalOrder = OrderFactory.emptyNewOrder
 
@@ -69,7 +69,7 @@ class ProductInputTransformerTests: XCTestCase {
     func test_sending_a_new_product_variation_input_adds_an_item_to_order() throws {
         // Given
         let productVariation = ProductVariation.fake().copy(productID: sampleProductID, productVariationID: sampleProductVariationID, price: "9.99")
-        let input = OrderSyncProductInput(product: .variation(productVariation), quantity: 1)
+        let input = OrderSyncProductInput(product: .variation(productVariation), quantity: 1, discount: 0)
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
@@ -95,8 +95,8 @@ class ProductInputTransformerTests: XCTestCase {
                                                                    productVariationID: anotherSampleProductVariationID,
                                                                    price: "9.99")
         let input = [
-            OrderSyncProductInput(product: .variation(productVariation), quantity: 1),
-            OrderSyncProductInput(product: .variation(anotherProductVariation), quantity: 1)
+            OrderSyncProductInput(product: .variation(productVariation), quantity: 1, discount: 0),
+            OrderSyncProductInput(product: .variation(anotherProductVariation), quantity: 1, discount: 0)
         ]
         let originalOrder = OrderFactory.emptyNewOrder
 
@@ -127,11 +127,11 @@ class ProductInputTransformerTests: XCTestCase {
     func test_sending_a_new_product_input_twice_adds_adds_two_items_to_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
-        let input1 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        let input1 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1, discount: 0)
         let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
-        let input2 = OrderSyncProductInput(id: sampleInputID + 1, product: .product(product), quantity: 1)
+        let input2 = OrderSyncProductInput(id: sampleInputID + 1, product: .product(product), quantity: 1, discount: 0)
         let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
@@ -141,11 +141,11 @@ class ProductInputTransformerTests: XCTestCase {
     func test_sending_an_update_product_input_updates_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
-        let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
+        let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1, discount: 0)
         let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
-        let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2)
+        let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2, discount: 0)
         let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
@@ -161,13 +161,13 @@ class ProductInputTransformerTests: XCTestCase {
     func test_updatedOrder_when_updateMultipleItems_sends_an_updated_product_input_then_updates_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
-        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
+        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1, discount: 0)
         let initialOrder = ProductInputTransformer.updateMultipleItems(with: [productInput],
                                                                        on: OrderFactory.emptyNewOrder,
                                                                        shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
-        let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2)
+        let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2, discount: 0)
         let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
@@ -191,7 +191,7 @@ class ProductInputTransformerTests: XCTestCase {
         let order = Order.fake().copy(items: [item])
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
+        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2, discount: 0)
         let updatedOrder = ProductInputTransformer.update(input: input, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // Then
@@ -208,7 +208,7 @@ class ProductInputTransformerTests: XCTestCase {
         let order = Order.fake().copy(items: [item])
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
+        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2, discount: 0)
         let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [input], on: order, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // Then
@@ -221,11 +221,11 @@ class ProductInputTransformerTests: XCTestCase {
     func test_sending_a_zero_quantity_update_product_input_deletes_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
-        let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
+        let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1, discount: 0)
         let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
-        let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
+        let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0, discount: 0)
         let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
@@ -235,13 +235,13 @@ class ProductInputTransformerTests: XCTestCase {
     func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_deletes_zero_quantities_then_deletes_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
-        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
+        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1, discount: 0)
         let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput],
                                                                              on: OrderFactory.emptyNewOrder,
                                                                              shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
-        let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
+        let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0, discount: 0)
         let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2],
                                                                       on: initialOrderUpdate,
                                                                       shouldUpdateOrDeleteZeroQuantities: .delete)
@@ -252,11 +252,11 @@ class ProductInputTransformerTests: XCTestCase {
     func test_sending_a_zero_quantity_update_product_input_does_not_delete_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
-        let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
+        let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1, discount: 0)
         let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // When
-        let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
+        let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0, discount: 0)
         let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // Then
@@ -267,13 +267,13 @@ class ProductInputTransformerTests: XCTestCase {
     func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updates_zero_quantities_then_updates_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
-        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
+        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1, discount: 0)
         let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput],
                                                                              on: OrderFactory.emptyNewOrder,
                                                                              shouldUpdateOrDeleteZeroQuantities: .update)
 
         // When
-        let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
+        let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0, discount: 0)
         let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2],
                                                                       on: initialOrderUpdate,
                                                                       shouldUpdateOrDeleteZeroQuantities: .update)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -158,7 +158,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.total, "19.98")
     }
 
-    func test_sending_an_product_with_a_discount_input_updates_item_on_order() throws {
+    func test_sending_a_product_with_a_discount_input_updates_item_on_order() throws {
         // Given
         let price: Decimal = 9.99
         let product = Product.fake().copy(productID: sampleProductID, price: "\(price)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -51,7 +51,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1, discount: 0)
         synchronizer.setProduct.send(input)
 
         // Then
@@ -67,7 +67,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1)
+        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1, discount: 0)
         synchronizer.setProduct.send(input)
 
         // Then
@@ -86,7 +86,8 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let productInput = OrderSyncProductInput(
             id: sampleInputID,
             product: .product(product),
-            quantity: 1)
+            quantity: 1,
+            discount: 0)
 
         // Confidence check
         XCTAssertEqual(synchronizer.order.items.count, 0)
@@ -111,7 +112,8 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let productInput = OrderSyncProductInput(
             id: sampleInputID,
             product: .productID(sampleProductID),
-            quantity: 1)
+            quantity: 1,
+            discount: 0)
 
         // Confidence check
         XCTAssertEqual(synchronizer.order.items.count, 0)
@@ -139,11 +141,13 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let productInput = OrderSyncProductInput(
             id: sampleInputID,
             product: .product(product),
-            quantity: 1)
+            quantity: 1,
+            discount: 0)
         let anotherProductInput = OrderSyncProductInput(
             id: anotherSampleInputID,
             product: .product(anotherProduct),
-            quantity: 1)
+            quantity: 1,
+            discount: 0)
 
         // Confidence check
         XCTAssertEqual(synchronizer.order.items.count, 0)
@@ -173,11 +177,13 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let productInput = OrderSyncProductInput(
             id: sampleInputID,
             product: .productID(12345),
-            quantity: 1)
+            quantity: 1,
+            discount: 0)
         let anotherProductInput = OrderSyncProductInput(
             id: anotherSampleInputID,
             product: .productID(67890),
-            quantity: 1)
+            quantity: 1,
+            discount: 0)
 
         // Confidence check
         XCTAssertEqual(synchronizer.order.items.count, 0)
@@ -207,11 +213,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1, discount: 0)
         synchronizer.setProduct.send(initialInput)
 
         // When
-        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2, discount: 0)
         synchronizer.setProduct.send(updatedInput)
 
         // Then
@@ -225,11 +231,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1, discount: 0)
         synchronizer.setProduct.send(initialInput)
 
         // When
-        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 2)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 2, discount: 0)
         synchronizer.setProduct.send(updatedInput)
 
         // Then
@@ -245,11 +251,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1, discount: 0)
         synchronizer.setProduct.send(initialInput)
 
         // When
-        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 0)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 0, discount: 0)
         synchronizer.setProduct.send(updatedInput)
 
         // Then
@@ -261,11 +267,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1, discount: 0)
         synchronizer.setProduct.send(initialInput)
 
         // When
-        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 0)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 0, discount: 0)
         synchronizer.setProduct.send(updatedInput)
 
         // Then
@@ -350,7 +356,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -374,7 +380,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -399,7 +405,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -427,7 +433,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -456,7 +462,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -483,7 +489,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -513,10 +519,10 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1)
+            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1, discount: 0)
             self.createOrder(on: synchronizer, input: initialInput)
 
-            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2)
+            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -546,10 +552,10 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 1)
+            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             self.createOrder(on: synchronizer, input: initialInput)
 
-            let input = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2)
+            let input = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -580,11 +586,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1)
+            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1, discount: 0)
             self.createOrder(on: synchronizer, input: initialInput)
 
             // Update the same input, using productID ProductType
-            let updatedInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2)
+            let updatedInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2, discount: 0)
             synchronizer.setProduct.send(updatedInput)
         }
 
@@ -836,10 +842,10 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
 
         // When
         synchronizer.setNote.send(firstNote)
-        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
-        let input2 = OrderSyncProductInput(product: .product(product), quantity: 2)
+        let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
         synchronizer.setProduct.send(input2)
         synchronizer.setNote.send(expectedNote)
 
@@ -903,7 +909,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
                 .store(in: &self.subscriptions)
 
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -934,7 +940,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
                 .store(in: &self.subscriptions)
 
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -959,7 +965,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Wait for order creation
-        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         let states: [OrderSyncState] = waitFor { promise in
@@ -972,7 +978,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 .store(in: &self.subscriptions)
 
             // Trigger order update
-            let input2 = OrderSyncProductInput(product: .product(product), quantity: 2)
+            let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
         }
 
@@ -996,7 +1002,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Wait for order creation
-        let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+        let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         let states: [OrderSyncState] = waitFor { promise in
@@ -1009,7 +1015,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 .store(in: &self.subscriptions)
 
             // Trigger order update
-            let updatedInput = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 2)
+            let updatedInput = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 2, discount: 0)
             synchronizer.setProduct.send(updatedInput)
         }
 
@@ -1035,7 +1041,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Wait for order creation
-        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         let states: [OrderSyncState] = waitFor { promise in
@@ -1048,7 +1054,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 .store(in: &self.subscriptions)
 
             // Trigger order update
-            let input2 = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2)
+            let input2 = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
         }
 
@@ -1073,7 +1079,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Wait for order creation
-        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(self.sampleProductID), quantity: 1)
+        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(self.sampleProductID), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         let states: [OrderSyncState] = waitFor { promise in
@@ -1086,7 +1092,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 .store(in: &self.subscriptions)
 
             // Trigger order update
-            let updatedInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2)
+            let updatedInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2, discount: 0)
             synchronizer.setProduct.send(updatedInput)
         }
 
@@ -1113,7 +1119,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
         XCTAssertTrue(receivedError)
@@ -1128,7 +1134,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -1154,7 +1160,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
         XCTAssertTrue(receivedError)
@@ -1169,7 +1175,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -1202,7 +1208,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
                 .store(in: &self.subscriptions)
 
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -1234,7 +1240,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
                 .store(in: &self.subscriptions)
 
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -1260,7 +1266,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Wait for order creation
-        let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         let states: [OrderSyncState] = waitFor { promise in
@@ -1273,7 +1279,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 .store(in: &self.subscriptions)
 
             // Trigger order update
-            let input2 = OrderSyncProductInput(product: .product(product), quantity: 2)
+            let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
         }
 
@@ -1298,7 +1304,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Wait for order creation
-        let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1)
+        let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         let states: [OrderSyncState] = waitFor { promise in
@@ -1311,7 +1317,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 .store(in: &self.subscriptions)
 
             // Trigger order update
-            let updatedInput = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 2)
+            let updatedInput = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 2, discount: 0)
             synchronizer.setProduct.send(updatedInput)
         }
 
@@ -1339,10 +1345,10 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
         }
 
-        let input1 = OrderSyncProductInput(product: .product(product), quantity: 1)
+        let input1 = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
         synchronizer.setProduct.send(input1)
 
-        let input2 = OrderSyncProductInput(product: .product(product), quantity: 2)
+        let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
         synchronizer.setProduct.send(input2)
 
         // Then
@@ -1362,7 +1368,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 switch action {
                 case .createOrder(_, _, let completion):
                     // Send update request before order is created
-                    let input2 = OrderSyncProductInput(product: .product(product), quantity: 2)
+                    let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
                     synchronizer.setProduct.send(input2)
 
                     // Complete order creation
@@ -1378,7 +1384,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
 
             // Send creation request
-            let input1 = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input1 = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input1)
         }
     }
@@ -1463,11 +1469,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
 
             // Wait for order creation
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             self.createOrder(on: synchronizer, input: input)
 
             // Send order update
-            let input2 = OrderSyncProductInput(product: .product(product), quantity: 2)
+            let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
         }
 
@@ -1499,7 +1505,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
 
             // Send order update
-            let input = OrderSyncProductInput(product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -1526,7 +1532,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 }
             }
 
-            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
         XCTAssertTrue(orderCreationFailed)
@@ -1572,11 +1578,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
 
             // Wait for order creation
-            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1)
+            let input = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1, discount: 0)
             self.createOrder(on: synchronizer, input: input)
 
             // Trigger order update
-            let input2 = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2)
+            let input2 = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
         }
         XCTAssertTrue(orderUpdateFailed)
@@ -1664,7 +1670,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
         }
 
-        let input = OrderSyncProductInput.init(product: .product(.fake()), quantity: 1)
+        let input = OrderSyncProductInput.init(product: .product(.fake()), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         // When
@@ -1701,12 +1707,12 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Wait for order creation
-        let input1 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        let input1 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input1)
 
         // Trigger product quantity updates
-        let input2 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
-        let input3 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 3)
+        let input2 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2, discount: 0)
+        let input3 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 3, discount: 0)
         synchronizer.setProduct.send(input2)
         synchronizer.setProduct.send(input3)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10202 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the business logic to add a discount to a product. The EditableOrderViewModel creates a new product input with the discount and passes it to the order synchronizer, in a similar way we do for quantities. We therefore refactor the functions and classes involved to accomplish that.
We add a discount to a product by changing the item total (subtotal - discount). This is done in the `ProductInputTransformer`.
Apart from that, I didn't implement any mechanism to avoid higher discounts than the product price itself, as it doesn't make the order fail, and it's already allowed with (negative) fees. We can end up with a negative order total, but that's also allowed in WC Core.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Orders.
2. Tap to Create a new order.
3. Add a product.
4. Tap on the product row.
5. Tap to add a discount. Tap on Done.
6. Go back to order details. See that the order total shows the discounted value. You can also check that once you create the order in wp-admin (See screenshots)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/29d29170-3180-4689-b5ff-90516d2bf6cd" width="375">

<img width="1376" alt="Screenshot 2023-07-11 at 14 23 37" src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/edebfb20-8e28-40d5-aa13-d1b93828718d">


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
