### PR TITLE
Add product from image: scan text from the image and generate product details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
@@ -60,6 +60,6 @@ private extension AddProductFromImageFormImageView {
 
 struct AddProductFromImageFormImageView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductFromImageFormImageView(viewModel: .init(onAddImage: { _ in nil }))
+        AddProductFromImageFormImageView(viewModel: .init(siteID: 0, onAddImage: { _ in nil }))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -31,7 +31,7 @@ struct AddProductFromImageView: View {
          stores: StoresManager = ServiceLocator.stores,
          completion: @escaping (AddProductFromImageData) -> Void) {
         self.completion = completion
-        self._viewModel = .init(wrappedValue: AddProductFromImageViewModel(onAddImage: addImage))
+        self._viewModel = .init(wrappedValue: AddProductFromImageViewModel(siteID: siteID, stores: stores, onAddImage: addImage))
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import SwiftUI
+import Vision
 import Yosemite
 
 /// View model for `AddProductFromImageView` to handle user actions from the view and provide data for the view.
@@ -22,7 +23,18 @@ final class AddProductFromImageViewModel: ObservableObject {
     private let onAddImage: (MediaPickingSource) async -> MediaPickerImage?
     private var selectedImageSubscription: AnyCancellable?
 
-    init(onAddImage: @escaping (MediaPickingSource) async -> MediaPickerImage?) {
+    // MARK: - Scanned Texts
+
+    @Published private(set) var isGeneratingDetails: Bool = false
+
+    private let siteID: Int64
+    private let stores: StoresManager
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         onAddImage: @escaping (MediaPickingSource) async -> MediaPickerImage?) {
+        self.siteID = siteID
+        self.stores = stores
         self.onAddImage = onAddImage
 
         selectedImageSubscription = $imageState.compactMap { $0.image?.image }
@@ -47,6 +59,68 @@ final class AddProductFromImageViewModel: ObservableObject {
 
 private extension AddProductFromImageViewModel {
     func onSelectedImage(_ image: UIImage) {
-        // TODO: 10180 - scan texts from the image
+        // Gets the CGImage on which to perform requests.
+        guard let cgImage = image.cgImage else {
+            return
+        }
+
+        // Creates a new image-request handler.
+        let requestHandler = VNImageRequestHandler(cgImage: cgImage)
+
+        // Creates a new request to recognize text.
+        let request = VNRecognizeTextRequest { [weak self] request, error in
+            self?.onScannedTextRequestCompletion(request: request, error: error)
+        }
+
+        if #available(iOS 16.0, *) {
+            request.revision = VNRecognizeTextRequestRevision3
+            request.automaticallyDetectsLanguage = true
+        }
+
+        do {
+            // Performs the text-recognition request.
+            try requestHandler.perform([request])
+        } catch {
+            DDLogError("⛔️ Unable to perform image text generation request: \(error)")
+        }
+    }
+
+    func onScannedTextRequestCompletion(request: VNRequest, error: Error?) {
+        let texts = scannedTexts(from: request)
+        Task { @MainActor in
+            isGeneratingDetails = true
+            await generateAndPopulateProductDetails(from: texts)
+            isGeneratingDetails = false
+        }
+    }
+
+    func scannedTexts(from request: VNRequest) -> [String] {
+        guard let observations = request.results as? [VNRecognizedTextObservation] else {
+            return []
+        }
+        let recognizedStrings = observations.compactMap { observation in
+            // Returns the string of the top VNRecognizedText instance.
+            observation.topCandidates(1).first?.string
+        }
+        return recognizedStrings
+    }
+
+    func generateAndPopulateProductDetails(from scannedTexts: [String]) async {
+        switch await generateProductDetails(from: scannedTexts) {
+            case .success(let details):
+                name = details.name
+                description = details.description
+            case .failure(let error):
+                DDLogError("⛔️ Error generating product details from scanned text: \(error)")
+        }
+    }
+
+    func generateProductDetails(from scannedTexts: [String]) async -> Result<ProductDetailsFromScannedTexts, Error> {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(ProductAction.generateProductDetails(siteID: siteID,
+                                                                 scannedTexts: scannedTexts) { result in
+                continuation.resume(returning: result)
+            })
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class AddProductFromImageViewModelTests: XCTestCase {
     func test_initial_name_is_empty() throws {
         // Given
-        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in nil })
+        let viewModel = AddProductFromImageViewModel(siteID: 6, onAddImage: { _ in nil })
 
         // Then
         XCTAssertEqual(viewModel.name, "")
@@ -15,7 +15,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
 
     func test_initial_description_is_empty() throws {
         // Given
-        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in nil })
+        let viewModel = AddProductFromImageViewModel(siteID: 6, onAddImage: { _ in nil })
 
         // Then
         XCTAssertEqual(viewModel.description, "")
@@ -26,7 +26,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
     func test_imageState_is_reverted_to_empty_when_addImage_returns_nil() {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
-        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in
+        let viewModel = AddProductFromImageViewModel(siteID: 6, onAddImage: { _ in
             nil
         })
         XCTAssertEqual(viewModel.imageState, .empty)
@@ -45,7 +45,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         var imageToReturn: MediaPickerImage? = image
-        let viewModel = AddProductFromImageViewModel(onAddImage: { _ in
+        let viewModel = AddProductFromImageViewModel(siteID: 6, onAddImage: { _ in
             imageToReturn
         })
         XCTAssertEqual(viewModel.imageState, .empty)


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're running an A/B experiment for a new starting screen for the product creation flow. This new screen just contains 3 fields: image, name, and description. When selecting a packaging image, the texts can be scanned and used to generate product details (name and description for now). The latest POC looks like pe5sF9-1Es-p2#comment-2427.

This PR includes the behind-the-scene flow where the selected image is scanned for text, and the list of scanned texts is used to generate product details with Jetpack AI.

## How

Most of the changes are in `AddProductFromImageViewModel`, with one new observable property `isGeneratingDetails` for the view to show a loading state on the name/description fields. Please note that the UI/UX will be updated in a future PR to allow editing of the text fields with the AI-generated suggestion below them.

Once an image is selected, it first creates a Vision request to scan the text from the image. Then, if any scanned texts are returned, they are used to make an API request to generate product details. The generated details update the name/description text.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- Tap on the image header to add an image with some text using any source (camera/device library/media library) --> the name/description fields should transition to a loading state. Shortly, the name/description should be populated with the AI-generated details from the scanned texts. 🗒️ if you don't see the generated details, there might be some error with the request in the console. please share the error in this case
- Tap `Continue` --> the new screen should be dismissed and then it navigates to the main product form
- Tap `Publish` to publish the product --> the product should be saved remotely with the selected image and generated name and description

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/302c74f0-04b7-41eb-b60a-046d49e8f096



loading state | generated details 
-- | --
![Simulator Screenshot - iPhone 14 - 2023-07-11 at 17 04 30](https://github.com/woocommerce/woocommerce-ios/assets/1945542/9587c961-e837-44b7-97de-e9879795a83e) | ![Simulator Screenshot - iPhone 14 - 2023-07-11 at 17 04 35](https://github.com/woocommerce/woocommerce-ios/assets/1945542/4ae62786-cf4f-4fc3-9c72-fe8c4f474877)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
