### PR TITLE
Product form: Update share button to use text instead of icon

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 14.5
 -----
+- [*] Product details: The share button is displayed with text instead of icon for better discoverability. [https://github.com/woocommerce/woocommerce-ios/pull/10216]
 
 
 14.4

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -54,7 +54,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         presentationStyle.createExitForm(viewController: self)
     }()
 
-    private lazy var shareBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action,
+    private lazy var shareBarButtonItem = UIBarButtonItem(title: Localization.share,
+                                                          style: .plain,
                                                           target: self,
                                                           action: #selector(shareProduct))
 
@@ -1843,6 +1844,7 @@ private extension ProductFormViewController {
 // MARK: Constants
 //
 private enum Localization {
+    static let share = NSLocalizedString("Share", comment: "Action for sharing a product from the product details screen")
     static let publishTitle = NSLocalizedString("Publish", comment: "Action for creating a new product remotely with a published status")
     static let saveTitle = NSLocalizedString("Save", comment: "Action for saving a Product remotely")
     static let previewTitle = NSLocalizedString("Preview", comment: "Action for previewing draft Product changes in the webview")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10213 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR follows the internal discussion about the performance of the share button between iOS and Android. The share button is updated to use text instead of icon to see if it improves the tap rate.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a public store with at least one published product.
- Select an existing product.
- Notice the share button is now a text instead of icon.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/abc21803-c23c-43c6-8a93-23d4172661f2" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
