### PR TITLE
Add product from image: show a list of selectable & editable scanned texts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Selectable and editable scanned text for generating product details in the "add product from image" flow in `AddProductFromImageView`.
+struct AddProductFromImageScannedTextView: View {
+    @ObservedObject private var viewModel: AddProductFromImageViewModel.ScannedTextViewModel
+
+    init(viewModel: AddProductFromImageViewModel.ScannedTextViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        HStack {
+            TextField("", text: $viewModel.text)
+                .font(.body)
+            Spacer()
+            Button(action: {
+                viewModel.isSelected.toggle()
+            }) {
+                Image(systemName: viewModel.isSelected ? "checkmark.circle.fill" : "circle")
+            }
+        }
+        .padding(.vertical, insets: Layout.verticalPadding)
+    }
+}
+
+private extension AddProductFromImageScannedTextView {
+    enum Layout {
+        static let verticalPadding: EdgeInsets = .init(top: 6, leading: 0, bottom: 6, trailing: 0)
+    }
+}
+
+struct AddProductFromImageScannedTextView_Previews: PreviewProvider {
+    static var previews: some View {
+        List {
+            AddProductFromImageScannedTextView(viewModel: .init(text: "Parmesan", isSelected: true))
+            AddProductFromImageScannedTextView(viewModel: .init(text: "Looking for a healthy snack option that's both delicious and convenient? Look no further than our downloadable variety nuts!", isSelected: false))
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
@@ -33,7 +33,8 @@ struct AddProductFromImageScannedTextView_Previews: PreviewProvider {
     static var previews: some View {
         List {
             AddProductFromImageScannedTextView(viewModel: .init(text: "Parmesan", isSelected: true))
-            AddProductFromImageScannedTextView(viewModel: .init(text: "Looking for a healthy snack option that's both delicious and convenient? Look no further than our downloadable variety nuts!", isSelected: false))
+            AddProductFromImageScannedTextView(viewModel: .init(text: "Looking for a healthy snack option that's both delicious and convenient?",
+                                                                isSelected: false))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
@@ -9,7 +9,7 @@ struct AddProductFromImageScannedTextView: View {
     }
 
     var body: some View {
-        HStack {
+        HStack(spacing: Layout.horizontalPadding) {
             TextField("", text: $viewModel.text)
                 .font(.body)
             Spacer()
@@ -18,6 +18,7 @@ struct AddProductFromImageScannedTextView: View {
             }) {
                 Image(systemName: viewModel.isSelected ? "checkmark.circle.fill" : "circle")
             }
+            .buttonStyle(TextButtonStyle())
         }
         .padding(.vertical, Layout.verticalPadding)
     }
@@ -25,7 +26,8 @@ struct AddProductFromImageScannedTextView: View {
 
 private extension AddProductFromImageScannedTextView {
     enum Layout {
-        static let verticalPadding: CGFloat = 6
+        static let verticalPadding: CGFloat = 8
+        static let horizontalPadding: CGFloat = 6
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageScannedTextView.swift
@@ -19,13 +19,13 @@ struct AddProductFromImageScannedTextView: View {
                 Image(systemName: viewModel.isSelected ? "checkmark.circle.fill" : "circle")
             }
         }
-        .padding(.vertical, insets: Layout.verticalPadding)
+        .padding(.vertical, Layout.verticalPadding)
     }
 }
 
 private extension AddProductFromImageScannedTextView {
     enum Layout {
-        static let verticalPadding: EdgeInsets = .init(top: 6, leading: 0, bottom: 6, trailing: 0)
+        static let verticalPadding: CGFloat = 6
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -67,6 +67,7 @@ struct AddProductFromImageView: View {
 
                     // Info text about selecting/editing the scanned text list.
                     Text(Localization.scannedTextListInfo)
+                        .foregroundColor(.init(uiColor: .secondaryLabel))
                         .captionStyle()
                 }
                 List(viewModel.scannedTexts) { scannedText in

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -36,6 +36,7 @@ struct AddProductFromImageView: View {
 
     var body: some View {
         Form {
+            // Image header view.
             Section {
                 HStack {
                     Spacer()
@@ -44,6 +45,7 @@ struct AddProductFromImageView: View {
                 }
             }
 
+            // Name & description fields.
             Section {
                 // TODO: 10180 - use `TextEditor` with a placeholder overlay
                 TextField(Localization.nameFieldPlaceholder, text: $viewModel.name)
@@ -53,6 +55,25 @@ struct AddProductFromImageView: View {
                     .lineLimit(5)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            // Scanned text list.
+            Section {
+                VStack(alignment: .leading) {
+                    // Button to regenerate product details based on the selected scanned texts.
+                    Button(Localization.regenerateButtonTitle) {
+                        viewModel.generateProductDetails()
+                    }
+                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isGeneratingDetails))
+
+                    // Info text about selecting/editing the scanned text list.
+                    Text(Localization.scannedTextListInfo)
+                        .captionStyle()
+                }
+                List(viewModel.scannedTexts) { scannedText in
+                    AddProductFromImageScannedTextView(viewModel: scannedText)
+                }
+            }
+            .renderedIf(viewModel.scannedTexts.isNotEmpty)
         }
         .navigationTitle(Localization.title)
         .toolbar {
@@ -83,6 +104,14 @@ private extension AddProductFromImageView {
         static let continueButtonTitle = NSLocalizedString(
             "Continue",
             comment: "Continue button on the add product from image form."
+        )
+        static let regenerateButtonTitle = NSLocalizedString(
+            "Regenerate",
+            comment: "Regenerate button on the add product from image form to regenerate product details."
+        )
+        static let scannedTextListInfo = NSLocalizedString(
+            "Tweak your text: Unselect scans you don't need or tap to edit",
+            comment: "Info text about the scanned text list on the add product from image form."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -41,7 +41,7 @@ final class AddProductFromImageViewModel: ObservableObject {
     @Published private(set) var isGeneratingDetails: Bool = false
 
     private var selectedScannedTexts: [String] {
-        scannedTexts.filter { $0.isSelected }.map { $0.text }
+        scannedTexts.filter { $0.isSelected && $0.text.isNotEmpty }.map { $0.text }
     }
 
     private let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -6,13 +6,13 @@ import Yosemite
 /// View model for `AddProductFromImageView` to handle user actions from the view and provide data for the view.
 @MainActor
 final class AddProductFromImageViewModel: ObservableObject {
+    /// View model for `AddProductFromImageScannedTextView`.
     final class ScannedTextViewModel: ObservableObject, Identifiable {
         let id: String = UUID().uuidString
         @Published var text: String
         @Published var isSelected: Bool
 
-        init(text: String,
-             isSelected: Bool) {
+        init(text: String, isSelected: Bool) {
             self.text = text
             self.isSelected = isSelected
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -39,7 +39,6 @@ final class AddProductFromImageViewModel: ObservableObject {
 
     @Published var scannedTexts: [ScannedTextViewModel] = []
     @Published private(set) var isGeneratingDetails: Bool = false
-    @Published private(set) var showsRegenerateButton: Bool = false
 
     private var selectedScannedTexts: [String] {
         scannedTexts.filter { $0.isSelected }.map { $0.text }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -6,6 +6,18 @@ import Yosemite
 /// View model for `AddProductFromImageView` to handle user actions from the view and provide data for the view.
 @MainActor
 final class AddProductFromImageViewModel: ObservableObject {
+    final class ScannedTextViewModel: ObservableObject, Identifiable {
+        let id: String = UUID().uuidString
+        @Published var text: String
+        @Published var isSelected: Bool
+
+        init(text: String,
+             isSelected: Bool) {
+            self.text = text
+            self.isSelected = isSelected
+        }
+    }
+
     typealias ImageState = EditableImageViewState
 
     // MARK: - Product Details
@@ -25,7 +37,13 @@ final class AddProductFromImageViewModel: ObservableObject {
 
     // MARK: - Scanned Texts
 
+    @Published var scannedTexts: [ScannedTextViewModel] = []
     @Published private(set) var isGeneratingDetails: Bool = false
+    @Published private(set) var showsRegenerateButton: Bool = false
+
+    private var selectedScannedTexts: [String] {
+        scannedTexts.filter { $0.isSelected }.map { $0.text }
+    }
 
     private let siteID: Int64
     private let stores: StoresManager
@@ -53,6 +71,15 @@ final class AddProductFromImageViewModel: ObservableObject {
                 return imageState = previousState
             }
             imageState = .success(image)
+        }
+    }
+
+    /// Generates product details with the currently selected scanned texts.
+    func generateProductDetails() {
+        Task { @MainActor in
+            isGeneratingDetails = true
+            await generateAndPopulateProductDetails(from: Array(selectedScannedTexts))
+            isGeneratingDetails = false
         }
     }
 }
@@ -87,6 +114,7 @@ private extension AddProductFromImageViewModel {
 
     func onScannedTextRequestCompletion(request: VNRequest, error: Error?) {
         let texts = scannedTexts(from: request)
+        scannedTexts = texts.map { .init(text: $0, isSelected: true) }
         Task { @MainActor in
             isGeneratingDetails = true
             await generateAndPopulateProductDetails(from: texts)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -552,6 +552,7 @@
 		02F6800325807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */; };
 		02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800825807CD300C3BAD2 /* GridStackView.swift */; };
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
+		02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FFDDC62A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */; };
@@ -2925,6 +2926,7 @@
 		02F6800225807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionListView.swift; sourceTree = "<group>"; };
 		02F6800825807CD300C3BAD2 /* GridStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridStackView.swift; sourceTree = "<group>"; };
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
+		02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageScannedTextView.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Blaze.swift"; sourceTree = "<group>"; };
@@ -5648,6 +5650,7 @@
 				028B68BB2A57419700FE03A8 /* AddProductFromImageViewModel.swift */,
 				028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */,
 				02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */,
+				02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -12301,6 +12304,7 @@
 				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,
 				DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */,
 				26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */,
+				02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */,
 				022F2FA6295E77F4003A0A46 /* StoreCreationCountrySectionView.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
 				DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're running an A/B experiment for a new starting screen for the product creation flow. This new screen just contains 3 fields: image, name, and description. When selecting a packaging image, the texts can be scanned and used to generate product details (name and description for now). The latest POC looks like pe5sF9-1Es-p2#comment-2427.

The focus of this PR: After the text is scanned from the selected image, the list is now shown at the bottom of the form for the user to select/unselect or edit each scanned text. The selected scanned texts can then be used to regenerate product details.

## How

- A new view `AddProductFromImageScannedTextView` was created for each row in the scanned text list, for each scanned text to be selectable and editable
- In `AddProductFromImageViewModel`, added a new @Published var `scannedTexts` to be shown in the UI. A new function `generateProductDetails` was also added to support regeneration
- In `AddProductFromImageView`, a section was added to show the list of scanned texts with a CTA to regenerate product details by view model's `generateProductDetails`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- If the store has 0-2 products, tap `Add manually`
- Tap to select `Simple physical product`
- Tap on the image header to add an image with some text using any source (camera/device library/media library) --> a new section with a list of the scanned texts should be shown, and each scanned text is selectable and editable
- Unselect and edit the text of some rows
- Tap `Regenerate` --> the name/description should be updated shortly
- Tap `Continue` --> the new screen should be dismissed and then it navigates to the main product form
- Tap `Publish` to publish the product --> the product should be saved remotely with the selected image and generated name and description

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/12a3331e-3d50-4b09-89e7-bbc9e92f0061

light | dark
-- | --
![Simulator Screenshot - iPhone 14 - 2023-07-12 at 14 57 10](https://github.com/woocommerce/woocommerce-ios/assets/1945542/ec188719-3207-4991-beb0-673e72c1ebb8) | ![Simulator Screenshot - iPhone 14 - 2023-07-12 at 14 57 25](https://github.com/woocommerce/woocommerce-ios/assets/1945542/78fa57e9-4438-41e5-b145-67e2b1ccec20)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
