### PR TITLE
Store creation: Update timeout view to align with Android

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.5
 -----
 - [*] Product details: The share button is displayed with text instead of icon for better discoverability. [https://github.com/woocommerce/woocommerce-ios/pull/10216]
+- [*] Store creation: Update the timeout view with the option to retry the site check. [https://github.com/woocommerce/woocommerce-ios/pull/10221]
 
 
 14.4

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -114,6 +114,12 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreationTimedOut, properties: [:])
         }
 
+        /// Tracked when the Retry button on the timeout screen is tapped.
+        /// 
+        static func siteCreationTimeoutRetried() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationTimeoutRetried, properties: [:])
+        }
+
         /// Tracked when the store is jetpack ready, but other store properties are not in sync yet.
         ///
         static func siteCreationPropertiesOutOfSync() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -217,6 +217,7 @@ public enum WooAnalyticsStat: String {
     case siteCreationProfilerQuestionSkipped = "site_creation_profiler_question_skipped"
     case siteCreationTryForFreeTapped = "site_creation_try_for_free_tapped"
     case siteCreationTimedOut = "site_creation_timed_out"
+    case siteCreationTimeoutRetried = "site_creation_timeout_retried"
     case siteCreationPropertiesOutOfSync = "site_creation_properties_out_of_sync"
     case siteCreationFreeTrialCreatedSuccess = "site_creation_free_trial_created_success"
     case loginPrologueCreateSiteTapped = "login_prologue_create_site_tapped"

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -769,11 +769,10 @@ private extension StoreCreationCoordinator {
     func handleCompletionStatus(siteID: Int64, site: Site?, waitingTimeStart: Date, expectedStoreName: String) {
         cancelLocalNotificationWhenStoreIsReady()
         guard let site else {
-            showJetpackSiteTimeoutView { [weak self] in
+            return showJetpackSiteTimeoutView { [weak self] in
                 guard let self else { return }
                 await self.waitForSiteToBecomeJetpackSite(from: self.navigationController, siteID: siteID, expectedStoreName: expectedStoreName)
             }
-            return
         }
 
         // Sometimes, as soon as the jetpack installation is done some properties like `name` and `isWordPressComStore` are outdated.

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -771,6 +771,7 @@ private extension StoreCreationCoordinator {
         guard let site else {
             return showJetpackSiteTimeoutView { [weak self] in
                 guard let self else { return }
+                self.analytics.track(event: .StoreCreation.siteCreationTimeoutRetried())
                 await self.waitForSiteToBecomeJetpackSite(from: self.navigationController, siteID: siteID, expectedStoreName: expectedStoreName)
             }
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -521,12 +521,15 @@ private extension StoreCreationCoordinator {
             showInProgressView(from: navigationController, viewProperties: .init(title: Localization.WaitingForJetpackSite.title, message: ""))
             // Wait for jetpack to be installed
             DDLogInfo("🟢 Free trial enabled on site. Waiting for jetpack to be installed...")
-            waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteResult.siteID, expectedStoreName: siteResult.name)
-            analytics.track(event: .StoreCreation.siteCreationRequestSuccess(
-                siteID: siteResult.siteID,
-                domainName: siteResult.siteSlug
-            ))
-            analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
+            Task { @MainActor in
+                await waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteResult.siteID, expectedStoreName: siteResult.name)
+                analytics.track(event: .StoreCreation.siteCreationRequestSuccess(
+                    siteID: siteResult.siteID,
+                    domainName: siteResult.siteSlug
+                ))
+                analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
+            }
+
         case .failure(let error):
             showStoreCreationErrorAlert(from: navigationController.topmostPresentedViewController, error: error)
             analytics.track(event: .StoreCreation.siteCreationFailed(source: source.analyticsValue,
@@ -696,9 +699,11 @@ private extension StoreCreationCoordinator {
     func showInProgressViewWhileWaitingForJetpackSite(from navigationController: UINavigationController,
                                                       siteID: Int64,
                                                       expectedStoreName: String) {
-        waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteID, expectedStoreName: expectedStoreName)
-        showInProgressView(from: navigationController, viewProperties: .init(title: Localization.WaitingForJetpackSite.title, message: ""))
-        analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
+        Task { @MainActor in
+            await waitForSiteToBecomeJetpackSite(from: navigationController, siteID: siteID, expectedStoreName: expectedStoreName)
+            showInProgressView(from: navigationController, viewProperties: .init(title: Localization.WaitingForJetpackSite.title, message: ""))
+            analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
+        }
     }
 
     @MainActor
@@ -731,41 +736,44 @@ private extension StoreCreationCoordinator {
     }
 
     @MainActor
-    func waitForSiteToBecomeJetpackSite(from navigationController: UINavigationController, siteID: Int64, expectedStoreName: String) {
+    func waitForSiteToBecomeJetpackSite(from navigationController: UINavigationController, siteID: Int64, expectedStoreName: String) async {
         /// Timestamp when we start observing times. Needed to track the store creating waiting duration.
         ///
         let waitingTimeStart = Date()
 
         let statusChecker = StoreCreationStatusChecker(isFreeTrialCreation: isFreeTrialCreation, storeName: expectedStoreName, stores: stores)
         self.statusChecker = statusChecker
-        jetpackSiteSubscription = statusChecker.waitForSiteToBeReady(siteID: siteID)
-            .handleEvents(receiveCompletion: { [weak self] completion in
-                guard let self, case .failure = completion else {
-                    return
-                }
-                self.storeCreationProgressViewModel?.incrementProgress()
-            })
+        let site: Site? = await withCheckedContinuation { continuation in
+            jetpackSiteSubscription = statusChecker.waitForSiteToBeReady(siteID: siteID)
+                .handleEvents(receiveCompletion: { [weak self] completion in
+                    guard let self, case .failure = completion else {
+                        return
+                    }
+                    self.storeCreationProgressViewModel?.incrementProgress()
+                })
             // Retries 15 times with some seconds pause in between to wait for the newly created site to be available as a Jetpack/Woo site.
-            .retry(15)
-            .sink (receiveCompletion: { [weak self] completion in
-                guard let self, case .failure = completion else {
-                    return
-                }
-                self.handleCompletionStatus(site: nil, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
-            }, receiveValue: { [weak self] site in
-                guard let self else { return }
-                self.handleCompletionStatus(site: site, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
-            })
+                .retry(15)
+                .sink (receiveCompletion: { completion in
+                    guard case .failure = completion else {
+                        return
+                    }
+                    continuation.resume(returning: nil)
+                }, receiveValue: { site in
+                    continuation.resume(returning: site)
+                })
+        }
+        handleCompletionStatus(siteID: siteID, site: site, waitingTimeStart: waitingTimeStart, expectedStoreName: expectedStoreName)
     }
 
     @MainActor
-    func handleCompletionStatus(site: Site?, waitingTimeStart: Date, expectedStoreName: String) {
+    func handleCompletionStatus(siteID: Int64, site: Site?, waitingTimeStart: Date, expectedStoreName: String) {
         cancelLocalNotificationWhenStoreIsReady()
         guard let site else {
-            return navigationController.dismiss(animated: true) { [weak self] in
+            showJetpackSiteTimeoutView { [weak self] in
                 guard let self else { return }
-                self.showJetpackSiteTimeoutAlert(from: self.navigationController)
+                await self.waitForSiteToBecomeJetpackSite(from: self.navigationController, siteID: siteID, expectedStoreName: expectedStoreName)
             }
+            return
         }
 
         // Sometimes, as soon as the jetpack installation is done some properties like `name` and `isWordPressComStore` are outdated.
@@ -816,14 +824,16 @@ private extension StoreCreationCoordinator {
     }
 
     @MainActor
-    func showJetpackSiteTimeoutAlert(from navigationController: UINavigationController) {
-        let alertController = UIAlertController(title: Localization.WaitingForJetpackSite.TimeoutAlert.title,
-                                                message: Localization.WaitingForJetpackSite.TimeoutAlert.message,
-                                                preferredStyle: .alert)
-        alertController.view.tintColor = .text
-        _ = alertController.addCancelActionWithTitle(Localization.WaitingForJetpackSite.TimeoutAlert.cancelActionTitle) { _ in }
-        navigationController.present(alertController, animated: true)
-
+    func showJetpackSiteTimeoutView(onRetry: @escaping () async -> Void) {
+        guard (navigationController.topViewController is StoreCreationTimeoutHostingController) == false else {
+            return
+        }
+        let controller = StoreCreationTimeoutHostingController(onRetry: onRetry)
+        navigationController.isNavigationBarHidden = true
+        // Make sure that nothing is presented on the view controller before showing the timeout screen
+        navigationController.presentedViewController?.dismiss(animated: true) { [weak self] in
+            self?.navigationController.pushViewController(controller, animated: true)
+        }
         analytics.track(event: .StoreCreation.siteCreationTimedOut())
     }
 
@@ -966,21 +976,6 @@ private extension StoreCreationCoordinator {
                 comment: "Title of the in-progress view when waiting for the site to become a Jetpack site " +
                 "after WPCOM plan purchase in the store creation flow."
             )
-
-            enum TimeoutAlert {
-                static let title = NSLocalizedString(
-                    "Store creation still in progress",
-                    comment: "Title of the alert when the created store never becomes a Jetpack site in the store creation flow."
-                )
-                static let message = NSLocalizedString(
-                    "The new store will be available soon in the store picker. If you have any issues, please contact support.",
-                    comment: "Message of the alert when the created store never becomes a Jetpack site in the store creation flow."
-                )
-                static let cancelActionTitle = NSLocalizedString(
-                    "OK",
-                    comment: "Button title to dismiss the alert when the created store never becomes a Jetpack site in the store creation flow."
-                )
-            }
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationTimeoutView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationTimeoutView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Hosting controller for `StoreCreationTimeoutView`.
+///
+final class StoreCreationTimeoutHostingController: UIHostingController<StoreCreationTimeoutView> {
+    init(onRetry: @escaping () async -> Void) {
+        super.init(rootView: StoreCreationTimeoutView(onRetry: onRetry))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// View displayed upon timeout checking store for store creation.
+///
+struct StoreCreationTimeoutView: View {
+    private let onRetry: () async -> Void
+    @State private var isRetrying: Bool = false
+
+    init(onRetry: @escaping () async -> Void) {
+        self.onRetry = onRetry
+    }
+
+    var body: some View {
+        VStack(spacing: Layout.verticalSpacing) {
+            Text(Localization.title)
+                .headlineStyle()
+            Image(uiImage: .noStoreImage)
+            Text(Localization.message)
+                .bodyStyle()
+            Button(Localization.retryActionTitle) {
+                Task { @MainActor in
+                    isRetrying = true
+                    await onRetry()
+                    isRetrying = false
+                }
+            }
+            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isRetrying))
+        }
+        .padding(.horizontal, Layout.horizontalMargin)
+    }
+}
+
+private extension StoreCreationTimeoutView {
+    enum Layout {
+        static let horizontalMargin: CGFloat = 32
+        static let verticalSpacing: CGFloat = 16
+    }
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Store creation still in progress",
+            comment: "Title of the screen when the created store never becomes a Jetpack site in the store creation flow."
+        )
+        static let message = NSLocalizedString(
+            "The new store will be available soon in the store picker. Please wait a bit and try again.",
+            comment: "Message of the screen when the created store never becomes a Jetpack site in the store creation flow."
+        )
+        static let retryActionTitle = NSLocalizedString(
+            "Retry",
+            comment: "Button title to retry checking for store details after store creation."
+        )
+    }
+}
+
+struct StoreCreationTimeoutView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreCreationTimeoutView(onRetry: {})
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2176,6 +2176,7 @@
 		DEF8CF1D29AC84BC00800A60 /* WPComEmailLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */; };
 		DEF8CF1F29AC870A00800A60 /* WPComEmailLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */; };
 		DEF8CF2229ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF2129ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift */; };
+		DEF99D852A5FE9BE004B5938 /* StoreCreationTimeoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF99D842A5FE9BE004B5938 /* StoreCreationTimeoutView.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4563,6 +4564,7 @@
 		DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginView.swift; sourceTree = "<group>"; };
 		DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginViewModel.swift; sourceTree = "<group>"; };
 		DEF8CF2129ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginViewModelTests.swift; sourceTree = "<group>"; };
+		DEF99D842A5FE9BE004B5938 /* StoreCreationTimeoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationTimeoutView.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5511,6 +5513,7 @@
 				26C1633A29DA2CD800E482CE /* Free Trial */,
 				02759B9028FFA09600918176 /* StoreCreationWebViewModel.swift */,
 				02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */,
+				DEF99D842A5FE9BE004B5938 /* StoreCreationTimeoutView.swift */,
 				02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */,
 				021940E7291FDBF90090354E /* StoreCreationSummaryView.swift */,
 				02D3B68429657061009BF0BC /* SupportButton.swift */,
@@ -12355,6 +12358,7 @@
 				02EAF5C029FA04850058071C /* ProductDescriptionGenerationViewModel.swift in Sources */,
 				025FDD3223717D2900824006 /* EditorFactory.swift in Sources */,
 				45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorCommand.swift in Sources */,
+				DEF99D852A5FE9BE004B5938 /* StoreCreationTimeoutView.swift in Sources */,
 				453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */,
 				024DF30E23742A70006658FE /* AztecBoldFormatBarCommand.swift in Sources */,
 				DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10200 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new screen to replace the current timeout alert for parity with Android when the Jetpack check after site creation fails.

Changes include:
- New view for the timeout state with the Retry CTA. The wording on the view that on the old alert though, as I think it reads better than on Android.
- The `waitForSiteToBecomeJetpackSite` method was changed to `async` to make it easier to show the loading state for the retry CTA on the timeout view.
- Replaced the old alert with the new view.
- Added new Tracks event when the Retry CTA is tapped.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
We solved the timeout issue so it's not easy to test that case. Try simulating store creation timeout using this [diff](https://github.com/woocommerce/woocommerce-ios/compare/feat/10200-store-creation-timeout-view...try/simulate-store-creation-timeout?expand=1).
- Go to the store creation flow either from the Get Started button on the Prologue screen or from the store picker if you are already logged in.
- Enter a store name and skip through the profiler questions.
- Tap on the CTA to start a free trial plan.
- After the loading screen is displayed for a minute or so, notice that it is dismissed and the timeout screen is displayed.
- Tap the Retry CTA, notice in Xcode console: `🔵 Tracked site_creation_timeout_retried`
- After loading the site info again, you should be navigated to the new store.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="210" alt="Screenshot 2023-07-13 at 17 59 25" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/235fab1e-6724-472e-89dc-ccbd09966a55">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
