### PR TITLE
Fix for 'Unable to Add a New Note' Issue in Order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 14.5
 -----
 - [*] Product details: The share button is displayed with text instead of icon for better discoverability. [https://github.com/woocommerce/woocommerce-ios/pull/10216]
-- [*] Resolved an issue where users were unable to add a new note to an order. Previously, upon opening an order detail and selecting the "Add a new note" option, the text field was non-selectable, preventing users from writing down the note. This issue has now been addressed and users should be able to add notes to their orders without any issues.
+- [*] Resolved an issue where users were unable to add a new note to an order. Previously, upon opening an order detail and selecting the "Add a new note" option, the text field was non-selectable, preventing users from writing down the note. This issue has now been addressed and users should be able to add notes to their orders without any issues. [https://github.com/woocommerce/woocommerce-ios/pull/10222]
 
 
 14.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.5
 -----
 - [*] Product details: The share button is displayed with text instead of icon for better discoverability. [https://github.com/woocommerce/woocommerce-ios/pull/10216]
+- [*] Resolved an issue where users were unable to add a new note to an order. Previously, upon opening an order detail and selecting the "Add a new note" option, the text field was non-selectable, preventing users from writing down the note. This issue has now been addressed and users should be able to add notes to their orders without any issues.
 
 
 14.4

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -139,6 +139,7 @@ private extension NewNoteViewController {
         let cellViewModel = TextViewTableViewCell.ViewModel(icon: .asideImage,
                                                             iconAccessibilityLabel: iconAccessibilityLabel,
                                                             iconTint: isCustomerNote ? .primary : .textSubtle,
+                                                            isSelectable: true,
                                                             onTextChange: { [weak self] (text) in
                                                                 self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
                                                                 self?.noteText = text

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -139,7 +139,6 @@ private extension NewNoteViewController {
         let cellViewModel = TextViewTableViewCell.ViewModel(icon: .asideImage,
                                                             iconAccessibilityLabel: iconAccessibilityLabel,
                                                             iconTint: isCustomerNote ? .primary : .textSubtle,
-                                                            isSelectable: true,
                                                             onTextChange: { [weak self] (text) in
                                                                 self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
                                                                 self?.noteText = text

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -13,7 +13,7 @@ final class TextViewTableViewCell: UITableViewCell {
         var placeholder: String? = nil
         var textViewMinimumHeight: CGFloat? = nil
         var isEditable: Bool = true
-        var isSelectable: Bool = false
+        var isSelectable: Bool = true
         var isScrollEnabled: Bool = true
         var onTextChange: ((_ text: String) -> Void)? = nil
         var onTextDidBeginEditing: (() -> Void)? = nil


### PR DESCRIPTION
Closes: #10198

## Description
This PR addresses the issue of users being unable to add a new note to an order (#10198). The root cause of this problem was traced back to a change introduced three weeks ago (see commit [9acdab6](https://github.com/woocommerce/woocommerce-ios/commit/9acdab6eba13a9499af4231ecfd35933e93121ca)). 

The change inadvertently made the text field non-selectable, thus preventing users from writing down a note. This PR rectifies the issue, ensuring that users can once again add notes to their orders without any hindrance. 

## Testing instructions
1. Open an order detail.
2. Try to add a new order note.

## Screenshots

#### Before

<img src="https://github.com/woocommerce/woocommerce-ios/assets/495617/2a0fc9bf-5ee3-4cd8-a577-0e18954c0cae" width=300 />

#### After
<img src="https://github.com/woocommerce/woocommerce-ios/assets/495617/0de1461d-857e-4fd0-8ee5-db13ebf8df07" width=300 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
