### PR TITLE
[Orders with Coupons M4] Remove/edit discounts on products

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1056,7 +1056,7 @@ private extension EditableOrderViewModel {
                                             shouldDisableAddingCoupons: order.items.isEmpty,
                                             couponLineViewModels: self.couponLineViewModels(from: order.coupons),
                                             couponCode: order.coupons.first?.code ?? "",
-                                            discountTotal: order.discountTotal,
+                                            discountTotal: orderTotals.discountTotal.stringValue,
                                             shouldShowDiscountTotal: order.discountTotal.isNotEmpty,
                                             isLoading: isDataSyncing && !showNonEditableIndicators,
                                             showNonEditableIndicators: showNonEditableIndicators,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -679,7 +679,8 @@ extension EditableOrderViewModel {
 
         let couponLineViewModels: [CouponLineViewModel]
         let couponCode: String
-        let discountTotal: String
+        var discountTotal: String
+        let shouldShowDiscountTotal: Bool
         let shouldShowCoupon: Bool
         let shouldDisableAddingCoupons: Bool
 
@@ -710,6 +711,7 @@ extension EditableOrderViewModel {
              couponLineViewModels: [CouponLineViewModel] = [],
              couponCode: String = "",
              discountTotal: String = "",
+             shouldShowDiscountTotal: Bool = false,
              isLoading: Bool = false,
              showNonEditableIndicators: Bool = false,
              saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
@@ -734,6 +736,7 @@ extension EditableOrderViewModel {
             self.couponLineViewModels = couponLineViewModels
             self.couponCode = couponCode
             self.discountTotal = "-" + (currencyFormatter.formatAmount(discountTotal) ?? "0.00")
+            self.shouldShowDiscountTotal = shouldShowDiscountTotal
             self.shippingLineViewModel = ShippingLineDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
                                                                       initialMethodTitle: shippingMethodTitle,
                                                                       shippingTotal: shippingMethodTotal,
@@ -1054,6 +1057,7 @@ private extension EditableOrderViewModel {
                                             couponLineViewModels: self.couponLineViewModels(from: order.coupons),
                                             couponCode: order.coupons.first?.code ?? "",
                                             discountTotal: order.discountTotal,
+                                            shouldShowDiscountTotal: order.discountTotal.isNotEmpty,
                                             isLoading: isDataSyncing && !showNonEditableIndicators,
                                             showNonEditableIndicators: showNonEditableIndicators,
                                             saveShippingLineClosure: self.saveShippingLine,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1209,7 +1209,11 @@ private extension EditableOrderViewModel {
             return nil
         }
 
+        let totalDecimal = currencyFormatter.convertToDecimal(orderItem.total) ?? subTotalDecimal
+        let productAddedDiscount = subTotalDecimal.subtracting(totalDecimal)
+
         return ProductInOrderViewModel(productRowViewModel: rowViewModel,
+                                       addedDiscount: productAddedDiscount as Decimal,
                                        baseAmountForDiscountPercentage: subTotalDecimal as Decimal,
                                        onRemoveProduct: { [weak self] in
                                             self?.removeItemFromOrder(orderItem)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -76,6 +76,9 @@ struct OrderPaymentSection: View {
 
             TitleAndValueRow(title: Localization.taxesTotal, value: .content(viewModel.taxesTotal))
 
+            TitleAndValueRow(title: Localization.discountTotal, value: .content(viewModel.discountTotal))
+                .renderedIf(viewModel.shouldShowDiscountTotal)
+
             TitleAndValueRow(title: Localization.orderTotal, value: .content(viewModel.orderTotal), bold: true, selectionStyle: .none) {}
         }
         .padding(.horizontal, insets: safeAreaInsets)
@@ -131,6 +134,7 @@ private extension OrderPaymentSection {
         static let payment = NSLocalizedString("Payment", comment: "Title text of the section that shows Payment details when creating a new order")
         static let productsTotal = NSLocalizedString("Products Total", comment: "Label for the row showing the total cost of products in the order")
         static let orderTotal = NSLocalizedString("Order Total", comment: "Label for the the row showing the total cost of the order")
+        static let discountTotal = NSLocalizedString("Discount Total", comment: "Label for the the row showing the total discount of the order")
         static let addShipping = NSLocalizedString("Add Shipping", comment: "Title text of the button that adds shipping line when creating a new order")
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
         static let addFee = NSLocalizedString("Add Fee", comment: "Title text of the button that adds a fee when creating a new order")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -65,7 +65,7 @@ struct ProductInOrder: View {
                         Divider()
                     }
                     .background(Color(.listForeground(modal: false)))
-                    .renderedIf(viewModel.showCurrentDiscountSection)
+                    .renderedIf(viewModel.showCurrentDiscountSection && viewModel.formattedDiscount != nil)
 
                     Spacer(minLength: Layout.sectionSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -15,6 +15,8 @@ struct ProductInOrder: View {
     ///
     @State private var shouldShowDiscountLineDetails: Bool = false
 
+    @Environment(\.presentationMode) private var presentationMode
+
     var body: some View {
         NavigationView {
             ScrollView {
@@ -56,7 +58,7 @@ struct ProductInOrder: View {
                             Spacer()
                             Text("Amount")
                                 .subheadlineStyle()
-                            Text("$10")
+                            Text(viewModel.formattedDiscount ?? "")
                         }
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -94,6 +96,9 @@ struct ProductInOrder: View {
             }
         }
         .wooNavigationBarStyle()
+        .onReceive(viewModel.viewDismissPublisher) {
+            presentationMode.wrappedValue.dismiss()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -54,7 +54,7 @@ struct ProductInOrder: View {
                             }
 
                             Spacer()
-                            Text(String.localizedStringWithFormat(Localization.amountField, viewModel.currencySymbol))
+                            Text("Amount")
                                 .subheadlineStyle()
                             Text("$10")
                         }
@@ -111,8 +111,6 @@ private extension ProductInOrder {
                                               comment: "Text for the button to add a discount to a product during order creation")
         static let remove = NSLocalizedString("Remove Product from Order",
                                               comment: "Text for the button to remove a product from the order during order creation")
-        static let amountField = NSLocalizedString("Amount (%1$@)", comment: "Title for the amount field on the Product in Order screen during order creation"
-                                                   + "Parameters: %1$@ - currency symbol")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -47,16 +47,16 @@ struct ProductInOrder: View {
                         Divider()
                         VStack(alignment: .leading, spacing: Layout.noSpacing) {
                             HStack() {
-                                Text("Discount")
+                                Text(Localization.discountTitle)
                                     .headlineStyle()
                                 Spacer()
-                                Button("Edit") {
+                                Button(Localization.editDiscount) {
                                     shouldShowDiscountLineDetails = true
                                 }
                             }
 
                             Spacer()
-                            Text("Amount")
+                            Text(Localization.discountAmount)
                                 .subheadlineStyle()
                             Text(viewModel.formattedDiscount ?? "")
                         }
@@ -116,6 +116,9 @@ private extension ProductInOrder {
                                               comment: "Text for the button to add a discount to a product during order creation")
         static let remove = NSLocalizedString("Remove Product from Order",
                                               comment: "Text for the button to remove a product from the order during order creation")
+        static let discountTitle = NSLocalizedString("Discount", comment: "Title for the Discount section on the Product Details screen during order creation")
+        static let editDiscount = NSLocalizedString("Edit", comment: "Text for the button to edit a discount to a product during order creation")
+        static let discountAmount = NSLocalizedString("Amount", comment: "Title for the discount amount of a product during order creation")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -33,13 +33,37 @@ struct ProductInOrder: View {
                                 .accessibilityIdentifier("add-discount-button")
                             Divider()
                         }
-                        .renderedIf(viewModel.isAddingDiscountToProductEnabled)
+                        .renderedIf(viewModel.showAddDiscountRow)
                     }
                     .background(Color(.listForeground(modal: false)))
                     .sheet(isPresented: $shouldShowDiscountLineDetails) {
                         FeeOrDiscountLineDetails(viewModel: viewModel.discountDetailsViewModel)
                     }
                     Spacer(minLength: Layout.sectionSpacing)
+
+                    Section {
+                        Divider()
+                        VStack(alignment: .leading, spacing: Layout.noSpacing) {
+                            HStack() {
+                                Text("Discount")
+                                    .headlineStyle()
+                                Spacer()
+                                Button("Edit") {}
+                            }
+
+                            Spacer()
+                            Text("Amount")
+                                .subheadlineStyle()
+                            Text("$10")
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        Divider()
+                    }
+                    .background(Color(.listForeground(modal: false)))
+
+                    Spacer(minLength: Layout.sectionSpacing)
+
                     Section {
                         Divider()
                         Button(Localization.remove) {
@@ -98,7 +122,7 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             manageStock: true,
                                             canChangeQuantity: false,
                                             imageURL: nil)
-        let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
+        let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,                                                addedDiscount: 0,
                                                 baseAmountForDiscountPercentage: 0,
                                                 onRemoveProduct: {},
                                                 onSaveFormattedDiscount: {_ in })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -65,7 +65,7 @@ struct ProductInOrder: View {
                         Divider()
                     }
                     .background(Color(.listForeground(modal: false)))
-                    .renderedIf(viewModel.addedDiscount > 0)
+                    .renderedIf(viewModel.showCurrentDiscountSection)
 
                     Spacer(minLength: Layout.sectionSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -54,7 +54,7 @@ struct ProductInOrder: View {
                             }
 
                             Spacer()
-                            Text("Amount")
+                            Text(String.localizedStringWithFormat(Localization.amountField, viewModel.currencySymbol))
                                 .subheadlineStyle()
                             Text("$10")
                         }
@@ -111,6 +111,8 @@ private extension ProductInOrder {
                                               comment: "Text for the button to add a discount to a product during order creation")
         static let remove = NSLocalizedString("Remove Product from Order",
                                               comment: "Text for the button to remove a product from the order during order creation")
+        static let amountField = NSLocalizedString("Amount (%1$@)", comment: "Title for the amount field on the Product in Order screen during order creation"
+                                                   + "Parameters: %1$@ - currency symbol")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -48,7 +48,9 @@ struct ProductInOrder: View {
                                 Text("Discount")
                                     .headlineStyle()
                                 Spacer()
-                                Button("Edit") {}
+                                Button("Edit") {
+                                    shouldShowDiscountLineDetails = true
+                                }
                             }
 
                             Spacer()
@@ -61,6 +63,7 @@ struct ProductInOrder: View {
                         Divider()
                     }
                     .background(Color(.listForeground(modal: false)))
+                    .renderedIf(viewModel.addedDiscount > 0)
 
                     Spacer(minLength: Layout.sectionSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -125,7 +125,8 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             manageStock: true,
                                             canChangeQuantity: false,
                                             imageURL: nil)
-        let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,                                                addedDiscount: 0,
+        let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
+                                                addedDiscount: 0,
                                                 baseAmountForDiscountPercentage: 0,
                                                 onRemoveProduct: {},
                                                 onSaveFormattedDiscount: {_ in })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -131,10 +131,8 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             canChangeQuantity: false,
                                             imageURL: nil)
         let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
-                                                addedDiscount: 0,
-                                                baseAmountForDiscountPercentage: 0,
-                                                onRemoveProduct: {},
-                                                onSaveFormattedDiscount: {_ in })
+                                                productDiscountConfiguration: nil,
+                                                onRemoveProduct: {})
         ProductInOrder(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -59,7 +59,7 @@ final class ProductInOrderViewModel: Identifiable {
     }
 
     lazy var discountDetailsViewModel: FeeOrDiscountLineDetailsViewModel = {
-        FeeOrDiscountLineDetailsViewModel(isExistingLine: addedDiscount > 0,
+        FeeOrDiscountLineDetailsViewModel(isExistingLine: addedDiscount != 0,
                                           baseAmountForPercentage: baseAmountForDiscountPercentage,
                                           initialTotal: formattedDiscount ?? "0",
                                           lineType: .discount,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -27,6 +27,10 @@ final class ProductInOrderViewModel: Identifiable {
         isAddingDiscountToProductEnabled && addedDiscount == 0
     }
 
+    var showCurrentDiscountSection: Bool {
+        isAddingDiscountToProductEnabled && addedDiscount != 0
+    }
+
     let onSaveFormattedDiscount: (String?) -> Void
 
     var viewDismissPublisher = PassthroughSubject<(), Never>()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -5,6 +5,14 @@ import WooFoundation
 /// View model for `ProductInOrder`.
 ///
 final class ProductInOrderViewModel: Identifiable {
+    /// Encapsulates the necessary information to execute adding discounts to products
+    /// 
+    struct DiscountConfiguration {
+        let addedDiscount: Decimal
+        let baseAmountForDiscountPercentage: Decimal
+        let onSaveFormattedDiscount: (String?) -> Void
+    }
+
     /// The product being edited.
     ///
     let productRowViewModel: ProductRowViewModel
@@ -38,18 +46,15 @@ final class ProductInOrderViewModel: Identifiable {
     private let currencyFormatter: CurrencyFormatter
 
     init(productRowViewModel: ProductRowViewModel,
-         addedDiscount: Decimal,
-         baseAmountForDiscountPercentage: Decimal,
+         productDiscountConfiguration: DiscountConfiguration?,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         onRemoveProduct: @escaping () -> Void,
-         onSaveFormattedDiscount: @escaping (String?) -> Void,
-         isAddingDiscountToProductEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4)) {
+         onRemoveProduct: @escaping () -> Void) {
         self.productRowViewModel = productRowViewModel
-        self.addedDiscount = addedDiscount
-        self.baseAmountForDiscountPercentage = baseAmountForDiscountPercentage
+        self.addedDiscount = productDiscountConfiguration?.addedDiscount ?? .zero
+        self.baseAmountForDiscountPercentage = productDiscountConfiguration?.baseAmountForDiscountPercentage  ?? .zero
         self.onRemoveProduct = onRemoveProduct
-        self.onSaveFormattedDiscount = onSaveFormattedDiscount
-        self.isAddingDiscountToProductEnabled = isAddingDiscountToProductEnabled
+        self.onSaveFormattedDiscount = productDiscountConfiguration?.onSaveFormattedDiscount ?? { _ in }
+        self.isAddingDiscountToProductEnabled = productDiscountConfiguration != nil
         self.currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import WooFoundation
 
 /// View model for `ProductInOrder`.
 ///
@@ -10,6 +11,10 @@ final class ProductInOrderViewModel: Identifiable {
     let addedDiscount: Decimal
 
     let baseAmountForDiscountPercentage: Decimal
+
+    /// Currency symbol to display with amount text field
+    ///
+    let currencySymbol: String
 
     /// Closure invoked when the product is removed.
     ///
@@ -28,8 +33,10 @@ final class ProductInOrderViewModel: Identifiable {
          baseAmountForDiscountPercentage: Decimal,
          onRemoveProduct: @escaping () -> Void,
          onSaveFormattedDiscount: @escaping (String?) -> Void,
+         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          isAddingDiscountToProductEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4)) {
         self.productRowViewModel = productRowViewModel
+        self.currencySymbol = storeCurrencySettings.symbol(from: storeCurrencySettings.currencyCode)
         self.addedDiscount = addedDiscount
         self.baseAmountForDiscountPercentage = baseAmountForDiscountPercentage
         self.onRemoveProduct = onRemoveProduct

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -1,5 +1,4 @@
 import Yosemite
-import WooFoundation
 
 /// View model for `ProductInOrder`.
 ///
@@ -11,10 +10,6 @@ final class ProductInOrderViewModel: Identifiable {
     let addedDiscount: Decimal
 
     let baseAmountForDiscountPercentage: Decimal
-
-    /// Currency symbol to display with amount text field
-    ///
-    let currencySymbol: String
 
     /// Closure invoked when the product is removed.
     ///
@@ -33,10 +28,8 @@ final class ProductInOrderViewModel: Identifiable {
          baseAmountForDiscountPercentage: Decimal,
          onRemoveProduct: @escaping () -> Void,
          onSaveFormattedDiscount: @escaping (String?) -> Void,
-         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          isAddingDiscountToProductEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4)) {
         self.productRowViewModel = productRowViewModel
-        self.currencySymbol = storeCurrencySettings.symbol(from: storeCurrencySettings.currencyCode)
         self.addedDiscount = addedDiscount
         self.baseAmountForDiscountPercentage = baseAmountForDiscountPercentage
         self.onRemoveProduct = onRemoveProduct

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -7,22 +7,30 @@ final class ProductInOrderViewModel: Identifiable {
     ///
     let productRowViewModel: ProductRowViewModel
 
+    let addedDiscount: Decimal
+
     let baseAmountForDiscountPercentage: Decimal
 
     /// Closure invoked when the product is removed.
     ///
     let onRemoveProduct: () -> Void
 
-    let isAddingDiscountToProductEnabled: Bool
+    private let isAddingDiscountToProductEnabled: Bool
+
+    var showAddDiscountRow: Bool {
+        isAddingDiscountToProductEnabled && addedDiscount == 0
+    }
 
     let onSaveFormattedDiscount: (String?) -> Void
 
     init(productRowViewModel: ProductRowViewModel,
+         addedDiscount: Decimal,
          baseAmountForDiscountPercentage: Decimal,
          onRemoveProduct: @escaping () -> Void,
          onSaveFormattedDiscount: @escaping (String?) -> Void,
          isAddingDiscountToProductEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4)) {
         self.productRowViewModel = productRowViewModel
+        self.addedDiscount = addedDiscount
         self.baseAmountForDiscountPercentage = baseAmountForDiscountPercentage
         self.onRemoveProduct = onRemoveProduct
         self.onSaveFormattedDiscount = onSaveFormattedDiscount

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -17,7 +17,6 @@ struct OrderSyncProductInput {
     ///
     enum ProductType {
         case product(Product)
-        case productID(Int64)
         case variation(ProductVariation)
     }
     var id: Int64 = .zero

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
@@ -49,13 +49,15 @@ final class OrderTotalsCalculator {
             .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
     }
 
-    /// Total value of all coupons on an order.
-    ///
-    var couponsTotal: NSDecimalNumber {
-        order.coupons
-            .map { $0.discount }
+    /// Total value of discounts, including coupons and product discounts.
+    /// 
+    var discountTotal: NSDecimalNumber {
+        let itemsDiscountedTotal = order.items
+            .map { $0.total }
             .compactMap { currencyFormatter.convertToDecimal($0) }
             .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
+
+        return itemsTotal.subtracting(itemsDiscountedTotal)
     }
 
     init(for order: Order, using currencyFormatter: CurrencyFormatter) {
@@ -66,7 +68,7 @@ final class OrderTotalsCalculator {
     /// Returns a copy of the order with a new, locally calculated order total.
     ///
     func updateOrderTotal() -> Order {
-        let orderTotal = itemsTotal.adding(shippingTotal).adding(feesTotal).adding(taxesTotal).subtracting(couponsTotal)
+        let orderTotal = itemsTotal.adding(shippingTotal).adding(feesTotal).adding(taxesTotal).subtracting(discountTotal)
         return order.copy(total: orderTotal.stringValue)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -84,11 +84,11 @@ private extension ProductInputTransformer {
     ///   - updatedOrderItems: An array of `[OrderItem]` entities
     ///
     static func updateOrderItems(from order: Order, with input: OrderSyncProductInput, orderItems updatedOrderItems: inout [OrderItem]) {
+        let newItem = createOrderItem(using: input)
+
         if let itemIndex = order.items.firstIndex(where: { $0.itemID == input.id }) {
-            let newItem = createOrderItem(using: input, usingPriceFrom: updatedOrderItems[itemIndex])
             updatedOrderItems[itemIndex] = newItem
         } else {
-            let newItem = createOrderItem(using: input, usingPriceFrom: nil)
             updatedOrderItems.append(newItem)
         }
     }
@@ -125,20 +125,16 @@ private extension ProductInputTransformer {
     }
 
     /// Creates and order item by using the `input.id` as the `item.itemID`.
-    /// When `usingPriceFrom` is set, the price from the item will be used instead of the price of the product.
     ///
-    private static func createOrderItem(using input: OrderSyncProductInput, usingPriceFrom existingItem: OrderItem?) -> OrderItem {
+    private static func createOrderItem(using input: OrderSyncProductInput) -> OrderItem {
         let parameters: OrderItemParameters = {
             // Prefer the item price as it should have been properly sanitized by the remote source.
             switch input.product {
             case .product(let product):
-                let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: product.price) ?? .zero
+                let price: Decimal = Decimal(string: product.price) ?? .zero
                 return OrderItemParameters(quantity: input.quantity, price: price, discount: input.discount, productID: product.productID, variationID: nil)
-            case .productID(let productID):
-                let price: Decimal = existingItem?.price.decimalValue ?? .zero
-                return OrderItemParameters(quantity: input.quantity, price: price, discount: input.discount, productID: productID, variationID: nil)
             case .variation(let variation):
-                let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: variation.price) ?? .zero
+                let price: Decimal = Decimal(string: variation.price) ?? .zero
                 return OrderItemParameters(quantity: input.quantity,
                                            price: price,
                                            discount: input.discount,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -128,7 +128,6 @@ private extension ProductInputTransformer {
     ///
     private static func createOrderItem(using input: OrderSyncProductInput) -> OrderItem {
         let parameters: OrderItemParameters = {
-            // Prefer the item price as it should have been properly sanitized by the remote source.
             switch input.product {
             case .product(let product):
                 let price: Decimal = Decimal(string: product.price) ?? .zero

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
@@ -50,7 +50,7 @@ class OrderTotalsCalculatorTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let order = Order.fake().copy(shippingTotal: "5.00",
                                       totalTax: "3.00",
-                                      items: [OrderItem.fake().copy(subtotal: "2.00"), OrderItem.fake().copy(subtotal: "8.00")],
+                                      items: [OrderItem.fake().copy(subtotal: "2.00", total: "2.00"), OrderItem.fake().copy(subtotal: "8.00", total: "8.00")],
                                       fees: [OrderFeeLine.fake().copy(total: "2.00"), OrderFeeLine.fake().copy(total: "8.00")])
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
@@ -60,4 +60,20 @@ class OrderTotalsCalculatorTests: XCTestCase {
         // Then
         XCTAssertEqual(updatedOrder.total, "28")
     }
+
+    func test_updateOrderTotal_when_there_are_discounts_then_returns_order_with_expected_total() {
+        // Given
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let order = Order.fake().copy(shippingTotal: "5.00",
+                                      totalTax: "3.00",
+                                      items: [OrderItem.fake().copy(subtotal: "2.00", total: "1.00"), OrderItem.fake().copy(subtotal: "8.00", total: "5.00")],
+                                      fees: [OrderFeeLine.fake().copy(total: "2.00"), OrderFeeLine.fake().copy(total: "8.00")])
+
+        // When
+        let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
+        let updatedOrder = orderTotalsCalculator.updateOrderTotal()
+
+        // Then
+        XCTAssertEqual(updatedOrder.total, "24")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -206,7 +206,7 @@ class ProductInputTransformerTests: XCTestCase {
 
     }
 
-    func test_sending_an_update_product_input_uses_item_price_from_order() throws {
+    func test_sending_an_update_product_input_uses_price_from_product() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
         let item = OrderItem.fake().copy(itemID: sampleInputID, price: 8.00)
@@ -218,9 +218,9 @@ class ProductInputTransformerTests: XCTestCase {
 
         // Then
         let updatedItem = try XCTUnwrap(updatedOrder.items.first)
-        XCTAssertEqual(updatedItem.price, 8.00) // Existing item price from order.
-        XCTAssertEqual(updatedItem.subtotal, "16")
-        XCTAssertEqual(updatedItem.total, "16")
+        XCTAssertEqual(updatedItem.price, 9.99) // Existing item price from product.
+        XCTAssertEqual(updatedItem.subtotal, "19.98")
+        XCTAssertEqual(updatedItem.total, "19.98")
     }
 
     func test_updatedOrder_when_updateMultipleItems_sends_an_updated_product_input_then_updates_price_on_order() throws {
@@ -235,9 +235,9 @@ class ProductInputTransformerTests: XCTestCase {
 
         // Then
         let updatedItem = try XCTUnwrap(updatedOrder.items.first)
-        XCTAssertEqual(updatedItem.price, 8.00) // Existing item price from order.
-        XCTAssertEqual(updatedItem.subtotal, "16")
-        XCTAssertEqual(updatedItem.total, "16")
+        XCTAssertEqual(updatedItem.price, 9.99) // Existing item price from product.
+        XCTAssertEqual(updatedItem.subtotal, "19.98")
+        XCTAssertEqual(updatedItem.total, "19.98")
     }
 
     func test_sending_a_zero_quantity_update_product_input_deletes_item_on_order() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -61,23 +61,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(item.quantity, input.quantity)
     }
 
-    func test_sending_new_productID_input_adds_product_to_local_order() throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1, discount: 0)
-        synchronizer.setProduct.send(input)
-
-        // Then
-        let item = try XCTUnwrap(synchronizer.order.items.first)
-        XCTAssertEqual(item.itemID, input.id)
-        XCTAssertEqual(item.productID, sampleProductID)
-        XCTAssertEqual(item.variationID, 0)
-        XCTAssertEqual(item.quantity, input.quantity)
-    }
-
     func test_setProducts_sends_single_product_input_then_updates_order_successfully() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
@@ -102,33 +85,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let item = try XCTUnwrap(synchronizer.order.items.first)
         XCTAssertEqual(item.itemID, productInput.id)
         XCTAssertEqual(item.productID, product.productID)
-        XCTAssertEqual(item.quantity, productInput.quantity)
-    }
-
-    func test_setProducts_sends_single_productID_input_then_updates_order_successfully() throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let productInput = OrderSyncProductInput(
-            id: sampleInputID,
-            product: .productID(sampleProductID),
-            quantity: 1,
-            discount: 0)
-
-        // Confidence check
-        XCTAssertEqual(synchronizer.order.items.count, 0)
-
-        // When
-        let inputs: [OrderSyncProductInput] = [productInput]
-        synchronizer.setProducts.send(inputs)
-
-        // Then
-        XCTAssertEqual(synchronizer.order.items.count, 1)
-
-        let item = try XCTUnwrap(synchronizer.order.items.first)
-        XCTAssertEqual(item.itemID, productInput.id)
-        XCTAssertEqual(item.productID, sampleProductID)
-        XCTAssertEqual(item.variationID, 0)
         XCTAssertEqual(item.quantity, productInput.quantity)
     }
 
@@ -170,44 +126,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(anotherItem.quantity, anotherProductInput.quantity)
     }
 
-    func test_setProducts_sends_multiple_productID_input_then_updates_order_successfully() throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let productInput = OrderSyncProductInput(
-            id: sampleInputID,
-            product: .productID(12345),
-            quantity: 1,
-            discount: 0)
-        let anotherProductInput = OrderSyncProductInput(
-            id: anotherSampleInputID,
-            product: .productID(67890),
-            quantity: 1,
-            discount: 0)
-
-        // Confidence check
-        XCTAssertEqual(synchronizer.order.items.count, 0)
-
-        // When
-        let inputs: [OrderSyncProductInput] = [productInput, anotherProductInput]
-        synchronizer.setProducts.send(inputs)
-
-        // Then
-        XCTAssertEqual(synchronizer.order.items.count, 2)
-        let item = try XCTUnwrap(synchronizer.order.items[0])
-        let anotherItem = try XCTUnwrap(synchronizer.order.items[1])
-
-        XCTAssertEqual(item.itemID, productInput.id)
-        XCTAssertEqual(item.productID, 12345)
-        XCTAssertEqual(item.variationID, 0)
-        XCTAssertEqual(item.quantity, productInput.quantity)
-
-        XCTAssertEqual(anotherItem.itemID, anotherProductInput.id)
-        XCTAssertEqual(anotherItem.productID, 67890)
-        XCTAssertEqual(item.variationID, 0)
-        XCTAssertEqual(anotherItem.quantity, anotherProductInput.quantity)
-    }
-
     func test_sending_update_product_input_updates_local_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
@@ -227,25 +145,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(item.quantity, updatedInput.quantity)
     }
 
-    func test_sending_update_productID_input_updates_local_order() throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1, discount: 0)
-        synchronizer.setProduct.send(initialInput)
-
-        // When
-        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 2, discount: 0)
-        synchronizer.setProduct.send(updatedInput)
-
-        // Then
-        let item = try XCTUnwrap(synchronizer.order.items.first)
-        XCTAssertEqual(item.itemID, updatedInput.id)
-        XCTAssertEqual(item.productID, sampleProductID)
-        XCTAssertEqual(item.variationID, 0)
-        XCTAssertEqual(item.quantity, updatedInput.quantity)
-    }
-
     func test_sending_delete_product_input_updates_local_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
@@ -256,22 +155,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
 
         // When
         let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 0, discount: 0)
-        synchronizer.setProduct.send(updatedInput)
-
-        // Then
-        XCTAssertEqual(synchronizer.order.items.count, 1)
-        XCTAssertEqual(synchronizer.order.items[0].quantity, .zero)
-    }
-
-    func test_sending_delete_productID_input_updates_local_order() throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1, discount: 0)
-        synchronizer.setProduct.send(initialInput)
-
-        // When
-        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 0, discount: 0)
         synchronizer.setProduct.send(updatedInput)
 
         // Then
@@ -364,30 +247,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertTrue(orderCreationInvoked)
     }
 
-    func test_sending_productID_input_triggers_order_creation() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        // When
-        let orderCreationInvoked: Bool = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case .createOrder:
-                    promise(true)
-                default:
-                    promise(false)
-                }
-            }
-
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-
-        // Then
-        XCTAssertTrue(orderCreationInvoked)
-    }
-
     func test_sending_new_product_input_sends_order_without_totals() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "20.0")
@@ -417,34 +276,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
     }
 
-    func test_sending_new_productID_input_sends_order_without_totals() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        // When
-        let submittedItems: [OrderItem] = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case .createOrder(_, let order, _):
-                    promise(order.items)
-                default:
-                    XCTFail("Unexpected Action received: \(action)")
-                }
-            }
-
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-
-        // Then
-        XCTAssertTrue(submittedItems.isNotEmpty)
-        for item in submittedItems {
-            XCTAssertTrue(item.total.isEmpty)
-            XCTAssertTrue(item.subtotal.isEmpty)
-        }
-    }
-
     func test_sending_new_product_input_sends_order_with_zero_ids() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "20.0")
@@ -463,33 +294,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
 
             let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-
-        // Then
-        XCTAssertTrue(submittedItems.isNotEmpty)
-        for item in submittedItems {
-            XCTAssertEqual(item.itemID, .zero)
-        }
-    }
-
-    func test_sending_new_productID_input_sends_order_with_zero_ids() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        // When
-        let submittedItems: [OrderItem] = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case .createOrder(_, let order, _):
-                    promise(order.items)
-                default:
-                    XCTFail("Unexpected Action received: \(action)")
-                }
-            }
-
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -531,76 +335,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         for item in submittedItems {
             XCTAssertTrue(item.total.isNotEmpty)
             XCTAssertTrue(item.subtotal.isNotEmpty)
-        }
-    }
-
-    func test_sending_existing_productID_input_sends_order_with_totals() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        // When
-        let submittedItems: [OrderItem] = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case .createOrder(_, let order, let completion):
-                    completion(.success(order.copy(orderID: self.sampleOrderID)))
-                case .updateOrder(_, let order, _, _):
-                    promise(order.items)
-                default:
-                    XCTFail("Unexpected Action received: \(action)")
-                }
-            }
-
-            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-            self.createOrder(on: synchronizer, input: initialInput)
-
-            let input = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-
-        // Then
-        XCTAssertTrue(submittedItems.isNotEmpty)
-        for item in submittedItems {
-            XCTAssertEqual(item.total, "0")
-            XCTAssertEqual(item.subtotal, "0")
-        }
-    }
-
-    func test_sending_existing_productID_input_sends_order_with_totals_given_price_is_different_than_zero() {
-        // Given
-        let product = Product.fake().copy(productID: sampleProductID, price: "20.0")
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        // When
-        let submittedItems: [OrderItem] = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case .createOrder(_, let order, let completion):
-                    completion(.success(order.copy(orderID: self.sampleOrderID)))
-                case .updateOrder(_, let order, _, _):
-                    promise(order.items)
-                default:
-                    XCTFail("Unexpected Action received: \(action)")
-                }
-            }
-
-            let initialInput = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 1, discount: 0)
-            self.createOrder(on: synchronizer, input: initialInput)
-
-            // Update the same input, using productID ProductType
-            let updatedInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2, discount: 0)
-            synchronizer.setProduct.send(updatedInput)
-        }
-
-        // Then
-        XCTAssertTrue(submittedItems.isNotEmpty)
-        for item in submittedItems {
-            XCTAssertEqual(item.price, 20.0)
-            XCTAssertEqual(item.quantity, 2)
-            XCTAssertEqual(item.subtotal, "40")
-            XCTAssertEqual(item.total, "40")
         }
     }
 
@@ -917,37 +651,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(states, [.syncing(blocking: true), .synced])
     }
 
-    func test_states_are_properly_set_upon_success_order_creation_via_productID_input() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            switch action {
-            case .createOrder(_, _, let onCompletion):
-                onCompletion(.success(.fake()))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-
-        // When
-        let states: [OrderSyncState] = waitFor { promise in
-            synchronizer.statePublisher
-                .dropFirst() // Initialized with .synced state, so we drop the first value
-                .collect(2) // Collect the following sync states when an Order is created
-                .sink { states in
-                    promise(states)
-                }
-                .store(in: &self.subscriptions)
-
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-
-        // Then
-        assertEqual([.syncing(blocking: true), .synced], states)
-    }
-
     func test_states_are_properly_set_upon_success_order_update_with_new_items() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
@@ -980,43 +683,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             // Trigger order update
             let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
-        }
-
-        // Then
-        XCTAssertEqual(states, [.syncing(blocking: true), .synced])
-    }
-
-    func test_states_are_properly_set_upon_success_order_update_via_productID_input_with_new_items() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            switch action {
-            case .createOrder(_, _, let completion):
-                completion(.success(.fake().copy(orderID: self.sampleOrderID)))
-            case .updateOrder(_, let order, _, let completion):
-                completion(.success(order))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-
-        // Wait for order creation
-        let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-        createOrder(on: synchronizer, input: input)
-
-        let states: [OrderSyncState] = waitFor { promise in
-            synchronizer.statePublisher
-                .dropFirst()
-                .collect(2)
-                .sink { states in
-                    promise(states)
-                }
-                .store(in: &self.subscriptions)
-
-            // Trigger order update
-            let updatedInput = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 2, discount: 0)
-            synchronizer.setProduct.send(updatedInput)
         }
 
         // Then
@@ -1056,44 +722,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             // Trigger order update
             let input2 = OrderSyncProductInput(id: self.sampleInputID, product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
-        }
-
-        // Then
-        XCTAssertEqual(states, [.syncing(blocking: false), .synced])
-    }
-
-    func test_states_are_properly_set_upon_success_order_update_via_productID_input_with_no_new_items() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            switch action {
-            case .createOrder(_, _, let completion):
-                completion(.success(.fake().copy(orderID: self.sampleOrderID)))
-            case .updateOrder(_, let order, _, let completion):
-                completion(.success(order))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-
-        // Wait for order creation
-        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-        createOrder(on: synchronizer, input: input)
-
-        let states: [OrderSyncState] = waitFor { promise in
-            synchronizer.statePublisher
-                .dropFirst()
-                .collect(2)
-                .sink { states in
-                    promise(states)
-                }
-                .store(in: &self.subscriptions)
-
-            // Trigger order update
-            let updatedInput = OrderSyncProductInput(id: self.sampleInputID, product: .productID(self.sampleProductID), quantity: 2, discount: 0)
-            synchronizer.setProduct.send(updatedInput)
         }
 
         // Then
@@ -1142,47 +770,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertTrue(receivedCreationRequest)
     }
 
-    func test_order_creation_via_productID_input_can_resume_after_receiving_errors() {
-        // Given
-        let error = NSError(domain: "", code: 0, userInfo: nil)
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-
-        // When
-        let receivedError: Bool = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case .createOrder(_, _, let completion):
-                    completion(.failure(error))
-                    promise(true)
-                default:
-                    XCTFail("Unexpected action: \(action)")
-                }
-            }
-
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-        XCTAssertTrue(receivedError)
-
-        let receivedCreationRequest: Bool = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case .createOrder:
-                    promise(true)
-                default:
-                    XCTFail("Unexpected action: \(action)")
-                }
-            }
-
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-
-        // Then
-        XCTAssertTrue(receivedCreationRequest)
-    }
-
     func test_states_are_properly_set_upon_failing_order_creation() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
@@ -1209,38 +796,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
                 .store(in: &self.subscriptions)
 
             let input = OrderSyncProductInput(product: .product(product), quantity: 1, discount: 0)
-            synchronizer.setProduct.send(input)
-        }
-
-        // Then
-        assertEqual(states, [.syncing(blocking: true), .error(error)])
-    }
-
-    func test_states_are_properly_set_upon_failing_order_creation_via_productID_input() {
-        // Given
-        let error = NSError(domain: "", code: 0, userInfo: nil)
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            switch action {
-            case .createOrder(_, _, let completion):
-                completion(.failure(error))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-
-        // When
-        let states: [OrderSyncState] = waitFor { promise in
-            synchronizer.statePublisher
-                .dropFirst()
-                .collect(2)
-                .sink { states in
-                    promise(states)
-                }
-                .store(in: &self.subscriptions)
-
-            let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
             synchronizer.setProduct.send(input)
         }
 
@@ -1281,44 +836,6 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             // Trigger order update
             let input2 = OrderSyncProductInput(product: .product(product), quantity: 2, discount: 0)
             synchronizer.setProduct.send(input2)
-        }
-
-        // Then
-        XCTAssertEqual(states, [.syncing(blocking: true), .error(error)])
-    }
-
-    func test_states_are_properly_set_upon_failing_order_update_via_productID_input() {
-        // Given
-        let error = NSError(domain: "", code: 0, userInfo: nil)
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
-        stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            switch action {
-            case .createOrder(_, _, let completion):
-                completion(.success(.fake().copy(orderID: self.sampleOrderID)))
-            case .updateOrder(_, _, _, let completion):
-                completion(.failure(error))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-
-        // Wait for order creation
-        let input = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 1, discount: 0)
-        createOrder(on: synchronizer, input: input)
-
-        let states: [OrderSyncState] = waitFor { promise in
-            synchronizer.statePublisher
-                .dropFirst()
-                .collect(2)
-                .sink { states in
-                    promise(states)
-                }
-                .store(in: &self.subscriptions)
-
-            // Trigger order update
-            let updatedInput = OrderSyncProductInput(product: .productID(self.sampleProductID), quantity: 2, discount: 0)
-            synchronizer.setProduct.send(updatedInput)
         }
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10203 and #10204
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we want to merge these features:

- UI: Discount total in the Editable Order Details screen, including coupon discounts.
- UI: Discount on the ProductInOrder View when a discount is added, with the choice of editing it.
- Logic: Change a discount for a product
- Logic: Remove a discount for a product
- Logic: Do not allow adding a discount when a coupon is added, as the backend doesn't handle both simultaneously.

Know issues: 
- A product discount is overridden if we add coupons.
- As stated above, we don't allow adding a product discount if there are coupons. This has some side effects, as in the case when we want to change a discount in an order with coupons that don't apply to that product. We allow this edge case for now as it's not common and it's easily reversible by removing the product.

Other changes:
- Using the item price in `ProductInputTransformer` caused a bug when editing/removing discounts, as the price changes together with the previous discount. Because of this, the newly calculated discount was erroneous as we took the wrong base price. Because of this, we always use the product price now, which is more reliable.
- We don't add products by IDs to an order anymore, so I removed that type from `ProductType` on `OrderSyncProductInput`, hence so many delete lines in tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Removing a discount

1. Go to Orders
2. Tap on + to create a new one
3. Add a product
4. Add a discount to the product, you go back to the Order Details. See that the discount is shown in Discount Total.
5. Tap on the product
6. See that the discount info is added on the ProductInOrder Screen. Tap on Edit.
7. Tap to remove discount
8. See that it's removed

https://github.com/woocommerce/woocommerce-ios/assets/1864060/d5006cdf-75c7-4840-b8bf-51952d512ba4

### Changing a discount

1. Go to Orders
2. Tap on + to create a new one
3. Add a product
4. Add a discount to the product, you go back to the Order Details. See that the discount is shown in Discount Total.
5. Tap on the product
6. See that the discount info is added on the ProductInOrder Screen. Tap on Edit.
7. Change discount and tap on Done
8. See that it's updated in order details

https://github.com/woocommerce/woocommerce-ios/assets/1864060/84ffd62c-5a6c-4d0a-b977-98971ac78717

### No discount with Coupons

1. Go to Orders
2. Tap on + to create a new one
3. Add a product 
4. Add a coupon. See that the discount total is updated
5. Tap on the product.
6. There is no button to add discount 

https://github.com/woocommerce/woocommerce-ios/assets/1864060/18cdd324-f64e-4cc4-9f67-bf23b9ca791d

### Other
- Adding a discount to a product and then changing the quantity should keep the discount amount.
- We can add different discounts to different products.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

See above

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
