### PR TITLE
Add product from image: update text field to support AI-generated suggestion

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// Text field in the "add product from image" form.
+struct AddProductFromImageTextFieldView: View {
+    final class ViewModel: ObservableObject {
+        @Published var text: String
+        let placeholder: String
+
+        init(text: String, placeholder: String) {
+            self.text = text
+            self.placeholder = placeholder
+        }
+    }
+
+    struct Customizations {
+        /// A range of number of lines for the text field.
+        /// Only applicable for iOS 16.0 and up.
+        let lineLimit: ClosedRange<Int>
+    }
+
+    @ObservedObject private var viewModel: ViewModel
+    private let customizations: Customizations
+
+    init(viewModel: ViewModel, customizations: Customizations) {
+        self.viewModel = viewModel
+        self.customizations = customizations
+    }
+
+    var body: some View {
+        if #available(iOS 16.0, *) {
+            TextField(viewModel.placeholder, text: $viewModel.text, axis: .vertical)
+                .lineLimit(customizations.lineLimit)
+        } else {
+            TextEditor(text: $viewModel.text)
+        }
+    }
+}
+
+struct AddProductFromImageTextFieldView_Previews: PreviewProvider {
+    static var previews: some View {
+        Form {
+            Section {
+                AddProductFromImageTextFieldView(
+                    viewModel: .init(text: "", placeholder: "Placeholder text"),
+                    customizations: .init(lineLimit: 2...5))
+            }
+
+            Section {
+                AddProductFromImageTextFieldView(
+                    viewModel: .init(text: "Xcode 15 beta enables you to develop, test, and distribute apps for all Apple platforms.",
+                                     placeholder: "Placeholder text"),
+                    customizations: .init(lineLimit: 2...5)
+                )
+            }
+
+            Section {
+                AddProductFromImageTextFieldView(
+                    viewModel: .init(text: "", placeholder: "Placeholder text"),
+                    customizations: .init(lineLimit: 2...5)
+                )
+            }
+            .redacted(reason: .placeholder)
+            .shimmering(active: true)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
@@ -2,48 +2,7 @@ import SwiftUI
 
 /// Text field in the "add product from image" form.
 struct AddProductFromImageTextFieldView: View {
-    /// View model for `AddProductFromImageTextFieldView`.
-    final class ViewModel: ObservableObject {
-        @Published var text: String
-        @Published private(set) var suggestedText: String?
-        let placeholder: String
-
-        /// - Parameters:
-        ///   - text: Initial value of the text.
-        ///   - placeholder: Placeholder text of the text field.
-        ///   - suggestedText: Initial value of the suggested text for previews and unit testing.
-        init(text: String,
-             placeholder: String,
-             suggestedText: String? = nil) {
-            self.text = text
-            self.placeholder = placeholder
-            self.suggestedText = suggestedText
-        }
-
-        /// Invoked when a suggestion for the text field is available.
-        /// - Parameter suggestion: Suggested text for the text field.
-        func onSuggestion(_ suggestion: String) {
-            guard suggestion.isNotEmpty, suggestion != text else {
-                return suggestedText = nil
-            }
-            if text.isNotEmpty {
-                suggestedText = suggestion
-            } else {
-                text = suggestion
-            }
-        }
-
-        /// Invoked when the user taps to apply the suggested text.
-        func applySuggestedText() {
-            text = suggestedText ?? ""
-            suggestedText = nil
-        }
-
-        /// Invoked when the user taps to dismiss the suggested text.
-        func dismissSuggestedText() {
-            suggestedText = nil
-        }
-    }
+    typealias ViewModel = AddProductFromImageTextFieldViewModel
 
     struct Customizations {
         /// A range of number of lines for the text field.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Text field in the "add product from image" form.
 struct AddProductFromImageTextFieldView: View {
+    /// View model for `AddProductFromImageTextFieldView`.
     final class ViewModel: ObservableObject {
         @Published var text: String
         @Published private(set) var suggestedText: String?
@@ -22,8 +23,8 @@ struct AddProductFromImageTextFieldView: View {
         /// Invoked when a suggestion for the text field is available.
         /// - Parameter suggestion: Suggested text for the text field.
         func onSuggestion(_ suggestion: String) {
-            guard suggestion != text else {
-                return
+            guard suggestion.isNotEmpty, suggestion != text else {
+                return suggestedText = nil
             }
             if text.isNotEmpty {
                 suggestedText = suggestion
@@ -57,7 +58,9 @@ struct AddProductFromImageTextFieldView: View {
     /// - Parameters:
     ///   - viewModel: Provides text field view data.
     ///   - customizations: Customizations on the layout.
-    ///   - isGeneratingSuggestion: Whether a suggestion is being generated. This is separate from the view model since its value is shared for the main view from `AddProductFromImageViewModel` while the view model is initialized as a separate instance.
+    ///   - isGeneratingSuggestion: Whether a suggestion is being generated.
+    ///     This is separate from the view model since its value is shared for the main view from
+    ///     `AddProductFromImageViewModel` while the view model is initialized as a separate instance.
     init(viewModel: ViewModel,
          customizations: Customizations,
          isGeneratingSuggestion: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
@@ -22,6 +22,9 @@ struct AddProductFromImageTextFieldView: View {
         /// Invoked when a suggestion for the text field is available.
         /// - Parameter suggestion: Suggested text for the text field.
         func onSuggestion(_ suggestion: String) {
+            guard suggestion != text else {
+                return
+            }
             if text.isNotEmpty {
                 suggestedText = suggestion
             } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
@@ -97,17 +97,14 @@ struct AddProductFromImageTextFieldView: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .textSelection(.enabled)
 
-                    AdaptiveStack(spacing: 0) {
+                    AdaptiveStack(spacing: Layout.defaultSpacing) {
                         Spacer()
                         // CTA to copy the generated text.
-                        Button {
+                        Button(Localization.copyGeneratedText) {
                             UIPasteboard.general.string = suggestedText
                             // TODO: 10180 - show a notice when the text is copied
-                        } label: {
-                            Text(Localization.copyGeneratedText)
-                                .secondaryBodyStyle()
                         }
-                        .buttonStyle(LinkButtonStyle())
+                        .buttonStyle(TextButtonStyle())
                         .fixedSize(horizontal: true, vertical: false)
 
                         // CTA to replace with the generated text.
@@ -125,14 +122,14 @@ struct AddProductFromImageTextFieldView: View {
                         } label: {
                             Image(systemName: "xmark")
                         }
-                        .buttonStyle(LinkButtonStyle())
+                        .buttonStyle(TextButtonStyle())
                         .fixedSize(horizontal: true, vertical: false)
                     }
                 }
                 .padding(Layout.suggestedTextInsets)
                 .background(
                     RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                        .foregroundColor(.init(uiColor: .tertiarySystemBackground))
+                        .foregroundColor(.init(uiColor: .tertiarySystemGroupedBackground))
                 )
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldView.swift
@@ -4,11 +4,40 @@ import SwiftUI
 struct AddProductFromImageTextFieldView: View {
     final class ViewModel: ObservableObject {
         @Published var text: String
+        @Published private(set) var suggestedText: String?
         let placeholder: String
 
-        init(text: String, placeholder: String) {
+        /// - Parameters:
+        ///   - text: Initial value of the text.
+        ///   - placeholder: Placeholder text of the text field.
+        ///   - suggestedText: Initial value of the suggested text for previews and unit testing.
+        init(text: String,
+             placeholder: String,
+             suggestedText: String? = nil) {
             self.text = text
             self.placeholder = placeholder
+            self.suggestedText = suggestedText
+        }
+
+        /// Invoked when a suggestion for the text field is available.
+        /// - Parameter suggestion: Suggested text for the text field.
+        func onSuggestion(_ suggestion: String) {
+            if text.isNotEmpty {
+                suggestedText = suggestion
+            } else {
+                text = suggestion
+            }
+        }
+
+        /// Invoked when the user taps to apply the suggested text.
+        func applySuggestedText() {
+            text = suggestedText ?? ""
+            suggestedText = nil
+        }
+
+        /// Invoked when the user taps to dismiss the suggested text.
+        func dismissSuggestedText() {
+            suggestedText = nil
         }
     }
 
@@ -20,19 +49,110 @@ struct AddProductFromImageTextFieldView: View {
 
     @ObservedObject private var viewModel: ViewModel
     private let customizations: Customizations
+    private let isGeneratingSuggestion: Bool
 
-    init(viewModel: ViewModel, customizations: Customizations) {
+    /// - Parameters:
+    ///   - viewModel: Provides text field view data.
+    ///   - customizations: Customizations on the layout.
+    ///   - isGeneratingSuggestion: Whether a suggestion is being generated. This is separate from the view model since its value is shared for the main view from `AddProductFromImageViewModel` while the view model is initialized as a separate instance.
+    init(viewModel: ViewModel,
+         customizations: Customizations,
+         isGeneratingSuggestion: Bool) {
         self.viewModel = viewModel
         self.customizations = customizations
+        self.isGeneratingSuggestion = isGeneratingSuggestion
     }
 
     var body: some View {
-        if #available(iOS 16.0, *) {
-            TextField(viewModel.placeholder, text: $viewModel.text, axis: .vertical)
-                .lineLimit(customizations.lineLimit)
-        } else {
-            TextEditor(text: $viewModel.text)
+        VStack {
+            // Text field.
+            if #available(iOS 16.0, *) {
+                TextField(viewModel.placeholder, text: $viewModel.text, axis: .vertical)
+                    .lineLimit(customizations.lineLimit)
+            } else {
+                TextEditor(text: $viewModel.text)
+            }
+
+            HStack(spacing: Layout.defaultSpacing) {
+                ProgressView()
+                Text(Localization.generationInProgress)
+                    .captionStyle()
+                    .foregroundColor(.init(uiColor: .secondaryLabel))
+                Spacer()
+            }
+            .renderedIf(isGeneratingSuggestion)
+
+            // Suggested text when the suggestion becomes available while the text field is non-empty.
+            if let suggestedText = viewModel.suggestedText, suggestedText.isNotEmpty, !isGeneratingSuggestion {
+                VStack(alignment: .leading, spacing: Layout.defaultSpacing) {
+                    Text(Localization.suggestionHeader)
+                        .captionStyle()
+                    Text(suggestedText)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
+
+                    AdaptiveStack(spacing: 0) {
+                        Spacer()
+                        // CTA to copy the generated text.
+                        Button {
+                            UIPasteboard.general.string = suggestedText
+                            // TODO: 10180 - show a notice when the text is copied
+                        } label: {
+                            Text(Localization.copyGeneratedText)
+                                .secondaryBodyStyle()
+                        }
+                        .buttonStyle(LinkButtonStyle())
+                        .fixedSize(horizontal: true, vertical: false)
+
+                        // CTA to replace with the generated text.
+                        Button {
+                            viewModel.applySuggestedText()
+                        } label: {
+                            Image(systemName: "checkmark")
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .fixedSize(horizontal: true, vertical: false)
+
+                        // CTA to dismiss the generated text.
+                        Button {
+                            viewModel.dismissSuggestedText()
+                        } label: {
+                            Image(systemName: "xmark")
+                        }
+                        .buttonStyle(LinkButtonStyle())
+                        .fixedSize(horizontal: true, vertical: false)
+                    }
+                }
+                .padding(Layout.suggestedTextInsets)
+                .background(
+                    RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                        .foregroundColor(.init(uiColor: .tertiarySystemBackground))
+                )
+            }
         }
+    }
+}
+
+private extension AddProductFromImageTextFieldView {
+    enum Localization {
+        static let generationInProgress = NSLocalizedString(
+            "Generating suggestion from photo...",
+            comment: "Loading state for the suggested text in the add product from image form."
+        )
+        static let suggestionHeader = NSLocalizedString(
+            "Suggestion from photo",
+            comment: "Header of the suggested text in the add product from image form."
+        )
+        static let copyGeneratedText = NSLocalizedString(
+            "Copy",
+            comment: "Button title to copy generated text in the add product from image form."
+        )
+    }
+
+    enum Layout {
+        static let defaultSpacing: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
+        static let suggestedTextInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
     }
 }
 
@@ -42,21 +162,26 @@ struct AddProductFromImageTextFieldView_Previews: PreviewProvider {
             Section {
                 AddProductFromImageTextFieldView(
                     viewModel: .init(text: "", placeholder: "Placeholder text"),
-                    customizations: .init(lineLimit: 2...5))
+                    customizations: .init(lineLimit: 2...5),
+                    isGeneratingSuggestion: true
+                )
             }
 
             Section {
                 AddProductFromImageTextFieldView(
                     viewModel: .init(text: "Xcode 15 beta enables you to develop, test, and distribute apps for all Apple platforms.",
-                                     placeholder: "Placeholder text"),
-                    customizations: .init(lineLimit: 2...5)
+                                     placeholder: "Placeholder text",
+                                     suggestedText: "Once all the selected simulator and manifest files are downloaded"),
+                    customizations: .init(lineLimit: 2...5),
+                    isGeneratingSuggestion: false
                 )
             }
 
             Section {
                 AddProductFromImageTextFieldView(
                     viewModel: .init(text: "", placeholder: "Placeholder text"),
-                    customizations: .init(lineLimit: 2...5)
+                    customizations: .init(lineLimit: 2...5),
+                    isGeneratingSuggestion: false
                 )
             }
             .redacted(reason: .placeholder)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldViewModel.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// View model for `AddProductFromImageTextFieldView`.
+final class AddProductFromImageTextFieldViewModel: ObservableObject {
+    @Published var text: String
+    @Published private(set) var suggestedText: String?
+    let placeholder: String
+
+    /// - Parameters:
+    ///   - text: Initial value of the text.
+    ///   - placeholder: Placeholder text of the text field.
+    ///   - suggestedText: Initial value of the suggested text for previews and unit testing.
+    init(text: String,
+         placeholder: String,
+         suggestedText: String? = nil) {
+        self.text = text
+        self.placeholder = placeholder
+        self.suggestedText = suggestedText
+    }
+
+    /// Invoked when a suggestion for the text field is available.
+    /// - Parameter suggestion: Suggested text for the text field.
+    func onSuggestion(_ suggestion: String) {
+        guard suggestion.isNotEmpty, suggestion != text else {
+            return suggestedText = nil
+        }
+        if text.isNotEmpty {
+            suggestedText = suggestion
+        } else {
+            text = suggestion
+        }
+    }
+
+    /// Invoked when the user taps to apply the suggested text.
+    func applySuggestedText() {
+        text = suggestedText ?? ""
+        suggestedText = nil
+    }
+
+    /// Invoked when the user taps to dismiss the suggested text.
+    func dismissSuggestedText() {
+        suggestedText = nil
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -55,7 +55,7 @@ struct AddProductFromImageView: View {
             // Description field.
             Section {
                 AddProductFromImageTextFieldView(viewModel: viewModel.descriptionViewModel,
-                                                 customizations: .init(lineLimit: 2...5),
+                                                 customizations: .init(lineLimit: 2...10),
                                                  isGeneratingSuggestion: viewModel.isGeneratingDetails)
             }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -45,16 +45,21 @@ struct AddProductFromImageView: View {
                 }
             }
 
-            // Name & description fields.
+            // Name field.
             Section {
-                // TODO: 10180 - use `TextEditor` with a placeholder overlay
-                TextField(Localization.nameFieldPlaceholder, text: $viewModel.name)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
-                TextField(Localization.descriptionFieldPlaceholder, text: $viewModel.description)
-                    .lineLimit(5)
-                    .fixedSize(horizontal: false, vertical: true)
+                AddProductFromImageTextFieldView(viewModel: viewModel.nameViewModel,
+                                                 customizations: .init(lineLimit: 1...2))
             }
+            .redacted(reason: viewModel.isGeneratingDetails ? .placeholder: [])
+            .shimmering(active: viewModel.isGeneratingDetails)
+
+            // Description field.
+            Section {
+                AddProductFromImageTextFieldView(viewModel: viewModel.descriptionViewModel,
+                                                 customizations: .init(lineLimit: 2...5))
+            }
+            .redacted(reason: viewModel.isGeneratingDetails ? .placeholder: [])
+            .shimmering(active: viewModel.isGeneratingDetails)
 
             // Scanned text list.
             Section {
@@ -93,14 +98,6 @@ private extension AddProductFromImageView {
         static let title = NSLocalizedString(
             "Add product",
             comment: "Navigation bar title of the add product from image form."
-        )
-        static let nameFieldPlaceholder = NSLocalizedString(
-            "Name",
-            comment: "Product name placeholder on the add product from image form."
-        )
-        static let descriptionFieldPlaceholder = NSLocalizedString(
-            "Description",
-            comment: "Product description placeholder on the add product from image form."
         )
         static let continueButtonTitle = NSLocalizedString(
             "Continue",

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -48,18 +48,16 @@ struct AddProductFromImageView: View {
             // Name field.
             Section {
                 AddProductFromImageTextFieldView(viewModel: viewModel.nameViewModel,
-                                                 customizations: .init(lineLimit: 1...2))
+                                                 customizations: .init(lineLimit: 1...2),
+                                                 isGeneratingSuggestion: viewModel.isGeneratingDetails)
             }
-            .redacted(reason: viewModel.isGeneratingDetails ? .placeholder: [])
-            .shimmering(active: viewModel.isGeneratingDetails)
 
             // Description field.
             Section {
                 AddProductFromImageTextFieldView(viewModel: viewModel.descriptionViewModel,
-                                                 customizations: .init(lineLimit: 2...5))
+                                                 customizations: .init(lineLimit: 2...5),
+                                                 isGeneratingSuggestion: viewModel.isGeneratingDetails)
             }
-            .redacted(reason: viewModel.isGeneratingDetails ? .placeholder: [])
-            .shimmering(active: viewModel.isGeneratingDetails)
 
             // Scanned text list.
             Section {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -18,12 +18,20 @@ final class AddProductFromImageViewModel: ObservableObject {
         }
     }
 
+    typealias TextFieldViewModel = AddProductFromImageTextFieldView.ViewModel
     typealias ImageState = EditableImageViewState
 
     // MARK: - Product Details
 
-    @Published var name: String = ""
-    @Published var description: String = ""
+    @Published var nameViewModel: TextFieldViewModel
+    @Published var descriptionViewModel: TextFieldViewModel
+
+    var name: String {
+        nameViewModel.text
+    }
+    var description: String {
+        descriptionViewModel.text
+    }
 
     // MARK: - Product Image
 
@@ -53,6 +61,8 @@ final class AddProductFromImageViewModel: ObservableObject {
         self.siteID = siteID
         self.stores = stores
         self.onAddImage = onAddImage
+        self.nameViewModel = .init(text: "", placeholder: Localization.nameFieldPlaceholder)
+        self.descriptionViewModel = .init(text: "", placeholder: Localization.descriptionFieldPlaceholder)
 
         selectedImageSubscription = $imageState.compactMap { $0.image?.image }
         .sink { [weak self] image in
@@ -135,8 +145,8 @@ private extension AddProductFromImageViewModel {
     func generateAndPopulateProductDetails(from scannedTexts: [String]) async {
         switch await generateProductDetails(from: scannedTexts) {
             case .success(let details):
-                name = details.name
-                description = details.description
+                nameViewModel.text = details.name
+                descriptionViewModel.text = details.description
             case .failure(let error):
                 DDLogError("⛔️ Error generating product details from scanned text: \(error)")
         }
@@ -149,5 +159,18 @@ private extension AddProductFromImageViewModel {
                 continuation.resume(returning: result)
             })
         }
+    }
+}
+
+private extension AddProductFromImageViewModel {
+    enum Localization {
+        static let nameFieldPlaceholder = NSLocalizedString(
+            "Name",
+            comment: "Product name placeholder on the add product from image form."
+        )
+        static let descriptionFieldPlaceholder = NSLocalizedString(
+            "Description",
+            comment: "Product description placeholder on the add product from image form."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -145,8 +145,8 @@ private extension AddProductFromImageViewModel {
     func generateAndPopulateProductDetails(from scannedTexts: [String]) async {
         switch await generateProductDetails(from: scannedTexts) {
             case .success(let details):
-                nameViewModel.text = details.name
-                descriptionViewModel.text = details.description
+                nameViewModel.onSuggestion(details.name)
+                descriptionViewModel.onSuggestion(details.description)
             case .failure(let error):
                 DDLogError("⛔️ Error generating product details from scanned text: \(error)")
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -18,7 +18,7 @@ final class AddProductFromImageViewModel: ObservableObject {
         }
     }
 
-    typealias TextFieldViewModel = AddProductFromImageTextFieldView.ViewModel
+    typealias TextFieldViewModel = AddProductFromImageTextFieldViewModel
     typealias ImageState = EditableImageViewState
 
     // MARK: - Product Details

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -23,8 +23,8 @@ final class AddProductFromImageViewModel: ObservableObject {
 
     // MARK: - Product Details
 
-    @Published var nameViewModel: TextFieldViewModel
-    @Published var descriptionViewModel: TextFieldViewModel
+    let nameViewModel: TextFieldViewModel
+    let descriptionViewModel: TextFieldViewModel
 
     var name: String {
         nameViewModel.text

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -143,6 +143,9 @@ private extension AddProductFromImageViewModel {
     }
 
     func generateAndPopulateProductDetails(from scannedTexts: [String]) async {
+        guard scannedTexts.isNotEmpty else {
+            return
+        }
         switch await generateProductDetails(from: scannedTexts) {
             case .success(let details):
                 nameViewModel.onSuggestion(details.name)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		02ACD25A2852E11700EC928E /* CloseAccountCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ACD2592852E11700EC928E /* CloseAccountCoordinator.swift */; };
 		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
 		02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */; };
+		02B038CC2A61843E00467F06 /* AddProductFromImageTextFieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B038CB2A61843E00467F06 /* AddProductFromImageTextFieldViewModel.swift */; };
 		02B1AA6529A4705A00D54FCB /* TabbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AA6429A4705A00D54FCB /* TabbedViewController.swift */; };
 		02B1AA6729A4709400D54FCB /* FilterTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AA6629A4709400D54FCB /* FilterTabBar.swift */; };
 		02B1AFEC24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AFEB24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift */; };
@@ -2782,6 +2783,7 @@
 		02ACD2592852E11700EC928E /* CloseAccountCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseAccountCoordinator.swift; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
+		02B038CB2A61843E00467F06 /* AddProductFromImageTextFieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageTextFieldViewModel.swift; sourceTree = "<group>"; };
 		02B1AA6429A4705A00D54FCB /* TabbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewController.swift; sourceTree = "<group>"; };
 		02B1AA6629A4709400D54FCB /* FilterTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTabBar.swift; sourceTree = "<group>"; };
 		02B1AFEB24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductListSelectorDataSource.swift; sourceTree = "<group>"; };
@@ -5658,6 +5660,7 @@
 				02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */,
 				02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */,
 				02FADA9E2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift */,
+				02B038CB2A61843E00467F06 /* AddProductFromImageTextFieldViewModel.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -11995,6 +11998,7 @@
 				02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */,
 				CCCFFC5A2934EF5E006130AF /* StatsIntervalDataParser.swift in Sources */,
 				AEA3F90F27BE8EB400B9F555 /* ShippingLineDetailsViewModel.swift in Sources */,
+				02B038CC2A61843E00467F06 /* AddProductFromImageTextFieldViewModel.swift in Sources */,
 				26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */,
 				027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */,
 				26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -554,6 +554,7 @@
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */; };
 		02FADA9F2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9E2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift */; };
+		02FADAA12A6052BF00FE8683 /* AddProductFromImageTextFieldViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA02A6052BF00FE8683 /* AddProductFromImageTextFieldViewModelTests.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FFDDC62A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */; };
@@ -2930,6 +2931,7 @@
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageScannedTextView.swift; sourceTree = "<group>"; };
 		02FADA9E2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageTextFieldView.swift; sourceTree = "<group>"; };
+		02FADAA02A6052BF00FE8683 /* AddProductFromImageTextFieldViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageTextFieldViewModelTests.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Blaze.swift"; sourceTree = "<group>"; };
@@ -5665,6 +5667,7 @@
 			children = (
 				028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */,
 				028B68C42A57566300FE03A8 /* AddProductFromImageEligibilityCheckerTests.swift */,
+				02FADAA02A6052BF00FE8683 /* AddProductFromImageTextFieldViewModelTests.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -13142,6 +13145,7 @@
 				2631D4FA29ED108400F13F20 /* WPComPlanNameSanitizer.swift in Sources */,
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,
 				773077F3251E954300178696 /* ProductDownloadFileViewModelTests.swift in Sources */,
+				02FADAA12A6052BF00FE8683 /* AddProductFromImageTextFieldViewModelTests.swift in Sources */,
 				2602A64A27BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift in Sources */,
 				DE4B3B2E269455D400EEF2D8 /* MockShipmentActionStoresManager.swift in Sources */,
 				0246405F258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -553,6 +553,7 @@
 		02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800825807CD300C3BAD2 /* GridStackView.swift */; };
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */; };
+		02FADA9F2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9E2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FFDDC62A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */; };
@@ -2928,6 +2929,7 @@
 		02F6800825807CD300C3BAD2 /* GridStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridStackView.swift; sourceTree = "<group>"; };
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageScannedTextView.swift; sourceTree = "<group>"; };
+		02FADA9E2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageTextFieldView.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Blaze.swift"; sourceTree = "<group>"; };
@@ -5653,6 +5655,7 @@
 				028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */,
 				02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */,
 				02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */,
+				02FADA9E2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -11804,6 +11807,7 @@
 				451A04EC2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift in Sources */,
 				02DD81F9242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.swift in Sources */,
 				D8C2A28823190B2300F503E9 /* StorageProductReview+Woo.swift in Sources */,
+				02FADA9F2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift in Sources */,
 				02D3B68529657061009BF0BC /* SupportButton.swift in Sources */,
 				2664210126F3E1BB001FC5B4 /* ModalHostingPresentationController.swift in Sources */,
 				D8B4D5F026C2C7EC00F34E94 /* InPersonPaymentsStripeAccountPendingView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageTextFieldViewModelTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import XCTest
+
+@testable import WooCommerce
+
+final class AddProductFromImageTextFieldViewModelTests: XCTestCase {
+    typealias ViewModel = AddProductFromImageTextFieldView.ViewModel
+
+    // MARK: - `onSuggestion`
+
+    func test_onSuggestion_updates_suggestedText_when_text_is_not_empty() {
+        // Given
+        let viewModel = ViewModel(text: "Asparagus", placeholder: "")
+        XCTAssertNil(viewModel.suggestedText)
+
+        // When
+        viewModel.onSuggestion("Mushroom")
+
+        // Then
+        XCTAssertEqual(viewModel.suggestedText, "Mushroom")
+    }
+
+    func test_onSuggestion_updates_text_when_text_is_empty() {
+        // Given
+        let viewModel = ViewModel(text: "", placeholder: "")
+
+        // When
+        viewModel.onSuggestion("Mushroom")
+
+        // Then
+        XCTAssertEqual(viewModel.text, "Mushroom")
+        XCTAssertNil(viewModel.suggestedText)
+    }
+
+    func test_onSuggestion_does_not_update_suggestedText_when_suggestion_is_the_same_as_text() {
+        // Given
+        let viewModel = ViewModel(text: "Asparagus", placeholder: "")
+        XCTAssertNil(viewModel.suggestedText)
+
+        // When
+        viewModel.onSuggestion("Asparagus")
+
+        // Then
+        XCTAssertNil(viewModel.suggestedText)
+    }
+
+    func test_onSuggestion_resets_suggestedText_when_suggestion_is_empty() {
+        // Given
+        let viewModel = ViewModel(text: "", placeholder: "")
+        XCTAssertNil(viewModel.suggestedText)
+
+        // When
+        viewModel.onSuggestion("Asparagus")
+        viewModel.onSuggestion("")
+
+        // Then
+        XCTAssertNil(viewModel.suggestedText)
+    }
+
+    // MARK: - `applySuggestedText`
+
+    func test_applySuggestedText_replaces_text_with_suggestedText_and_resets_suggestedText() {
+        // Given
+        let viewModel = ViewModel(text: "Fish", placeholder: "")
+
+        // When
+        viewModel.onSuggestion("Asparagus")
+        viewModel.applySuggestedText()
+
+        // Then
+        XCTAssertEqual(viewModel.text, "Asparagus")
+        XCTAssertNil(viewModel.suggestedText)
+    }
+
+    // MARK: - `dismissSuggestedText`
+
+    func test_dismissSuggestedText_resets_suggestedText_and_does_not_change_text() {
+        // Given
+        let viewModel = ViewModel(text: "Fish", placeholder: "")
+
+        // When
+        viewModel.onSuggestion("Asparagus")
+        viewModel.dismissSuggestedText()
+
+        // Then
+        XCTAssertEqual(viewModel.text, "Fish")
+        XCTAssertNil(viewModel.suggestedText)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're running an A/B experiment for a new starting screen for the product creation flow. This new screen just contains 3 fields: image, name, and description. When selecting a packaging image, the texts can be scanned and used to generate product details (name and description for now). The latest POC looks like pe5sF9-1Es-p2#comment-2495.

The focus of this PR: the text fields now support multiple lines, and a suggestion box is shown if the text field is non-empty. When generating product details from the image, a loading UI is also shown to indicate that a suggestion might be available.

🗒️ There is a known issue where the multiline text field can have an unexpectedly taller height after applying the suggested text. It's a subtask in https://github.com/woocommerce/woocommerce-ios/issues/10180.

## How

- A new view `AddProductFromImageTextFieldView` was created for the name and description fields in the form `AddProductFromImageView`. Its view model can be invoked with a suggestion `onSuggestion`, and then conditionally updates either its `text` or `suggestedText` based on the following logic:
  - If the suggestion is empty or the same as the `text`, then it resets the `suggestedText`
  - If `text` is non-empty, the suggestion is set to `suggestedText`. Otherwise, the suggestion is set to `text` 
  - Test cases were added for this behavior
- `AddProductFromImageViewModel` and `AddProductFromImageView` were updated with the new text field view

🗒️ I've tried using a `TextEditor` for the multiline text field, but the height also has unexpected issues. Using a `TextField` with iOS 16+ multiline support has fewer height issues from my testing. Please feel free to suggest any improvements on the text field.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- If the store has 0-2 products, tap `Add manually`
- Tap to select `Simple physical product`
- Enter some text to either the name or description field
- Tap on the image header to add an image with some text using any source (camera/device library/media library) --> after a list of the scanned texts is shown, there should be a loading state below both text fields. Shortly, if the details generation succeeds, the suggested text should be shown in a suggestion box for the non-empty text field
- Feel free to unselect and edit the text of some rows and test the regeneration flow
- Tap `Continue` --> the new screen should be dismissed and then it navigates to the main product form
- Tap `Publish` to publish the product --> the product should be saved remotely with the selected image and generated name and description

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/cc4a732d-e24b-4605-b8e0-acbb8c49f549

light - loading | light - suggested text | dark - loading | dark - suggested text
-- | -- | -- | --
![Simulator Screenshot - iPhone 14 - 2023-07-13 at 13 59 06](https://github.com/woocommerce/woocommerce-ios/assets/1945542/4bc0e126-26ad-4afe-b4df-7e5388620d95) | ![Simulator Screenshot - iPhone 14 - 2023-07-13 at 13 59 18](https://github.com/woocommerce/woocommerce-ios/assets/1945542/a983a800-69f4-40ea-b4a5-e6a03a5320a8) | ![Simulator Screenshot - iPhone 14 - 2023-07-13 at 13 59 49](https://github.com/woocommerce/woocommerce-ios/assets/1945542/2737cd87-9a00-48ee-8e0f-d22503ba4dc2) | ![Simulator Screenshot - iPhone 14 - 2023-07-13 at 14 00 00](https://github.com/woocommerce/woocommerce-ios/assets/1945542/33ef67b3-063b-41be-b9c1-c70065b8a41f)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.