### PR TITLE
Add product from image: extract image text-scanning logic for unit testing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -100,6 +100,9 @@ private extension AddProductFromImageViewModel {
     }
 
     func generateAndPopulateProductDetails(from scannedTexts: [String]) async {
+        guard scannedTexts.isNotEmpty else {
+            return
+        }
         switch await generateProductDetails(from: scannedTexts) {
             case .success(let details):
                 name = details.name

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -46,12 +46,15 @@ final class AddProductFromImageViewModel: ObservableObject {
 
     private let siteID: Int64
     private let stores: StoresManager
+    private let imageTextScanner: ImageTextScannerProtocol
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
+         imageTextScanner: ImageTextScannerProtocol = ImageTextScanner(),
          onAddImage: @escaping (MediaPickingSource) async -> MediaPickerImage?) {
         self.siteID = siteID
         self.stores = stores
+        self.imageTextScanner = imageTextScanner
         self.onAddImage = onAddImage
 
         selectedImageSubscription = $imageState.compactMap { $0.image?.image }
@@ -85,51 +88,15 @@ final class AddProductFromImageViewModel: ObservableObject {
 
 private extension AddProductFromImageViewModel {
     func onSelectedImage(_ image: UIImage) {
-        // Gets the CGImage on which to perform requests.
-        guard let cgImage = image.cgImage else {
-            return
-        }
-
-        // Creates a new image-request handler.
-        let requestHandler = VNImageRequestHandler(cgImage: cgImage)
-
-        // Creates a new request to recognize text.
-        let request = VNRecognizeTextRequest { [weak self] request, error in
-            self?.onScannedTextRequestCompletion(request: request, error: error)
-        }
-
-        if #available(iOS 16.0, *) {
-            request.revision = VNRecognizeTextRequestRevision3
-            request.automaticallyDetectsLanguage = true
-        }
-
-        do {
-            // Performs the text-recognition request.
-            try requestHandler.perform([request])
-        } catch {
-            DDLogError("⛔️ Unable to perform image text generation request: \(error)")
-        }
-    }
-
-    func onScannedTextRequestCompletion(request: VNRequest, error: Error?) {
-        let texts = scannedTexts(from: request)
-        scannedTexts = texts.map { .init(text: $0, isSelected: true) }
         Task { @MainActor in
-            isGeneratingDetails = true
-            await generateAndPopulateProductDetails(from: texts)
-            isGeneratingDetails = false
+            do {
+                let texts = try await imageTextScanner.scanText(from: image)
+                scannedTexts = texts.map { .init(text: $0, isSelected: true) }
+                generateProductDetails()
+            } catch {
+                DDLogError("⛔️ Error scanning text from image: \(error)")
+            }
         }
-    }
-
-    func scannedTexts(from request: VNRequest) -> [String] {
-        guard let observations = request.results as? [VNRecognizedTextObservation] else {
-            return []
-        }
-        let recognizedStrings = observations.compactMap { observation in
-            // Returns the string of the top VNRecognizedText instance.
-            observation.topCandidates(1).first?.string
-        }
-        return recognizedStrings
     }
 
     func generateAndPopulateProductDetails(from scannedTexts: [String]) async {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/ImageTextScanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/ImageTextScanner.swift
@@ -1,0 +1,61 @@
+import UIKit
+import Vision
+
+protocol ImageTextScannerProtocol {
+    /// Scans text from the given image.
+    /// - Parameter image: Image that can contain text.
+    /// - Returns: An array of texts detected in the image.
+    func scanText(from image: UIImage) async throws -> [String]
+}
+
+/// Scans text from an image using the Vision framework.
+final class ImageTextScanner: ImageTextScannerProtocol {
+    func scanText(from image: UIImage) async throws -> [String] {
+        // Gets the CGImage on which to perform requests.
+        guard let cgImage = image.cgImage else {
+            return []
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            // Creates a new image-request handler.
+            let requestHandler = VNImageRequestHandler(cgImage: cgImage)
+
+            // Creates a new request to recognize text.
+            let request = VNRecognizeTextRequest { [weak self] request, error in
+                if let error {
+                    return continuation.resume(throwing: error)
+                }
+                guard let self else {
+                    return continuation.resume(returning: [])
+                }
+                let scannedTexts = self.scannedTexts(from: request)
+                continuation.resume(returning: scannedTexts)
+            }
+
+            if #available(iOS 16.0, *) {
+                request.revision = VNRecognizeTextRequestRevision3
+                request.automaticallyDetectsLanguage = true
+            }
+
+            do {
+                // Performs the text-recognition request.
+                try requestHandler.perform([request])
+            } catch {
+                DDLogError("⛔️ Unable to perform image text generation request: \(error)")
+            }
+        }
+    }
+}
+
+private extension ImageTextScanner {
+    func scannedTexts(from request: VNRequest) -> [String] {
+        guard let observations = request.results as? [VNRecognizedTextObservation] else {
+            return []
+        }
+        let recognizedStrings = observations.compactMap { observation in
+            // Returns the string of the top VNRecognizedText instance.
+            observation.topCandidates(1).first?.string
+        }
+        return recognizedStrings
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -553,6 +553,7 @@
 		02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6800825807CD300C3BAD2 /* GridStackView.swift */; };
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */; };
+		02FADAA32A60759200FE8683 /* ImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA22A60759200FE8683 /* ImageTextScanner.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FFDDC62A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */; };
@@ -2928,6 +2929,7 @@
 		02F6800825807CD300C3BAD2 /* GridStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridStackView.swift; sourceTree = "<group>"; };
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageScannedTextView.swift; sourceTree = "<group>"; };
+		02FADAA22A60759200FE8683 /* ImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTextScanner.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Blaze.swift"; sourceTree = "<group>"; };
@@ -5653,6 +5655,7 @@
 				028B68BD2A57479A00FE03A8 /* AddProductFromImageEligibilityChecker.swift */,
 				02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */,
 				02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */,
+				02FADAA22A60759200FE8683 /* ImageTextScanner.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -12513,6 +12516,7 @@
 				2662D90A26E16B3600E25611 /* FilterListSelector.swift in Sources */,
 				DECE1400279A595200816ECD /* Coupon+Woo.swift in Sources */,
 				B6C78B90293BAF37008934A1 /* AnalyticsHubLastYearRangeData.swift in Sources */,
+				02FADAA32A60759200FE8683 /* ImageTextScanner.swift in Sources */,
 				314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,
 				0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -554,6 +554,7 @@
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */; };
 		02FADAA32A60759200FE8683 /* ImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA22A60759200FE8683 /* ImageTextScanner.swift */; };
+		02FADAA52A607CEE00FE8683 /* MockImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FFDDC62A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */; };
@@ -2930,6 +2931,7 @@
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageScannedTextView.swift; sourceTree = "<group>"; };
 		02FADAA22A60759200FE8683 /* ImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTextScanner.swift; sourceTree = "<group>"; };
+		02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageTextScanner.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Blaze.swift"; sourceTree = "<group>"; };
@@ -7707,6 +7709,7 @@
 				026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */,
 				02863F6E2925FC29006A06AA /* MockInAppPurchasesForWPComPlansManager.swift */,
 				028B68BF2A574BE200FE03A8 /* MockAddProductFromImageEligibilityChecker.swift */,
+				02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -12935,6 +12938,7 @@
 				022F2FAA295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift in Sources */,
 				DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */,
 				DEEDA23D298A22180088256B /* SiteCredentialLoginUseCaseTests.swift in Sources */,
+				02FADAA52A607CEE00FE8683 /* MockImageTextScanner.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */,
 				027385B02A17093C00835889 /* StoreCreationStatusCheckerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -555,6 +555,7 @@
 		02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */; };
 		02FADAA32A60759200FE8683 /* ImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA22A60759200FE8683 /* ImageTextScanner.swift */; };
 		02FADAA52A607CEE00FE8683 /* MockImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */; };
+		02FADAA72A608F6B00FE8683 /* ImageTextScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA62A608F6B00FE8683 /* ImageTextScannerTests.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FFDDC62A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */; };
@@ -2932,6 +2933,7 @@
 		02FADA9C2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageScannedTextView.swift; sourceTree = "<group>"; };
 		02FADAA22A60759200FE8683 /* ImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTextScanner.swift; sourceTree = "<group>"; };
 		02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageTextScanner.swift; sourceTree = "<group>"; };
+		02FADAA62A608F6B00FE8683 /* ImageTextScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTextScannerTests.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Blaze.swift"; sourceTree = "<group>"; };
@@ -5667,6 +5669,7 @@
 			children = (
 				028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */,
 				028B68C42A57566300FE03A8 /* AddProductFromImageEligibilityCheckerTests.swift */,
+				02FADAA62A608F6B00FE8683 /* ImageTextScannerTests.swift */,
 			);
 			path = AddProductFromImage;
 			sourceTree = "<group>";
@@ -12907,6 +12910,7 @@
 				265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */,
 				03FBDAFD263EE4E800ACE257 /* CouponListViewModelTests.swift in Sources */,
 				02DAE7FF291B8C8A009342B7 /* FreeDomainSelectorViewModelTests.swift in Sources */,
+				02FADAA72A608F6B00FE8683 /* ImageTextScannerTests.swift in Sources */,
 				036F6EA6281847D5006D84F8 /* LegacyPaymentCaptureOrchestratorTests.swift in Sources */,
 				B555531321B57E8800449E71 /* MockUserNotificationsCenterAdapter.swift in Sources */,
 				682210ED2909666600814E14 /* CustomerSearchUICommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockImageTextScanner.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockImageTextScanner.swift
@@ -1,0 +1,19 @@
+@testable import WooCommerce
+import UIKit
+
+final class MockImageTextScanner: ImageTextScannerProtocol {
+    let result: Result<[String], Error>
+
+    init(result: Result<[String], Error>) {
+        self.result = result
+    }
+
+    func scanText(from image: UIImage) async throws -> [String] {
+        switch result {
+            case .success(let value):
+                return value
+            case .failure(let error):
+                throw error
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/ImageTextScannerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/ImageTextScannerTests.swift
@@ -1,0 +1,30 @@
+import TestKit
+import XCTest
+
+@testable import WooCommerce
+
+final class ImageTextScannerTests: XCTestCase {
+    private let scanner = ImageTextScanner()
+
+    func test_scanText_returns_empty_list_from_image_without_text() async throws {
+        // Given
+        let imageWithoutText = UIImage.addImage
+
+        // When
+        let scannedTexts = try await scanner.scanText(from: imageWithoutText)
+
+        // Then
+        XCTAssertEqual(scannedTexts, [])
+    }
+
+    func test_scanText_returns_text_from_image_with_text() async throws {
+        // Given
+        let imageWithText = UIImage.wooLogoPrologueImage
+
+        // When
+        let scannedTexts = try await scanner.scanText(from: imageWithText)
+
+        // Then
+        XCTAssertTrue(scannedTexts.isNotEmpty)
+    }
+}

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1137,4 +1137,10 @@ public struct ProductDetailsFromScannedTexts: Equatable, Decodable {
     public let description: String
     /// The language code detected for the product.
     public let language: String
+
+    public init(name: String, description: String, language: String) {
+        self.name = name
+        self.description = description
+        self.language = language
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the image text-scanning implementation is embedded in `AddProductFromImageViewModel` which makes it hard to test. This PR extracted the code to a separate class for unit testing.

## How

The part of code from an `UIImage` to `[String]` was extracted from `AddProductFromImageViewModel` to `ImageTextScanner: ImageTextScannerProtocol`. Some test cases were added for `AddProductFromImageViewModel`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to smoke test the affected flow:

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- If the store has 0-2 products, tap `Add manually`
- Tap to select `Simple physical product`
- Tap on the image header to add an image with some text using any source (camera/device library/media library) --> a new section with a list of the scanned texts should be shown, and each scanned text is selectable and editable

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
