### PR TITLE
Requirements Checker: Remove check for isWordPressComStore before checking site plan

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [*] Product details: The share button is displayed with text instead of icon for better discoverability. [https://github.com/woocommerce/woocommerce-ios/pull/10216]
 - [*] Store creation: Update the timeout view with the option to retry the site check. [https://github.com/woocommerce/woocommerce-ios/pull/10221]
-
+- [*] Fixed issue showing the expired alert for sites that got reverted to simple sites after their plan expired. [https://github.com/woocommerce/woocommerce-ios/pull/10228]
 
 14.4
 -----

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -43,8 +43,7 @@ final class RequirementsChecker {
         Task { @MainActor in
             do {
                 let result = try await checkMinimumWooVersion(for: site)
-                /// skips checking site plan for non-wpcom stores.
-                guard case .invalidWCVersion = result, site.isWordPressComStore else {
+                guard case .invalidWCVersion = result else {
                     onCompletion?(.success(result))
                     return
                 }

--- a/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
@@ -29,7 +29,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkSiteEligibility_returns_expiredWPComPlan_if_plan_expired() {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let checker = RequirementsChecker(stores: stores)
 
@@ -72,7 +72,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkSiteEligibility_returns_expiredWPComPlan_if_plan_check_fails_with_noCurrentPlan() {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let checker = RequirementsChecker(stores: stores)
 
@@ -114,7 +114,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkSiteEligibility_fails_if_plan_check_fails_with_error_other_than_noCurrentPlan() throws {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let checker = RequirementsChecker(stores: stores)
 
@@ -142,7 +142,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkSiteEligibility_returns_validWCVersion_if_highest_Woo_version_is_3() {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let checker = RequirementsChecker(stores: stores)
 
@@ -175,7 +175,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkSiteEligibility_returns_invalidWCVersion_if_highest_Woo_version_is_not_3() {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: false)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let checker = RequirementsChecker(stores: stores)
 
@@ -183,6 +183,14 @@ final class RequirementsCheckerTests: XCTestCase {
             switch action {
             case .retrieveSiteAPI(_, let onCompletion):
                 onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: ["wc/v2"])))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            switch action {
+            case .loadSiteCurrentPlan(_, let completion):
+                completion(.failure(NSError(domain: "test", code: 404, userInfo: nil)))
             default:
                 break
             }
@@ -208,7 +216,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkSiteEligibility_returns_failure_if_site_setting_check_fails() {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let checker = RequirementsChecker(stores: stores)
 
@@ -238,7 +246,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkEligibilityForDefaultStore_presents_wc_version_alert_when_highest_Woo_version_is_not_3() {
         // Given
-        let site = Site.fake().copy(siteID: 123, isWordPressComStore: false)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
         let checker = RequirementsChecker(stores: stores, baseViewController: viewController)
 
@@ -246,6 +254,15 @@ final class RequirementsCheckerTests: XCTestCase {
             switch action {
             case .retrieveSiteAPI(_, let onCompletion):
                 onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: [])))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            switch action {
+            case .loadSiteCurrentPlan(_, let completion):
+                completion(.failure(NSError(domain: "test", code: 404, userInfo: nil)))
             default:
                 break
             }
@@ -262,7 +279,7 @@ final class RequirementsCheckerTests: XCTestCase {
 
     func test_checkEligibilityForDefaultStore_presents_plan_upgrade_alert_for_wpcom_store_with_expired_free_trial_plan() {
         // Given
-        let site = Site.fake().copy(siteID: 123, isWordPressComStore: true)
+        let site = Site.fake().copy(siteID: 123)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
         let checker = RequirementsChecker(stores: stores, baseViewController: viewController)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to #10033
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously a new alert was added to check when a site has an expired plan and gets reverted back to a simple site. This works when a user opens the app when their site first got reverted.

A problem that I didn't catch: after the site is fetched again, all the site information is updated including `is_wpcom_store`, which is then false. This PR removes this check in `RequirementChecker` to still check for the site plan if this property is false. This should not affect self-hosted sites because the check `checkIfWPComSitePlanExpired` will fail for them and we can still show the invalid Woo version alert for them. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
It's not easy to test this unless you are logged in to a site that ran on a trial plan that expired more than 7 days ago. Please feel free to test with the steps in #10081, the alert should still be displayed. To force the site's `is_wpcom_store` to false, you can try altering the information for your selected store in `/me/sites` response using ProxyMan.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
