### PR TITLE
[Coupons in Orders M4] Improve product discounts coupons interaction

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1214,6 +1214,7 @@ private extension EditableOrderViewModel {
 
         return ProductInOrderViewModel(productRowViewModel: rowViewModel,
                                        productDiscountConfiguration: addProductDiscountConfiguration(on: orderItem),
+                                       showCouponsAndDiscountsAlert: orderSynchronizer.order.coupons.isNotEmpty,
                                        onRemoveProduct: { [weak self] in
                                             self?.removeItemFromOrder(orderItem)
                                        })
@@ -1224,6 +1225,7 @@ private extension EditableOrderViewModel {
     func addProductDiscountConfiguration(on orderItem: OrderItem) -> ProductInOrderViewModel.DiscountConfiguration? {
         guard featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4),
               orderSynchronizer.order.coupons.isEmpty,
+              case OrderSyncState.synced = orderSynchronizer.state,
               let subTotalDecimal = currencyFormatter.convertToDecimal(orderItem.subtotal) else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1214,7 +1214,8 @@ private extension EditableOrderViewModel {
 
         return ProductInOrderViewModel(productRowViewModel: rowViewModel,
                                        productDiscountConfiguration: addProductDiscountConfiguration(on: orderItem),
-                                       showCouponsAndDiscountsAlert: orderSynchronizer.order.coupons.isNotEmpty,
+                                       showCouponsAndDiscountsAlert: orderSynchronizer.order.coupons.isNotEmpty &&
+                                                                     featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM4),
                                        onRemoveProduct: { [weak self] in
                                             self?.removeItemFromOrder(orderItem)
                                        })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -37,6 +37,11 @@ struct ProductInOrder: View {
                             Divider()
                         }
                         .renderedIf(viewModel.showAddDiscountRow)
+
+                        Text(Localization.couponsAndDiscountAlert)
+                            .subheadlineStyle()
+                            .padding()
+                            .renderedIf(viewModel.showCouponsAndDiscountsAlert)
                     }
                     .background(Color(.listForeground(modal: false)))
                     .sheet(isPresented: $shouldShowDiscountLineDetails) {
@@ -116,6 +121,9 @@ private extension ProductInOrder {
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Product screen")
         static let addDiscount = NSLocalizedString("Add discount",
                                               comment: "Text for the button to add a discount to a product during order creation")
+        static let couponsAndDiscountAlert = NSLocalizedString("Adding discount is currently not available. Remove coupons first.",
+                                              comment: "Alert on the Product Details screen during order creation when" +
+                                                               "we cannot add a discount because we have coupons")
         static let remove = NSLocalizedString("Remove Product from Order",
                                               comment: "Text for the button to remove a product from the order during order creation")
         static let discountTitle = NSLocalizedString("Discount", comment: "Title for the Discount section on the Product Details screen during order creation")
@@ -136,7 +144,7 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             canChangeQuantity: false,
                                             imageURL: nil)
         let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
-                                                productDiscountConfiguration: nil,
+                                                productDiscountConfiguration: nil, showCouponsAndDiscountsAlert: false,
                                                 onRemoveProduct: {})
         ProductInOrder(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -45,12 +45,15 @@ final class ProductInOrderViewModel: Identifiable {
 
     let onSaveFormattedDiscount: (String?) -> Void
 
+    let showCouponsAndDiscountsAlert: Bool
+
     var viewDismissPublisher = PassthroughSubject<(), Never>()
 
     private let currencyFormatter: CurrencyFormatter
 
     init(productRowViewModel: ProductRowViewModel,
          productDiscountConfiguration: DiscountConfiguration?,
+         showCouponsAndDiscountsAlert: Bool,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          analytics: Analytics = ServiceLocator.analytics,
          onRemoveProduct: @escaping () -> Void) {
@@ -60,6 +63,7 @@ final class ProductInOrderViewModel: Identifiable {
         self.onRemoveProduct = onRemoveProduct
         self.onSaveFormattedDiscount = productDiscountConfiguration?.onSaveFormattedDiscount ?? { _ in }
         self.isAddingDiscountToProductEnabled = productDiscountConfiguration != nil
+        self.showCouponsAndDiscountsAlert = showCouponsAndDiscountsAlert
         self.currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
         self.analytics = analytics
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModelTests.swift
@@ -14,6 +14,7 @@ final class ProductInOrderViewModelTests: XCTestCase {
         let productRowViewModel = ProductRowViewModel(product: product, quantity: 0, canChangeQuantity: true)
         viewModel = ProductInOrderViewModel(productRowViewModel: productRowViewModel,
                                             productDiscountConfiguration: nil,
+                                            showCouponsAndDiscountsAlert: false,
                                             analytics: WooAnalytics(analyticsProvider: analytics),
                                             onRemoveProduct: {})
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10230
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add a text alert when the user cannot add discounts to products because the order contains coupons. As our backend doesn't handle coupons and discounts simultaneously, we prevented the user from adding discounts in that condition. With this PR we make the process more transparent by adding that alert.

Furthermore, we add a new condition for adding discounts: the order should be synced remotely. This way we avoid getting into inconsistent states.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go Orders
2. Tap on + to create an order
3. Add a product
4. Add a coupon
5. Tap on the Product. You should see the alert about why the user cannot add a discount
6. Remove the Coupon. Wait for the order to be synced
7. Tap on the Product. You can add a discount


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1864060/fe6b356d-1b77-42b7-84b0-33a17e8b0b97

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
