### PR TITLE
[Order with Coupons M4] Show product discount on the Editable Order Details Product Row 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -460,12 +460,16 @@ final class EditableOrderViewModel: ObservableObject {
             return nil
         }
 
+        let itemDiscount = currentDiscount(on: item)
+        let passingDiscountValue = itemDiscount > 0 ? itemDiscount : nil
+
         if item.variationID != 0,
             let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {
             let parent = allProducts.first(where: { $0.productID == item.parent })
             let attributes = ProductVariationFormatter().generateAttributes(for: variation, from: parent?.attributes ?? [])
             return ProductRowViewModel(id: item.itemID,
                                        productVariation: variation,
+                                       discount: passingDiscountValue,
                                        name: item.name,
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
@@ -479,6 +483,7 @@ final class EditableOrderViewModel: ObservableObject {
         } else if let product = allProducts.first(where: { $0.productID == item.productID }) {
             return ProductRowViewModel(id: item.itemID,
                                        product: product,
+                                       discount: passingDiscountValue,
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
                                        quantityUpdatedCallback: { [weak self] _ in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -74,8 +74,18 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             return nil
         }
         let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
-        return currencyFormatter.formatAmount(productSubtotal)
+        let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal)
+
+        guard let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal),
+              let discount = discount,
+              let discountLabelComponent = currencyFormatter.formatAmount(discount) else {
+            return priceLabelComponent
+        }
+
+        return priceLabelComponent + " - " + discountLabelComponent
     }
+
+    private let discount: Decimal?
 
     /// Variations label for a variable product.
     ///
@@ -147,6 +157,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          name: String,
          sku: String?,
          price: String?,
+         discount: Decimal? = nil,
          stockStatusKey: String,
          stockQuantity: Decimal?,
          manageStock: Bool,
@@ -165,6 +176,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.name = name
         self.sku = sku
         self.price = price
+        self.discount = discount
         self.stockStatus = .init(rawValue: stockStatusKey)
         self.stockQuantity = stockQuantity
         self.manageStock = manageStock
@@ -182,6 +194,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     convenience init(id: Int64? = nil,
                      product: Product,
+                     discount: Decimal? = nil,
                      quantity: Decimal = 1,
                      canChangeQuantity: Bool,
                      selectedState: ProductRow.SelectedState = .notSelected,
@@ -232,6 +245,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   name: product.name,
                   sku: product.sku,
                   price: price,
+                  discount: discount,
                   stockStatusKey: stockStatusKey,
                   stockQuantity: stockQuantity,
                   manageStock: manageStock,
@@ -249,6 +263,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     convenience init(id: Int64? = nil,
                      productVariation: ProductVariation,
+                     discount: Decimal? = nil,
                      name: String,
                      quantity: Decimal = 1,
                      canChangeQuantity: Bool,
@@ -269,6 +284,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   name: name,
                   sku: productVariation.sku,
                   price: productVariation.price,
+                  discount: discount,
                   stockStatusKey: productVariation.stockStatus.rawValue,
                   stockQuantity: productVariation.stockQuantity,
                   manageStock: productVariation.manageStock,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -116,6 +116,22 @@ class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
+    func test_view_model_creates_expected_label_for_product_with_price_and_discount() {
+        // Given
+        let price = "2.50"
+        let discount: Decimal = 0.50
+        let product = Product.fake().copy(price: price)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, discount: discount, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+
+        // Then
+        let expectedPriceLabel = "2.50" + " - " + (currencyFormatter.formatAmount(discount) ?? "")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedPriceLabel),
+                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
+    }
+
     func test_view_model_creates_expected_label_for_product_with_no_price() {
         // Given
         let price = ""


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10233 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the discount to the product row in the Editable Order Details so it can be more visible. It's shown when adding simple discounts and coupons.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to create a new order
3. Add a new product
4. Add a new coupon that applies to the product. The discount should be shown in the product row
5. Remove the coupon. The discount should be removed from the product row
6. Tap on the product. Follow the flow to add a discount to the product.
7. The discount should be shown on the product row.
8. Remove the discount. The discount should be removed from the product row

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/7c3418b3-4a1d-4ba1-9927-0c2cd468e74c




---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
