### PR TITLE
Add product from image: add a dismiss CTA to allow dismissal in landscape mode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -39,6 +39,9 @@ final class AddProductFromImageCoordinator: Coordinator {
             guard let self else { return }
             Task { @MainActor in
                 await self.navigationController.dismiss(animated: true)
+                guard let data else {
+                    return
+                }
                 guard let product = self.createProduct(name: data.name, description: data.description) else {
                     return
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -88,11 +88,9 @@ struct AddProductFromImageView: View {
                 .buttonStyle(LinkButtonStyle())
             }
             ToolbarItem(placement: .cancellationAction) {
-                Button(action: {
+                Button(Localization.cancelButtonTitle) {
                     completion(nil)
-                }, label: {
-                    Image(systemName: "xmark")
-                })
+                }
                 .buttonStyle(TextButtonStyle())
             }
         }
@@ -108,6 +106,10 @@ private extension AddProductFromImageView {
         static let continueButtonTitle = NSLocalizedString(
             "Continue",
             comment: "Continue button on the add product from image form."
+        )
+        static let cancelButtonTitle = NSLocalizedString(
+            "Cancel",
+            comment: "Cancel button on the add product from image form."
         )
         static let regenerateButtonTitle = NSLocalizedString(
             "Regenerate",

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -12,7 +12,7 @@ struct AddProductFromImageData {
 final class AddProductFromImageHostingController: UIHostingController<AddProductFromImageView> {
     init(siteID: Int64,
          addImage: @escaping (MediaPickingSource) async -> MediaPickerImage?,
-         completion: @escaping (AddProductFromImageData) -> Void) {
+         completion: @escaping (AddProductFromImageData?) -> Void) {
         super.init(rootView: AddProductFromImageView(siteID: siteID, addImage: addImage, completion: completion))
     }
 
@@ -23,13 +23,13 @@ final class AddProductFromImageHostingController: UIHostingController<AddProduct
 
 /// A form to create a product from an image, where any texts in the image can be scanned to generate product details with Jetpack AI.
 struct AddProductFromImageView: View {
-    private let completion: (AddProductFromImageData) -> Void
+    private let completion: (AddProductFromImageData?) -> Void
     @StateObject private var viewModel: AddProductFromImageViewModel
 
     init(siteID: Int64,
          addImage: @escaping (MediaPickingSource) async -> MediaPickerImage?,
          stores: StoresManager = ServiceLocator.stores,
-         completion: @escaping (AddProductFromImageData) -> Void) {
+         completion: @escaping (AddProductFromImageData?) -> Void) {
         self.completion = completion
         self._viewModel = .init(wrappedValue: AddProductFromImageViewModel(siteID: siteID, stores: stores, onAddImage: addImage))
     }
@@ -86,6 +86,14 @@ struct AddProductFromImageView: View {
                     completion(.init(name: viewModel.name, description: viewModel.description, image: viewModel.image))
                 }
                 .buttonStyle(LinkButtonStyle())
+            }
+            ToolbarItem(placement: .cancellationAction) {
+                Button(action: {
+                    completion(nil)
+                }, label: {
+                    Image(systemName: "xmark")
+                })
+                .buttonStyle(TextButtonStyle())
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the landscape mode, interactive dismissal is disabled. This PR added an X CTA to allow dismissal in any orientation.

## How

In `AddProductFromImageView`, the completion block's returning data is now optional to support dismissal. A new `ToolbarItem(placement: .cancellationAction)` was added for the dismiss CTA.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- If the store has 0-2 products, tap `Add manually`
- Tap to select `Simple physical product`
- Rotate to the landscape mode if needed
- Tap on the X button on the top left --> the form should be dismissed

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark | dark - landscape
-- | -- | --
![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 14 43 12](https://github.com/woocommerce/woocommerce-ios/assets/1945542/fd4762de-487b-478c-8a31-705f7be19c60) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 14 43 23](https://github.com/woocommerce/woocommerce-ios/assets/1945542/185e51ea-1c6b-414a-ae6c-50fe5a75ff40) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 14 43 25](https://github.com/woocommerce/woocommerce-ios/assets/1945542/e1edc769-16d2-4ee1-82e8-6e338f812d8c)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
