### PR TITLE
Add product from image: show error from generating product details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -61,12 +61,20 @@ struct AddProductFromImageView: View {
 
             // Scanned text list.
             Section {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: Layout.defaultSpacing) {
                     // Button to regenerate product details based on the selected scanned texts.
                     Button(Localization.regenerateButtonTitle) {
                         viewModel.generateProductDetails()
                     }
                     .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isGeneratingDetails))
+
+                    // Error message.
+                    if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .fontWeight(.semibold)
+                            .foregroundColor(Color(uiColor: .error))
+                    }
 
                     // Info text about selecting/editing the scanned text list.
                     Text(Localization.scannedTextListInfo)
@@ -109,6 +117,10 @@ private extension AddProductFromImageView {
             "Tweak your text: Unselect scans you don't need or tap to edit",
             comment: "Info text about the scanned text list on the add product from image form."
         )
+    }
+
+    enum Layout {
+        static let defaultSpacing: CGFloat = 16
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -47,6 +47,7 @@ final class AddProductFromImageViewModel: ObservableObject {
 
     @Published var scannedTexts: [ScannedTextViewModel] = []
     @Published private(set) var isGeneratingDetails: Bool = false
+    @Published private(set) var errorMessage: String? = Localization.defaultError
 
     private var selectedScannedTexts: [String] {
         scannedTexts.filter { $0.isSelected && $0.text.isNotEmpty }.map { $0.text }
@@ -110,6 +111,7 @@ private extension AddProductFromImageViewModel {
     }
 
     func generateAndPopulateProductDetails(from scannedTexts: [String]) async {
+        errorMessage = nil
         guard scannedTexts.isNotEmpty else {
             return
         }
@@ -118,6 +120,7 @@ private extension AddProductFromImageViewModel {
                 nameViewModel.onSuggestion(details.name)
                 descriptionViewModel.onSuggestion(details.description)
             case .failure(let error):
+                errorMessage = Localization.defaultError
                 DDLogError("⛔️ Error generating product details from scanned text: \(error)")
         }
     }
@@ -141,6 +144,10 @@ private extension AddProductFromImageViewModel {
         static let descriptionFieldPlaceholder = NSLocalizedString(
             "Description",
             comment: "Product description placeholder on the add product from image form."
+        )
+        static let defaultError = NSLocalizedString(
+            "Error generating product details. Please try again.",
+            comment: "Default error message on the add product from image form."
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -108,6 +108,40 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.description, "Desc")
     }
 
+    func test_generatesProductDetails_failure_sets_errorMessage_and_resets_errorMessage_after_regenerating() {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let imageTextScanner = MockImageTextScanner(result: .success(["test"]))
+        mockGenerateProductDetails(result: .failure(SampleError.first))
+        let viewModel = AddProductFromImageViewModel(siteID: 6,
+                                                     stores: stores,
+                                                     imageTextScanner: imageTextScanner,
+                                                     onAddImage: { _ in
+            image
+        })
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // Then
+        waitUntil {
+            viewModel.isGeneratingDetails == false
+        }
+        XCTAssertNotNil(viewModel.errorMessage)
+
+        // When regenerating product details with success
+        mockGenerateProductDetails(result: .success(.init(name: "", description: "", language: "")))
+        viewModel.generateProductDetails()
+
+        // Then `errorMessage` is reset
+        waitUntil {
+            viewModel.errorMessage == nil
+        }
+    }
+
     func test_generateProductDetails_without_scanned_text_does_not_dispatch_product_action() {
         // Given
         stores.whenReceivingAction(ofType: ProductAction.self) { action in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Currently, the error from generating product details is silent with a `DDLogError`. This PR added a label to show the error.

## How

In `AddProductFromImageViewModel`, a new `errorMessage` property is set to a default error string until we define a set of known errors to handle and show different error messages. This property is reset whenever it's generating product details. In `AddProductFromImageView`, the error is shown when the message is non-nil.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store
- Go to the Products tab
- Tap + to add a product
- If the store has 0-2 products, tap `Add manually`
- Tap to select `Simple physical product`
- Tap on the image header and select an image with text in it --> a list of texts in the image should be shown
- When Regenerate CTA is enabled, turn off the internet to go offline
- Tap `Regenerate` --> an error should be shown below the CTA
- Turn on the internet
- Tap `Regenerate` --> the error should disappear

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screenshot - iPhone 14 Pro - 2023-07-14 at 16 25 24](https://github.com/woocommerce/woocommerce-ios/assets/1945542/ffe99ca0-0fb0-43d9-ba2c-377f373f4d54) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-14 at 16 25 32](https://github.com/woocommerce/woocommerce-ios/assets/1945542/ab521990-4485-4811-861b-130f5b59a15c)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
