### PR TITLE
[UI Tests] - Add note to existing order test

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
@@ -31,6 +31,13 @@ public final class CustomerNoteScreen: ScreenObject {
         return self
     }
 
+    @discardableResult
+    public func verifyNoteAdded(_ text: String) throws -> Self {
+        XCTAssertTrue(app.keyboards.firstMatch.exists)
+        XCTAssertEqual(noteTextEditor.value as? String, text)
+        return self
+    }
+
     /// Confirms entered note and closes Customer Note screen.
     /// - Returns: Unified Order screen object.
     @discardableResult

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -12,7 +12,7 @@ final class OrdersTests: XCTestCase {
         app.launch()
         try LoginFlow.login()
     }
-    
+
     let customerNote = "New customer note"
 
     func test_load_orders_screen() throws {

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -12,6 +12,8 @@ final class OrdersTests: XCTestCase {
         app.launch()
         try LoginFlow.login()
     }
+    
+    let customerNote = "New customer note"
 
     func test_load_orders_screen() throws {
         let orders = try GetMocks.readOrdersData()
@@ -52,6 +54,17 @@ final class OrdersTests: XCTestCase {
             .checkForExistingProducts(byName: orders[0].line_items.map { $0.name })
             .closeEditingFlow()
             .verifySingleOrderScreenLoaded()
+    }
+
+    func test_add_note_to_existing_order() throws {
+        let orders = try GetMocks.readOrdersData()
+
+        try TabNavComponent().goToOrdersScreen()
+            .tapOrder(byOrderNumber: orders[0].number)
+            .tapEditOrderButton()
+            .openCustomerNoteScreen()
+            .enterNote(customerNote)
+            .verifyNoteAdded(customerNote)
     }
 
     func test_cancel_order_creation() throws {


### PR DESCRIPTION
## Description
A regression was fixed in https://github.com/woocommerce/woocommerce-ios/pull/10222 in which users couldn't add a note to an existing order. This PR adds a simple UI test to catch it from happening again, since this was a user-reported issue I think it's worth to be added as a UI test.

Originally, this was supposed to be a simpler change where I would expand the existing `test_load_existing_order()` test to include a `addCustomerNote()` step, however, found that due to the way we're using mocks (from the test, a new note is added but the mock file that is served for existing orders is still the file before the note is added -  we could start thinking about using stateful mocks but that's a separate topic for another time 🙂), that would end up with an error which I think can be more confusing than helpful (error not seen when not using mocks). See last second:

https://github.com/woocommerce/woocommerce-ios/assets/17252150/380a17a4-b37b-4a27-b8c7-46611b4157dc

Because of that, I decided to create a separate UI test to verify that the customer note section can be edited and we can catch this before our users do.

## Testing instructions
New test `test_add_note_to_existing_order` should work as expected. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
