### PR TITLE
[Orders with Coupons M4] Enable Feature Flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -100,7 +100,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .addProductFromImage:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .ordersWithCouponsM4:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.6
 -----
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
+- [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
 
 
 14.5


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10206 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we set the Orders with Coupons M4 feature flag to true so we can have the functionality in the Release configuration.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run the app in Release build configuration and ensure that the feature is visible (you can add discounts to products). You can set the Release build configuration by editing the WooCommerce schema (see screenshot).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="928" alt="Screenshot 2023-07-17 at 10 44 14" src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/676ff06d-352c-431d-b8e5-9545eaee0753">



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
