### PR TITLE
[Orders with Coupons M4] Expand text background to screen edges

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -41,6 +41,7 @@ struct ProductInOrder: View {
                         Text(Localization.couponsAndDiscountAlert)
                             .subheadlineStyle()
                             .padding()
+                            .frame(maxWidth: .infinity, alignment: .center)
                             .renderedIf(viewModel.showCouponsAndDiscountsAlert)
                     }
                     .background(Color(.listForeground(modal: false)))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we extend the Text white background to the screen edges so it looks better.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to create a new order
3. Add a product
4. Add a coupon that applies to that product
5. Tap on the product row
6. The background of the coupons message reaches the horizontal edges (see screenshots)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/b67e5001-3d33-40c6-8870-90debf632d18" width="375">

### After

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/94e7af49-ff12-4d32-9fbd-954c443df9fc" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
