### PR TITLE
[Resilience] Improve error banner message when orders can't load due to parsing error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.6
 -----
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
+- [Internal] Orders: Improved error message when orders can't be loaded due to a parsing (decoding) error. [https://github.com/woocommerce/woocommerce-ios/pull/10252]
 
 
 14.5

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -88,8 +88,7 @@ final class DashboardViewController: UIViewController {
     /// Top banner that shows an error if there is a problem loading data
     ///
     private lazy var topBannerView = {
-        ErrorTopBannerFactory.createTopBanner(isExpanded: false,
-                                              expandedStateChangeHandler: {},
+        ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
                                               onTroubleshootButtonPressed: { [weak self] in
                                                 guard let self = self else { return }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -261,8 +261,8 @@ private extension OrderListViewController {
                 switch topBannerType {
                 case .none:
                     self.hideTopBannerView()
-                case .error:
-                    self.setErrorTopBanner()
+                case .error(let error):
+                    self.setErrorTopBanner(for: error)
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
                 case .inPersonPaymentsFeedback(let survey):
@@ -380,7 +380,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
         }
 
         transitionToSyncingState()
-        viewModel.hasErrorLoadingData = false
+        viewModel.dataLoadingError = nil
         viewModel.updateBannerVisibility()
 
         let action = viewModel.synchronizationAction(
@@ -393,10 +393,10 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
                     return
                 }
 
-                if let error = error {
+                if let error {
                     ServiceLocator.analytics.track(event: .ordersListLoadError(error))
                     DDLogError("⛔️ Error synchronizing orders: \(error)")
-                    self.viewModel.hasErrorLoadingData = true
+                    self.viewModel.dataLoadingError = error
                 } else {
                     if pageNumber == self.syncingCoordinator.pageFirstIndex {
                         // save timestamp of last successful update
@@ -564,7 +564,7 @@ private extension OrderListViewController {
         childController.configure(createFilterConfig())
 
         // Show Error Loading Data banner if the empty state is caused by a sync error
-        if viewModel.hasErrorLoadingData {
+        if viewModel.dataLoadingError != nil {
             childController.showTopBannerView()
         } else {
             childController.hideTopBannerView()
@@ -777,8 +777,9 @@ private extension OrderListViewController {
 private extension OrderListViewController {
     /// Sets the `topBannerView` property to an error banner.
     ///
-    func setErrorTopBanner() {
-        topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: { [weak self] in
+    func setErrorTopBanner(for error: Error) {
+        topBannerView = ErrorTopBannerFactory.createTopBanner(for: error,
+                                                              expandedStateChangeHandler: { [weak self] in
             self?.tableView.updateHeaderHeight()
         },
         onTroubleshootButtonPressed: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -778,7 +778,7 @@ private extension OrderListViewController {
     /// Sets the `topBannerView` property to an error banner.
     ///
     func setErrorTopBanner() {
-        topBannerView = ErrorTopBannerFactory.createTopBanner(isExpanded: false, expandedStateChangeHandler: { [weak self] in
+        topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: { [weak self] in
             self?.tableView.updateHeaderHeight()
         },
         onTroubleshootButtonPressed: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -759,7 +759,6 @@ private extension ProductsViewController {
     ///
     func requestAndShowErrorTopBannerView() {
         let errorBanner = ErrorTopBannerFactory.createTopBanner(
-            isExpanded: false,
             expandedStateChangeHandler: { [weak self] in
                 self?.tableView.updateHeaderHeight()
             },

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -119,8 +119,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     /// Top banner that shows an error if there is a problem loading reviews data
     ///
     private lazy var topBannerView: TopBannerView = {
-        ErrorTopBannerFactory.createTopBanner(isExpanded: false,
-                                              expandedStateChangeHandler: {},
+        ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
                                               onTroubleshootButtonPressed: { [weak self] in
                                                 guard let self = self else { return }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -99,8 +99,7 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
     /// Top banner that shows an error if there is a problem loading reviews data
     ///
     private lazy var topBannerView: TopBannerView = {
-        ErrorTopBannerFactory.createTopBanner(isExpanded: false,
-                                              expandedStateChangeHandler: { [weak self] in
+        ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: { [weak self] in
                                                 self?.tableView.updateHeaderHeight()
                                               },
                                               onTroubleshootButtonPressed: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
@@ -15,6 +15,7 @@ struct ErrorTopBannerFactory {
                                            infoText: errorType.info,
                                            icon: .infoOutlineImage,
                                            isExpanded: true,
+                                           shouldResizeInfo: false,
                                            topButton: .chevron(handler: expandedStateChangeHandler),
                                            actionButtons: actions)
         let topBannerView = TopBannerView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
@@ -3,8 +3,7 @@ import Yosemite
 /// Creates a top banner to be used when there is an error loading data on a screen.
 /// The banner has two action buttons: "Troubleshoot" and "Contact Support."
 struct ErrorTopBannerFactory {
-    static func createTopBanner(isExpanded: Bool,
-                                expandedStateChangeHandler: @escaping () -> Void,
+    static func createTopBanner(expandedStateChangeHandler: @escaping () -> Void,
                                 onTroubleshootButtonPressed: @escaping () -> Void,
                                 onContactSupportButtonPressed: @escaping () -> Void) -> TopBannerView {
         let troubleshootAction = TopBannerViewModel.ActionButton(title: Localization.troubleshoot, action: { _ in onTroubleshootButtonPressed() })
@@ -13,7 +12,7 @@ struct ErrorTopBannerFactory {
         let viewModel = TopBannerViewModel(title: Localization.title,
                                            infoText: Localization.info,
                                            icon: .infoOutlineImage,
-                                           isExpanded: isExpanded,
+                                           isExpanded: true,
                                            topButton: .chevron(handler: expandedStateChangeHandler),
                                            actionButtons: actions)
         let topBannerView = TopBannerView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
@@ -3,14 +3,16 @@ import Yosemite
 /// Creates a top banner to be used when there is an error loading data on a screen.
 /// The banner has two action buttons: "Troubleshoot" and "Contact Support."
 struct ErrorTopBannerFactory {
-    static func createTopBanner(expandedStateChangeHandler: @escaping () -> Void,
+    static func createTopBanner(for error: Error? = nil,
+                                expandedStateChangeHandler: @escaping () -> Void,
                                 onTroubleshootButtonPressed: @escaping () -> Void,
                                 onContactSupportButtonPressed: @escaping () -> Void) -> TopBannerView {
+        let errorType: ErrorType = error is DecodingError ? .decodingError : .generalError
         let troubleshootAction = TopBannerViewModel.ActionButton(title: Localization.troubleshoot, action: { _ in onTroubleshootButtonPressed() })
         let contactSupportAction = TopBannerViewModel.ActionButton(title: Localization.contactSupport, action: { _ in onContactSupportButtonPressed() })
         let actions = [troubleshootAction, contactSupportAction]
         let viewModel = TopBannerViewModel(title: Localization.title,
-                                           infoText: Localization.info,
+                                           infoText: errorType.info,
                                            icon: .infoOutlineImage,
                                            isExpanded: true,
                                            topButton: .chevron(handler: expandedStateChangeHandler),
@@ -22,12 +24,29 @@ struct ErrorTopBannerFactory {
     }
 }
 
-private extension ErrorTopBannerFactory {
+extension ErrorTopBannerFactory {
+    enum ErrorType {
+        case decodingError
+        case generalError
+
+        var info: String {
+            switch self {
+            case .decodingError:
+                return Localization.decodingInfo
+            case .generalError:
+                return Localization.generalInfo
+            }
+        }
+    }
+
     enum Localization {
         static let title = NSLocalizedString("We couldn't load your data",
                                              comment: "The title of the Error Loading Data banner")
-        static let info = NSLocalizedString("Please try again later or reach out to us and we'll be happy to assist you!",
-                                            comment: "The info of the Error Loading Data banner")
+        static let generalInfo = NSLocalizedString("Please try again later or reach out to us and we'll be happy to assist you!",
+                                                   comment: "The info of the Error Loading Data banner")
+        static let decodingInfo = NSLocalizedString("This could be related to a conflict with a plugin. " +
+                                                    "Please try again later or reach out to us and we'll be happy to assist you!",
+                                                    comment: "The info on the Error Loading Data banner when there was a decoding error.")
         static let troubleshoot = NSLocalizedString("Troubleshoot",
                                                     comment: "The title of the button to get troubleshooting information in the Error Loading Data banner")
         static let contactSupport = NSLocalizedString("Contact support",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -377,16 +377,17 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_storing_error_shows_error_banner() {
         // Given
+        let expectedError = MockError()
         let viewModel = OrderListViewModel(siteID: siteID, filters: nil)
         viewModel.activate()
 
         // When
         viewModel.updateBannerVisibility()
-        viewModel.hasErrorLoadingData = true
+        viewModel.dataLoadingError = expectedError
 
         // Then
         waitUntil {
-            viewModel.topBanner == .error
+            viewModel.topBanner == .error(expectedError)
         }
     }
 
@@ -408,17 +409,18 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_hiding_orders_banners_still_shows_error_banner() {
         // Given
+        let expectedError = MockError()
         let viewModel = OrderListViewModel(siteID: siteID, filters: nil)
         viewModel.activate()
 
         // When
         viewModel.updateBannerVisibility()
-        viewModel.hasErrorLoadingData = true
+        viewModel.dataLoadingError = expectedError
         viewModel.hideOrdersBanners = true
 
         // Then
         waitUntil {
-            viewModel.topBanner == .error
+            viewModel.topBanner == .error(expectedError)
         }
     }
 
@@ -793,7 +795,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.IPPFeedbackBannerWasSubmitted()
-        viewModel.hasErrorLoadingData = false
+        viewModel.dataLoadingError = nil
         viewModel.hideOrdersBanners = true
 
         // Then
@@ -981,4 +983,6 @@ private extension OrderListViewModelTests {
         let storageGateway = storage.insertNewObject(ofType: StoragePaymentGateway.self)
         storageGateway.update(with: codGateway)
     }
+
+    final class MockError: Error { }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/ErrorTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/ErrorTopBannerFactoryTests.swift
@@ -5,10 +5,9 @@ class ErrorTopBannerFactoryTests: XCTestCase {
 
     func test_top_banner_has_two_actions() throws {
         // Given
-        let topBannerView = ErrorTopBannerFactory.createTopBanner(isExpanded: false,
-                                    expandedStateChangeHandler: {},
-                                    onTroubleshootButtonPressed: {},
-                                    onContactSupportButtonPressed: {})
+        let topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
+                                                                  onTroubleshootButtonPressed: {},
+                                                                  onContactSupportButtonPressed: {})
 
         // Then
         XCTAssertNotNil(topBannerView)
@@ -20,8 +19,7 @@ class ErrorTopBannerFactoryTests: XCTestCase {
     func test_tapping_top_banner_troubleshoot_button_triggers_callback() throws {
         // Given
         var isTroubleshootButtonPressed = false
-        let topBannerView = ErrorTopBannerFactory.createTopBanner(isExpanded: false,
-                                                                  expandedStateChangeHandler: {},
+        let topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
                                                                   onTroubleshootButtonPressed: {
                                                                     isTroubleshootButtonPressed = true
                                                                   },
@@ -37,8 +35,7 @@ class ErrorTopBannerFactoryTests: XCTestCase {
     func test_tapping_top_banner_contact_support_button_triggers_callback() throws {
         // Given
         var isContactSupportButtonPressed = false
-        let topBannerView = ErrorTopBannerFactory.createTopBanner(isExpanded: false,
-                                                                  expandedStateChangeHandler: {},
+        let topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
                                                                   onTroubleshootButtonPressed: {},
                                                                   onContactSupportButtonPressed: {
                                                                     isContactSupportButtonPressed = true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10162
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes two changes to the error banner:

1. The error banner is now always auto-expanded when it appears (on any screen).
2. On the Orders tab, if the error was a parsing (decoding) error, the banner message now mentions possible plugin conflicts.

### Changes

* `ErrorTopBannerFactory` now always creates the banner expanded, and takes an error type to determine what message to display. This defaults to the general error type/message.
* In the order list VC and VM, we now keep track of what error occurred during sync and use it to create the corresponding error banner.

We can also use this approach in other places where the error banner is shown, but for this PR the behavior is only changed in the order list.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can test using a tool like Charles Proxy or Proxyman to intercept and modify the API response:

1. Set a breakpoint in your tool of choice for requests to the `/wc/v3/orders` endpoint.
2. Build and run the app.
3. Open the Orders tab.
4. Modify the response so there is an invalid order object (e.g. remove a required field).
5. Execute the response and confirm the error banner appears with the new message, mentioning a possible plugin conflict.
6. Disable your internet connection and pull to refresh the Orders list (to trigger a non-decoding error).
7. Confirm the error banner appears with the general error message.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

General error|Decoding error
-|-
![Screenshot 2023-07-18 at 11 43 17](https://github.com/woocommerce/woocommerce-ios/assets/8658164/f8b75a4e-307b-4e3f-8cf2-01a477ff57a0)|![Screenshot 2023-07-18 at 11 43 06](https://github.com/woocommerce/woocommerce-ios/assets/8658164/094218d9-877b-46ef-93b0-33cb120a0ddf)


https://github.com/woocommerce/woocommerce-ios/assets/8658164/2bc962b5-c639-4a88-b612-46b899942903



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
