### PR TITLE
[Add product from image] Check ABTest variation

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -10,6 +10,10 @@ public enum ABTest: String, Codable, CaseIterable {
     /// Experiment ref: pbxNRc-1QS-p2
     case aaTestLoggedIn = "woocommerceios_explat_aa_test_logged_in_202212_v2"
 
+    /// A/B test for flow to add product from an image.
+    /// Experiment ref: pbxNRc-2MS-p2
+    case addProductFromImage = "woocommerceios_add_product_from_photo_202307"
+
     /// A/A test to make sure there is no bias in the logged out state.
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202212_v2"
@@ -26,6 +30,8 @@ public enum ABTest: String, Codable, CaseIterable {
     public var context: ExperimentContext {
         switch self {
         case .aaTestLoggedIn:
+            return .loggedIn
+        case .addProductFromImage:
             return .loggedIn
         case .aaTestLoggedOut:
             return .loggedOut

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -97,8 +97,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .freeTrialInAppPurchasesUpgradeM2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .addProductFromImage:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .ordersWithCouponsM4:
             return true
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -208,10 +208,6 @@ public enum FeatureFlag: Int {
     ///
     case freeTrialInAppPurchasesUpgradeM2
 
-    /// A new flow to add product from an image.
-    ///
-    case addProductFromImage
-
     /// Enables the Milestone 4 of the Orders with Coupons project: Adding discounts to products
     case ordersWithCouponsM4
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
 - [Internal] Orders: Improved error message when orders can't be loaded due to a parsing (decoding) error. [https://github.com/woocommerce/woocommerce-ios/pull/10252]
 - [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
+- [Internal] A new way to create a product from an image using AI is being A/B tested. [https://github.com/woocommerce/woocommerce-ios/pull/10253]
 
 
 14.5

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
@@ -16,11 +16,14 @@ protocol AddProductFromImageEligibilityCheckerProtocol {
 final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
+    private let abTestVariationProvider: ABTestVariationProvider
 
     init(stores: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider()) {
         self.stores = stores
         self.featureFlagService = featureFlagService
+        self.abTestVariationProvider = abTestVariationProvider
     }
 
     func isEligibleToParticipateInABTest() -> Bool {
@@ -39,6 +42,6 @@ final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilit
             return false
         }
 
-        return ABTest.addProductFromImage.variation == .treatment
+        return abTestVariationProvider.variation(for: .addProductFromImage) == .treatment
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import protocol Experiments.FeatureFlagService
+import Experiments
 
 /// Protocol for checking "add product from image" eligibility for easier unit testing.
 protocol AddProductFromImageEligibilityCheckerProtocol {
@@ -34,7 +35,10 @@ final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilit
             return false
         }
 
-        // TODO: 10180 - A/B experiment check
-        return featureFlagService.isFeatureFlagEnabled(.addProductFromImage)
+        guard featureFlagService.isFeatureFlagEnabled(.addProductFromImage) else {
+            return false
+        }
+
+        return ABTest.addProductFromImage.variation == .treatment
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityChecker.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Yosemite
-import protocol Experiments.FeatureFlagService
 import Experiments
 
 /// Protocol for checking "add product from image" eligibility for easier unit testing.
@@ -15,14 +14,11 @@ protocol AddProductFromImageEligibilityCheckerProtocol {
 /// Checks the eligibility for the "add product from image" feature.
 final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol {
     private let stores: StoresManager
-    private let featureFlagService: FeatureFlagService
     private let abTestVariationProvider: ABTestVariationProvider
 
     init(stores: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider()) {
         self.stores = stores
-        self.featureFlagService = featureFlagService
         self.abTestVariationProvider = abTestVariationProvider
     }
 
@@ -35,10 +31,6 @@ final class AddProductFromImageEligibilityChecker: AddProductFromImageEligibilit
         // checked before this in its use case, but it's still included here so that it remains a condition when
         // removing the A/B experiment.
         guard isEligibleToParticipateInABTest() else {
-            return false
-        }
-
-        guard featureFlagService.isFeatureFlagEnabled(.addProductFromImage) else {
             return false
         }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -27,7 +27,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShareProductAIEnabled: Bool
     private let isJustInTimeMessagesOnDashboardEnabled: Bool
     private let isFreeTrialInAppPurchasesUpgradeM2: Bool
-    private let isAddProductFromImageEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -53,8 +52,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
          isJustInTimeMessagesOnDashboardEnabled: Bool = false,
-         isFreeTrialInAppPurchasesUpgradeM2: Bool = false,
-         isAddProductFromImageEnabled: Bool = false) {
+         isFreeTrialInAppPurchasesUpgradeM2: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -80,7 +78,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isBlazeEnabled = isBlazeEnabled
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.isJustInTimeMessagesOnDashboardEnabled = isJustInTimeMessagesOnDashboardEnabled
-        self.isAddProductFromImageEnabled = isAddProductFromImageEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -133,8 +130,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isJustInTimeMessagesOnDashboardEnabled
         case .freeTrialInAppPurchasesUpgradeM2:
             return isFreeTrialInAppPurchasesUpgradeM2
-        case .addProductFromImage:
-            return isAddProductFromImageEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityCheckerTests.swift
@@ -51,9 +51,7 @@ final class AddProductFromImageEligibilityCheckerTests: XCTestCase {
         mockABTestVariationProvider.mockVariationValue = .treatment
 
         updateDefaultStore(isWPCOMStore: true)
-        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
         let checker = AddProductFromImageEligibilityChecker(stores: stores,
-                                                            featureFlagService: featureFlagService,
                                                             abTestVariationProvider: mockABTestVariationProvider)
 
         // When
@@ -69,27 +67,7 @@ final class AddProductFromImageEligibilityCheckerTests: XCTestCase {
         mockABTestVariationProvider.mockVariationValue = .treatment
 
         updateDefaultStore(isWPCOMStore: false)
-        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
         let checker = AddProductFromImageEligibilityChecker(stores: stores,
-                                                            featureFlagService: featureFlagService,
-                                                            abTestVariationProvider: mockABTestVariationProvider)
-
-        // When
-        let isEligible = checker.isEligible()
-
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
-    func test_isEligible_is_false_for_wpcom_store_when_feature_flag_is_disabled() throws {
-        // Given
-        let mockABTestVariationProvider = MockABTestVariationProvider()
-        mockABTestVariationProvider.mockVariationValue = .treatment
-
-        updateDefaultStore(isWPCOMStore: true)
-        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: false)
-        let checker = AddProductFromImageEligibilityChecker(stores: stores,
-                                                            featureFlagService: featureFlagService,
                                                             abTestVariationProvider: mockABTestVariationProvider)
 
         // When
@@ -105,9 +83,7 @@ final class AddProductFromImageEligibilityCheckerTests: XCTestCase {
         mockABTestVariationProvider.mockVariationValue = .control
 
         updateDefaultStore(isWPCOMStore: true)
-        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
         let checker = AddProductFromImageEligibilityChecker(stores: stores,
-                                                            featureFlagService: featureFlagService,
                                                             abTestVariationProvider: mockABTestVariationProvider)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageEligibilityCheckerTests.swift
@@ -1,5 +1,6 @@
 import TestKit
 import XCTest
+import Experiments
 
 @testable import WooCommerce
 
@@ -46,9 +47,14 @@ final class AddProductFromImageEligibilityCheckerTests: XCTestCase {
 
     func test_isEligible_is_true_for_wpcom_store() throws {
         // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .treatment
+
         updateDefaultStore(isWPCOMStore: true)
         let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
-        let checker = AddProductFromImageEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores,
+                                                            featureFlagService: featureFlagService,
+                                                            abTestVariationProvider: mockABTestVariationProvider)
 
         // When
         let isEligible = checker.isEligible()
@@ -59,9 +65,14 @@ final class AddProductFromImageEligibilityCheckerTests: XCTestCase {
 
     func test_isEligible_is_false_for_non_wpcom_store() throws {
         // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .treatment
+
         updateDefaultStore(isWPCOMStore: false)
         let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
-        let checker = AddProductFromImageEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores,
+                                                            featureFlagService: featureFlagService,
+                                                            abTestVariationProvider: mockABTestVariationProvider)
 
         // When
         let isEligible = checker.isEligible()
@@ -72,9 +83,32 @@ final class AddProductFromImageEligibilityCheckerTests: XCTestCase {
 
     func test_isEligible_is_false_for_wpcom_store_when_feature_flag_is_disabled() throws {
         // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .treatment
+
         updateDefaultStore(isWPCOMStore: true)
         let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: false)
-        let checker = AddProductFromImageEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores,
+                                                            featureFlagService: featureFlagService,
+                                                            abTestVariationProvider: mockABTestVariationProvider)
+
+        // When
+        let isEligible = checker.isEligible()
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligible_is_false_for_wpcom_store_when_ab_test_variation_is_control() throws {
+        // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .control
+
+        updateDefaultStore(isWPCOMStore: true)
+        let featureFlagService = MockFeatureFlagService(isAddProductFromImageEnabled: true)
+        let checker = AddProductFromImageEligibilityChecker(stores: stores,
+                                                            featureFlagService: featureFlagService,
+                                                            abTestVariationProvider: mockABTestVariationProvider)
 
         // When
         let isEligible = checker.isEligible()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10180 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

- Adds A/B test `woocommerceios_add_product_from_photo_202307`
- Checks A/B test variation for eligibility

Notes
- I plan to start the experiment on 24 July, with 21 August as the end date. pbxNRc-2MS-p2#comment-4635
- Abacus link - 21302-explat-experiment
- I will enable the feature flag `addProductFromImage` in a different PR. (Need to confirm with the team before releasing this.)

## Testing instructions

**Prerequisites**
A sandbox is required for testing manual assignments on A/B experiments.

The following steps are to force a particular variation for the experiment,
- Please follow the setup in PCYsg-Fq7-p2#assignments-api for proxied sandboxed API requests: connect to sandbox via ssh, and point WP.com API to the sandbox IP address (`ipconfig`) in the local machine's `/etc/hosts`
- Then, you need to make an authenticated WPCOM request to assign the variant manually

Make an API request `PATCH /wpcom/v2/experiments/0.1.0/assignments` with the following `body` and make sure it's successful:
```
{
  "username_override": "<replace_with_wpcom_username>",
  "variations": {
    "woocommerceios_add_product_from_photo_202307": "treatment"
  }
}
```

**Steps**
1. Log in to a WPCom store.
1. Switch to the Products tab and tab the "+" button to create a new product.
1. If the site has no products, select the manual option in the presented action sheet.
1. Select the physical product in the product type action sheet.
1. Validate that you see the image form where you can select a photo and generated name and description using AI

Make an API request `PATCH /wpcom/v2/experiments/0.1.0/assignments` with the following `body` and make sure it's successful:
```
{
  "username_override": "<replace_with_wpcom_username>",
  "variations": {
    "woocommerceios_add_product_from_photo_202307": "control"
  }
}
```

1. Log in to a WPCom store.
1. Switch to the Products tab and tab the "+" button to create a new product.
1. If the site has no products, select the manual option in the presented action sheet.
1. Select the physical product in the product type action sheet.
1. Validate that you see the usual Add product form

## Screenshots
| Treatment | Variation |
|--------|--------|
| ![IMG_BFC415D6C820-1](https://github.com/woocommerce/woocommerce-ios/assets/524475/e7360ce3-13c6-42e5-aff6-3036cb5adea3) | ![IMG_B5EB427A4665-1](https://github.com/woocommerce/woocommerce-ios/assets/524475/0965a893-e67c-43e1-b96e-54ef6234886d) |
| [Screen recording](https://github.com/woocommerce/woocommerce-ios/assets/524475/2ec180a5-7a4a-4364-88d0-780282768fed) | [Screen recording](https://github.com/woocommerce/woocommerce-ios/assets/524475/86cf6b9e-77ea-44b3-b725-32d92b841bd1) |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.