### PR TITLE
Fix Crash in `BottomSheetViewController`

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -90,7 +90,7 @@ target 'WooCommerce' do
 
   wordpress_shared
 
-  pod 'WordPressUI', '~> 1.13'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'task/fix-crash-BottomSheetViewController'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
 
   aztec

--- a/Podfile
+++ b/Podfile
@@ -90,7 +90,7 @@ target 'WooCommerce' do
 
   wordpress_shared
 
-  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'task/fix-crash-BottomSheetViewController'
+  pod 'WordPressUI', '~> 1.13'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
 
   aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -57,7 +57,7 @@ PODS:
     - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.1.0)
-  - WordPressUI (1.13.0)
+  - WordPressUI (1.13.1)
   - Wormholy (1.6.6)
   - WPMediaPicker (1.8.1)
   - wpxmlrpc (0.10.0)
@@ -88,7 +88,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.1)
-  - WordPressUI (~> 1.13)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, branch `task/fix-crash-BottomSheetViewController`)
   - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8.1)
   - ZendeskSupportSDK (~> 6.0)
@@ -119,7 +119,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressShared
-    - WordPressUI
     - Wormholy
     - WPMediaPicker
     - wpxmlrpc
@@ -135,11 +134,17 @@ EXTERNAL SOURCES:
   WordPressAuthenticator:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressUI:
+    :branch: task/fix-crash-BottomSheetViewController
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
     :commit: bfdfde6fcd9a0faf0509db8380aa208e6d093a08
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressUI:
+    :commit: 7c48ae434db04d0244009a609859e8288ad2f175
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -166,7 +171,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 8a27a3c61ca0d740df66f260902aa2ca8528c61b
   WordPressKit: b65a51863982d8166897bea8b753f1fc51732aad
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
-  WordPressUI: 9951bdade87c8c64b50535aaed2a53a11d0c52ee
+  WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -178,6 +183,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 33119766b8581a4e76206f345a770ca2c617f78d
+PODFILE CHECKSUM: e0f09766fdce4a0d69cca5f4724e81c8bba21104
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -88,7 +88,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.1)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, branch `task/fix-crash-BottomSheetViewController`)
+  - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8.1)
   - ZendeskSupportSDK (~> 6.0)
@@ -119,6 +119,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressShared
+    - WordPressUI
     - Wormholy
     - WPMediaPicker
     - wpxmlrpc
@@ -134,17 +135,11 @@ EXTERNAL SOURCES:
   WordPressAuthenticator:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WordPressUI:
-    :branch: task/fix-crash-BottomSheetViewController
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
     :commit: bfdfde6fcd9a0faf0509db8380aa208e6d093a08
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WordPressUI:
-    :commit: 7c48ae434db04d0244009a609859e8288ad2f175
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -183,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: e0f09766fdce4a0d69cca5f4724e81c8bba21104
+PODFILE CHECKSUM: 33119766b8581a4e76206f345a770ca2c617f78d
 
 COCOAPODS: 1.12.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,6 @@
 - [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
 - [*] We've resolved an issue that was causing the app to crash when trying to dismiss certain screens (bottom sheets). [https://github.com/woocommerce/woocommerce-ios/pull/10254]
 - [Internal] Fixed a bug preventing the "We couldn't load your data" error banner from appearing on the My store dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/10262]
-
 - [Internal] A new way to create a product from an image using AI is being A/B tested. [https://github.com/woocommerce/woocommerce-ios/pull/10253]
 
 14.5

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [Internal] Switched AI endpoint to be able to track and measure costs. [https://github.com/woocommerce/woocommerce-ios/pull/10218]
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
 - [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
+- [*] We've resolved an issue that was causing the app to crash when trying to dismiss certain screens (bottom sheets).
 
 
 14.5

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [Internal] Switched AI endpoint to be able to track and measure costs. [https://github.com/woocommerce/woocommerce-ios/pull/10218]
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
 - [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
-- [*] We've resolved an issue that was causing the app to crash when trying to dismiss certain screens (bottom sheets).
+- [*] We've resolved an issue that was causing the app to crash when trying to dismiss certain screens (bottom sheets). [https://github.com/woocommerce/woocommerce-ios/pull/10254]
 
 
 14.5


### PR DESCRIPTION
Fixes: #10250 

## Description
I encountered a crash on iOS 16.4, simulator iPhone 14 Pro Max, while I was trying to add a new product. In the end, I discovered that this crash happens in every screen where we use the `BottomSheetViewController` component from the WordPressUI library.

## Testing instructions
1. Tap add new physical product
2. Tap "Add more details"
3. Tap the "top line" in the bottom sheet.
4. Crash

Run this PR, you should not be able to expact a crash anymore. 

## Before merging to trunk
- [x] Point WordPressUI pod to the release 1.13.1


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
