### PR TITLE
[Orders with Coupons M5] Add coupon selector to the order creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.6
 -----
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
+- [*] Orders with Coupons: Users can now select a coupon from a list when adding it to an order. [https://github.com/woocommerce/woocommerce-ios/pull/10255]
 
 
 14.5

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -1,10 +1,13 @@
 import SwiftUI
+import Yosemite
 
 struct CouponListView: UIViewControllerRepresentable {
     let siteID: Int64
+    let onCouponSelected: ((Coupon) -> Void)
 
     func makeUIViewController(context: Self.Context) -> CouponListViewController {
         let viewController = CouponListViewController(siteID: siteID, showFeedbackBannerIfAppropriate: false)
+        viewController.onCouponSelected = onCouponSelected
         return viewController
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -3,36 +3,10 @@ import SwiftUI
 struct CouponListView: UIViewControllerRepresentable {
     let siteID: Int64
 
-    typealias UIViewControllerType = CouponListViewController
-
-    class Coordinator {
-        var parentObserver: NSKeyValueObservation?
-        var rightBarButtonItemsObserver: NSKeyValueObservation?
-    }
-
-    /// This is a UIKit solution for fixing Navigation Title and Bar Button Items ignored in NavigationView.
-    /// This solution doesn't require making internal changes to the destination `UIViewController`
-    /// and should be called once, when wrapped.
-    /// Solution proposed here: https://stackoverflow.com/a/68567095/7241994
-    ///
     func makeUIViewController(context: Self.Context) -> CouponListViewController {
         let viewController = CouponListViewController(siteID: siteID, showFeedbackBannerIfAppropriate: false)
-        context.coordinator.parentObserver = viewController.observe(\.parent, changeHandler: { vc, _ in
-            vc.parent?.navigationItem.title = vc.title
-            vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
-        })
-
-        // This fixes the issue when `rightBarButtonItem` is updated in `CouponListViewController`,
-        // the hosting controller should be updated to reflect the change.
-        context.coordinator.rightBarButtonItemsObserver = viewController.observe(\.navigationItem.rightBarButtonItems, changeHandler: { vc, _ in
-            vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
-        })
         return viewController
     }
 
-    func updateUIViewController(_ uiViewController: CouponListViewController, context: Context) {
-        // nothing to do here
-    }
-
-    func makeCoordinator() -> Self.Coordinator { Coordinator() }
+    func updateUIViewController(_ uiViewController: CouponListViewController, context: Context) {}
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -3,14 +3,16 @@ import Yosemite
 
 struct CouponListView: UIViewControllerRepresentable {
     let siteID: Int64
-    let emptyStateCreateCouponAction: (() -> Void)
+    let emptyStateActionTitle: String
+    let emptyStateAction: (() -> Void)
     let onCouponSelected: ((Coupon) -> Void)
 
 
     func makeUIViewController(context: Self.Context) -> CouponListViewController {
         let viewController = CouponListViewController(siteID: siteID, showFeedbackBannerIfAppropriate: false)
+        viewController.emptyStateActionTitle = emptyStateActionTitle
         viewController.onCouponSelected = onCouponSelected
-        viewController.emptyStateCreateCouponAction = emptyStateCreateCouponAction
+        viewController.emptyStateAction = emptyStateAction
         return viewController
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct CouponListView: UIViewControllerRepresentable {
+    let siteID: Int64
+
+    typealias UIViewControllerType = CouponListViewController
+
+    class Coordinator {
+        var parentObserver: NSKeyValueObservation?
+        var rightBarButtonItemsObserver: NSKeyValueObservation?
+    }
+
+    /// This is a UIKit solution for fixing Navigation Title and Bar Button Items ignored in NavigationView.
+    /// This solution doesn't require making internal changes to the destination `UIViewController`
+    /// and should be called once, when wrapped.
+    /// Solution proposed here: https://stackoverflow.com/a/68567095/7241994
+    ///
+    func makeUIViewController(context: Self.Context) -> CouponListViewController {
+        let viewController = CouponListViewController(siteID: siteID, showFeedbackBannerIfAppropriate: false)
+        context.coordinator.parentObserver = viewController.observe(\.parent, changeHandler: { vc, _ in
+            vc.parent?.navigationItem.title = vc.title
+            vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
+        })
+
+        // This fixes the issue when `rightBarButtonItem` is updated in `CouponListViewController`,
+        // the hosting controller should be updated to reflect the change.
+        context.coordinator.rightBarButtonItemsObserver = viewController.observe(\.navigationItem.rightBarButtonItems, changeHandler: { vc, _ in
+            vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems
+        })
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: CouponListViewController, context: Context) {
+        // nothing to do here
+    }
+
+    func makeCoordinator() -> Self.Coordinator { Coordinator() }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -3,11 +3,14 @@ import Yosemite
 
 struct CouponListView: UIViewControllerRepresentable {
     let siteID: Int64
+    let emptyStateCreateCouponAction: (() -> Void)
     let onCouponSelected: ((Coupon) -> Void)
+
 
     func makeUIViewController(context: Self.Context) -> CouponListViewController {
         let viewController = CouponListViewController(siteID: siteID, showFeedbackBannerIfAppropriate: false)
         viewController.onCouponSelected = onCouponSelected
+        viewController.emptyStateCreateCouponAction = emptyStateCreateCouponAction
         return viewController
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -7,12 +7,12 @@ struct CouponListView: UIViewControllerRepresentable {
     let emptyStateAction: (() -> Void)
     let onCouponSelected: ((Coupon) -> Void)
 
-
     func makeUIViewController(context: Self.Context) -> CouponListViewController {
-        let viewController = CouponListViewController(siteID: siteID, showFeedbackBannerIfAppropriate: false)
-        viewController.emptyStateActionTitle = emptyStateActionTitle
-        viewController.onCouponSelected = onCouponSelected
-        viewController.emptyStateAction = emptyStateAction
+        let viewController = CouponListViewController(siteID: siteID,
+                                                      showFeedbackBannerIfAppropriate: false,
+                                                      emptyStateActionTitle: emptyStateActionTitle,
+                                                      emptyStateAction: emptyStateAction,
+                                                      onCouponSelected: onCouponSelected)
         return viewController
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -39,7 +39,8 @@ final class CouponListViewController: UIViewController, GhostableViewController 
     private lazy var topBannerView: TopBannerView = createFeedbackBannerView()
 
     var onDataLoaded: ((Bool) -> Void)?
-    var emptyStateCreateCouponAction: (() -> Void)?
+    var emptyStateAction: (() -> Void)?
+    var emptyStateActionTitle: String?
     var onCouponSelected: ((Coupon) -> Void)?
 
     init(siteID: Int64, showFeedbackBannerIfAppropriate: Bool) {
@@ -288,12 +289,13 @@ private extension CouponListViewController {
         let emptyStateViewController = EmptyStateViewController(style: .list)
         displayEmptyStateViewController(emptyStateViewController)
 
-        if let emptyStateCreateCouponAction = emptyStateCreateCouponAction {
+        if let emptyStateCreateCouponAction = emptyStateAction,
+           let emptyStateActionTitle = emptyStateActionTitle {
             let configuration = EmptyStateViewController.Config.withButton(
                 message: .init(string: Localization.couponCreationSuggestionMessage),
                 image: .emptyCouponsImage,
                 details: Localization.emptyStateDetails,
-                buttonTitle: Localization.createCouponAction
+                buttonTitle: emptyStateActionTitle
             ) { _ in
                 emptyStateCreateCouponAction()
             }
@@ -399,7 +401,5 @@ private extension CouponListViewController {
         static let emptyStateDetails = NSLocalizedString(
             "Boost your business by sending customers special offers and discounts.",
             comment: "The details text on the placeholder overlay when there are no coupons on the coupon list screen.")
-        static let createCouponAction = NSLocalizedString("Create Coupon",
-                                                          comment: "Title of the create coupon button on the coupon list screen when it's empty")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -39,7 +39,7 @@ final class CouponListViewController: UIViewController, GhostableViewController 
     private lazy var topBannerView: TopBannerView = createFeedbackBannerView()
 
     var onDataLoaded: ((Bool) -> Void)?
-    var noResultConfig: EmptyStateViewController.Config?
+    var emptyStateCreateCouponAction: (() -> Void)?
     var onCouponSelected: ((Coupon) -> Void)?
 
     init(siteID: Int64, showFeedbackBannerIfAppropriate: Bool) {
@@ -288,8 +288,17 @@ private extension CouponListViewController {
         let emptyStateViewController = EmptyStateViewController(style: .list)
         displayEmptyStateViewController(emptyStateViewController)
 
-        if let noResultConfig = noResultConfig {
-            emptyStateViewController.configure(noResultConfig)
+        if let emptyStateCreateCouponAction = emptyStateCreateCouponAction {
+            let configuration = EmptyStateViewController.Config.withButton(
+                message: .init(string: Localization.couponCreationSuggestionMessage),
+                image: .emptyCouponsImage,
+                details: Localization.emptyStateDetails,
+                buttonTitle: Localization.createCouponAction
+            ) { _ in
+                emptyStateCreateCouponAction()
+            }
+
+            emptyStateViewController.configure(configuration)
         }
     }
 
@@ -383,5 +392,14 @@ private extension CouponListViewController {
 
         static let giveFeedbackAction = NSLocalizedString("Give feedback", comment: "Title of the feedback action button on the coupon list screen")
         static let dismissAction = NSLocalizedString("Dismiss", comment: "Title of the dismiss action button on the coupon list screen")
+
+        static let couponCreationSuggestionMessage = NSLocalizedString(
+            "Everyone loves a deal",
+            comment: "The title on the placeholder overlay when there are no coupons on the coupon list screen and creating a coupon is possible.")
+        static let emptyStateDetails = NSLocalizedString(
+            "Boost your business by sending customers special offers and discounts.",
+            comment: "The details text on the placeholder overlay when there are no coupons on the coupon list screen.")
+        static let createCouponAction = NSLocalizedString("Create Coupon",
+                                                          comment: "Title of the create coupon button on the coupon list screen when it's empty")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
@@ -6,7 +6,7 @@ import Yosemite
 /// Shows a coupons list plus the entry to other accessory actions: search, creation.
 ///
 final class EnhancedCouponListViewController: UIViewController {
-    private let couponListViewController: CouponListViewController
+    private var couponListViewController: CouponListViewController?
     private let siteID: Int64
 
     private lazy var noticePresenter: DefaultNoticePresenter = {
@@ -17,14 +17,8 @@ final class EnhancedCouponListViewController: UIViewController {
 
     init(siteID: Int64) {
         self.siteID = siteID
-        couponListViewController = CouponListViewController(siteID: siteID, showFeedbackBannerIfAppropriate: true)
 
         super.init(nibName: nil, bundle: nil)
-
-        couponListViewController.onDataLoaded = configureNavigationBarItems
-        couponListViewController.emptyStateAction = displayCouponTypeBottomSheet
-        couponListViewController.emptyStateActionTitle = Localization.createCouponAction
-        couponListViewController.onCouponSelected = showDetails
     }
 
     required init?(coder: NSCoder) {
@@ -71,11 +65,19 @@ final class EnhancedCouponListViewController: UIViewController {
 
 private extension EnhancedCouponListViewController {
     func configureCouponListViewController() {
+        let couponListViewController = CouponListViewController(siteID: siteID,
+                                                            showFeedbackBannerIfAppropriate: true,
+                                                            emptyStateActionTitle: Localization.createCouponAction,
+                                                            emptyStateAction: displayCouponTypeBottomSheet,
+                                                            onCouponSelected: showDetails)
+
         couponListViewController.view.translatesAutoresizingMaskIntoConstraints = false
         addChild(couponListViewController)
         view.addSubview(couponListViewController.view)
         view.pinSubviewToAllEdges(couponListViewController.view)
         couponListViewController.didMove(toParent: self)
+
+        self.couponListViewController = couponListViewController
     }
 
     func configureNavigation() {
@@ -110,7 +112,7 @@ private extension EnhancedCouponListViewController {
         let viewModel = AddEditCouponViewModel(siteID: siteID,
                                                discountType: discountType,
                                                onSuccess: { [weak self] _ in
-            self?.couponListViewController.refreshCouponList()
+            self?.couponListViewController?.refreshCouponList()
         })
         let addEditHostingController = AddEditCouponHostingController(viewModel: viewModel, onDisappear: { [weak self] in
             guard let self = self else { return }
@@ -136,7 +138,7 @@ private extension EnhancedCouponListViewController {
     func showDetails(from coupon: Coupon) {
         let detailsViewModel = CouponDetailsViewModel(coupon: coupon, onUpdate: { [weak self] in
             guard let self = self else { return }
-            self.couponListViewController.refreshCouponList()
+            self.couponListViewController?.refreshCouponList()
         }, onDeletion: { [weak self] in
             guard let self = self else { return }
             self.navigationController?.popViewController(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
@@ -22,7 +22,8 @@ final class EnhancedCouponListViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         couponListViewController.onDataLoaded = configureNavigationBarItems
-        couponListViewController.emptyStateCreateCouponAction = displayCouponTypeBottomSheet
+        couponListViewController.emptyStateAction = displayCouponTypeBottomSheet
+        couponListViewController.emptyStateActionTitle = Localization.createCouponAction
         couponListViewController.onCouponSelected = showDetails
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
@@ -22,7 +22,7 @@ final class EnhancedCouponListViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         couponListViewController.onDataLoaded = configureNavigationBarItems
-        couponListViewController.noResultConfig = buildNoResultConfig()
+        couponListViewController.emptyStateCreateCouponAction = displayCouponTypeBottomSheet
         couponListViewController.onCouponSelected = showDetails
     }
 
@@ -86,18 +86,6 @@ private extension EnhancedCouponListViewController {
             navigationItem.rightBarButtonItems = [createCouponButtonItem, searchBarButtonItem]
         } else {
             navigationItem.rightBarButtonItems = [createCouponButtonItem]
-        }
-    }
-
-    func buildNoResultConfig() -> EmptyStateViewController.Config {
-        return .withButton(
-            message: .init(string: Localization.couponCreationSuggestionMessage),
-            image: .emptyCouponsImage,
-            details: Localization.emptyStateDetails,
-            buttonTitle: Localization.createCouponAction
-        ) { [weak self] button in
-            guard let self = self else { return }
-            self.displayCouponTypeBottomSheet()
         }
     }
 
@@ -169,19 +157,13 @@ private extension EnhancedCouponListViewController {
         static let accessibilityLabelCreateCoupons = NSLocalizedString("Create coupons", comment: "Accessibility label for the Create Coupons button")
         static let accessibilityHintCreateCoupons = NSLocalizedString("Start a Coupon creation by selecting a discount type in a bottom sheet",
                 comment: "VoiceOver accessibility hint, informing the user the button can be used to create coupons.")
-        static let createCouponAction = NSLocalizedString("Create Coupon",
-                                                          comment: "Title of the create coupon button on the coupon list screen when it's empty")
         static let accessibilityLabelSearchCoupons = NSLocalizedString("Search coupons", comment: "Accessibility label for the Search Coupons button")
         static let accessibilityHintSearchCoupons = NSLocalizedString(
             "Retrieves a list of coupons that contain a given keyword.",
             comment: "VoiceOver accessibility hint, informing the user the button can be used to search coupons."
         )
-        static let couponCreationSuggestionMessage = NSLocalizedString(
-            "Everyone loves a deal",
-            comment: "The title on the placeholder overlay when there are no coupons on the coupon list screen and creating a coupon is possible.")
-        static let emptyStateDetails = NSLocalizedString(
-            "Boost your business by sending customers special offers and discounts.",
-            comment: "The details text on the placeholder overlay when there are no coupons on the coupon list screen.")
         static let couponDeleted = NSLocalizedString("Coupon deleted", comment: "Notice message after deleting coupon from the Coupon Details screen")
+        static let createCouponAction = NSLocalizedString("Create Coupon",
+                                                          comment: "Title of the create coupon button on the coupon list screen when it's empty")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -43,6 +43,11 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         return inPersonPaymentsMenuViewController
     }
 
+    func showCoupons() {
+        let enhancedCouponListViewController = EnhancedCouponListViewController(siteID: viewModel.siteID)
+        show(enhancedCouponListViewController, sender: self)
+    }
+
     /// Pushes the Settings & Privacy screen onto the navigation stack.
     ///
     func showPrivacySettings() {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -195,7 +195,7 @@ final class MainTabBarController: UITabBarController {
     ///   - animated: Whether the tab switch is animated.
     ///   - completion: Invoked when switching to the tab's root screen is complete.
     func navigateToTabWithNavigationController(_ tab: WooTab, animated: Bool = false, completion: ((UINavigationController) -> Void)? = nil) {
-        view.window?.rootViewController?.dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
 
         selectedIndex = tab.visibleIndex()
         if let navController = selectedViewController as? UINavigationController {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -195,9 +195,8 @@ final class MainTabBarController: UITabBarController {
     ///   - animated: Whether the tab switch is animated.
     ///   - completion: Invoked when switching to the tab's root screen is complete.
     func navigateToTabWithNavigationController(_ tab: WooTab, animated: Bool = false, completion: ((UINavigationController) -> Void)? = nil) {
-        if let presentedController = Self.childViewController()?.presentedViewController {
-            presentedController.dismiss(animated: true)
-        }
+        view.window?.rootViewController?.dismiss(animated: true, completion: nil)
+
         selectedIndex = tab.visibleIndex()
         if let navController = selectedViewController as? UINavigationController {
             navController.popToRootViewController(animated: animated) {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -452,6 +452,16 @@ extension MainTabBarController {
         return hubMenuViewController.showPaymentsMenu()
     }
 
+    static func presentCoupons() {
+        switchToHubMenuTab()
+        
+        guard let hubMenuViewController: HubMenuViewController = childViewController() else {
+            return
+        }
+
+        hubMenuViewController.showCoupons()
+    }
+
     static func presentCollectPayment() {
         let viewController = presentPayments()
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -454,7 +454,6 @@ extension MainTabBarController {
 
     static func presentCoupons() {
         switchToHubMenuTab()
-        
         guard let hubMenuViewController: HubMenuViewController = childViewController() else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -698,7 +698,7 @@ extension EditableOrderViewModel {
 
         let shippingLineViewModel: ShippingLineDetailsViewModel
         let feeLineViewModel: FeeOrDiscountLineDetailsViewModel
-        let addCouponLineViewModel: CouponLineDetailsViewModel
+        let addNewCouponLineClosure: (Coupon) -> Void
 
         init(siteID: Int64 = 0,
              itemsTotal: String = "0",
@@ -722,7 +722,7 @@ extension EditableOrderViewModel {
              showNonEditableIndicators: Bool = false,
              saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
              saveFeeLineClosure: @escaping (String?) -> Void = { _ in },
-             saveCouponLineClosure: @escaping (CouponLineDetailsResult) -> Void = { _ in },
+             addNewCouponLineClosure: @escaping (Coupon) -> Void = { _ in },
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
             self.siteID = siteID
             self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? "0.00"
@@ -753,9 +753,7 @@ extension EditableOrderViewModel {
                                                                       initialTotal: feeLineTotal,
                                                                       lineType: .fee,
                                                             didSelectSave: saveFeeLineClosure)
-            self.addCouponLineViewModel = CouponLineDetailsViewModel(isExistingCouponLine: false,
-                                                                     siteID: siteID,
-                                                                     didSelectSave: saveCouponLineClosure)
+            self.addNewCouponLineClosure = addNewCouponLineClosure
         }
     }
 
@@ -1069,7 +1067,9 @@ private extension EditableOrderViewModel {
                                             showNonEditableIndicators: showNonEditableIndicators,
                                             saveShippingLineClosure: self.saveShippingLine,
                                             saveFeeLineClosure: self.saveFeeLine,
-                                            saveCouponLineClosure: self.saveCouponLine,
+                                            addNewCouponLineClosure: { [weak self] coupon in
+                                                self?.saveCouponLine(result: .added(newCode: coupon.code))
+                                            },
                                             currencyFormatter: self.currencyFormatter)
             }
             .assign(to: &$paymentDataViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -663,6 +663,7 @@ extension EditableOrderViewModel {
     /// Representation of payment data display properties
     ///
     struct PaymentDataViewModel {
+        let siteID: Int64
         let itemsTotal: String
         let orderTotal: String
 
@@ -723,6 +724,7 @@ extension EditableOrderViewModel {
              saveFeeLineClosure: @escaping (String?) -> Void = { _ in },
              saveCouponLineClosure: @escaping (CouponLineDetailsResult) -> Void = { _ in },
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+            self.siteID = siteID
             self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? "0.00"
             self.shouldShowShippingTotal = shouldShowShippingTotal
             self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? "0.00"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1341,8 +1341,7 @@ private extension EditableOrderViewModel {
         couponLines.map {
             CouponLineViewModel(title: String.localizedStringWithFormat(Localization.CouponSummary.singular, $0.code),
                           discount: "-" + (currencyFormatter.formatAmount($0.discount) ?? "0.00"),
-                          detailsViewModel: CouponLineDetailsViewModel(isExistingCouponLine: true,
-                                                                       code: $0.code,
+                          detailsViewModel: CouponLineDetailsViewModel(code: $0.code,
                                                                        siteID: siteID,
                                                                        didSelectSave: saveCouponLine))
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetails.swift
@@ -44,9 +44,7 @@ struct CouponLineDetails: View {
                     .disabled(showValidateCouponLoading)
 
                     Spacer(minLength: Layout.sectionSpacing)
-
-                    if viewModel.isExistingCouponLine {
-                        Section {
+                    Section {
                             Button(Localization.remove) {
                                 focusedField = nil
                                 viewModel.removeCoupon()
@@ -59,11 +57,10 @@ struct CouponLineDetails: View {
                         }
                         .background(Color(.listForeground(modal: false)))
                     }
-                }
             }
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
-            .navigationTitle(viewModel.isExistingCouponLine ? Localization.coupon : Localization.addCoupon)
+            .navigationTitle(Localization.coupon)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -102,7 +99,6 @@ private extension CouponLineDetails {
     }
 
     enum Localization {
-        static let addCoupon = NSLocalizedString("Add coupon", comment: "Title for the Coupon screen during order creation")
         static let coupon = NSLocalizedString("Coupon", comment: "Title for the Coupon screen during order creation")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Coupon Details screen")
         static let done = NSLocalizedString("Done", comment: "Text for the done button in the Coupon Details screen")
@@ -117,8 +113,7 @@ private extension CouponLineDetails {
 
 struct CouponLineDetails_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = CouponLineDetailsViewModel(isExistingCouponLine: true,
-                                                   code: "",
+        let viewModel = CouponLineDetailsViewModel(code: "",
                                                    siteID: 0,
                                                    didSelectSave: { _ in })
         CouponLineDetails(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
@@ -21,10 +21,6 @@ final class CouponLineDetailsViewModel: Identifiable, ObservableObject {
     ///
     @Published var code: String = ""
 
-    /// Returns true when existing coupon line is edited.
-    ///
-    let isExistingCouponLine: Bool
-
     /// Returns true when there are no valid pending changes.
     ///
     var shouldDisableDoneButton: Bool {
@@ -43,12 +39,10 @@ final class CouponLineDetailsViewModel: Identifiable, ObservableObject {
 
     private let stores: StoresManager
 
-    init(isExistingCouponLine: Bool,
-         code: String? = nil,
+    init(code: String? = nil,
          siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          didSelectSave: @escaping ((CouponLineDetailsResult) -> Void)) {
-        self.isExistingCouponLine = isExistingCouponLine
         self.code = code ?? ""
         self.siteID = siteID
         self.stores = stores
@@ -87,8 +81,7 @@ final class CouponLineDetailsViewModel: Identifiable, ObservableObject {
 
 private extension CouponLineDetailsViewModel {
     func saveData() {
-        guard isExistingCouponLine,
-             let initialCode = initialCode,
+        guard let initialCode = initialCode,
              initialCode.isNotEmpty else {
             return didSelectSave(.added(newCode: code))
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -71,10 +71,14 @@ struct OrderPaymentSection: View {
             addCouponRow
                 .sheet(isPresented: $shouldShowAddCouponLineDetails) {
                     NavigationView {
-                        CouponListView(siteID: viewModel.siteID, onCouponSelected: { coupon in
-                            viewModel.addNewCouponLineClosure(coupon)
-                            shouldShowAddCouponLineDetails = false
-                        })
+                        CouponListView(siteID: viewModel.siteID,
+                                       emptyStateCreateCouponAction: {
+                                        MainTabBarController.switchToHubMenuTab()
+                                        },
+                                       onCouponSelected: { coupon in
+                                            viewModel.addNewCouponLineClosure(coupon)
+                                            shouldShowAddCouponLineDetails = false
+                                        })
                         .navigationTitle(Localization.addCoupon)
                             .navigationBarTitleDisplayMode(.inline)
                             .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -71,7 +71,7 @@ struct OrderPaymentSection: View {
 
             addCouponRow
                 .sheet(isPresented: $shouldShowAddCouponLineDetails) {
-                    CouponLineDetails(viewModel: viewModel.addCouponLineViewModel)
+                    CouponListView(siteID: viewModel.siteID)
                 }
 
             TitleAndValueRow(title: Localization.taxesTotal, value: .content(viewModel.taxesTotal))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -76,11 +76,11 @@ struct OrderPaymentSection: View {
                             viewModel.addNewCouponLineClosure(coupon)
                             shouldShowAddCouponLineDetails = false
                         })
-                            .navigationTitle("Coupons")
+                        .navigationTitle(Localization.addCoupon)
                             .navigationBarTitleDisplayMode(.inline)
                             .toolbar {
                                 ToolbarItem(placement: .navigationBarLeading) {
-                                    Button("Cancel") {
+                                    Button(Localization.cancelButton) {
                                         shouldShowAddCouponLineDetails = false
                                     }
                                 }
@@ -156,6 +156,7 @@ private extension OrderPaymentSection {
         static let taxesTotal = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
         static let addCoupon = NSLocalizedString("Add coupon", comment: "Title for the Coupon screen during order creation")
         static let coupon = NSLocalizedString("Coupon", comment: "Label for the row showing the cost of coupon in the order")
+        static let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button title when showing the coupon list selector")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -176,7 +176,7 @@ private extension OrderPaymentSection {
                                                    "when creating a new order that navigates to the Coupons Section")
         static let goToCouponsAlertMessage = NSLocalizedString("Do you want to navigate to the Coupons Menu? These changes will be discarded.",
                                                                comment: "Confirm message for navigating to coupons when creating a new order")
-        static let goToCouponsAlertButtonTitle = NSLocalizedString("Go", comment: "Confirm buton titele for navigating to coupons when creating a new order")
+        static let goToCouponsAlertButtonTitle = NSLocalizedString("Go", comment: "Confirm button title for navigating to coupons when creating a new order")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button title when showing the coupon list selector")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -71,7 +71,18 @@ struct OrderPaymentSection: View {
 
             addCouponRow
                 .sheet(isPresented: $shouldShowAddCouponLineDetails) {
-                    CouponListView(siteID: viewModel.siteID)
+                    NavigationView {
+                        CouponListView(siteID: viewModel.siteID)
+                            .navigationTitle("Coupons")
+                            .navigationBarTitleDisplayMode(.inline)
+                            .toolbar {
+                                ToolbarItem(placement: .navigationBarLeading) {
+                                    Button("Cancel") {
+                                        shouldShowAddCouponLineDetails = false
+                                    }
+                                }
+                            }
+                    }
                 }
 
             TitleAndValueRow(title: Localization.taxesTotal, value: .content(viewModel.taxesTotal))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Yosemite
 
 /// Represents the Payment section in an order
 ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -72,7 +72,10 @@ struct OrderPaymentSection: View {
             addCouponRow
                 .sheet(isPresented: $shouldShowAddCouponLineDetails) {
                     NavigationView {
-                        CouponListView(siteID: viewModel.siteID)
+                        CouponListView(siteID: viewModel.siteID, onCouponSelected: { coupon in
+                            viewModel.addNewCouponLineClosure(coupon)
+                            shouldShowAddCouponLineDetails = false
+                        })
                             .navigationTitle("Coupons")
                             .navigationBarTitleDisplayMode(.inline)
                             .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -72,8 +72,9 @@ struct OrderPaymentSection: View {
                 .sheet(isPresented: $shouldShowAddCouponLineDetails) {
                     NavigationView {
                         CouponListView(siteID: viewModel.siteID,
-                                       emptyStateCreateCouponAction: {
-                                        MainTabBarController.switchToHubMenuTab()
+                                       emptyStateActionTitle: Localization.goToCoupons,
+                                       emptyStateAction: {
+                                        MainTabBarController.presentCoupons()
                                         },
                                        onCouponSelected: { coupon in
                                             viewModel.addNewCouponLineClosure(coupon)
@@ -159,6 +160,8 @@ private extension OrderPaymentSection {
         static let taxesTotal = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
         static let addCoupon = NSLocalizedString("Add coupon", comment: "Title for the Coupon screen during order creation")
         static let coupon = NSLocalizedString("Coupon", comment: "Label for the row showing the cost of coupon in the order")
+        static let goToCoupons = NSLocalizedString("Go to Coupons", comment: "Button title on the Coupon screen empty state" +
+                                                   "when creating a new order that navigates to the Coupons Section")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button title when showing the coupon list selector")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -18,6 +18,10 @@ struct OrderPaymentSection: View {
     ///
     @State private var shouldShowAddCouponLineDetails: Bool = false
 
+    /// Indicates if the go to coupons alert should be shown or not.
+    ///
+    @State private var shouldShowGoToCouponsAlert: Bool = false
+
     /// Keeps track of the selected coupon line details view model.
     ///
     @State private var selectedCouponLineDetailsViewModel: CouponLineDetailsViewModel? = nil
@@ -74,7 +78,7 @@ struct OrderPaymentSection: View {
                         CouponListView(siteID: viewModel.siteID,
                                        emptyStateActionTitle: Localization.goToCoupons,
                                        emptyStateAction: {
-                                        MainTabBarController.presentCoupons()
+                                            shouldShowGoToCouponsAlert = true
                                         },
                                        onCouponSelected: { coupon in
                                             viewModel.addNewCouponLineClosure(coupon)
@@ -89,6 +93,14 @@ struct OrderPaymentSection: View {
                                     }
                                 }
                             }
+                            .alert(isPresented: $shouldShowGoToCouponsAlert, content: {
+                                Alert(title: Text(Localization.goToCoupons),
+                                      message: Text(Localization.goToCouponsAlertMessage),
+                                      primaryButton: .default(Text(Localization.goToCouponsAlertButtonTitle), action: {
+                                    MainTabBarController.presentCoupons()
+                                }),
+                                      secondaryButton: .cancel())
+                            })
                     }
                 }
 
@@ -162,6 +174,9 @@ private extension OrderPaymentSection {
         static let coupon = NSLocalizedString("Coupon", comment: "Label for the row showing the cost of coupon in the order")
         static let goToCoupons = NSLocalizedString("Go to Coupons", comment: "Button title on the Coupon screen empty state" +
                                                    "when creating a new order that navigates to the Coupons Section")
+        static let goToCouponsAlertMessage = NSLocalizedString("Do you want to navigate to the Coupons Menu? These changes will be discarded.",
+                                                               comment: "Confirm message for navigating to coupons when creating a new order")
+        static let goToCouponsAlertButtonTitle = NSLocalizedString("Go", comment: "Confirm buton titele for navigating to coupons when creating a new order")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button title when showing the coupon list selector")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -154,8 +154,8 @@ private extension OrderPaymentSection {
         static let addFee = NSLocalizedString("Add Fee", comment: "Title text of the button that adds a fee when creating a new order")
         static let feesTotal = NSLocalizedString("Fees", comment: "Label for the row showing the cost of fees in the order")
         static let taxesTotal = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
+        static let addCoupon = NSLocalizedString("Add coupon", comment: "Title for the Coupon screen during order creation")
         static let coupon = NSLocalizedString("Coupon", comment: "Label for the row showing the cost of coupon in the order")
-        static let addCoupon = NSLocalizedString("Add Coupon", comment: "Title text of the button that adds a coupon when creating a new order")
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1640,6 +1640,7 @@
 		B95112DA28BF79CA00D9578D /* PaymentsRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95112D928BF79CA00D9578D /* PaymentsRoute.swift */; };
 		B95864082A657D2F002C4C6E /* EnhancedCouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95864072A657D2F002C4C6E /* EnhancedCouponListViewController.swift */; };
 		B958640A2A657F44002C4C6E /* EnhancedCouponListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95864092A657F44002C4C6E /* EnhancedCouponListView.swift */; };
+		B958640C2A66847B002C4C6E /* CouponListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958640B2A66847B002C4C6E /* CouponListView.swift */; };
 		B958A7C728B3D44A00823EEF /* UniversalLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7C628B3D44A00823EEF /* UniversalLinkRouter.swift */; };
 		B958A7C928B3D47B00823EEF /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7C828B3D47B00823EEF /* Route.swift */; };
 		B958A7CB28B3D4A100823EEF /* RouteMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7CA28B3D4A100823EEF /* RouteMatcher.swift */; };
@@ -4030,6 +4031,7 @@
 		B95112D928BF79CA00D9578D /* PaymentsRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRoute.swift; sourceTree = "<group>"; };
 		B95864072A657D2F002C4C6E /* EnhancedCouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedCouponListViewController.swift; sourceTree = "<group>"; };
 		B95864092A657F44002C4C6E /* EnhancedCouponListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedCouponListView.swift; sourceTree = "<group>"; };
+		B958640B2A66847B002C4C6E /* CouponListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListView.swift; sourceTree = "<group>"; };
 		B958A7C628B3D44A00823EEF /* UniversalLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkRouter.swift; sourceTree = "<group>"; };
 		B958A7C828B3D47B00823EEF /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		B958A7CA28B3D4A100823EEF /* RouteMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMatcher.swift; sourceTree = "<group>"; };
@@ -6204,6 +6206,7 @@
 				DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */,
 				B95864072A657D2F002C4C6E /* EnhancedCouponListViewController.swift */,
 				B95864092A657F44002C4C6E /* EnhancedCouponListView.swift */,
+				B958640B2A66847B002C4C6E /* CouponListView.swift */,
 			);
 			path = Coupons;
 			sourceTree = "<group>";
@@ -12046,6 +12049,7 @@
 				DE6906E527D7439C00735E3B /* OrdersSplitViewWrapperController.swift in Sources */,
 				AEC12B7A2758D55900845F97 /* OrderStatusList.swift in Sources */,
 				0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */,
+				B958640C2A66847B002C4C6E /* CouponListView.swift in Sources */,
 				D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */,
 				02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */,
 				45381B4527341B8A003FEC5F /* DateRangeFilterViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CouponLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CouponLineDetailsViewModelTests.swift
@@ -13,8 +13,7 @@ final class CouponLineDetailsViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
-        viewModel = CouponLineDetailsViewModel(isExistingCouponLine: true,
-                                               code: initialCode,
+        viewModel = CouponLineDetailsViewModel(code: initialCode,
                                                siteID: sampleSiteID,
                                                stores: stores,
                                                didSelectSave: { _ in })
@@ -58,17 +57,6 @@ final class CouponLineDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
-    }
-
-    func test_view_model_initializes_correctly_with_no_existing_coupon_line() {
-        // Given
-        let viewModel = CouponLineDetailsViewModel(isExistingCouponLine: false,
-                                                   code: "",
-                                                   siteID: sampleSiteID,
-                                                   didSelectSave: { _ in })
-
-        // Then
-        XCTAssertFalse(viewModel.isExistingCouponLine)
     }
 
     func test_validateAndSaveData_then_calls_action_with_right_parameters() {
@@ -134,49 +122,6 @@ final class CouponLineDetailsViewModelTests: XCTestCase {
             XCTAssertEqual(newCode, passedCouponCode)
         default:
             XCTFail("Result should be edited case")
-        }
-    }
-
-    func test_validateAndSaveData_when_coupon_is_new_and_validated_then_completes_successfully() {
-        // Given
-        var savedResult: CouponLineDetailsResult?
-        viewModel = CouponLineDetailsViewModel(isExistingCouponLine: false,
-                                               code: "",
-                                               siteID: sampleSiteID,
-                                               stores: stores,
-                                               didSelectSave: { _ in })
-        viewModel.didSelectSave = { result in
-            savedResult = result
-        }
-
-        let passedCouponCode = "COUPON"
-        viewModel.code = passedCouponCode
-
-
-        stores.whenReceivingAction(ofType: CouponAction.self) { action in
-            switch action {
-            case let .validateCouponCode(_, _, onCompletion):
-                onCompletion(.success(true))
-            default:
-                break
-            }
-        }
-
-        // When
-        let shouldDismiss = waitFor { [weak self] promise in
-            self?.viewModel.validateAndSaveData() { shouldDismiss in
-                promise(shouldDismiss)
-            }
-        }
-
-        // Then
-        XCTAssertTrue(shouldDismiss)
-
-        switch savedResult {
-        case let .added(newCode):
-            XCTAssertEqual(newCode, passedCouponCode)
-        default:
-            XCTFail("Result should be added case")
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10246 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the second part of adding a Coupon Selector in Order Creation. For that, we use the work of the previous [PR](https://github.com/woocommerce/woocommerce-ios/pull/10248) to link the coupon selector to the Order Details.

Furthermore, we implement the empty state logic used in the Order Creation context. We decouple the action and button title elements making them configurable, sending the user to the Coupons Menu when they tap on the empty state button action. Navigating to the Coupons section means that the order changes are discarded; because of that, we show an alert before navigating so the user can confirm.

With that in mind, we implement the navigation to the Coupons menu from the MainTabBarController, as implemented in other cases (e.g., Payments)

Apart from that we remove the option to create coupons from the `CouponLineDetailsViewModel`, as we don't use it anymore.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### There are coupons

With coupons added to your store

1. Go to Orders
2. Tap on + to create a new order
3. Add a product
4. Tap to Add a Coupon
5. You should see a list of coupons. Select one.
6. The coupon should be added to the order.

https://github.com/woocommerce/woocommerce-ios/assets/1864060/cdc395e8-ba79-471f-ba14-8865777ca971


### There are no coupons

1. Go to Orders
2. Tap on + to create a new order
3. Add a product
4. Tap to Add a Coupon
5. You should see the empty state.
6. Tap on Go to Coupons
7. You should see an alert.
8. Tap on Go
9. You should navigate to the Menu and Coupons section

https://github.com/woocommerce/woocommerce-ios/assets/1864060/d70319c7-16a6-4d85-a34d-10c32da9f0b9

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

See above
---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
