### PR TITLE
Extract Application Password Encoding

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -172,6 +172,8 @@
 		24F98C602502EF8200F49B68 /* FeatureFlagRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */; };
 		24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 24F98C612502EFF600F49B68 /* feature-flags-load-all.json */; };
 		261870782540A252006522A1 /* ShippingLineTax.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261870772540A252006522A1 /* ShippingLineTax.swift */; };
+		261C466B2A6738EE00734070 /* AppicationPasswordEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261C466A2A6738EE00734070 /* AppicationPasswordEncoder.swift */; };
+		261C466D2A67478800734070 /* ApplicationPasswordEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261C466C2A67478800734070 /* ApplicationPasswordEncoderTests.swift */; };
 		261CF1B4255AD6B30090D8D3 /* payment-gateway-list.json in Resources */ = {isa = PBXBuildFile; fileRef = 261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */; };
 		261CF1B8255AE62D0090D8D3 /* PaymentGatewayRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1B7255AE62D0090D8D3 /* PaymentGatewayRemote.swift */; };
 		261CF1BC255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1BB255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift */; };
@@ -1122,6 +1124,8 @@
 		24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemoteTests.swift; sourceTree = "<group>"; };
 		24F98C612502EFF600F49B68 /* feature-flags-load-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "feature-flags-load-all.json"; sourceTree = "<group>"; };
 		261870772540A252006522A1 /* ShippingLineTax.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineTax.swift; sourceTree = "<group>"; };
+		261C466A2A6738EE00734070 /* AppicationPasswordEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppicationPasswordEncoder.swift; sourceTree = "<group>"; };
+		261C466C2A67478800734070 /* ApplicationPasswordEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordEncoderTests.swift; sourceTree = "<group>"; };
 		261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-list.json"; sourceTree = "<group>"; };
 		261CF1B7255AE62D0090D8D3 /* PaymentGatewayRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayRemote.swift; sourceTree = "<group>"; };
 		261CF1BB255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsGatewayRemoteTests.swift; sourceTree = "<group>"; };
@@ -3166,6 +3170,7 @@
 				EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */,
 				DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */,
 				EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */,
+				261C466A2A6738EE00734070 /* AppicationPasswordEncoder.swift */,
 				EE99814D295AA7430074AE68 /* RequestAuthenticator.swift */,
 				EE99814F295AACE10074AE68 /* RequestConverter.swift */,
 			);
@@ -3233,6 +3238,7 @@
 				EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */,
 				EE76762E2962B85E000066FA /* RequestProcessorTests.swift */,
 				45C6D0E329B9F327009CE29C /* CookieNonceAuthenticatorTests.swift */,
+				261C466C2A67478800734070 /* ApplicationPasswordEncoderTests.swift */,
 			);
 			path = ApplicationPassword;
 			sourceTree = "<group>";
@@ -4083,6 +4089,7 @@
 				0359EA1727AAC7740048DE2D /* WCPayCardFunding.swift in Sources */,
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,
+				261C466B2A6738EE00734070 /* AppicationPasswordEncoder.swift in Sources */,
 				2665032A261F41510079A159 /* ProductAddOn.swift in Sources */,
 				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,
 				0359EA1327AAC6D00048DE2D /* WCPayCardPaymentDetails.swift in Sources */,
@@ -4325,6 +4332,7 @@
 				45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */,
 				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,
 				261CF1BC255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift in Sources */,
+				261C466D2A67478800734070 /* ApplicationPasswordEncoderTests.swift in Sources */,
 				453305EF2459E46100264E50 /* SitePostsRemoteTests.swift in Sources */,
 				45C6D0E429B9F327009CE29C /* CookieNonceAuthenticatorTests.swift in Sources */,
 				24F98C602502EF8200F49B68 /* FeatureFlagRemoteTests.swift in Sources */,

--- a/Networking/Networking/ApplicationPassword/AppicationPasswordEncoder.swift
+++ b/Networking/Networking/ApplicationPassword/AppicationPasswordEncoder.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Utility class to encode the stored application password.
+/// By default it uses the stored application password.
+///
+public struct ApplicationPasswordEncoder {
+
+    /// Password envelope.
+    ///
+    private let passwordEnvelope: ApplicationPassword?
+
+    init(passwordEnvelope: ApplicationPassword? = ApplicationPasswordStorage().applicationPassword) {
+        self.passwordEnvelope = passwordEnvelope
+    }
+
+    /// Returns the application password on a base64 encoded format.
+    /// The output is ready to be used in the authentication header.
+    /// Returns `nil` if the password can't be encoded.
+    ///
+    public func encodedPassword() -> String? {
+        guard let passwordEnvelope else {
+            return nil
+        }
+
+        let loginString = "\(passwordEnvelope.wpOrgUsername):\(passwordEnvelope.password.secretValue)"
+        guard let loginData = loginString.data(using: .utf8) else {
+            return nil
+        }
+
+        return loginData.base64EncodedString()
+    }
+}

--- a/Networking/Networking/ApplicationPassword/AppicationPasswordEncoder.swift
+++ b/Networking/Networking/ApplicationPassword/AppicationPasswordEncoder.swift
@@ -9,8 +9,8 @@ public struct ApplicationPasswordEncoder {
     ///
     private let passwordEnvelope: ApplicationPassword?
 
-    init(passwordEnvelope: ApplicationPassword? = ApplicationPasswordStorage().applicationPassword) {
-        self.passwordEnvelope = passwordEnvelope
+    public init(passwordEnvelope: ApplicationPassword? = nil) {
+        self.passwordEnvelope = passwordEnvelope ?? ApplicationPasswordStorage().applicationPassword
     }
 
     /// Returns the application password on a base64 encoded format.

--- a/Networking/Networking/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
@@ -61,18 +61,14 @@ private extension OneTimeApplicationPasswordUseCase {
     }
 
     func authenticateRequest(request: URLRequest) -> URLRequest {
-        guard let username = applicationPassword?.wpOrgUsername,
-              let password = applicationPassword?.password.secretValue else {
+        guard let applicationPassword else {
             return request
         }
         var authenticatedRequest = request
         authenticatedRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         authenticatedRequest.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 
-        let loginString = "\(username):\(password)"
-
-        if let loginData = loginString.data(using: .utf8) {
-            let base64LoginString = loginData.base64EncodedString()
+        if let base64LoginString = ApplicationPasswordEncoder(passwordEnvelope: applicationPassword).encodedPassword() {
             authenticatedRequest.setValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
         }
 

--- a/Networking/Networking/Requests/AuthenticatedRESTRequest.swift
+++ b/Networking/Networking/Requests/AuthenticatedRESTRequest.swift
@@ -14,12 +14,7 @@ struct AuthenticatedRESTRequest: URLRequestConvertible {
         authenticated.setValue("application/json", forHTTPHeaderField: "Accept")
         authenticated.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 
-        let username = applicationPassword.wpOrgUsername
-        let password = applicationPassword.password.secretValue
-        let loginString = "\(username):\(password)"
-
-        if let loginData = loginString.data(using: .utf8) {
-            let base64LoginString = loginData.base64EncodedString()
+        if let base64LoginString = ApplicationPasswordEncoder(passwordEnvelope: applicationPassword).encodedPassword() {
             authenticated.setValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
         }
 

--- a/Networking/NetworkingTests/ApplicationPassword/ApplicationPasswordEncoderTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/ApplicationPasswordEncoderTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Networking
+
+final class ApplicationPasswordEncoderTests: XCTestCase {
+
+    func test_nil_password_envelope_returns_nil_password() {
+        let encoder = ApplicationPasswordEncoder(passwordEnvelope: nil)
+        XCTAssertNil(encoder.encodedPassword())
+    }
+
+    func test_sample_password_envelope_returns_encoded_password() {
+        // Given
+        let envelope = ApplicationPassword(wpOrgUsername: "This", password: .init("is-a-test"), uuid: "")
+
+        // When
+        let encoder = ApplicationPasswordEncoder(passwordEnvelope: envelope)
+
+        // Then
+        let expected = "VGhpczppcy1hLXRlc3Q=" /// `This:is-a-test` encoded with https://www.base64encode.org/
+        XCTAssertEqual(encoder.encodedPassword(), expected)
+    }
+}


### PR DESCRIPTION
# Why

On our react native experiment, we need to pass the encoded application password string to the react native module to properly authenticate requests.

Prior this PR, that information was hidden inside the Networking layer, this PR adds a new `ApplicationPasswordEncoder` type to expose the encoded password to the main target, so it can be passed to the React Native module later.

# Testing Steps

- Create a new jurassic ninja site, with woocommerce and without jetpack.
- Login into the app with those creadentials
- See that network requests are working as expected.