### PR TITLE
[Resilience] Customize error banner message when data can't be loaded due to parsing errors

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [Internal] Switched AI endpoint to be able to track and measure costs. [https://github.com/woocommerce/woocommerce-ios/pull/10218]
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
-- [Internal] Orders: Improved error message when orders can't be loaded due to a parsing (decoding) error. [https://github.com/woocommerce/woocommerce-ios/pull/10252]
+- [Internal] Errors: Improved error message when orders, products, or reviews can't be loaded due to a parsing (decoding) error. [https://github.com/woocommerce/woocommerce-ios/pull/10252, https://github.com/woocommerce/woocommerce-ios/pull/10260]
 - [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -564,8 +564,8 @@ private extension OrderListViewController {
         childController.configure(createFilterConfig())
 
         // Show Error Loading Data banner if the empty state is caused by a sync error
-        if viewModel.dataLoadingError != nil {
-            childController.showTopBannerView()
+        if let error = viewModel.dataLoadingError {
+            childController.showTopBannerView(for: error)
         } else {
             childController.hideTopBannerView()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -180,7 +180,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     /// Set when sync fails, and used to display an error loading data banner
     ///
-    @Published private var hasErrorLoadingData: Bool = false
+    @Published private var dataLoadingError: Error?
 
     /// Free trial banner presentation handler.
     ///
@@ -727,8 +727,8 @@ private extension ProductsViewController {
     /// Displays an error banner if there is an error loading products data.
     ///
     func showTopBannerViewIfNeeded() {
-        if hasErrorLoadingData {
-            requestAndShowErrorTopBannerView()
+        if let error = dataLoadingError {
+            requestAndShowErrorTopBannerView(for: error)
         }
 
         updateBlazeBannerVisibility()
@@ -757,8 +757,8 @@ private extension ProductsViewController {
 
     /// Request a new error loading data banner from `ErrorTopBannerFactory` and display it in the table header
     ///
-    func requestAndShowErrorTopBannerView() {
-        let errorBanner = ErrorTopBannerFactory.createTopBanner(
+    func requestAndShowErrorTopBannerView(for error: Error) {
+        let errorBanner = ErrorTopBannerFactory.createTopBanner(for: error,
             expandedStateChangeHandler: { [weak self] in
                 self?.tableView.updateHeaderHeight()
             },
@@ -866,10 +866,10 @@ private extension ProductsViewController {
     func observeBlazeBannerVisibility() {
         viewModel.$shouldShowBlazeBanner
             .removeDuplicates()
-            .combineLatest($hasErrorLoadingData.removeDuplicates())
-            .sink { [weak self] shouldShow, hasErrorLoadingData in
+            .combineLatest($dataLoadingError)
+            .sink { [weak self] shouldShow, loadingError in
                 guard let self else { return }
-                if shouldShow, !hasErrorLoadingData {
+                if shouldShow, loadingError == nil {
                     self.showBlazeBanner()
                 } else {
                     self.hideBlazeBanner()
@@ -1207,7 +1207,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
     ///
     func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)? = nil) {
         transitionToSyncingState(pageNumber: pageNumber)
-        hasErrorLoadingData = false
+        dataLoadingError = nil
 
         let action = ProductAction
             .synchronizeProducts(siteID: siteID,
@@ -1226,7 +1226,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                     case .failure(let error):
                                         ServiceLocator.analytics.track(.productListLoadError, withError: error)
                                         DDLogError("⛔️ Error synchronizing products: \(error)")
-                                        self.hasErrorLoadingData = true
+                                        self.dataLoadingError = error
                                     case .success:
                                         ServiceLocator.analytics.track(.productListLoaded)
                                     }
@@ -1335,7 +1335,7 @@ private extension ProductsViewController {
                 ensureFooterSpinnerIsStarted()
             }
             // Remove error banner when sync starts
-            if hasErrorLoadingData {
+            if dataLoadingError != nil {
                 hideTopBannerView()
             }
         case .results:

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -116,22 +116,9 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
         return centerGuide
     }()
 
-    /// Top banner that shows an error if there is a problem loading reviews data
+    /// Top banner that shows an error if there is a problem loading data
     ///
-    private lazy var topBannerView: TopBannerView = {
-        ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
-                                              onTroubleshootButtonPressed: { [weak self] in
-                                                guard let self = self else { return }
-
-                                                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
-                                              },
-                                              onContactSupportButtonPressed: { [weak self] in
-                                                guard let self = self else { return }
-
-            let supportForm = SupportFormHostingController(viewModel: .init())
-            supportForm.show(from: self)
-        })
-    }()
+    private var topBannerView: TopBannerView?
 
     convenience init(style: Style = .basic, configuration: Config? = nil, zendeskManager: ZendeskManagerProtocol? = nil) {
         if let zendeskManager = zendeskManager {
@@ -272,7 +259,22 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
 
     /// Display the error banner at the top of the view
     ///
-    func showTopBannerView() {
+    func showTopBannerView(for error: Error) {
+        topBannerView = ErrorTopBannerFactory.createTopBanner(for: error,
+                                                              expandedStateChangeHandler: {},
+                                                              onTroubleshootButtonPressed: { [weak self] in
+            guard let self else { return }
+
+            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
+        },
+                                                              onContactSupportButtonPressed: { [weak self] in
+            guard let self else { return }
+
+            let supportForm = SupportFormHostingController(viewModel: .init())
+            supportForm.show(from: self)
+        })
+
+        guard let topBannerView else { return }
         contentView.insertSubview(topBannerView, at: 0)
         NSLayoutConstraint.activate([
             topBannerView.leadingAnchor.constraint(equalTo: contentView.safeLeadingAnchor),
@@ -286,7 +288,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     /// Hide the error banner at the top of the view
     ///
     func hideTopBannerView() {
-        topBannerView.removeFromSuperview()
+        topBannerView?.removeFromSuperview()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -18,7 +18,7 @@ protocol ReviewsViewModelOutput {
 
     var shouldPromptForAppReview: Bool { get }
 
-    var hasErrorLoadingData: Bool { get set }
+    var dataLoadingError: Error? { get set }
 
     func containsMorePages(_ highestVisibleReview: Int) -> Bool
 }
@@ -76,7 +76,7 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
 
     /// Set when sync fails, and used to display an error loading data banner
     ///
-    var hasErrorLoadingData: Bool = false
+    var dataLoadingError: Error?
 
     init(siteID: Int64, data: ReviewsDataSourceProtocol, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
@@ -124,7 +124,7 @@ extension ReviewsViewModel {
     func synchronizeReviews(pageNumber: Int,
                             pageSize: Int,
                             onCompletion: (() -> Void)?) {
-        hasErrorLoadingData = false
+        dataLoadingError = nil
 
         let group = DispatchGroup()
 
@@ -160,7 +160,7 @@ extension ReviewsViewModel {
                 DDLogError("⛔️ Error synchronizing reviews: \(error)")
                 ServiceLocator.analytics.track(.reviewsListLoadFailed,
                                                withError: error)
-                self?.hasErrorLoadingData = true
+                self?.dataLoadingError = error
                 onCompletion?([])
             case .success(let reviews):
                 let loadingMore = pageNumber != Settings.firstPage
@@ -180,7 +180,7 @@ extension ReviewsViewModel {
                 DDLogError("⛔️ Error synchronizing products: \(error)")
                 ServiceLocator.analytics.track(.reviewsProductsLoadFailed,
                                                withError: error)
-                self?.hasErrorLoadingData = true
+                self?.dataLoadingError = error
             case .success:
                 ServiceLocator.analytics.track(.reviewsProductsLoaded)
             }
@@ -199,7 +199,7 @@ extension ReviewsViewModel {
                 DDLogError("⛔️ Error synchronizing notifications: \(error)")
                 ServiceLocator.analytics.track(.notificationsLoadFailed,
                                                withError: error)
-                self?.hasErrorLoadingData = true
+                self?.dataLoadingError = error
             } else {
                 ServiceLocator.analytics.track(.notificationListLoaded)
             }

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -115,6 +115,7 @@ final class ReviewsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(viewModel.dataLoadingError)
+        XCTAssertEqual(viewModel.dataLoadingError as? SampleError, .first)
     }
 
     func test_synchronizeReviews_triggers_retrieveProducts_with_all_reviewsProductIDs() {

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -73,7 +73,7 @@ final class ReviewsViewModelTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
     }
 
-    func test_hasErrorLoadingData_false_after_successful_sync() {
+    func test_dataLoadingError_nil_after_successful_sync() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
@@ -86,16 +86,16 @@ final class ReviewsViewModelTests: XCTestCase {
             }
         }
         let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
-        viewModel.hasErrorLoadingData = true
+        viewModel.dataLoadingError = MockError()
 
         // When
         viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25, onCompletion: nil)
 
         // Then
-        XCTAssertFalse(viewModel.hasErrorLoadingData)
+        XCTAssertNil(viewModel.dataLoadingError)
     }
 
-    func test_hasErrorLoadingData_true_after_failed_sync() {
+    func test_dataLoadingError_not_nil_after_failed_sync() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
@@ -108,13 +108,13 @@ final class ReviewsViewModelTests: XCTestCase {
             }
         }
         let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
-        viewModel.hasErrorLoadingData = false
+        viewModel.dataLoadingError = nil
 
         // When
         viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25, onCompletion: nil)
 
         // Then
-        XCTAssertTrue(viewModel.hasErrorLoadingData)
+        XCTAssertNotNil(viewModel.dataLoadingError)
     }
 
     func test_synchronizeReviews_triggers_retrieveProducts_with_all_reviewsProductIDs() {
@@ -170,6 +170,10 @@ final class ReviewsViewModelTests: XCTestCase {
 
 
 // MARK: - Mocks
+
+private extension ReviewsViewModelTests {
+    final class MockError: Error { }
+}
 
 final class MockReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewsViewControllerTests.swift
@@ -79,7 +79,7 @@ private final class MockReviewsViewModel: ReviewsViewModelOutput, ReviewsViewMod
 
     var shouldPromptForAppReview = false
 
-    var hasErrorLoadingData = true
+    var dataLoadingError: Error?
 
     func containsMorePages(_ highestVisibleReview: Int) -> Bool { false }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10162
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a followup to https://github.com/woocommerce/woocommerce-ios/pull/10252. In that PR, we improved the message on the Orders list error banner when there is a parsing error while loading data. This PR makes the same change for **Products**, **Reviews**, and the **empty state** screen.

If the error was a parsing (decoding) error, the banner message now mentions possible plugin conflicts.

### Changes

* On the products or reviews screens, we now keep track of what error occurred during sync and use it to create the corresponding error banner.
* On the empty state screen, we now use the error to create the corresponding error banner in `showTopBannerView(for:)`.

Note: The banner isn't updated yet on the My store screen (see the issue in https://github.com/woocommerce/woocommerce-ios/issues/10259).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can test using a tool like Charles Proxy or Proxyman to intercept and modify the API response:

1. Set a breakpoint in your tool of choice for requests to the `/wc/v3/products` endpoint.
2. Build and run the app.
3. Open the Products tab.
4. Modify the response so there is an invalid product object (e.g. remove a required field).
5. Execute the response and confirm the error banner appears with the new message, mentioning a possible plugin conflict.
6. Disable your internet connection and pull to refresh the Products list (to trigger a non-decoding error).
7. Confirm the error banner appears with the general error message.

Repeat the steps with a breakpoint for requests to the `/wc/v3/products/reviews` endpoint, opening Menu > Reviews in the app.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
/|General error|Parsing error
-|-|-
Products|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 11 28 18](https://github.com/woocommerce/woocommerce-ios/assets/8658164/9b21cdaa-8b9e-46d8-a0ca-388ec3157af5)|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 11 28 07](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d49234a6-c2d3-427d-83f6-094afe6542b5)
Reviews|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 11 27 12](https://github.com/woocommerce/woocommerce-ios/assets/8658164/5d391bf7-8711-413d-a320-4a6cf902943a)|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 11 26 57](https://github.com/woocommerce/woocommerce-ios/assets/8658164/13ae3652-bbc5-468a-a997-442f3af56f4a)
Empty state|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 11 25 31](https://github.com/woocommerce/woocommerce-ios/assets/8658164/5ce770cf-94e2-4851-9562-208dc125270e)|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 11 26 17](https://github.com/woocommerce/woocommerce-ios/assets/8658164/53b5a14b-5d77-4d9d-803b-16b5114d47aa)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
