### PR TITLE
[Orders with Coupons M5]Tap on Go to Coupons tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -604,6 +604,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCouponRemove, properties: [Keys.flow: flow.rawValue])
         }
 
+        static func orderGoToCouponsButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderGoToCouponsButtonTapped, properties: [:])
+        }
+
         static func productDiscountAdd(type: FeeOrDiscountLineDetailsViewModel.FeeOrDiscountType) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductDiscountAdd, properties: [Keys.type: type.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -407,6 +407,7 @@ public enum WooAnalyticsStat: String {
     case orderFeeRemove = "order_fee_remove"
     case orderCouponAdd = "order_coupon_add"
     case orderCouponRemove = "order_coupon_remove"
+    case orderGoToCouponsButtonTapped = "order_go_to_coupons_button_tapped"
     case orderProductDiscountAdd = "order_product_discount_add"
     case orderProductDiscountRemove = "order_product_discount_remove"
     case orderProductDiscountAddButtonTapped = "order_product_discount_add_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -699,6 +699,7 @@ extension EditableOrderViewModel {
         let shippingLineViewModel: ShippingLineDetailsViewModel
         let feeLineViewModel: FeeOrDiscountLineDetailsViewModel
         let addNewCouponLineClosure: (Coupon) -> Void
+        let onGoToCouponsClosure: () -> Void
 
         init(siteID: Int64 = 0,
              itemsTotal: String = "0",
@@ -723,6 +724,7 @@ extension EditableOrderViewModel {
              saveShippingLineClosure: @escaping (ShippingLine?) -> Void = { _ in },
              saveFeeLineClosure: @escaping (String?) -> Void = { _ in },
              addNewCouponLineClosure: @escaping (Coupon) -> Void = { _ in },
+             onGoToCouponsClosure: @escaping () -> Void = {},
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
             self.siteID = siteID
             self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? "0.00"
@@ -754,6 +756,7 @@ extension EditableOrderViewModel {
                                                                       lineType: .fee,
                                                             didSelectSave: saveFeeLineClosure)
             self.addNewCouponLineClosure = addNewCouponLineClosure
+            self.onGoToCouponsClosure = onGoToCouponsClosure
         }
     }
 
@@ -1069,6 +1072,9 @@ private extension EditableOrderViewModel {
                                             saveFeeLineClosure: self.saveFeeLine,
                                             addNewCouponLineClosure: { [weak self] coupon in
                                                 self?.saveCouponLine(result: .added(newCode: coupon.code))
+                                            },
+                                            onGoToCouponsClosure: { [weak self] in
+                                                self?.analytics.track(event: WooAnalyticsEvent.Orders.orderGoToCouponsButtonTapped())
                                             },
                                             currencyFormatter: self.currencyFormatter)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -97,6 +97,7 @@ struct OrderPaymentSection: View {
                                 Alert(title: Text(Localization.goToCoupons),
                                       message: Text(Localization.goToCouponsAlertMessage),
                                       primaryButton: .default(Text(Localization.goToCouponsAlertButtonTitle), action: {
+                                    viewModel.onGoToCouponsClosure()
                                     MainTabBarController.presentCoupons()
                                 }),
                                       secondaryButton: .cancel())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -499,6 +499,18 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£0.00")
     }
 
+    func test_payment_data_view_model_when_calling_onGoToCouponsClosure_then_calls_to_track_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        viewModel.paymentDataViewModel.onGoToCouponsClosure()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderGoToCouponsButtonTapped.rawValue)
+    }
+
     // MARK: - Add Products to Order via SKU Scanner Tests
 
     func test_trackBarcodeScanningButtonTapped_tracks_right_event() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10246 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we track the tap on the Go to Coupons button, shown in the empty state of the Order Coupons selector.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Without any coupons added into your store:

1. Go to Orders
2. Tap on + to create a new order
3. Add a product
4. Tap to add a new coupon. You should see the empty state of the coupons selector
5. Tap on Go to Coupons. Also when the alert is shown.
6. The event should be tracked:

`🔵 Tracked order_go_to_coupons_button_tapped, properties: [AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true]
`
## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
