### PR TITLE
[My store] Fix error banner so it appears when stats data can't be loaded

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [Internal] Media picker flow was refactored to support interactive dismissal for device photo picker and WordPress media picker sources. Affected flows: product form > images, and virtual product form > downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/10236]
 - [Internal] Orders: Improved error message when orders can't be loaded due to a parsing (decoding) error. [https://github.com/woocommerce/woocommerce-ios/pull/10252]
 - [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
+- [Internal] Fixed a bug preventing the "We couldn't load your data" error banner from appearing on the My store dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/10262]
 
 
 14.5

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -931,6 +931,7 @@ private extension DashboardViewController {
 
     func onPullToRefresh() async {
         ServiceLocator.analytics.track(.dashboardPulledToRefresh)
+        hideTopBannerView() // Hide error banner optimistically on pull to refresh
         await withTaskGroup(of: Void.self) { group in
             group.addTask { [weak self] in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -113,6 +113,11 @@ final class DashboardViewModel {
                             timeRange: StatsTimeRangeV4,
                             latestDateToInclude: Date,
                             onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        guard stores.isAuthenticatedWithoutWPCom == false else { // Visit stats are only available for stores connected to WPCom
+            onCompletion?(.success(()))
+            return
+        }
+
         let action = StatsActionV4.retrieveSiteVisitStats(siteID: siteID,
                                                           siteTimezone: siteTimezone,
                                                           timeRange: timeRange,
@@ -132,6 +137,11 @@ final class DashboardViewModel {
                               timeRange: StatsTimeRangeV4,
                               latestDateToInclude: Date,
                               onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        guard stores.isAuthenticatedWithoutWPCom == false else { // Summary stats are only available for stores connected to WPCom
+            onCompletion?(.success(()))
+            return
+        }
+
         let action = StatsActionV4.retrieveSiteSummaryStats(siteID: siteID,
                                                             siteTimezone: siteTimezone,
                                                             period: timeRange.summaryStatsGranularity,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -240,7 +240,7 @@ private extension StoreStatsAndTopPerformersViewController {
                 }
                 periodGroup.leave()
                 periodStoreStatsGroup.leave()
-                group.leave()
+                group.leave() // Leave this group last so `syncError` is set, if needed
             }
 
             group.enter()
@@ -256,7 +256,7 @@ private extension StoreStatsAndTopPerformersViewController {
                 }
                 periodGroup.leave()
                 periodStoreStatsGroup.leave()
-                group.leave()
+                group.leave() // Leave this group last so `syncError` is set, if needed
             }
 
             group.enter()
@@ -272,7 +272,7 @@ private extension StoreStatsAndTopPerformersViewController {
                 }
                 periodGroup.leave()
                 periodStoreStatsGroup.leave()
-                group.leave()
+                group.leave() // Leave this group last so `syncError` is set, if needed
             }
 
             group.enter()
@@ -287,7 +287,7 @@ private extension StoreStatsAndTopPerformersViewController {
                     periodSyncError = error
                 }
                 periodGroup.leave()
-                group.leave()
+                group.leave() // Leave this group last so `syncError` is set, if needed
 
                 vc.removeTopPerformersGhostContent()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -238,9 +238,9 @@ private extension StoreStatsAndTopPerformersViewController {
                     DDLogError("⛔️ Error synchronizing order stats: \(error)")
                     periodSyncError = error
                 }
-                group.leave()
                 periodGroup.leave()
                 periodStoreStatsGroup.leave()
+                group.leave()
             }
 
             group.enter()
@@ -254,9 +254,9 @@ private extension StoreStatsAndTopPerformersViewController {
                     DDLogError("⛔️ Error synchronizing visitor stats: \(error)")
                     periodSyncError = error
                 }
-                group.leave()
                 periodGroup.leave()
                 periodStoreStatsGroup.leave()
+                group.leave()
             }
 
             group.enter()
@@ -270,9 +270,9 @@ private extension StoreStatsAndTopPerformersViewController {
                     DDLogError("⛔️ Error synchronizing summary stats: \(error)")
                     periodSyncError = error
                 }
-                group.leave()
                 periodGroup.leave()
                 periodStoreStatsGroup.leave()
+                group.leave()
             }
 
             group.enter()
@@ -286,8 +286,8 @@ private extension StoreStatsAndTopPerformersViewController {
                     DDLogError("⛔️ Error synchronizing top earners stats: \(error)")
                     periodSyncError = error
                 }
-                group.leave()
                 periodGroup.leave()
+                group.leave()
 
                 vc.removeTopPerformersGhostContent()
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10259
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The error banner (to explain there is a problem loading data) was not showing up on the My store dashboard. This PR fixes 3 related issues:

1. The check for sync errors was happening before the syncing was complete (and before any sync error was set).
   * Fix: In `StoreStatsAndTopPerformersViewController` there are several dispatch groups used for syncing (`group`, `periodGroup`, and `periodStoreStatsGroup`). We now call `group.leave()` last to make sure all the work for the time period is complete (including setting any period sync error) before checking for and handling sync errors for the dashboard as a whole.
2. We were attempting to fetch WPCom stats (visit and summary stats) even for sites not connected to WPCom, causing sync errors. 
   * Fix: Now in `DashboardViewModel` we check if the store is authenticated with WPCom before dispatching those actions, to avoid extra API calls and unnecessary sync errors.
3. The pull to refresh mechanism has changed since the error banner was first introduced, and the error banner wasn't removed if the dashboard was refreshed after it appeared.
   * Fix: Now in `DashboardViewController` we hide the error banner optimistically on pull to refresh.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Disable your internet connection and pull to refresh the dashboard (to trigger an error).
3. Confirm the error banner appears at the top of the screen (under the site title).
4. Enable your internet connection and pull to refresh again.
5. Confirm the error banner is removed and the dashboard loads as expected.

You can test using a store with or without Jetpack, to confirm the expected stats load in both cases.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/f84a09bd-4433-46f3-8798-e0acbe2c6b41




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
