### PR TITLE
[Resilience] Customize dashboard error message for parsing errors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardUI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardUI.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 protocol DashboardUI: UIViewController {
     /// Called when the Dashboard should display syncing error
-    var displaySyncingError: () -> Void { get set }
+    var displaySyncingError: (Error) -> Void { get set }
 
     /// Called when the user pulls to refresh
     var onPullToRefresh: @MainActor () async -> Void { get set }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -669,6 +669,10 @@ private extension DashboardViewController {
     /// Display the error banner at the top of the dashboard content (below the site title)
     ///
     func showTopBannerView(for error: Error) {
+        if topBannerView != nil { // Clear the top banner first, if needed
+            hideTopBannerView()
+        }
+
         let errorBanner = ErrorTopBannerFactory.createTopBanner(for: error,
                                                                 expandedStateChangeHandler: {},
                                                                 onTroubleshootButtonPressed: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -87,19 +87,7 @@ final class DashboardViewController: UIViewController {
 
     /// Top banner that shows an error if there is a problem loading data
     ///
-    private lazy var topBannerView = {
-        ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
-                                              onTroubleshootButtonPressed: { [weak self] in
-                                                guard let self = self else { return }
-
-                                                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
-                                              },
-                                              onContactSupportButtonPressed: { [weak self] in
-                                                guard let self = self else { return }
-            let supportForm = SupportFormHostingController(viewModel: .init())
-            supportForm.show(from: self)
-        })
-    }()
+    private var topBannerView: TopBannerView?
 
     private var announcementViewHostingController: ConstraintsUpdatingHostingController<AnnouncementCardWrapper>?
 
@@ -354,7 +342,6 @@ private extension DashboardViewController {
 
     func configureHeaderStackView() {
         configureSubtitle()
-        configureErrorBanner()
         containerStackView.addArrangedSubview(headerStackView)
     }
 
@@ -363,13 +350,6 @@ private extension DashboardViewController {
         storeNameLabel.textColor = Constants.storeNameTextColor
         innerStackView.addArrangedSubview(storeNameLabel)
         headerStackView.addArrangedSubview(innerStackView)
-    }
-
-    func configureErrorBanner() {
-        headerStackView.addArrangedSubviews([topBannerView, spacerView])
-        // Don't show the error banner subviews until they are needed
-        topBannerView.isHidden = true
-        spacerView.isHidden = true
     }
 
     func addViewBelowHeaderStackView(contentView: UIView) {
@@ -689,15 +669,28 @@ private extension DashboardViewController {
     /// Display the error banner at the top of the dashboard content (below the site title)
     ///
     func showTopBannerView() {
-        topBannerView.isHidden = false
-        spacerView.isHidden = false
+        let errorBanner = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
+                                                                onTroubleshootButtonPressed: { [weak self] in
+            guard let self else { return }
+            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
+        },
+                                                                onContactSupportButtonPressed: { [weak self] in
+            guard let self else { return }
+            let supportForm = SupportFormHostingController(viewModel: .init())
+            supportForm.show(from: self)
+        })
+
+        // Configure header stack view
+        topBannerView = errorBanner
+        headerStackView.addArrangedSubviews([errorBanner, spacerView])
     }
 
     /// Hide the error banner
     ///
     func hideTopBannerView() {
-        topBannerView.isHidden = true
-        spacerView.isHidden = true
+        topBannerView?.removeFromSuperview()
+        spacerView.removeFromSuperview()
+        topBannerView = nil
     }
 
     func updateUI(site: Site) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -668,8 +668,9 @@ private extension DashboardViewController {
 
     /// Display the error banner at the top of the dashboard content (below the site title)
     ///
-    func showTopBannerView() {
-        let errorBanner = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
+    func showTopBannerView(for error: Error) {
+        let errorBanner = ErrorTopBannerFactory.createTopBanner(for: error,
+                                                                expandedStateChangeHandler: {},
                                                                 onTroubleshootButtonPressed: { [weak self] in
             guard let self else { return }
             WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
@@ -868,8 +869,8 @@ private extension DashboardViewController {
         // Sets `dashboardUI` after its view is added to the view hierarchy so that observers can update UI based on its view.
         dashboardUI = updatedDashboardUI
 
-        updatedDashboardUI.displaySyncingError = { [weak self] in
-            self?.showTopBannerView()
+        updatedDashboardUI.displaySyncingError = { [weak self] error in
+            self?.showTopBannerView(for: error)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -43,9 +43,9 @@ final class DeprecatedDashboardStatsViewController: UIViewController {
 // MARK: DashboardUI conformance
 // Everything is empty as this deprecated stats screen is static
 extension DeprecatedDashboardStatsViewController: DashboardUI {
-    var displaySyncingError: () -> Void {
+    var displaySyncingError: (Error) -> Void {
         get {
-            return {}
+            return { _ in }
         }
         set {}
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -9,7 +9,7 @@ import class WidgetKit.WidgetCenter
 final class StoreStatsAndTopPerformersViewController: TabbedViewController {
     // MARK: - DashboardUI protocol
 
-    var displaySyncingError: () -> Void = {}
+    var displaySyncingError: (Error) -> Void = { _ in }
 
     var onPullToRefresh: @MainActor () async -> Void = {}
 
@@ -430,7 +430,7 @@ private extension StoreStatsAndTopPerformersViewController {
             }
             trackDashboardStatsSyncComplete()
         default:
-            displaySyncingError()
+            displaySyncingError(error)
             trackDashboardStatsSyncComplete(withError: error)
         }
     }
@@ -440,7 +440,7 @@ private extension StoreStatsAndTopPerformersViewController {
         case let siteStatsStoreError as SiteStatsStoreError:
             handleSiteStatsStoreError(error: siteStatsStoreError)
         default:
-            displaySyncingError()
+            displaySyncingError(error)
             trackDashboardStatsSyncComplete(withError: error)
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1895,6 +1895,11 @@
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
+		CEF5A28F2A68466E0059CFD3 /* stats_summary_day.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A28E2A68466E0059CFD3 /* stats_summary_day.json */; };
+		CEF5A2912A68467C0059CFD3 /* stats_summary_week.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2902A68467C0059CFD3 /* stats_summary_week.json */; };
+		CEF5A2952A68469B0059CFD3 /* stats_summary_month.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2942A68469B0059CFD3 /* stats_summary_month.json */; };
+		CEF5A2972A6846A50059CFD3 /* stats_summary_year.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2962A6846A50059CFD3 /* stats_summary_year.json */; };
+		CEF5A29B2A6849DB0059CFD3 /* reports_products.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A29A2A6849DB0059CFD3 /* reports_products.json */; };
 		D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */; };
 		D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */; };
 		D449C51B26DE6B5000D75B02 /* ReportList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C51826DE6B5000D75B02 /* ReportList.swift */; };
@@ -4293,6 +4298,11 @@
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
+		CEF5A28E2A68466E0059CFD3 /* stats_summary_day.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_day.json; sourceTree = "<group>"; };
+		CEF5A2902A68467C0059CFD3 /* stats_summary_week.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_week.json; sourceTree = "<group>"; };
+		CEF5A2942A68469B0059CFD3 /* stats_summary_month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_month.json; sourceTree = "<group>"; };
+		CEF5A2962A6846A50059CFD3 /* stats_summary_year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_year.json; sourceTree = "<group>"; };
+		CEF5A29A2A6849DB0059CFD3 /* reports_products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reports_products.json; sourceTree = "<group>"; };
 		D41C9F2426D97D5400993558 /* IconListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconListItem.swift; sourceTree = "<group>"; };
 		D41C9F2626D994CD00993558 /* ReportListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListView.swift; sourceTree = "<group>"; };
 		D41C9F2826D99E9700993558 /* LargeTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeTitleView.swift; sourceTree = "<group>"; };
@@ -9137,6 +9147,7 @@
 				800A5BC3275889EC009DE2CD /* reports_revenue_stats_month.json */,
 				800A5BC4275889EC009DE2CD /* reports_revenue_stats_year.json */,
 				CCFC00C223E9BD5500157A78 /* reports_revenue_stats.json */,
+				CEF5A29A2A6849DB0059CFD3 /* reports_products.json */,
 			);
 			path = "wc-analytics";
 			sourceTree = "<group>";
@@ -9264,6 +9275,10 @@
 				CCFC00E223E9BD5500157A78 /* stats_visits_week.json */,
 				CCFC00E123E9BD5500157A78 /* stats_visits_month.json */,
 				CCFC00E023E9BD5500157A78 /* stats_visits_year.json */,
+				CEF5A28E2A68466E0059CFD3 /* stats_summary_day.json */,
+				CEF5A2902A68467C0059CFD3 /* stats_summary_week.json */,
+				CEF5A2942A68469B0059CFD3 /* stats_summary_month.json */,
+				CEF5A2962A6846A50059CFD3 /* stats_summary_year.json */,
 			);
 			path = stats;
 			sourceTree = "<group>";
@@ -11235,6 +11250,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				80E6FC6D276312D50086CD67 /* products.json in Resources */,
+				CEF5A28F2A68466E0059CFD3 /* stats_summary_day.json in Resources */,
 				80B8D3492785A0A900FE6E6B /* products_list_3.json in Resources */,
 				800A5BB827586A96009DE2CD /* products_reviews_6156.json in Resources */,
 				D8CD0605258B384E00B52D63 /* oauth2_token-error.json in Resources */,
@@ -11250,6 +11266,7 @@
 				800A5BA5275719E5009DE2CD /* orders_2201_shipment_trackings.json in Resources */,
 				800A5BAA2758661B009DE2CD /* products_2123.json in Resources */,
 				80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */,
+				CEF5A2952A68469B0059CFD3 /* stats_summary_month.json in Resources */,
 				CCF27B35280EF69700B755E1 /* orders_3337_add_product.json in Resources */,
 				800A5B9B2755E0B9009DE2CD /* orders_any.json in Resources */,
 				800A5BB2275869DC009DE2CD /* products_reviews_6154.json in Resources */,
@@ -11277,10 +11294,13 @@
 				80CC810729E6763F00CA1687 /* products_add_new_variable_2131.json in Resources */,
 				800A5B972755BA02009DE2CD /* status.json in Resources */,
 				800A5BC8275889ED009DE2CD /* reports_revenue_stats_year.json in Resources */,
+				CEF5A29B2A6849DB0059CFD3 /* reports_products.json in Resources */,
 				CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */,
 				800A5BBC27586AE1009DE2CD /* products_reviews_6162.json in Resources */,
 				80A6430E2A026D0800F65C0C /* complete_cash_simple_payment.json in Resources */,
 				80A643022A010F2100F65C0C /* connection_tokens.json in Resources */,
+				CEF5A2912A68467C0059CFD3 /* stats_summary_week.json in Resources */,
+				CEF5A2972A6846A50059CFD3 /* stats_summary_year.json in Resources */,
 				800A5B6127548F53009DE2CD /* sites_posts_password.json in Resources */,
 				800A5BB427586A0E009DE2CD /* products_reviews_6155.json in Resources */,
 				800A5B5F27548F31009DE2CD /* site_info_wordpress_com.json in Resources */,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc-analytics/reports_products.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc-analytics/reports_products.json
@@ -1,0 +1,71 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "matches": "\/wc-analytics\/reports\/products(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": [{
+                "product_id": 2130,
+                "items_sold": 3,
+                "net_revenue": 450,
+                "orders_count": 3,
+                "extended_info": {
+                    "name": "Black Coral shades",
+                    "price": 150,
+                    "image": "https:\/\/example.com\/wp-content\/uploads\/2020\/01\/Mask-Group-1.png?w=201",
+                    "permalink": "https:\/\/example.com\/product\/black-coral-shades\/",
+                    "stock_status": "instock",
+                    "stock_quantity": 0,
+                    "manage_stock": false,
+                    "low_stock_amount": 2,
+                    "category_ids": [],
+                    "sku": ""
+                }
+            }, {
+                "product_id": 2123,
+                "items_sold": 1,
+                "net_revenue": 140,
+                "orders_count": 1,
+                "extended_info": {
+                    "name": "Malaya shades",
+                    "price": 140,
+                    "image": "https:\/\/example.com\/wp-content\/uploads\/2020\/01\/Mask-Group.png?w=201",
+                    "permalink": "https:\/\/example.com\/product\/malaya-shades\/",
+                    "stock_status": "instock",
+                    "stock_quantity": 0,
+                    "manage_stock": false,
+                    "low_stock_amount": 2,
+                    "category_ids": [],
+                    "sku": ""
+                }
+            }, {
+                "product_id": 2132,
+                "items_sold": 1,
+                "net_revenue": 120,
+                "orders_count": 1,
+                "extended_info": {
+                    "name": "Rose Gold shades",
+                    "price": 120,
+                    "image": "https:\/\/example.com\/wp-content\/uploads\/2020\/01\/Mask-Group-2.png?w=201",
+                    "permalink": "https:\/\/example.com\/product\/rose-gold-shades\/",
+                    "stock_status": "instock",
+                    "stock_quantity": 0,
+                    "manage_stock": false,
+                    "low_stock_amount": 2,
+                    "category_ids": [],
+                    "sku": ""
+                }
+            }]
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_day.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_day.json
@@ -1,0 +1,27 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/sites/161477129/stats/summary/",
+        "queryParameters": {
+            "period": {
+                "equalTo": "day"
+            },
+            "date": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "date": "{{now format='yyyy-MM-dd'}}",
+            "period": "day",
+            "views": 0,
+            "visitors": 0,
+            "likes": 0,
+            "reblogs": 0,
+            "comments": 0,
+            "followers": 1
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_month.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_month.json
@@ -1,0 +1,27 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/sites/161477129/stats/summary/",
+        "queryParameters": {
+            "period": {
+                "equalTo": "month"
+            },
+            "date": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "date": "{{now format='yyyy-MM-dd'}}",
+            "period": "month",
+            "views": 0,
+            "visitors": 0,
+            "likes": 0,
+            "reblogs": 0,
+            "comments": 0,
+            "followers": 1
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_week.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_week.json
@@ -1,0 +1,27 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/sites/161477129/stats/summary/",
+        "queryParameters": {
+            "period": {
+                "equalTo": "week"
+            },
+            "date": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "date": "{{now format='yyyy-MM-dd'}}",
+            "period": "week",
+            "views": 0,
+            "visitors": 0,
+            "likes": 0,
+            "reblogs": 0,
+            "comments": 0,
+            "followers": 1
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_year.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_summary_year.json
@@ -1,0 +1,27 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/sites/161477129/stats/summary/",
+        "queryParameters": {
+            "period": {
+                "equalTo": "year"
+            },
+            "date": {
+                "matches": "(.*)"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "date": "{{now format='yyyy-MM-dd'}}",
+            "period": "year",
+            "views": 0,
+            "visitors": 0,
+            "likes": 0,
+            "reblogs": 0,
+            "comments": 0,
+            "followers": 1
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_day.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_day.json
@@ -13,7 +13,7 @@
                 "matches": "(.*)"
             },
             "stat_fields": {
-                "matches": "visitors"
+                "matches": "visitors,views"
             }
         }
     },

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_month.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_month.json
@@ -13,7 +13,7 @@
                 "matches": "(.*)"
             },
             "stat_fields": {
-                "matches": "visitors"
+                "matches": "visitors,views"
             }
         }
     },

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_week.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_week.json
@@ -13,7 +13,7 @@
                 "matches": "(.*)"
             },
             "stat_fields": {
-                "matches": "visitors"
+                "matches": "visitors,views"
             }
         }
     },

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_year.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/stats/stats_visits_year.json
@@ -13,7 +13,7 @@
                 "matches": "(.*)"
             },
             "stat_fields": {
-                "matches": "visitors"
+                "matches": "visitors,views"
             }
         }
     },


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10162
⚠️ Depends on #10262 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is the last PR (along with https://github.com/woocommerce/woocommerce-ios/pull/10252 and https://github.com/woocommerce/woocommerce-ios/pull/10260) to improve the error messaging for parsing (decoding) errors. On the My store dashboard, if there was a parsing (decoding) error while loading stats data, the banner message now mentions possible plugin conflicts.

### Changes

1. In `DashboardViewController`, instead of configuring the error banner and hiding/displaying it as needed, we now create and add it to the view when it's needed and remove it when it isn't needed. This allows us to customize the banner according to the error.
2. The `DashboardUI.displaySyncingError` method now passes the error so it can be used to create the corresponding error banner.
3. Adds new/updated mock API responses in `WooCommerceUITests` to resolve a UI test failure (failing because the error banner was appearing due to missing mocks).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can test using a tool like Charles Proxy or Proxyman to intercept and modify the API response:

1. Set a breakpoint in your tool of choice for requests to any of the stats endpoints (e.g. `/rest/v1.1/sites/{SITE_ID}/stats/visits` or `/wc-analytics/reports/revenue/stats`).
2. Build and run the app.
4. Modify the response for a stats request so there is an invalid stats object (e.g. remove a required field or add junk data).
5. Execute the response and confirm the error banner appears with the new message, mentioning a possible plugin conflict.
6. Disable your internet connection and pull to refresh the dashboard (to trigger a non-decoding error).
7. Confirm the error banner appears with the general error message.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
General error|Parsing error
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 15 54 42](https://github.com/woocommerce/woocommerce-ios/assets/8658164/6a8a44d0-8d35-4534-a1bc-b8e10f9ce802)|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-19 at 15 55 55](https://github.com/woocommerce/woocommerce-ios/assets/8658164/94463868-b0fa-4693-9120-147418228ad6)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
