### PR TITLE
Product details from image: Disable generate button if all texts are either empty or not selected

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
@@ -13,8 +13,8 @@ struct AddProductFromImageFormImageView: View {
         EditableImageView(imageState: viewModel.imageState,
                           emptyContent: {
             VStack(spacing: Layout.verticalSpacing) {
-                Image(systemName: "photo")
-                    .font(.system(size: Layout.emptyStateImageSize))
+                Image(uiImage: .addImage)
+
                 Label {
                     Text(Localization.packagingImageTip)
                 } icon: {
@@ -44,7 +44,6 @@ struct AddProductFromImageFormImageView: View {
 
 private extension AddProductFromImageFormImageView {
     enum Layout {
-        static let emptyStateImageSize: CGFloat = 40
         static let editImageSize: CGFloat = 30
         static let verticalSpacing: CGFloat = 16
         static let padding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -47,15 +47,12 @@ struct AddProductFromImageView: View {
                 }
             }
 
-            // Name field.
             Section {
+                // Name field.
                 AddProductFromImageTextFieldView(viewModel: viewModel.nameViewModel,
                                                  customizations: .init(lineLimit: 1...2),
                                                  isGeneratingSuggestion: viewModel.isGeneratingDetails)
-            }
-
-            // Description field.
-            Section {
+                // Description field.
                 AddProductFromImageTextFieldView(viewModel: viewModel.descriptionViewModel,
                                                  customizations: .init(lineLimit: 2...10),
                                                  isGeneratingSuggestion: viewModel.isGeneratingDetails)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -77,7 +77,7 @@ struct AddProductFromImageView: View {
                     }
 
                     // Info text about selecting/editing the scanned text list.
-                    Text(Localization.scannedTextListInfo)
+                    Text(viewModel.scannedTextInstruction)
                         .foregroundColor(.init(uiColor: .secondaryLabel))
                         .captionStyle()
                 }
@@ -123,10 +123,6 @@ private extension AddProductFromImageView {
         static let regenerateButtonTitle = NSLocalizedString(
             "Regenerate",
             comment: "Regenerate button on the add product from image form to regenerate product details."
-        )
-        static let scannedTextListInfo = NSLocalizedString(
-            "Tweak your text: Unselect scans you don't need or tap to edit",
-            comment: "Info text about the scanned text list on the add product from image form."
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -69,6 +69,7 @@ struct AddProductFromImageView: View {
                         viewModel.generateProductDetails()
                     }
                     .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isGeneratingDetails))
+                    .disabled(viewModel.regenerateButtonEnabled == false)
 
                     // Error message.
                     if let errorMessage = viewModel.errorMessage {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -15,6 +15,11 @@ final class AddProductFromImageViewModel: ObservableObject {
         init(text: String, isSelected: Bool) {
             self.text = text
             self.isSelected = isSelected
+
+            /// Sets text to be unselected if it's empty
+            $text.filter { $0.isEmpty }
+                .map { _ in false }
+                .assign(to: &$isSelected)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -53,6 +53,7 @@ final class AddProductFromImageViewModel: ObservableObject {
 
     @Published var scannedTexts: [ScannedTextViewModel] = []
 
+    /// Validation to keep track of texts that are non-empty and selected.
     @Published private var scannedTextValidation: [String: Bool] = [:]
     @Published private(set) var regenerateButtonEnabled: Bool = false
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -60,6 +60,10 @@ final class AddProductFromImageViewModel: ObservableObject {
     @Published private(set) var isGeneratingDetails: Bool = false
     @Published private(set) var errorMessage: String? = Localization.defaultError
 
+    var scannedTextInstruction: String {
+        selectedScannedTexts.isEmpty ? Localization.scannedTextListEmpty : Localization.scannedTextListInfo
+    }
+
     private var selectedScannedTexts: [String] {
         scannedTexts.filter { $0.isSelected && $0.text.isNotEmpty }.map { $0.text }
     }
@@ -210,6 +214,14 @@ private extension AddProductFromImageViewModel {
         static let defaultError = NSLocalizedString(
             "Error generating product details. Please try again.",
             comment: "Default error message on the add product from image form."
+        )
+        static let scannedTextListInfo = NSLocalizedString(
+            "Tweak your text: Unselect scans you don't need or tap to edit",
+            comment: "Info text about the scanned text list on the add product from image form."
+        )
+        static let scannedTextListEmpty = NSLocalizedString(
+            "Select one or more scans to generate product details",
+            comment: "Instruction to select scanned text for product detail generation on the add product from image form."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -187,7 +187,7 @@ private extension AddProductFromImageViewModel {
         }
     }
 
-    /// Disables regenerate button if there is at least one selected and non-empty text.
+    /// Enables regenerate button if there is at least one selected and non-empty text
     func configureRegenerateButton(with scannedTexts: [ScannedTextViewModel]) {
         scannedTextValidation = [:]
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -92,6 +92,10 @@ final class AddProductFromImageViewModel: ObservableObject {
             }
             .store(in: &subscriptions)
 
+        $scannedTextValidation
+            .map { $0.values.contains { $0 } }
+            .assign(to: &$regenerateButtonEnabled)
+
         $scannedTexts
             .sink { [weak self] texts in
                 self?.configureRegenerateButton(with: texts)
@@ -181,10 +185,6 @@ private extension AddProductFromImageViewModel {
     /// Disables regenerate button if there is at least one selected and non-empty text.
     func configureRegenerateButton(with scannedTexts: [ScannedTextViewModel]) {
         scannedTextValidation = [:]
-
-        $scannedTextValidation
-            .map { $0.values.contains { $0 } }
-            .assign(to: &$regenerateButtonEnabled)
 
         for text in scannedTexts {
             text.$text.combineLatest(text.$isSelected)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -59,7 +59,7 @@ final class AddProductFromImageViewModel: ObservableObject {
     @Published private(set) var isGeneratingDetails: Bool = false
     @Published private(set) var errorMessage: String? = Localization.defaultError
 
-    var selectedScannedTexts: [String] {
+    private var selectedScannedTexts: [String] {
         scannedTexts.filter { $0.isSelected && $0.text.isNotEmpty }.map { $0.text }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -357,6 +357,36 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         assertEqual(false, eventProperties["has_scanned_text"] as? Bool)
         assertEqual(false, eventProperties["has_generated_details"] as? Bool)
     }
+
+    // MARK: `regenerateButtonEnabled`
+
+    func test_regenerateButtonEnabled_returns_true_if_there_is_at_least_one_non_empty_and_selected_scanned_text() {
+        // Given
+        let viewModel = AddProductFromImageViewModel(siteID: 6,
+                                                     source: .productsTab,
+                                                     onAddImage: { _ in nil })
+
+        // When
+        viewModel.scannedTexts = [.init(text: "test", isSelected: true),
+                                  .init(text: "", isSelected: false)]
+
+        // Then
+        XCTAssertTrue(viewModel.regenerateButtonEnabled)
+    }
+
+    func test_regenerateButtonEnabled_returns_false_if_all_scanned_texts_are_either_empty_or_unselected() {
+        // Given
+        let viewModel = AddProductFromImageViewModel(siteID: 6,
+                                                     source: .productsTab,
+                                                     onAddImage: { _ in nil })
+
+        // When
+        viewModel.scannedTexts = [.init(text: "test", isSelected: false),
+                                  .init(text: "", isSelected: false)]
+
+        // Then
+        XCTAssertFalse(viewModel.regenerateButtonEnabled)
+    }
 }
 
 private extension AddProductFromImageViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -360,32 +360,33 @@ final class AddProductFromImageViewModelTests: XCTestCase {
 
     // MARK: `regenerateButtonEnabled`
 
-    func test_regenerateButtonEnabled_returns_true_if_there_is_at_least_one_non_empty_and_selected_scanned_text() {
+    func test_regenerateButtonEnabled_is_updated_correctly() {
         // Given
         let viewModel = AddProductFromImageViewModel(siteID: 6,
                                                      source: .productsTab,
                                                      onAddImage: { _ in nil })
+        let firstText: AddProductFromImageViewModel.ScannedTextViewModel = .init(text: "peach tea", isSelected: true)
+        let secondText: AddProductFromImageViewModel.ScannedTextViewModel = .init(text: "sweet", isSelected: true)
 
         // When
-        viewModel.scannedTexts = [.init(text: "test", isSelected: true),
-                                  .init(text: "", isSelected: false)]
+        viewModel.scannedTexts = [firstText, secondText]
 
         // Then
         XCTAssertTrue(viewModel.regenerateButtonEnabled)
-    }
 
-    func test_regenerateButtonEnabled_returns_false_if_all_scanned_texts_are_either_empty_or_unselected() {
-        // Given
-        let viewModel = AddProductFromImageViewModel(siteID: 6,
-                                                     source: .productsTab,
-                                                     onAddImage: { _ in nil })
-
-        // When
-        viewModel.scannedTexts = [.init(text: "test", isSelected: false),
-                                  .init(text: "", isSelected: false)]
+        // When: clear and unselect texts
+        firstText.text = ""
+        secondText.isSelected = false
 
         // Then
         XCTAssertFalse(viewModel.regenerateButtonEnabled)
+
+        // When: all texts are updated
+        viewModel.scannedTexts = [.init(text: "ramen", isSelected: true),
+                                  .init(text: "spicy", isSelected: true)]
+
+        // Then
+        XCTAssertTrue(viewModel.regenerateButtonEnabled)
     }
 }
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -609,7 +609,7 @@ private extension ProductStore {
     func generateProductDetails(siteID: Int64, scannedTexts: [String], completion: @escaping (Result<ProductDetailsFromScannedTexts, Error>) -> Void) {
         let prompt = [
             "Write a name and description of a product for an online store given the array of scanned text strings from a packaging photo at the end.",
-            "Return only a JSON with the name in `name` field, description in `description` field, " +
+            "Return only a JSON dictionary with the name in `name` field, description in `description` field, " +
             "and the detected language as the locale identifier in `language` field.",
             "The output should be in valid JSON format.",
             "Detect the language in the array and use the same language to write the name and description.",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10270 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds observation for scanned texts on the product details from image form. Changes include:
- Unselect text if it's edited to be empty.
- Observe scanned texts states to disable the Regenerate CTA.

Extra enhancements:
- Updated prompt to ask AI for JSON dictionary for product details explicitly.
- Updated form UI to look better:
  - Use the same icon for adding images to be consistent with the product form.
  - Move the product title and description to the same section to avoid distractions. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Since the feature is now under A/B test, please enable it by returning `true` in `AddProductFromImageEligibilityChecker`.
- Log in to a WPCom store and select the Products tab.
- Select the "+" button to add a new product.
- Select the manual option if the store has no product.
- Select Simple physical product in the product type action sheet.
- Notice the product details from image form is displayed.
- Select an image of a package.
- If any text can be detected from the image, they should be listed at the bottom of the form.
- Disable or clear each text. Notice that the Regenerate CTA is disabled.
- Enter any text again, the CTA should be enabled.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/ea011694-91a0-4f09-bd84-b70be5084660



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
