### PR TITLE
Order details: only make shipping label API requests if the order contains non-virtual products

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -575,10 +575,8 @@ extension OrderDetailsViewModel {
 
     @MainActor
     func syncShippingLabels() async {
-        guard orderContainsOnlyVirtualProducts == false else {
-            return
-        }
-        guard await isPluginActive(SitePlugin.SupportedPlugin.WCShip) else {
+        guard orderContainsOnlyVirtualProducts == false,
+              await isPluginActive(SitePlugin.SupportedPlugin.WCShip) else {
             return
         }
         return await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -52,6 +52,19 @@ final class OrderDetailsViewModel {
         return dataSource.products
     }
 
+    /// If the products for all order items have been loaded, checks if all products are virtual to skip shipping related syncs.
+    private var orderContainsOnlyVirtualProducts: Bool {
+        let productIDs = order.items.map { $0.productID }
+        let orderProducts = productIDs.compactMap { productID -> Product? in
+            products.first(where: { $0.productID == productID })
+        }
+        // Early returns `false` when the products haven't been fully loaded for all order items.
+        guard orderProducts.count == productIDs.count else {
+            return false
+        }
+        return orderProducts.allSatisfy { $0.virtual == true }
+    }
+
     /// Sorted order items
     ///
     private var items: [OrderItem] {
@@ -220,7 +233,8 @@ extension OrderDetailsViewModel {
         }
 
         group.enter()
-        syncShippingLabels() { _ in
+        Task { @MainActor in
+            await syncShippingLabels()
             group.leave()
         }
 
@@ -235,7 +249,9 @@ extension OrderDetailsViewModel {
         }
 
         group.enter()
-        checkShippingLabelCreationEligibility {
+        Task { @MainActor in
+            let isEligible = await checkShippingLabelCreationEligibility()
+            dataSource.isEligibleForShippingLabelCreation = isEligible
             onReloadSections?()
             group.leave()
         }
@@ -557,32 +573,30 @@ extension OrderDetailsViewModel {
         stores.dispatch(action)
     }
 
-    func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
-        // If the plugin is not active, there is no point on continuing with a request that will fail.
-        isPluginActive(SitePlugin.SupportedPlugin.WCShip) { [weak self] isActive in
-
-            guard let self = self, isActive else {
-                onCompletion?(nil)
-                return
-            }
-
-            let action = ShippingLabelAction.synchronizeShippingLabels(siteID: self.order.siteID, orderID: self.order.orderID) { result in
+    @MainActor
+    func syncShippingLabels() async {
+        guard orderContainsOnlyVirtualProducts == false else {
+            return
+        }
+        guard await isPluginActive(SitePlugin.SupportedPlugin.WCShip) else {
+            return
+        }
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(ShippingLabelAction.synchronizeShippingLabels(siteID: order.siteID, orderID: order.orderID) { result in
                 switch result {
-                case .success:
-                    ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .success))
-                    onCompletion?(nil)
-                case .failure(let error):
-                    ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .failed(error: error)))
-                    if error as? DotcomError == .noRestRoute {
-                        DDLogError("⚠️ Endpoint for synchronizing shipping labels is unreachable. WC Shipping plugin may be missing.")
-                    } else {
-                        DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
-                    }
-                    onCompletion?(error)
+                    case .success:
+                        ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .success))
+                        continuation.resume(returning: ())
+                    case .failure(let error):
+                        ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .failed(error: error)))
+                        if error as? DotcomError == .noRestRoute {
+                            DDLogError("⚠️ Endpoint for synchronizing shipping labels is unreachable. WC Shipping plugin may be missing.")
+                        } else {
+                            DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
+                        }
+                        continuation.resume(returning: ())
                 }
-            }
-            self.stores.dispatch(action)
-
+            })
         }
     }
 
@@ -632,24 +646,21 @@ extension OrderDetailsViewModel {
         }
     }
 
-    func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {
-        // If the plugin is not active, there is no point on continuing with a request that will fail.
-        isPluginActive(SitePlugin.SupportedPlugin.WCShip) { [weak self] isActive in
-            guard let self = self, isActive else {
-                onCompletion?()
-                return
-            }
-
-            let action = ShippingLabelAction.checkCreationEligibility(siteID: self.order.siteID,
-                                                                      orderID: self.order.orderID) { [weak self] isEligible in
-                self?.dataSource.isEligibleForShippingLabelCreation = isEligible
+    @MainActor
+    func checkShippingLabelCreationEligibility() async -> Bool {
+        guard orderContainsOnlyVirtualProducts == false,
+              await isPluginActive(SitePlugin.SupportedPlugin.WCShip) else {
+            return false
+        }
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(ShippingLabelAction.checkCreationEligibility(siteID: order.siteID,
+                                                                         orderID: order.orderID) { [weak self] isEligible in
                 if isEligible, let orderStatus = self?.orderStatus?.status.rawValue {
                     ServiceLocator.analytics.track(.shippingLabelOrderIsEligible,
                                                    withProperties: ["order_status": orderStatus])
                 }
-                onCompletion?()
-            }
-            self.stores.dispatch(action)
+                continuation.resume(returning: isEligible)
+            })
         }
     }
 
@@ -718,6 +729,17 @@ extension OrderDetailsViewModel {
         let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storageManager, matching: predicate, sortedBy: [])
         try? resultsController.performFetch()
         return !resultsController.isEmpty
+    }
+}
+
+private extension OrderDetailsViewModel {
+    @MainActor
+    func isPluginActive(_ plugin: String) async -> Bool {
+        await withCheckedContinuation { continuation in
+            isPluginActive(plugin) { isActive in
+                continuation.resume(returning: isActive)
+            }
+        }
     }
 }
 


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Part of #10272 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since API requests can add to the server load especially for self-hosted sites, we'd like to remove unnecessary API requests in the app. In order details, if the order only has virtual products, then there's no need to make the shipping label API requests.

## How

In `OrderDetailsViewModel`, `orderContainsOnlyVirtualProducts` was added to check if the order has any non-virtual products. Then, in the pre-existing `syncShippingLabels` and `checkShippingLabelCreationEligibility` functions, both skip the API request if the order doesn't have any non-virtual products. I updated the functions to use async/await so that we don't miss any completion paths.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Order without non-virtual products

Prerequisite: the store has the WC Shipping & Tax plugin, and an order with only virtual products

- Go to the Orders tab
- Tap on the order in the prerequisite --> there should not be a CTA to create a shipping label
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for `label`, there should be no results (no shipping label API requests were triggered)

### Order with non-virtual products

Prerequisite: the store has the WC Shipping & Tax plugin, and an order with at least one non-virtual products

- Go to the Orders tab
- Tap on the order in the prerequisite --> there should be a CTA to create a shipping label (either a button below the products or in the products' ellipsis menu). if the order already has any shipping labels, they should be shown
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for `label`, there should be 2 results for the creation eligibility and labels syncing

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

order with virtual products only | order with non-virtual products
-- | --
![Simulator Screenshot - iPhone 14 Pro - 2023-07-20 at 16 26 32](https://github.com/woocommerce/woocommerce-ios/assets/1945542/4e44a440-2bc1-49da-bad8-fbcf74ce0e49) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-20 at 16 26 44](https://github.com/woocommerce/woocommerce-ios/assets/1945542/4eeeb2b0-b713-4c3b-8799-9f946f4d0fe7)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
