### PR TITLE
My store tab: remove duplicate analytics API requests on app launch

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -183,7 +183,6 @@ final class DashboardViewController: UIViewController {
 
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
-            await reloadDashboardUIStatsVersion(forced: true)
         }
     }
 
@@ -847,13 +846,6 @@ extension DashboardViewController: UIAdaptivePresentationControllerDelegate {
 //
 private extension DashboardViewController {
     func onDashboardUIUpdate(forced: Bool, updatedDashboardUI: DashboardUI) {
-        defer {
-            Task { @MainActor [weak self] in
-                // Reloads data of the updated dashboard UI at the end.
-                await self?.reloadData(forced: true)
-            }
-        }
-
         // Optimistically hide the error banner any time the dashboard UI updates (not just pull to refresh)
         hideTopBannerView()
 
@@ -952,13 +944,6 @@ private extension DashboardViewController {
 // MARK: - Private Helpers
 //
 private extension DashboardViewController {
-    @MainActor
-    func reloadData(forced: Bool) async {
-        DDLogInfo("♻️ Requesting dashboard data be reloaded...")
-        await dashboardUI?.reloadData(forced: forced)
-        configureTitle()
-    }
-
     func observeSiteForUIUpdates() {
         ServiceLocator.stores.site.sink { [weak self] site in
             guard let self = self else { return }
@@ -970,7 +955,6 @@ private extension DashboardViewController {
             self.updateUI(site: site)
             self.trackDeviceTimezoneDifferenceWithStore(siteGMTOffset: site.gmtOffset)
             Task { @MainActor [weak self] in
-                await self?.reloadData(forced: true)
                 await self?.viewModel.updateBlazeBannerVisibility()
             }
         }.store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -47,7 +47,6 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
         }
     }
     private var selectedTimeRangeIndexSubscription: AnyCancellable?
-    private var reloadDataAfterSelectedTimeRangeSubscriptions: Set<AnyCancellable> = []
 
     private let pushNotificationsManager: PushNotesManager
     private var localOrdersSubscription: AnyCancellable?
@@ -131,15 +130,9 @@ extension StoreStatsAndTopPerformersViewController: DashboardUI {
     @MainActor
     func reloadData(forced: Bool) async {
         await withCheckedContinuation { continuation in
-            $selectedTimeRangeIndex
-                .compactMap { $0 }
-                .first()
-                .sink { [weak self] _ in
-                    self?.syncAllStats(forced: forced) { _ in
-                        continuation.resume(returning: ())
-                    }
-                }
-                .store(in: &reloadDataAfterSelectedTimeRangeSubscriptions)
+            syncAllStats(forced: forced) { _ in
+                continuation.resume(returning: ())
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10257 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When inspecting the API requests on the app launch, I noticed that there are two identical sets of analytics requests for the default tab within a few seconds. For performance reasons, we should only make analytics API requests for the default tab once.

## How

In `DashboardViewController`, there are several unnecessary triggers to reload the analytics data:
- `viewDidLoad`: since the view model's `statsVersion` defaults to v4, `StoreStatsAndTopPerformersViewController` is shown by default which triggers the syncs in `observeSelectedTimeRangeIndex` based on the last selected time range
- `onDashboardUIUpdate` after the dashboard UI is ready (either the deprecated stats UI `DeprecatedDashboardStatsViewController` or stats UI `StoreStatsAndTopPerformersViewController`): similar to above, `StoreStatsAndTopPerformersViewController` already triggers the syncs in `observeSelectedTimeRangeIndex`. When `DeprecatedDashboardStatsViewController` is shown, there's no data to load
- `observeSiteForUIUpdates` when the default site changes: the default `Site` doesn't have any properties that affect analytics. UI updates from site changes are mostly for the site name from my understanding

After this PR, the only triggers to reload the data are:

- When the stats UI is initially shown
- When the user taps to select a different time range tab, and if the last sync time for the same tab exceeds a minimum interval
- When the user pulls to refresh

While looking at the reload data code, I slightly refactored `StoreStatsAndTopPerformersViewController.reloadData(forced:)` to simplify the code.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has analytics enabled

- Launch the app in the logged-in state --> the stats should be shown shortly
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for the stats like `wc-analytics/reports/products` (since the WPCOM stats API requests can be skipped for stores not authenticated with WPCOM), there should only be one result
- Go back to the My store tab
- Tap on a different time range tab
- Pull down to refresh
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for the stats like `wc-analytics/reports/products`, there should be 3 results in total (2 more from the newly selected time range tab)
- Relaunch the app
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for the stats like `wc-analytics/reports/products`, there should be 1 result again

---

- [x] @jaclync tests that deprecated stats works as before after disabling and enabling analytics in `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
- [x] @jaclync tests that logging in to a site only triggers one set of analytics requests

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
