### PR TITLE
[Resilience] Customize error banner message when Jetpack connection is broken

### DIFF
--- a/Networking/Networking/Model/DotcomError.swift
+++ b/Networking/Networking/Model/DotcomError.swift
@@ -25,6 +25,13 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
     ///
     case noRestRoute
 
+    /// Jetpack is not connected
+    ///
+    /// This can be caused by an `unknown_token` error from Jetpack
+    /// or an `invalid_blog` error from WordPress.com Stats.
+    ///
+    case jetpackNotConnected
+
     /// Unknown: Represents an unmapped remote error. Capisce?
     ///
     case unknown(code: String, message: String?)
@@ -64,6 +71,9 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
             self = .statsModuleDisabled
         case Constants.restTermInvalid where message == ErrorMessages.resourceDoesNotExist:
             self = .resourceDoesNotExist
+        case Constants.unknownToken,
+            Constants.invalidBlog where message == ErrorMessages.jetpackNotConnected:
+            self = .jetpackNotConnected
         default:
             self = .unknown(code: error, message: message)
         }
@@ -79,6 +89,7 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
         static let requestFailed    = "http_request_failed"
         static let noRestRoute      = "rest_no_route"
         static let restTermInvalid  = "woocommerce_rest_term_invalid"
+        static let unknownToken     = "unknown_token"
     }
 
     /// Coding Keys
@@ -94,6 +105,7 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
         static let statsModuleDisabled = "This blog does not have the Stats module enabled"
         static let noStatsPermission = "user cannot view stats"
         static let resourceDoesNotExist = "Resource does not exist."
+        static let jetpackNotConnected = "This blog does not have Jetpack connected"
     }
 }
 
@@ -120,6 +132,8 @@ extension DotcomError: CustomStringConvertible {
             return NSLocalizedString("Dotcom Stats Module Disabled", comment: "WordPress.com error thrown when the Jetpack site stats module is disabled.")
         case .resourceDoesNotExist:
             return NSLocalizedString("Dotcom Resource does not exist", comment: "WordPress.com error thrown when a requested resource does not exist remotely.")
+        case .jetpackNotConnected:
+            return NSLocalizedString("Jetpack Not Connected", comment: "WordPress.com error thrown when Jetpack is not connected.")
         case .unknown(let code, let message):
             let theMessage = message ?? String()
             let messageFormat = NSLocalizedString(
@@ -136,15 +150,12 @@ extension DotcomError: CustomStringConvertible {
 //
 public func ==(lhs: DotcomError, rhs: DotcomError) -> Bool {
     switch (lhs, rhs) {
-    case (.requestFailed, .requestFailed):
-        return true
-    case (.unauthorized, .unauthorized):
-        return true
-    case (.noRestRoute, .noRestRoute):
-        return true
-    case (.noStatsPermission, .noStatsPermission):
-        return true
-    case (.statsModuleDisabled, .statsModuleDisabled):
+    case (.requestFailed, .requestFailed),
+        (.unauthorized, .unauthorized),
+        (.noRestRoute, .noRestRoute),
+        (.noStatsPermission, .noStatsPermission),
+        (.statsModuleDisabled, .statsModuleDisabled),
+        (.jetpackNotConnected, .jetpackNotConnected):
         return true
     case let (.unknown(codeLHS, _), .unknown(codeRHS, _)):
         return codeLHS == codeRHS

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 - [Internal] Orders: Improved error message when orders can't be loaded due to a parsing (decoding) error. [https://github.com/woocommerce/woocommerce-ios/pull/10252]
 - [**] Product discounts: Users can now add discounts to products when creating an order. [https://github.com/woocommerce/woocommerce-ios/pull/10244]
 - [Internal] Fixed a bug preventing the "We couldn't load your data" error banner from appearing on the My store dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/10262]
-
+- [Internal] Errors: Improved error message and troubleshooting guide when the Jetpack connection is broken. [https://github.com/woocommerce/woocommerce-ios/pull/10275]
 - [Internal] A new way to create a product from an image using AI is being A/B tested. [https://github.com/woocommerce/woocommerce-ios/pull/10253]
 
 14.5

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -243,6 +243,10 @@ extension WooConstants {
         ///
         case troubleshootErrorLoadingData = "https://docs.woocommerce.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
 
+        /// URL for troubleshooting documentation used in error banner when Jetpack is not connected
+        ///
+        case troubleshootJetpackConnection = "https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
+
         /// URL for roles and permissions information
         ///
         case rolesAndPermissionsInfo = "https://woocommerce.com/posts/a-guide-to-woocommerce-user-roles-permissions-and-security/"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -677,7 +677,7 @@ private extension DashboardViewController {
                                                                 expandedStateChangeHandler: {},
                                                                 onTroubleshootButtonPressed: { [weak self] in
             guard let self else { return }
-            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
+            WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
         },
                                                                 onContactSupportButtonPressed: { [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -785,7 +785,7 @@ private extension OrderListViewController {
         onTroubleshootButtonPressed: { [weak self] in
             guard let self = self else { return }
 
-            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
+            WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
         },
         onContactSupportButtonPressed: { [weak self] in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -765,7 +765,7 @@ private extension ProductsViewController {
             onTroubleshootButtonPressed: { [weak self] in
                 guard let self = self else { return }
 
-                WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
+                WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
             },
             onContactSupportButtonPressed: { [weak self] in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -265,7 +265,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
                                                               onTroubleshootButtonPressed: { [weak self] in
             guard let self else { return }
 
-            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
+            WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
         },
                                                               onContactSupportButtonPressed: { [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -530,7 +530,7 @@ extension ReviewsViewController: SyncingCoordinatorDelegate {
         },
                                                               onTroubleshootButtonPressed: { [weak self] in
             guard let self else { return }
-            WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: self)
+            WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
         },
                                                               onContactSupportButtonPressed: { [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import enum Networking.DotcomError
 
 /// Creates a top banner to be used when there is an error loading data on a screen.
 /// The banner has two action buttons: "Troubleshoot" and "Contact Support."
@@ -7,11 +8,19 @@ struct ErrorTopBannerFactory {
                                 expandedStateChangeHandler: @escaping () -> Void,
                                 onTroubleshootButtonPressed: @escaping () -> Void,
                                 onContactSupportButtonPressed: @escaping () -> Void) -> TopBannerView {
-        let errorType: ErrorType = error is DecodingError ? .decodingError : .generalError
+        let errorType: ErrorType = {
+            if error is DecodingError {
+                return .decodingError
+            } else if error as? DotcomError == .jetpackNotConnected {
+                return .jetpackConnectionError
+            } else {
+                return .generalError
+            }
+        }()
         let troubleshootAction = TopBannerViewModel.ActionButton(title: Localization.troubleshoot, action: { _ in onTroubleshootButtonPressed() })
         let contactSupportAction = TopBannerViewModel.ActionButton(title: Localization.contactSupport, action: { _ in onContactSupportButtonPressed() })
         let actions = [troubleshootAction, contactSupportAction]
-        let viewModel = TopBannerViewModel(title: Localization.title,
+        let viewModel = TopBannerViewModel(title: errorType.title,
                                            infoText: errorType.info,
                                            icon: .infoOutlineImage,
                                            isExpanded: true,
@@ -27,13 +36,33 @@ struct ErrorTopBannerFactory {
 
 extension ErrorTopBannerFactory {
     enum ErrorType {
+        /// An error decoding the JSON response
+        ///
         case decodingError
+
+        /// A broken Jetpack connection error
+        ///
+        case jetpackConnectionError
+
+        /// Any other error
+        ///
         case generalError
+
+        var title: String {
+            switch self {
+            case .jetpackConnectionError:
+                return Localization.jetpackConnectionTitle
+            default:
+                return Localization.generalTitle
+            }
+        }
 
         var info: String {
             switch self {
             case .decodingError:
                 return Localization.decodingInfo
+            case .jetpackConnectionError:
+                return Localization.jetpackConnectionInfo
             case .generalError:
                 return Localization.generalInfo
             }
@@ -41,13 +70,18 @@ extension ErrorTopBannerFactory {
     }
 
     enum Localization {
-        static let title = NSLocalizedString("We couldn't load your data",
-                                             comment: "The title of the Error Loading Data banner")
+        static let generalTitle = NSLocalizedString("We couldn't load your data",
+                                                    comment: "The title of the Error Loading Data banner")
+        static let jetpackConnectionTitle = NSLocalizedString("We couldn't connect to your store",
+                                                              comment: "The title of the Error Loading Data banner when there is a Jetpack connection error")
         static let generalInfo = NSLocalizedString("Please try again later or reach out to us and we'll be happy to assist you!",
                                                    comment: "The info of the Error Loading Data banner")
         static let decodingInfo = NSLocalizedString("This could be related to a conflict with a plugin. " +
                                                     "Please try again later or reach out to us and we'll be happy to assist you!",
                                                     comment: "The info on the Error Loading Data banner when there was a decoding error.")
+        static let jetpackConnectionInfo = NSLocalizedString("There is a problem with your store's Jetpack connection. " +
+                                                             "Please reconnect Jetpack or reach out to us and we'll be happy to assist you!",
+                                                             comment: "The info on the Error Loading Data banner when there was a Jetpack connection error.")
         static let troubleshoot = NSLocalizedString("Troubleshoot",
                                                     comment: "The title of the button to get troubleshooting information in the Error Loading Data banner")
         static let contactSupport = NSLocalizedString("Contact support",

--- a/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/ErrorTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/ErrorTopBannerFactoryTests.swift
@@ -1,11 +1,13 @@
 import XCTest
 @testable import WooCommerce
+import enum Networking.DotcomError
 
 class ErrorTopBannerFactoryTests: XCTestCase {
 
     func test_top_banner_has_two_actions() throws {
         // Given
-        let topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
+        let topBannerView = ErrorTopBannerFactory.createTopBanner(for: SampleError.first,
+                                                                  expandedStateChangeHandler: {},
                                                                   onTroubleshootButtonPressed: {},
                                                                   onContactSupportButtonPressed: {})
 
@@ -19,7 +21,8 @@ class ErrorTopBannerFactoryTests: XCTestCase {
     func test_tapping_top_banner_troubleshoot_button_triggers_callback() throws {
         // Given
         var isTroubleshootButtonPressed = false
-        let topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
+        let topBannerView = ErrorTopBannerFactory.createTopBanner(for: SampleError.first,
+                                                                  expandedStateChangeHandler: {},
                                                                   onTroubleshootButtonPressed: {
                                                                     isTroubleshootButtonPressed = true
                                                                   },
@@ -35,7 +38,8 @@ class ErrorTopBannerFactoryTests: XCTestCase {
     func test_tapping_top_banner_contact_support_button_triggers_callback() throws {
         // Given
         var isContactSupportButtonPressed = false
-        let topBannerView = ErrorTopBannerFactory.createTopBanner(expandedStateChangeHandler: {},
+        let topBannerView = ErrorTopBannerFactory.createTopBanner(for: SampleError.first,
+                                                                  expandedStateChangeHandler: {},
                                                                   onTroubleshootButtonPressed: {},
                                                                   onContactSupportButtonPressed: {
                                                                     isContactSupportButtonPressed = true
@@ -46,5 +50,21 @@ class ErrorTopBannerFactoryTests: XCTestCase {
         let mirrorView = try TopBannerViewMirror(from: view)
         mirrorView.actionButtons[1].sendActions(for: .touchUpInside)
         XCTAssertTrue(isContactSupportButtonPressed)
+    }
+
+    func test_troubleshootUrl_for_general_error_returns_expected_Url() {
+        // Given
+        let troubleshootUrl = ErrorTopBannerFactory.troubleshootUrl(for: SampleError.first)
+
+        // Then
+        XCTAssertEqual(troubleshootUrl, WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+    }
+
+    func test_troubleshootUrl_for_jetpack_connection_error_returns_expected_Url() {
+        // Given
+        let troubleshootUrl = ErrorTopBannerFactory.troubleshootUrl(for: DotcomError.jetpackNotConnected)
+
+        // Then
+        XCTAssertEqual(troubleshootUrl, WooConstants.URLs.troubleshootJetpackConnection.asURL())
     }
 }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -496,11 +496,13 @@ public enum StatsStoreV4Error: Error {
 ///
 /// - noPermission: the user has no permission to view site stats.
 /// - statsModuleDisabled: Jetpack site stats module is disabled for the site.
+/// - jetpackNotConnected: Jetpack is not connected on the site.
 /// - unknown: other error cases.
 ///
 public enum SiteStatsStoreError: Error {
     case statsModuleDisabled
     case noPermission
+    case jetpackNotConnected
     case unknown
 
     init(error: Error) {
@@ -513,6 +515,8 @@ public enum SiteStatsStoreError: Error {
             self = .noPermission
         case .statsModuleDisabled:
             self = .statsModuleDisabled
+        case .jetpackNotConnected:
+            self = .jetpackNotConnected
         default:
             self = .unknown
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10170
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When a store's Jetpack connection is broken, we now show a specific message in the error banner:

> **We couldn't connect to your store**
> There is a problem with your store's Jetpack connection. Please reconnect Jetpack or reach out to us and we'll be happy to assist you!

The "Troubleshoot" link in the banner also goes to the related support guide: https://jetpack.com/support/reconnecting-reinstalling-jetpack/

### Changes

* Adds a `jetpackNotConnected` case to `DotcomError` for the API responses related to a broken connection.
* Updates `ErrorTopBannerFactory.ErrorType` to return the specific title, message, and troubleshoot URL for a given error.
* Updates the `onTroubleshootButtonPressed` callback where the banner is used, to launch the right troubleshoot URL for the error.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a jurassic.ninja site with WooCommerce and Jetpack, and connect Jetpack to your WordPress.com account.
2. Build and run the app.
3. Select the test site you created to open it in the app.
4. Make any change on the test site to break the Jetpack connection (e.g. you can deactivate the Jetpack plugin or disconnect Jetpack from your WordPress.com account in the Jetpack settings).
5. In the app, pull to refresh and confirm the error message appears with the expected title and message.
6. Tap the "Troubleshoot" button and confirm the expected support guide is launched.

Also tested:

* This error message does not appear when logged in to a store without Jetpack.
* This error message does not appear when a different error occurs (e.g. network connection is disabled).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Jetpack connection error|Troubleshoot link
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-07-20 at 14 07 50](https://github.com/woocommerce/woocommerce-ios/assets/8658164/b384a851-7695-4017-825f-84d0cba315b1)|![Simulator Screen Shot - iPhone 14 Pro - 2023-07-20 at 14 08 17](https://github.com/woocommerce/woocommerce-ios/assets/8658164/b359162c-9e18-4c4b-bb6a-abbae18be153)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
