### PR TITLE
[Local notifications] Track IAP eligibility in tracks events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+LocalNotification.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+LocalNotification.swift
@@ -1,0 +1,39 @@
+extension WooAnalyticsEvent {
+    enum LocalNotification {
+        /// Event property keys.
+        enum Key {
+            static let type = "type"
+            static let isIAPAvailable = "is_iap_available"
+        }
+
+        static func tapped(type: String, userInfo: [AnyHashable: Any]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localNotificationTapped,
+                              properties: getTracksProperties(type: type, userInfo: userInfo))
+        }
+
+        static func dismissed(type: String, userInfo: [AnyHashable: Any]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localNotificationDismissed,
+                              properties: getTracksProperties(type: type, userInfo: userInfo))
+        }
+
+        static func scheduled(type: String, userInfo: [AnyHashable: Any]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localNotificationScheduled,
+                                     properties: getTracksProperties(type: type, userInfo: userInfo))
+        }
+
+        static func canceled(type: String, userInfo: [AnyHashable: Any]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localNotificationCanceled,
+                                     properties: getTracksProperties(type: type, userInfo: userInfo))
+        }
+
+        /// Helper method to build properties dictionary
+        ///
+        static private func getTracksProperties(type: String, userInfo: [AnyHashable: Any]) -> [String: WooAnalyticsEventPropertyType] {
+            var properties: [String: WooAnalyticsEventPropertyType] = [Key.type: type]
+            if let isIapAvailable = userInfo[Key.isIAPAvailable] as? Bool {
+                properties[Key.isIAPAvailable] = isIapAvailable
+            }
+            return properties
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -863,7 +863,9 @@ private extension StoreCreationCoordinator {
     }
 
     func cancelLocalNotificationWhenStoreIsReady() {
-        localNotificationScheduler.cancel(scenario: Constants.LocalNotificationScenario.storeCreationComplete)
+        Task {
+            await localNotificationScheduler.cancel(scenario: Constants.LocalNotificationScenario.storeCreationComplete)
+        }
     }
 
     func scheduleLocalNotificationToSubscribeFreeTrial(storeName: String) {
@@ -882,7 +884,9 @@ private extension StoreCreationCoordinator {
     }
 
     func cancelLocalNotificationToSubscribeFreeTrial(storeName: String) {
-        localNotificationScheduler.cancel(scenario: LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName))
+        Task {
+            await localNotificationScheduler.cancel(scenario: LocalNotification.Scenario.oneDayAfterStoreCreationNameWithoutFreeTrial(storeName: storeName))
+        }
     }
 }
 

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -80,6 +80,7 @@ struct LocalNotification {
     /// Holds `userInfo` dictionary keys
     enum UserInfoKey {
         static let storeName = "storeName"
+        static let isIAPAvailable = WooAnalyticsEvent.LocalNotification.Key.isIAPAvailable
     }
 }
 

--- a/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
@@ -40,8 +40,8 @@ final class LocalNotificationScheduler {
 
     /// Cancels a local notification of the given scenario.
     /// - Parameter scenario: The scenario to cancel.
-    func cancel(scenario: LocalNotification.Scenario) {
-        pushNotesManager.cancelLocalNotification(scenarios: [scenario])
+    func cancel(scenario: LocalNotification.Scenario) async {
+        await pushNotesManager.cancelLocalNotification(scenarios: [scenario])
     }
 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -363,11 +363,16 @@ extension PushNotificationsManager {
         await requestLocalNotification(notification, trigger: trigger)
     }
 
-    func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) {
-        let center = UNUserNotificationCenter.current()
-        center.removePendingNotificationRequests(withIdentifiers: scenarios.map { $0.identifier })
-        scenarios.map(\.identifier).forEach { identifier in
-            analytics.track(.localNotificationCanceled, withProperties: ["type": LocalNotification.Scenario.identifierForAnalytics(identifier)])
+    func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) async {
+        let center = configuration.userNotificationsCenter
+        let pending = await center.pendingNotificationRequests().filter {
+            scenarios.map { LocalNotification.Scenario.identifierForAnalytics($0.identifier) }
+                .contains(LocalNotification.Scenario.identifierForAnalytics($0.identifier))
+        }
+        center.removePendingNotificationRequests(withIdentifiers: pending.map { $0.identifier })
+        pending.forEach { request in
+            analytics.track(event: .LocalNotification.canceled(type: LocalNotification.Scenario.identifierForAnalytics(request.identifier),
+                                                               userInfo: request.content.userInfo))
         }
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -346,9 +346,8 @@ extension PushNotificationsManager {
                                             trigger: trigger)
         do {
             try await center.add(request)
-            analytics.track(.localNotificationScheduled, withProperties: [
-                "type": LocalNotification.Scenario.identifierForAnalytics(notification.scenario.identifier)
-            ])
+            analytics.track(event: .LocalNotification.scheduled(type: LocalNotification.Scenario.identifierForAnalytics(notification.scenario.identifier),
+                                                                userInfo: notification.userInfo))
         } catch {
             DDLogError("⛔️ Unable to request a local notification: \(error)")
         }
@@ -376,8 +375,9 @@ extension PushNotificationsManager {
         let center = configuration.userNotificationsCenter
         let pendingNotifications = await center.pendingNotificationRequests()
         removeAllNotifications()
-        pendingNotifications.map(\.identifier).forEach { identifier in
-            analytics.track(.localNotificationCanceled, withProperties: ["type": LocalNotification.Scenario.identifierForAnalytics(identifier)])
+        pendingNotifications.forEach { request in
+            analytics.track(event: .LocalNotification.canceled(type: LocalNotification.Scenario.identifierForAnalytics(request.identifier),
+                                                               userInfo: request.content.userInfo))
         }
     }
 }

--- a/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
+++ b/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
@@ -28,6 +28,8 @@ protocol UserNotificationsCenterAdapter {
 
     // Adds a notification request to be presented at a scheduled time.
     func add(_ request: UNNotificationRequest) async throws
+
+    func removePendingNotificationRequests(withIdentifiers: [String])
 }
 
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -101,7 +101,7 @@ protocol PushNotesManager {
 
     /// Cancels a local notification that was previously scheduled.
     /// - Parameter scenarios: the scenarios of the notification to be cancelled.
-    func cancelLocalNotification(scenarios: [LocalNotification.Scenario])
+    func cancelLocalNotification(scenarios: [LocalNotification.Scenario]) async
 
     /// Cancels all local notifications that were previously scheduled.
     func cancelAllNotifications() async

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -351,16 +351,15 @@ private extension AppCoordinator {
         let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires
         let twentyFourHoursAfterFreeTrialSubscribed = LocalNotification.Scenario.Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed
 
+        let userInfo = response.notification.request.content.userInfo
         guard response.actionIdentifier != UNNotificationDismissActionIdentifier else {
-            analytics.track(.localNotificationDismissed, withProperties: [
-                "type": LocalNotification.Scenario.identifierForAnalytics(identifier)
-            ])
+            analytics.track(event: .LocalNotification.dismissed(type: LocalNotification.Scenario.identifierForAnalytics(identifier),
+                                                                                 userInfo: userInfo))
             return
         }
 
-        analytics.track(.localNotificationTapped, withProperties: [
-            "type": LocalNotification.Scenario.identifierForAnalytics(identifier)
-        ])
+        analytics.track(event: .LocalNotification.tapped(type: LocalNotification.Scenario.identifierForAnalytics(identifier),
+                                                                          userInfo: userInfo))
 
         switch identifier {
         case let identifier where identifier.hasPrefix(oneDayBeforeFreeTrialExpiresIdentifier):

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -43,12 +43,16 @@ final class StorePlanSynchronizer: ObservableObject {
     ///
     private var subscriptions: Set<AnyCancellable> = []
 
+    private let inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol
+
     init(stores: StoresManager = ServiceLocator.stores,
          timeZone: TimeZone = .current,
-         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
+         inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
         self.stores = stores
         self.localNotificationScheduler = .init(pushNotesManager: pushNotesManager, stores: stores)
         self.timeZone = timeZone
+        self.inAppPurchaseManager = inAppPurchaseManager
 
         stores.site.sink { [weak self] site in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -142,12 +142,13 @@ private extension StorePlanSynchronizer {
     }
 
     func schedule24HrsAfterSubscribedNotification(siteID: Int64, subscribedDate: Date) {
-        let notification = LocalNotification(scenario: .twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID))
-
         /// Scheduled 24 hrs after subscribed date
         let triggerDateComponents = subscribedDate.addingTimeInterval(Constants.oneDayTimeInterval).dateAndTimeComponents()
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDateComponents, repeats: false)
         Task {
+            let iapAvailable = await inAppPurchaseManager.inAppPurchasesAreSupported()
+            let notification = LocalNotification(scenario: .twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID),
+                                                 userInfo: [LocalNotification.UserInfoKey.isIAPAvailable: iapAvailable])
             await localNotificationScheduler.schedule(notification: notification,
                                                       trigger: trigger,
                                                       remoteFeatureFlag: .twentyFourHoursAfterFreeTrialSubscribed,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2263,6 +2263,7 @@
 		EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */; };
 		EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */; };
 		EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */; };
+		EE5A0A1C2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */; };
 		EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6B2AD029DC522300048A8F /* StoreCreationProgressView.swift */; };
 		EE6B2AD329DD285A00048A8F /* StoreCreationProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */; };
 		EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */; };
@@ -4668,6 +4669,7 @@
 		EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandler.swift; sourceTree = "<group>"; };
 		EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ApplicationPassword.swift"; sourceTree = "<group>"; };
 		EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandlerTests.swift; sourceTree = "<group>"; };
+		EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+LocalNotification.swift"; sourceTree = "<group>"; };
 		EE6B2AD029DC522300048A8F /* StoreCreationProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressView.swift; sourceTree = "<group>"; };
 		EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModel.swift; sourceTree = "<group>"; };
 		EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdaterTests.swift; sourceTree = "<group>"; };
@@ -7784,6 +7786,7 @@
 				02D4472B2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift */,
 				0225091C2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift */,
 				DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */,
+				EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -12542,6 +12545,7 @@
 				B9F3DAAF29BB73CD00DDD545 /* CreateOrderAppIntent.swift in Sources */,
 				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,
 				7E7C5F862719A93C00315B61 /* ProductCategoryViewModelBuilder.swift in Sources */,
+				EE5A0A1C2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift in Sources */,
 				02E3B63129066858007E0F13 /* StoreCreationCoordinator.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
@@ -69,6 +69,10 @@ final class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
     func add(_ request: UNNotificationRequest) async throws {
         notificationRequests.append(request)
     }
+
+    func removePendingNotificationRequests(withIdentifiers: [String]) {
+
+    }
 }
 
 /// Mock coder to initialize UNNotificationSettings

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -642,7 +642,8 @@ final class PushNotificationsManagerTests: XCTestCase {
             userNotificationsCenter: mockCenter
         ), analytics: WooAnalytics(analyticsProvider: analytics))
         let siteID: Int64 = 123
-        let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
+        let notification = LocalNotification(scenario: .twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID),
+                                             userInfo: [LocalNotification.UserInfoKey.isIAPAvailable: true])
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Date().timeIntervalSinceNow + 1, repeats: false)
 
         // When
@@ -651,10 +652,11 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.localNotificationScheduled.rawValue }))
         let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-        assertEqual(LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
+        assertEqual(LocalNotification.Scenario.Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed, eventProperties["type"] as? String)
+        XCTAssertTrue(try XCTUnwrap(eventProperties["is_iap_available"] as? Bool))
     }
 
-    func test_cancelLocalNotification_tracks_local_notification_canceled() throws {
+    func test_cancelLocalNotification_tracks_local_notification_canceled() async throws {
         // Given
         let mockCenter = MockUserNotificationsCenterAdapter()
         let analytics = MockAnalyticsProvider()
@@ -665,13 +667,20 @@ final class PushNotificationsManagerTests: XCTestCase {
             userNotificationsCenter: mockCenter
         ), analytics: WooAnalytics(analyticsProvider: analytics))
 
+        let siteID: Int64 = 123
+        let notification = LocalNotification(scenario: .twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID),
+                                             userInfo: [LocalNotification.UserInfoKey.isIAPAvailable: true])
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Date().timeIntervalSinceNow + 1, repeats: false)
+        await manager.requestLocalNotification(notification, trigger: trigger)
+
         // When
-        manager.cancelLocalNotification(scenarios: [.storeCreationComplete])
+        await manager.cancelLocalNotification(scenarios: [.twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID)])
 
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.localNotificationCanceled.rawValue }))
         let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-        assertEqual(LocalNotification.Scenario.storeCreationComplete.identifier, eventProperties["type"] as? String)
+        assertEqual(LocalNotification.Scenario.Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed, eventProperties["type"] as? String)
+        XCTAssertTrue(try XCTUnwrap(eventProperties["is_iap_available"] as? Bool))
     }
 
     func test_cancelAllNotifications_tracks_local_notification_canceled() async throws {
@@ -685,7 +694,8 @@ final class PushNotificationsManagerTests: XCTestCase {
             userNotificationsCenter: mockCenter
         ), analytics: WooAnalytics(analyticsProvider: analytics))
         let siteID: Int64 = 123
-        let notification = LocalNotification(scenario: .oneDayAfterFreeTrialExpires(siteID: siteID))
+        let notification = LocalNotification(scenario: .twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID),
+                                             userInfo: [LocalNotification.UserInfoKey.isIAPAvailable: true])
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Date().timeIntervalSinceNow + 1, repeats: false)
 
         // When
@@ -695,7 +705,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.localNotificationCanceled.rawValue }))
         let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-        assertEqual(LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires, eventProperties["type"] as? String)
+        assertEqual(LocalNotification.Scenario.Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed, eventProperties["type"] as? String)
+        XCTAssertTrue(try XCTUnwrap(eventProperties["is_iap_available"] as? Bool))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
@@ -110,7 +110,8 @@ final class StorePlanSynchronizerTests: XCTestCase {
         // When
         _ = StorePlanSynchronizer(stores: stores,
                                   timeZone: timeZone,
-                                  pushNotesManager: pushNotesManager)
+                                  pushNotesManager: pushNotesManager,
+                                  inAppPurchaseManager: MockInAppPurchasesForWPComPlansManager(isIAPSupported: true))
 
         // Then
         waitUntil(timeout: 3) {
@@ -187,7 +188,8 @@ final class StorePlanSynchronizerTests: XCTestCase {
         // When
         let synchronizer = StorePlanSynchronizer(stores: stores,
                                                  timeZone: timeZone,
-                                                 pushNotesManager: pushNotesManager)
+                                                 pushNotesManager: pushNotesManager,
+                                                 inAppPurchaseManager: MockInAppPurchasesForWPComPlansManager(isIAPSupported: true))
 
         // Then
         waitUntil(timeout: 3) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10265 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Adds a property using `is_iap_available` key in local notification tracks event.

Changes
- Added a helper extension file to handle local notification tracks.
- Add IAP eligibility to the notification's userInfo dictionary.
- Use the value from the userInfo dictionary to track the event for all local notification cases. (Schedule, tap, dismiss, cancel)
- Track cancel event only if there is a pending notification present. 

## Testing instructions

- For easier testing, please run the app on a physical device.
- Launch the app, log in, and create a new free trial site from the site picker.
- After successfully landing on the "My Store" page. Validate that the following event is tracked. 
    - `is_iap_available` value will be true if you are testing from US. It is currently `true` for me. And I believe this is because I configured a sandbox in App Store Connect for testing. Kindly let me know what you see there.
```
Tracked local_notification_scheduled, properties: [AnyHashable("is_iap_available"): true, AnyHashable("type"): "twenty_four_hours_after_free_trial_subscribed", AnyHashable("blog_id"): 123456, AnyHashable("is_wpcom_store"): true]
```
- Send the app to the background.
- Open Settings, and change the time of the device to 23 hr 58 mins from the current time ( which is the free trial subscription time). 
- Wait for 2 minutes, and then you should see a notification reminding to purchase a plan. 
- Tap on the notification, and the app should be open. Validate that the following event is tracked.
```
Tracked local_notification_scheduled, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("type"): "twenty_four_hours_after_free_trial_subscribed", AnyHashable("blog_id"): 123456789, AnyHashable("is_iap_available"): true]
```
- Kill the app, reset the time and launch the app.
- To test tracking cancellation, switch to a non-free trial site and switch back to the newly created free trial site to schedule a notification. (You can see `local_notification_scheduled` event being tracked)
- Switch to a non-free trial site again and validate that the following event is tracked.
```
Tracked local_notification_canceled, properties: [AnyHashable("type"): "twenty_four_hours_after_free_trial_subscribed", AnyHashable("is_wpcom_store"): true, AnyHashable("is_iap_available"): true, AnyHashable("blog_id"): 123456]
```

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/98c8ac0e-8e53-4990-a262-7b9175a8e8af" width="320"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
