### PR TITLE
[AI endpoint] Add `_fields` parameter

### DIFF
--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -129,6 +129,11 @@ private extension GenerativeContentRemote {
         static let token = "token"
         static let prompt = "prompt"
         static let feature = "feature"
+        static let fields = "_fields"
+    }
+
+    enum ParameterValue {
+        static let completion = "completion"
     }
 
     enum TokenExpiredError {

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -87,7 +87,8 @@ private extension GenerativeContentRemote {
                       token: String) async throws -> String {
         let parameters = [ParameterKey.token: token,
                           ParameterKey.prompt: base,
-                          ParameterKey.feature: feature.rawValue]
+                          ParameterKey.feature: feature.rawValue,
+                          ParameterKey.fields: ParameterValue.completion]
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
                                     method: .post,
                                     path: Path.textCompletion,
@@ -107,7 +108,8 @@ private extension GenerativeContentRemote {
         ].joined(separator: "\n")
         let parameters = [ParameterKey.token: token,
                           ParameterKey.prompt: prompt,
-                          ParameterKey.feature: feature.rawValue]
+                          ParameterKey.feature: feature.rawValue,
+                          ParameterKey.fields: ParameterValue.completion]
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
                                     method: .post,
                                     path: Path.textCompletion,

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -21,6 +21,23 @@ final class GenerativeContentRemoteTests: XCTestCase {
 
     // MARK: - `generateText`
 
+    func test_generateText_sends_correct_fields_value() async throws {
+        // Given
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-openai-query/jwt", filename: "jwt-token-success")
+        network.simulateResponse(requestUrlSuffix: "text-completion", filename: "generative-text-success")
+
+        // When
+        _ = try await remote.generateText(siteID: sampleSiteID,
+                                          base: "generate a product description for wapuu pencil",
+                                          feature: .productDescription)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
+        let fieldsValue = try XCTUnwrap(request.parameters?["_fields"] as? String)
+        XCTAssertEqual("completion", fieldsValue)
+    }
+
     func test_generateText_with_success_returns_generated_text() async throws {
         // Given
         let remote = GenerativeContentRemote(network: network)
@@ -107,6 +124,23 @@ final class GenerativeContentRemoteTests: XCTestCase {
     }
 
     // MARK: - `identifyLanguage`
+
+    func test_identifyLanguage_sends_correct_fields_value() async throws {
+        // Given
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-openai-query/jwt", filename: "jwt-token-success")
+        network.simulateResponse(requestUrlSuffix: "text-completion", filename: "identify-language-success")
+
+        // When
+        _ = try await remote.identifyLanguage(siteID: sampleSiteID,
+                                              string: "Woo is awesome.",
+                                              feature: .productDescription)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
+        let fieldsValue = try XCTUnwrap(request.parameters?["_fields"] as? String)
+        XCTAssertEqual("completion", fieldsValue)
+    }
 
     func test_identifyLanguage_with_success_returns_language_code() async throws {
         // Given

--- a/Networking/NetworkingTests/Responses/generative-text-success.json
+++ b/Networking/NetworkingTests/Responses/generative-text-success.json
@@ -1,13 +1,3 @@
 {
-  "completion": "The Wapuu Pencil is a perfect writing tool for those who love cute things.",
-  "previous_messages": [
-    {
-      "role": "user",
-      "content": "Hello!"
-    },
-    {
-      "role": "assistant",
-      "content": "Hi!"
-    }
-  ]
+  "completion": "The Wapuu Pencil is a perfect writing tool for those who love cute things."
 }

--- a/Networking/NetworkingTests/Responses/identify-language-success.json
+++ b/Networking/NetworkingTests/Responses/identify-language-success.json
@@ -1,13 +1,3 @@
 {
-  "completion": "en",
-  "previous_messages": [
-    {
-      "role": "user",
-      "content": "Hello!"
-    },
-    {
-      "role": "assistant",
-      "content": "Hi!"
-    }
-  ]
+  "completion": "en"
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10278 
<!-- Id number of the GitHub issue this PR addresses. -->

Makes use of the `_fields` parameter to receive only the `completion` field in response. 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions

- Login into using a store hosted on WPCOM (Free trial/Paid)
- Navigate to Products tab and open a product
- Tap "Write with AI" and try generating content
- Ensure that AI generation works as before
- Dismiss the description sheet and tap "Share" button
- From the presented share sheet tap "Write with AI" and try generating share message
- Ensure that AI generation works as before


## Screenshots

| Product description | Sharing message |
|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-12 at 17 27 27](https://github.com/woocommerce/woocommerce-ios/assets/524475/598b71d9-abf7-4b0e-b970-ffae7e068815) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-12 at 17 28 43](https://github.com/woocommerce/woocommerce-ios/assets/524475/c90a4907-713c-4197-9e14-4062b4088238) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
