### PR TITLE
Add `_fields` parameter to the `text-completion` API request

### DIFF
--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -87,7 +87,8 @@ private extension GenerativeContentRemote {
                       token: String) async throws -> String {
         let parameters = [ParameterKey.token: token,
                           ParameterKey.prompt: base,
-                          ParameterKey.feature: feature.rawValue]
+                          ParameterKey.feature: feature.rawValue,
+                          ParameterKey.fields: ParameterValue.fields]
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
                                     method: .post,
                                     path: Path.textCompletion,
@@ -107,7 +108,8 @@ private extension GenerativeContentRemote {
         ].joined(separator: "\n")
         let parameters = [ParameterKey.token: token,
                           ParameterKey.prompt: prompt,
-                          ParameterKey.feature: feature.rawValue]
+                          ParameterKey.feature: feature.rawValue,
+                          ParameterKey.fields: ParameterValue.fields]
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
                                     method: .post,
                                     path: Path.textCompletion,
@@ -129,6 +131,11 @@ private extension GenerativeContentRemote {
         static let token = "token"
         static let prompt = "prompt"
         static let feature = "feature"
+        static let fields = "_fields"
+    }
+
+    enum ParameterValue {
+        static let fields = "completion"
     }
 
     enum TokenExpiredError {

--- a/Networking/NetworkingTests/Responses/generative-text-success.json
+++ b/Networking/NetworkingTests/Responses/generative-text-success.json
@@ -1,13 +1,3 @@
 {
-  "completion": "The Wapuu Pencil is a perfect writing tool for those who love cute things.",
-  "previous_messages": [
-    {
-      "role": "user",
-      "content": "Hello!"
-    },
-    {
-      "role": "assistant",
-      "content": "Hi!"
-    }
-  ]
+  "completion": "The Wapuu Pencil is a perfect writing tool for those who love cute things."
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10278 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since we only need the completion text from the `text-completion` API response, we can pass `_fields=completion` parameter to optimize the performance on both the server and client sides a bit. This parameter is already supported p1689900922996459/1689004535.279309-slack-C056QSJJQ91.

## How

Added `_fields: completion` parameter to the request body in `GenerativeContentRemote` in the calls to the `text-completion` endpoint.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the products tab
- Tap on any editable product or tap `+` to create a product
- Tap `Write with AI` and enter some product name & features if needed
- Tap `Write with AI` --> the description should be generated as before
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for `text-completion`, the response should only contain the `completion` text without the `previous_message`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.