### PR TITLE
[UI Tests] - Update header text in documentation WebView

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -31,7 +31,7 @@ public final class PaymentsScreen: ScreenObject {
     }
 
     private let IPPDocumentationHeaderTextGetter: (XCUIApplication) -> XCUIElement = {
-        $0.staticTexts["Getting started with In-Person Payments with WooCommerce Payments"]
+        $0.staticTexts["Getting started with In-Person Payments with WooPayments"]
     }
 
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }


### PR DESCRIPTION
## Description
`test_load_learn_more_link()` in `PaymentsTests` test started failing, it was because the header text in the documentation page was updated from `"Getting started with In-Person Payments with WooCommerce Payments"` to `"Getting started with In-Person Payments with WooPayments"` 

The test is asserting the static text instead of an accessibility ID because the page is displayed in WebView.

## Testing instructions
`test_load_learn_more_link()` in `PaymentsTests` should start passing again in CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
