### PR TITLE
[Photo to Product] Show message when no text detected

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
@@ -41,11 +41,12 @@ struct AddProductFromImageFormImageView: View {
                 viewModel.addImage(from: source)
             })
 
-            Text(Localization.noTextDetected)
-                .font(.footnote)
-                .fontWeight(.semibold)
-                .foregroundColor(Color(uiColor: .secondaryLabel))
-                .renderedIf(viewModel.shouldShowNoTextDetectedMessage)
+            if let message = viewModel.textDetectionErrorMessage {
+                Text(message)
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundColor(Color(uiColor: .secondaryLabel))
+            }
         }
     }
 }
@@ -61,10 +62,6 @@ private extension AddProductFromImageFormImageView {
         static let packagingImageTip = NSLocalizedString(
             "Take a packaging photo to create product details with AI",
             comment: "Tip in the add product from image form to add a packaging image for AI-generated product details."
-        )
-        static let noTextDetected = NSLocalizedString(
-            "No text detected. Please select another packaging photo or enter product details manually.",
-            comment: "No text detected message on the add product from image form."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageFormImageView.swift
@@ -10,35 +10,43 @@ struct AddProductFromImageFormImageView: View {
     }
 
     var body: some View {
-        EditableImageView(imageState: viewModel.imageState,
-                          emptyContent: {
-            VStack(spacing: Layout.verticalSpacing) {
-                Image(uiImage: .addImage)
+        VStack {
+            EditableImageView(imageState: viewModel.imageState,
+                              emptyContent: {
+                VStack(spacing: Layout.verticalSpacing) {
+                    Image(uiImage: .addImage)
 
-                Label {
-                    Text(Localization.packagingImageTip)
-                } icon: {
-                    Image(uiImage: .sparklesImage)
-                }
-                .foregroundColor(.init(uiColor: .accent))
-                .fixedSize(horizontal: false, vertical: true)
-            }
-        })
-        .padding(Layout.padding)
-        .overlay(alignment: .topTrailing) {
-            Button {
-                isShowingActionSheet = true
-            } label: {
-                Image(systemName: "pencil.circle.fill")
-                    .symbolRenderingMode(.multicolor)
-                    .font(.system(size: Layout.editImageSize))
+                    Label {
+                        Text(Localization.packagingImageTip)
+                    } icon: {
+                        Image(uiImage: .sparklesImage)
+                    }
                     .foregroundColor(.init(uiColor: .accent))
-                    .renderedIf(viewModel.imageState.image != nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+            })
+            .padding(Layout.padding)
+            .overlay(alignment: .topTrailing) {
+                Button {
+                    isShowingActionSheet = true
+                } label: {
+                    Image(systemName: "pencil.circle.fill")
+                        .symbolRenderingMode(.multicolor)
+                        .font(.system(size: Layout.editImageSize))
+                        .foregroundColor(.init(uiColor: .accent))
+                        .renderedIf(viewModel.imageState.image != nil)
+                }
             }
+            .mediaSourceActionSheet(showsActionSheet: $isShowingActionSheet, selectMedia: { source in
+                viewModel.addImage(from: source)
+            })
+
+            Text(Localization.noTextDetected)
+                .font(.footnote)
+                .fontWeight(.semibold)
+                .foregroundColor(Color(uiColor: .secondaryLabel))
+                .renderedIf(viewModel.shouldShowNoTextDetectedMessage)
         }
-        .mediaSourceActionSheet(showsActionSheet: $isShowingActionSheet, selectMedia: { source in
-            viewModel.addImage(from: source)
-        })
     }
 }
 
@@ -53,6 +61,10 @@ private extension AddProductFromImageFormImageView {
         static let packagingImageTip = NSLocalizedString(
             "Take a packaging photo to create product details with AI",
             comment: "Tip in the add product from image form to add a packaging image for AI-generated product details."
+        )
+        static let noTextDetected = NSLocalizedString(
+            "No text detected. Please select another packaging photo or enter product details manually.",
+            comment: "No text detected message on the add product from image form."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -69,7 +69,7 @@ struct AddProductFromImageView: View {
                     .disabled(viewModel.regenerateButtonEnabled == false)
 
                     // Error message.
-                    if let errorMessage = viewModel.errorMessage {
+                    if let errorMessage = viewModel.textGenerationErrorMessage {
                         Text(errorMessage)
                             .font(.footnote)
                             .fontWeight(.semibold)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -45,6 +45,12 @@ struct AddProductFromImageView: View {
                     AddProductFromImageFormImageView(viewModel: viewModel)
                     Spacer()
                 }
+
+                Text(Localization.noTextDetected)
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundColor(Color(uiColor: .secondaryLabel))
+                    .renderedIf(viewModel.shouldShowNoTextDetectedMessage)
             }
 
             Section {
@@ -123,6 +129,10 @@ private extension AddProductFromImageView {
         static let regenerateButtonTitle = NSLocalizedString(
             "Regenerate",
             comment: "Regenerate button on the add product from image form to regenerate product details."
+        )
+        static let noTextDetected = NSLocalizedString(
+            "No text detected. Please select another packaging photo or enter product details manually.",
+            comment: "No text detected message on the add product from image form."
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -45,12 +45,6 @@ struct AddProductFromImageView: View {
                     AddProductFromImageFormImageView(viewModel: viewModel)
                     Spacer()
                 }
-
-                Text(Localization.noTextDetected)
-                    .font(.footnote)
-                    .fontWeight(.semibold)
-                    .foregroundColor(Color(uiColor: .secondaryLabel))
-                    .renderedIf(viewModel.shouldShowNoTextDetectedMessage)
             }
 
             Section {
@@ -129,10 +123,6 @@ private extension AddProductFromImageView {
         static let regenerateButtonTitle = NSLocalizedString(
             "Regenerate",
             comment: "Regenerate button on the add product from image form to regenerate product details."
-        )
-        static let noTextDetected = NSLocalizedString(
-            "No text detected. Please select another packaging photo or enter product details manually.",
-            comment: "No text detected message on the add product from image form."
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -151,11 +151,12 @@ private extension AddProductFromImageViewModel {
         Task { @MainActor in
             do {
                 let texts = try await imageTextScanner.scanText(from: image)
+                analytics.track(event: .AddProductFromImage.scanCompleted(source: addProductSource, scannedTextCount: texts.count))
+
                 guard texts.isNotEmpty else {
                     throw ScanError.noTextDetected
                 }
 
-                analytics.track(event: .AddProductFromImage.scanCompleted(source: addProductSource, scannedTextCount: texts.count))
                 scannedTexts = texts.map { .init(text: $0, isSelected: true) }
                 [nameViewModel, descriptionViewModel].forEach { $0.reset() }
                 generateProductDetails()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -115,7 +115,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.description, "Desc")
     }
 
-    func test_generatesProductDetails_failure_sets_errorMessage_and_resets_errorMessage_after_regenerating() {
+    func test_generatesProductDetails_failure_sets_textGenerationErrorMessage_and_resets_textGenerationErrorMessage_after_regenerating() {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let imageTextScanner = MockImageTextScanner(result: .success(["test"]))
@@ -138,15 +138,15 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         waitUntil {
             viewModel.isGeneratingDetails == false
         }
-        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertNotNil(viewModel.textGenerationErrorMessage)
 
         // When regenerating product details with success
         mockGenerateProductDetails(result: .success(.init(name: "", description: "", language: "")))
         viewModel.generateProductDetails()
 
-        // Then `errorMessage` is reset
+        // Then `textGenerationErrorMessage` is reset
         waitUntil {
-            viewModel.errorMessage == nil
+            viewModel.textGenerationErrorMessage == nil
         }
     }
 
@@ -192,19 +192,19 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         }
     }
 
-    // MARK: `shouldShowNoTextDetectedMessage`
+    // MARK: `textDetectionErrorMessage`
 
-    func test_shouldShowNoTextDetectedMessage_is_false_initially() throws {
+    func test_textDetectionErrorMessage_is_nil_initially() throws {
         // Given
         let viewModel = AddProductFromImageViewModel(siteID: 6, source: .productsTab, onAddImage: { _ in
             nil
         })
 
         // Then
-        XCTAssertFalse(viewModel.shouldShowNoTextDetectedMessage)
+        XCTAssertNil(viewModel.textDetectionErrorMessage)
     }
 
-    func test_shouldShowNoTextDetectedMessage_is_true_when_no_text_is_detected() throws {
+    func test_textDetectionErrorMessage_has_correct_string_value_when_no_text_is_detected() throws {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let imageTextScanner = MockImageTextScanner(result: .success([]))
@@ -222,10 +222,34 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(viewModel.shouldShowNoTextDetectedMessage)
+        XCTAssertEqual(viewModel.textDetectionErrorMessage,
+                       "No text detected. Please select another packaging photo or enter product details manually.")
     }
 
-    func test_shouldShowNoTextDetectedMessage_stays_false_when_scanneds_text_are_available_already() throws {
+    func test_textDetectionErrorMessage_has_correct_string_value_when_no_text_detection_fails() throws {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let error = NSError(domain: "test", code: 10000)
+        let imageTextScanner = MockImageTextScanner(result: .failure(error))
+        let viewModel = AddProductFromImageViewModel(siteID: 123,
+                                                     source: .productsTab,
+                                                     stores: stores,
+                                                     imageTextScanner: imageTextScanner,
+                                                     analytics: analytics,
+                                                     onAddImage: { _ in image })
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.textDetectionErrorMessage,
+                       "An error occurred while scanning the photo. Please select another packaging photo or enter product details manually.")
+    }
+
+    func test_textDetectionErrorMessage_stays_nil_when_scanneds_text_are_available_already() throws {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let imageTextScanner = MockImageTextScanner(result: .success([]))
@@ -244,10 +268,10 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertFalse(viewModel.shouldShowNoTextDetectedMessage)
+        XCTAssertNil(viewModel.textDetectionErrorMessage)
     }
 
-    func test_shouldShowNoTextDetectedMessage_is_reset_when_image_is_loaded_again() throws {
+    func test_textDetectionErrorMessage_is_reset_when_image_is_loaded_again() throws {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let imageTextScanner = MockImageTextScanner(result: .success([]))
@@ -265,13 +289,13 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(viewModel.shouldShowNoTextDetectedMessage)
+        XCTAssertEqual(viewModel.textDetectionErrorMessage, "No text detected. Please select another packaging photo or enter product details manually.")
 
         // When
         viewModel.addImage(from: .siteMediaLibrary)
 
         // Then
-        XCTAssertFalse(viewModel.shouldShowNoTextDetectedMessage)
+        XCTAssertNil(viewModel.textDetectionErrorMessage)
     }
 
     // MARK: Analytics

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -196,7 +196,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
 
     func test_displayed_event_is_tracked_when_the_view_model_is_init() throws {
         // When
-        let viewModel = AddProductFromImageViewModel(siteID: 123,
+        _ = AddProductFromImageViewModel(siteID: 123,
                                                      source: .productsTab,
                                                      analytics: analytics,
                                                      onAddImage: { _ in nil })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -192,6 +192,88 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: `shouldShowNoTextDetectedMessage`
+
+    func test_shouldShowNoTextDetectedMessage_is_false_initially() throws {
+        // Given
+        let viewModel = AddProductFromImageViewModel(siteID: 6, source: .productsTab, onAddImage: { _ in
+            nil
+        })
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowNoTextDetectedMessage)
+    }
+
+    func test_shouldShowNoTextDetectedMessage_is_true_when_no_text_is_detected() throws {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let imageTextScanner = MockImageTextScanner(result: .success([]))
+        let viewModel = AddProductFromImageViewModel(siteID: 123,
+                                                     source: .productsTab,
+                                                     stores: stores,
+                                                     imageTextScanner: imageTextScanner,
+                                                     analytics: analytics,
+                                                     onAddImage: { _ in image })
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowNoTextDetectedMessage)
+    }
+
+    func test_shouldShowNoTextDetectedMessage_stays_false_when_scanneds_text_are_available_already() throws {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let imageTextScanner = MockImageTextScanner(result: .success([]))
+        let viewModel = AddProductFromImageViewModel(siteID: 123,
+                                                     source: .productsTab,
+                                                     stores: stores,
+                                                     imageTextScanner: imageTextScanner,
+                                                     analytics: analytics,
+                                                     onAddImage: { _ in image })
+        viewModel.scannedTexts = [.init(text: "test", isSelected: false)]
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowNoTextDetectedMessage)
+    }
+
+    func test_shouldShowNoTextDetectedMessage_is_reset_when_image_is_loaded_again() throws {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let imageTextScanner = MockImageTextScanner(result: .success([]))
+        let viewModel = AddProductFromImageViewModel(siteID: 123,
+                                                     source: .productsTab,
+                                                     stores: stores,
+                                                     imageTextScanner: imageTextScanner,
+                                                     analytics: analytics,
+                                                     onAddImage: { _ in image })
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowNoTextDetectedMessage)
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowNoTextDetectedMessage)
+    }
+
     // MARK: Analytics
 
     func test_displayed_event_is_tracked_when_the_view_model_is_init() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -249,7 +249,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
                        "An error occurred while scanning the photo. Please select another packaging photo or enter product details manually.")
     }
 
-    func test_textDetectionErrorMessage_stays_nil_when_scanneds_text_are_available_already() throws {
+    func test_textDetectionErrorMessage_stays_nil_when_scanned_texts_are_available_already() throws {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let imageTextScanner = MockImageTextScanner(result: .success([]))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10269
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Shows a message when no text is detected. This lets users know that they can try uploading a different image to auto-generate product details. 

## Testing instructions
- Since the feature is now under A/B test, please enable it by returning `true` in `AddProductFromImageEligibilityChecker`.
- Log in to a WPCom store and select the Products tab.
- Select the "+" button to add a new product.
- Select the manual option if the store has no product.
- Select Simple physical product in the product type action sheet.
- Notice the product details from image form is displayed.
- Select an image without any text in it.
- Observe that you see the message `No text detected. Please select another packaging photo or enter product details manually.` when no text is detected from the image.
- Try selecting a different image with text in it.
- Observe that the message is not displayed anymore.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Light | Dark |
|--------|--------|
| ![IMG_CC3D85FFE28D-1](https://github.com/woocommerce/woocommerce-ios/assets/524475/7597768b-53cd-447e-a4ec-e9eea04a8ece) | ![IMG_12E53840AB1D-1](https://github.com/woocommerce/woocommerce-ios/assets/524475/23cd5f0e-20df-4378-a5d0-300e5d54de6e) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
