### PR TITLE
Order details: only make shipment tracking API request if the order contains non-virtual products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 14.7
 -----
-
+- [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
 
 14.6
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -244,8 +244,16 @@ extension OrderDetailsViewModel {
         }
 
         group.enter()
-        syncTrackingsEnablingAddButtonIfReachable(onReloadSections: onReloadSections) {
-            group.leave()
+        Task { @MainActor in
+            defer {
+                group.leave()
+            }
+            guard await isShipmentTrackingEnabled() else {
+                return
+            }
+            trackingIsReachable = true
+            await syncTrackingsWhenShipmentTrackingIsEnabled()
+            onReloadSections?()
         }
 
         group.enter()
@@ -291,19 +299,37 @@ extension OrderDetailsViewModel {
         }
     }
 
-    func syncTrackingsEnablingAddButtonIfReachable(onReloadSections: (() -> ())? = nil, onCompletion: (() -> Void)? = nil) {
-        // If the plugin is not active, there is no point on continuing with a request that will fail.
-        isPluginActive(SitePlugin.SupportedPlugin.WCTracking) { [weak self] isActive in
-            guard let self = self, isActive else {
-                onCompletion?()
-                return
-            }
+    /// Checks if shipment tracking is enabled for the order.
+    /// - Returns: Whether shipment tracking is enabled for the user by checking the products and if the Shipment Tracking plugin is active.
+    @MainActor
+    func isShipmentTrackingEnabled() async -> Bool {
+        guard orderContainsOnlyVirtualProducts == false,
+              await isPluginActive(SitePlugin.SupportedPlugin.WCTracking) else {
+            return false
+        }
+        return true
+    }
 
-            self.trackingIsReachable = true
-            self.syncTracking { error in
-                onReloadSections?()
-                onCompletion?()
-            }
+    /// Syncs trackings when shipment tracking is enabled.
+    @MainActor
+    func syncTrackingsWhenShipmentTrackingIsEnabled() async {
+        let orderID = order.orderID
+        let siteID = order.siteID
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(
+                ShipmentAction.synchronizeShipmentTrackingData(siteID: siteID,
+                                                               orderID: orderID) { error in
+                                                                   if let error {
+                                                                       DDLogError("⛔️ Error synchronizing tracking: \(error.localizedDescription)")
+                                                                       continuation.resume(returning: ())
+                                                                       return
+                                                                   }
+
+                                                                   ServiceLocator.analytics.track(.orderTrackingLoaded, withProperties: ["id": orderID])
+
+                                                                   continuation.resume(returning: ())
+                                                               }
+            )
         }
     }
 }
@@ -481,25 +507,6 @@ extension OrderDetailsViewModel {
             }
 
             onCompletion?(order, nil)
-        }
-
-        stores.dispatch(action)
-    }
-
-    func syncTracking(onCompletion: ((Error?) -> Void)? = nil) {
-        let orderID = order.orderID
-        let siteID = order.siteID
-        let action = ShipmentAction.synchronizeShipmentTrackingData(siteID: siteID,
-                                                                    orderID: orderID) { error in
-                                                                        if let error = error {
-                                                                            DDLogError("⛔️ Error synchronizing tracking: \(error.localizedDescription)")
-                                                                            onCompletion?(error)
-                                                                            return
-                                                                        }
-
-                                                                        ServiceLocator.analytics.track(.orderTrackingLoaded, withProperties: ["id": orderID])
-
-                                                                        onCompletion?(nil)
         }
 
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -248,10 +248,10 @@ extension OrderDetailsViewModel {
             defer {
                 group.leave()
             }
-            guard await isShipmentTrackingEnabled() else {
+            trackingIsReachable = await isShipmentTrackingEnabled()
+            guard trackingIsReachable else {
                 return
             }
-            trackingIsReachable = true
             await syncTrackingsWhenShipmentTrackingIsEnabled()
             onReloadSections?()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10272 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Similar to https://github.com/woocommerce/woocommerce-ios/pull/10273 - in order details, if the order only has virtual products, then there's no need to make the shipment tracking API request.

## How

All the changes are in `OrderDetailsViewModel`. Previously, `syncTrackingsEnablingAddButtonIfReachable` has two side effects - setting `trackingIsReachable = true` when the shipment tracking plugin is active, and then invoking `onReloadSections?()` when the tracking is synced. This PR broke this function into two, `isShipmentTrackingEnabled` and `syncTrackingsWhenShipmentTrackingIsEnabled` so that it's easier to separate the logic to check if shipment tracking is enabled (that includes the check on the non-virtual products) and sync the tracking.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Order without non-virtual products

Prerequisite: the store has the [Shipment Tracking plugin](https://woocommerce.com/products/shipment-tracking/), and an order with only virtual products

- Go to the Orders tab
- Tap on the order in the prerequisite --> there should not be a CTA `Add Tracking` near the bottom to add a tracking
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for `shipment`, there should be no results (no shipment tracking API requests were triggered)

### Order with non-virtual products

Prerequisite: the store has the [Shipment Tracking plugin](https://woocommerce.com/products/shipment-tracking/), and an order with **at least one non-virtual products** and **no non-refunded shipping labels**

- Go to the Orders tab
- Tap on the order in the prerequisite --> there should be a CTA `Add Tracking` near the bottom to add a tracking
- Go to the Menu tab > Settings > Launch Wormholy Debug --> when searching for `shipment`, there should be 1 result

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

shipment tracking is disabled | shipment tracking is enabled
-- | --
![Simulator Screenshot - iPhone 14 Pro - 2023-07-24 at 10 33 21](https://github.com/woocommerce/woocommerce-ios/assets/1945542/af240934-d4d6-4b83-af68-36757adff905) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-24 at 10 35 43](https://github.com/woocommerce/woocommerce-ios/assets/1945542/d75a9db8-4500-4fc6-81a2-36f58b91e3a2)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
