### PR TITLE
Zendesk tag if user eligible to add product from image

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -14,6 +14,7 @@ class SupportFormMetadataProvider {
     private let sessionManager: SessionManagerProtocol
     private let storageManager: StorageManagerType
     private let connectivityObserver: ConnectivityObserver
+    private let addProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol
 
     /// Controller for fetching site plugins from Storage
     ///
@@ -27,12 +28,14 @@ class SupportFormMetadataProvider {
                   stores: StoresManager = ServiceLocator.stores,
                   sessionManager: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
                   storageManager: StorageManagerType = ServiceLocator.storageManager,
-                  connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver) {
+                  connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
+                  addProductFromImageEligibilityChecker: AddProductFromImageEligibilityCheckerProtocol = AddProductFromImageEligibilityChecker()) {
         self.fileLogger = fileLogger
         self.stores = stores
         self.sessionManager = sessionManager
         self.storageManager = storageManager
         self.connectivityObserver = connectivityObserver
+        self.addProductFromImageEligibilityChecker = addProductFromImageEligibilityChecker
         self.pluginResultsController = Self.createPluginResultsController(sessionManager: sessionManager, storageManager: storageManager)
         self.systemStatusReportViewModel = Self.createSSRViewModel(sessionManager: sessionManager)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -3,7 +3,6 @@ import CoreTelephony
 import Yosemite
 import class WordPressAuthenticator.AuthenticatorAnalyticsTracker
 import protocol Storage.StorageManagerType
-import enum Experiments.ABTest
 
 /// Helper that provides general device & site zendesk metadata.
 ///
@@ -60,7 +59,7 @@ class SupportFormMetadataProvider {
             site.isWordPressComStore ? Constants.wpComTag : nil,
             site.plan.isNotEmpty ? site.plan : nil,
             stores.isAuthenticatedWithoutWPCom ? Constants.authenticatedWithApplicationPasswordTag : nil,
-            addProductFromImageEligibilityChecker.isEligible() ? ABTest.addProductFromImage.rawValue : nil
+            addProductFromImageEligibilityChecker.isEligible() ? Constants.ABTest.aiProductFromImage : nil
         ].compactMap { $0 } + getIPPTags()
     }
 
@@ -254,6 +253,10 @@ private extension SupportFormMetadataProvider {
         static let networkCarrierLabel = "Carrier:"
         static let networkCountryCodeLabel = "Country Code:"
         static let sourcePlatform = "mobile_-_woo_ios"
+
+        enum ABTest {
+            static let aiProductFromImage = "ai_product_details_from_image"
+        }
     }
 
     /// Payments extensions Slugs

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -3,6 +3,7 @@ import CoreTelephony
 import Yosemite
 import class WordPressAuthenticator.AuthenticatorAnalyticsTracker
 import protocol Storage.StorageManagerType
+import enum Experiments.ABTest
 
 /// Helper that provides general device & site zendesk metadata.
 ///
@@ -58,7 +59,8 @@ class SupportFormMetadataProvider {
             Constants.platformTag,
             site.isWordPressComStore ? Constants.wpComTag : nil,
             site.plan.isNotEmpty ? site.plan : nil,
-            stores.isAuthenticatedWithoutWPCom ? Constants.authenticatedWithApplicationPasswordTag : nil
+            stores.isAuthenticatedWithoutWPCom ? Constants.authenticatedWithApplicationPasswordTag : nil,
+            addProductFromImageEligibilityChecker.isEligible() ? ABTest.addProductFromImage.rawValue : nil
         ].compactMap { $0 } + getIPPTags()
     }
 

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
@@ -30,7 +30,12 @@ final class SupportDataSourcesTests: XCTestCase {
         // Given
         let mockEligibilityChecker = MockAddProductFromImageEligibilityChecker(isEligibleToParticipateInABTest: true,
                                                              isEligible: true)
-        let metadataProvider = SupportFormMetadataProvider(addProductFromImageEligibilityChecker: mockEligibilityChecker)
+        let sessionManager: SessionManager = .makeForTesting(authenticated: true)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let metadataProvider = SupportFormMetadataProvider(stores: stores,
+                                                           sessionManager: sessionManager,
+                                                           addProductFromImageEligibilityChecker: mockEligibilityChecker)
         let dataSource = MobileAppSupportDataSource(metadataProvider: metadataProvider)
 
         // Then
@@ -41,7 +46,12 @@ final class SupportDataSourcesTests: XCTestCase {
         // Given
         let mockEligibilityChecker = MockAddProductFromImageEligibilityChecker(isEligibleToParticipateInABTest: true,
                                                              isEligible: false)
-        let metadataProvider = SupportFormMetadataProvider(addProductFromImageEligibilityChecker: mockEligibilityChecker)
+        let sessionManager: SessionManager = .makeForTesting(authenticated: true)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let metadataProvider = SupportFormMetadataProvider(stores: stores,
+                                                           sessionManager: sessionManager,
+                                                           addProductFromImageEligibilityChecker: mockEligibilityChecker)
         let dataSource = MobileAppSupportDataSource(metadataProvider: metadataProvider)
 
         // Then

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
@@ -187,7 +187,4 @@ final class SupportDataSourcesTests: XCTestCase {
             360000089123 // Device Free Space
         ].sorted())
     }
-
-    // MARK
-
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import WooCommerce
-import enum Experiments.ABTest
 import WordPressAuthenticator
 
 final class SupportDataSourcesTests: XCTestCase {
@@ -39,7 +38,7 @@ final class SupportDataSourcesTests: XCTestCase {
         let dataSource = MobileAppSupportDataSource(metadataProvider: metadataProvider)
 
         // Then
-        XCTAssertTrue(dataSource.tags.contains(ABTest.addProductFromImage.rawValue))
+        XCTAssertTrue(dataSource.tags.contains("ai_product_details_from_image"))
     }
 
     func test_mobile_app_tags_does_not_contain_addProductFromImage_tag_when_not_eligible() {
@@ -55,7 +54,7 @@ final class SupportDataSourcesTests: XCTestCase {
         let dataSource = MobileAppSupportDataSource(metadataProvider: metadataProvider)
 
         // Then
-        XCTAssertFalse(dataSource.tags.contains(ABTest.addProductFromImage.rawValue))
+        XCTAssertFalse(dataSource.tags.contains("ai_product_details_from_image"))
     }
 
     func test_mobile_app_fields_have_correct_ids() {


### PR DESCRIPTION
Part of: #10180 

## Description
Adds Zendesk tag `ai_product_details_from_image ` if the user is eligible to add a product from an image. 

Notes
- This is requested by Happiness here. p1690172063760519/1690168489.983889-slack-C03URUK5C
- Targeting beta as this tag as this "Add product from image" feature is being release (AB test) in 14.6

## Testing instructions
- Login into a WPCOM store. (Using a non A8C account to submit support ticket)
- To enable the treatment variation mock the `0.1.0/assignments/woocommerceios` endpoint response using Proxyman with the following JSON to force treatment 
```
{
  "variations": {
    "woocommerceios_add_product_from_photo_202307": "treatment"
  },
  "ttl": 7200
}
```
- Navigate to products tab and tap "+" -> "Physical product". Ensure that you see the "Photo -> Product" form to select an image to generate title and description
- Dismiss the screen.
- Navigate to "Menu -> Settings -> Help & Support -> Contact Support"
- Fill email and username
- Select "Mobile App" under the "I NEED HELP WITH" title
- Fill Subject and message. (To make it easy for happiness folks, enter a subject and message which explains that this is for testing purposes)
- Check the ticket from zendesk.
- Ensure that the ticket has `ai_product_details_from_image ` tag added to it.


## Screenshots
Product form
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/56db604b-c452-437b-8bd4-737b8e1643ac" width="320"/>

Support form
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/68b3af7b-bdcb-4003-a05f-ac87cf16af3e" width="320"/>

Tags
<img width="306" alt="Screenshot 2023-07-24 at 11 10 48 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/cb443d9b-6b44-40b7-800a-635ce20aa7cd">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.