### PR TITLE
[IAP] Use production plan ids

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -78,7 +78,7 @@ struct InAppPurchasesDebugView: View {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else if let siteID = selectedSiteIDSourceType.retrieveUpgradingSiteID() {
                     ForEach(wpcomPlans, id: \.id) { plan in
-                        Button(entitledWpcomPlanIDs.contains(plan.id) ? "Entitled: \(plan.description)" : plan.description) {
+                        Button(entitledWpcomPlanIDs.contains(plan.id) ? "Entitled: \(plan.displayName)" : plan.displayName) {
                             Task {
                                 isPurchasing = true
                                 do {

--- a/WooCommerce/Resources/WooCommerceTestSynced.storekit
+++ b/WooCommerce/Resources/WooCommerceTestSynced.storekit
@@ -13,7 +13,7 @@
     },
     "_developerTeamID" : "PZYM8XX95Q",
     "_failTransactionsEnabled" : false,
-    "_lastSynchronizedDate" : 709713857.71122098,
+    "_lastSynchronizedDate" : 711906066.66696799,
     "_storeKitError" : 0,
     "_timeRate" : 13
   },
@@ -34,7 +34,7 @@
           ],
           "displayPrice" : "39.0",
           "familyShareable" : false,
-          "groupNumber" : 1,
+          "groupNumber" : 2,
           "internalID" : "6450767566",
           "introductoryOffer" : null,
           "localizations" : [
@@ -47,6 +47,81 @@
           "productID" : "woocommerce.express.essential.monthly",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Woo Express Essential Monthly",
+          "subscriptionGroupID" : "21032734",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "300.0",
+          "familyShareable" : false,
+          "groupNumber" : 2,
+          "internalID" : "6452754234",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Everything you need to launch an online store",
+              "displayName" : "Essential Yearly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "woocommerce.express.essential.yearly",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Woo Express Essential Yearly",
+          "subscriptionGroupID" : "21032734",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "70.0",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "6452754174",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Next-level features to help you grow",
+              "displayName" : "Performance Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "woocommerce.express.performance.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Woo Express Performance Monthly",
+          "subscriptionGroupID" : "21032734",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "539.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "6452754457",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Next-level features to help you grow",
+              "displayName" : "Performance Yearly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "woocommerce.express.performance.yearly",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Woo Express Performance Yearly",
           "subscriptionGroupID" : "21032734",
           "type" : "RecurringSubscription"
         }

--- a/Yosemite/Yosemite/Model/WooPlans/LegacyWooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/LegacyWooPlan.swift
@@ -138,9 +138,9 @@ public struct LegacyWooPlan: Decodable {
 
 public enum AvailableInAppPurchasesWPComPlans: String {
     case essentialMonthly = "woocommerce.express.essential.monthly"
-    case essentialYearly = "debug.woocommerce.express.essential.yearly"
-    case performanceMonthly = "debug.woocommerce.express.performance.monthly"
-    case performanceYearly = "debug.woocommerce.express.performance.yearly"
+    case essentialYearly = "woocommerce.express.essential.yearly"
+    case performanceMonthly = "woocommerce.express.performance.monthly"
+    case performanceYearly = "woocommerce.express.performance.yearly"
 }
 
 private extension LegacyWooPlan {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10188 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With M2 of Project Pineapple, we're adding the ability to purchase a selection of plans (Essential/Performance, Monthly/Yearly). We've added these plans in App Store Connect, though not yet submitted them for review. They are available for testing nonetheless.

This PR changes our Upgrade screen to use the production plan IDs for all four plans on offer, where previously only Essential Monthly used the production ID.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a new Woo Express free trial store
2. Use a US-based Sandbox tester
3. Open the app and switch to the new free trial store
4. Tap `Upgrade` in the banner at the bottom of each main tab
5. Observe that when you select any of the plans, the button shows `Purchase Performance Yearly` or similar, without the `Debug` qualifier
6. Purchase a plan, observe that `Debug` is not mentioned anywhere.


Additionally, this changes the IAP debug screen to show plan display names, not descriptions, which are more distinctive to which plan they relate to.

1. Tap `Menu > Settings > Experimental Features`
2. Enable `In-app purchases`
3. Go back to the menu
4. Tap `IAP Debug`
5. Wait for the plans to load
6. Observe that plan names load, and none are duplicated.  

(Previously, descriptions would be duplicated between some plans, e.g. both Essential plans would read `Everything you need to start an online store`.)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/woocommerce/woocommerce-ios/assets/2472348/8af4db13-71a2-496b-be5f-92bacfa6c687


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
