### PR TITLE
[Photo to Product] Reset details from previous image when no text detected

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 14.7
 -----
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
+- [*] Photo -> Product: Reset details from previous image when no text detected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
 
 14.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 14.7
 -----
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
-- [*] Photo -> Product: Reset details from previous image when no text detected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
+- [*] Photo -> Product: Reset details from previous image when new image is selected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
 
 14.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -95,7 +95,10 @@ final class AddProductFromImageViewModel: ObservableObject {
         // Track display event
         analytics.track(event: .AddProductFromImage.formDisplayed(source: source))
 
-        $imageState.compactMap { $0.image?.image }
+        $imageState
+            .removeDuplicates()
+            .compactMap { $0.image?.image }
+            .removeDuplicates()
             .sink { [weak self] image in
                 self?.onSelectedImage(image)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -171,15 +171,11 @@ private extension AddProductFromImageViewModel {
 
                 switch error {
                 case ScanError.noTextDetected:
-                    if scannedTexts.isEmpty {
-                        textDetectionErrorMessage = Localization.noTextDetected
-                    }
+                    textDetectionErrorMessage = Localization.noTextDetected
                     DDLogError("⛔️ No text detected from image.")
                 default:
                     analytics.track(event: .AddProductFromImage.scanFailed(source: addProductSource, error: error))
-                    if scannedTexts.isEmpty {
-                        textDetectionErrorMessage = Localization.textDetectionFailed
-                    }
+                    textDetectionErrorMessage = Localization.textDetectionFailed
                     DDLogError("⛔️ Error scanning text from image: \(error)")
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -152,6 +152,10 @@ final class AddProductFromImageViewModel: ObservableObject {
 
 private extension AddProductFromImageViewModel {
     func onSelectedImage(_ image: UIImage) {
+        // Reset scanned texts and generated content from previous image
+        scannedTexts = []
+        [nameViewModel, descriptionViewModel].forEach { $0.reset() }
+
         Task { @MainActor in
             do {
                 let texts = try await imageTextScanner.scanText(from: image)
@@ -165,10 +169,6 @@ private extension AddProductFromImageViewModel {
                 [nameViewModel, descriptionViewModel].forEach { $0.reset() }
                 generateProductDetails()
             } catch {
-                // Reset scanned texts and generated content from previous image
-                scannedTexts = []
-                [nameViewModel, descriptionViewModel].forEach { $0.reset() }
-
                 switch error {
                 case ScanError.noTextDetected:
                     textDetectionErrorMessage = Localization.noTextDetected

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -96,7 +96,6 @@ final class AddProductFromImageViewModel: ObservableObject {
         analytics.track(event: .AddProductFromImage.formDisplayed(source: source))
 
         $imageState
-            .removeDuplicates()
             .compactMap { $0.image?.image }
             .sink { [weak self] image in
                 self?.onSelectedImage(image)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -98,7 +98,6 @@ final class AddProductFromImageViewModel: ObservableObject {
         $imageState
             .removeDuplicates()
             .compactMap { $0.image?.image }
-            .removeDuplicates()
             .sink { [weak self] image in
                 self?.onSelectedImage(image)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -165,6 +165,10 @@ private extension AddProductFromImageViewModel {
                 [nameViewModel, descriptionViewModel].forEach { $0.reset() }
                 generateProductDetails()
             } catch {
+                // Reset scanned texts and generated content from previous image
+                scannedTexts = []
+                [nameViewModel, descriptionViewModel].forEach { $0.reset() }
+
                 switch error {
                 case ScanError.noTextDetected:
                     if scannedTexts.isEmpty {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -103,11 +103,6 @@ final class AddProductFromImageViewModel: ObservableObject {
             }
             .store(in: &subscriptions)
 
-        $imageState
-            .filter { $0 == .empty || $0 == .loading }
-            .map { _ in nil }
-            .assign(to: &$textDetectionErrorMessage)
-
         $scannedTextValidation
             .map { $0.values.contains { $0 } }
             .assign(to: &$regenerateButtonEnabled)
@@ -157,6 +152,7 @@ private extension AddProductFromImageViewModel {
         // Reset scanned texts and generated content from previous image
         scannedTexts = []
         [nameViewModel, descriptionViewModel].forEach { $0.reset() }
+        textDetectionErrorMessage = nil
 
         Task { @MainActor in
             do {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -97,6 +97,7 @@ final class AddProductFromImageViewModel: ObservableObject {
 
         $imageState
             .compactMap { $0.image?.image }
+            .removeDuplicates()
             .sink { [weak self] image in
                 self?.onSelectedImage(image)
             }

--- a/WooCommerce/WooCommerceTests/Mocks/MockImageTextScanner.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockImageTextScanner.swift
@@ -2,7 +2,7 @@
 import UIKit
 
 final class MockImageTextScanner: ImageTextScannerProtocol {
-    let result: Result<[String], Error>
+    var result: Result<[String], Error>
 
     init(result: Result<[String], Error>) {
         self.result = result

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -249,28 +249,6 @@ final class AddProductFromImageViewModelTests: XCTestCase {
                        "An error occurred while scanning the photo. Please select another packaging photo or enter product details manually.")
     }
 
-    func test_textDetectionErrorMessage_stays_nil_when_scanned_texts_are_available_already() throws {
-        // Given
-        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
-        let imageTextScanner = MockImageTextScanner(result: .success([]))
-        let viewModel = AddProductFromImageViewModel(siteID: 123,
-                                                     source: .productsTab,
-                                                     stores: stores,
-                                                     imageTextScanner: imageTextScanner,
-                                                     analytics: analytics,
-                                                     onAddImage: { _ in image })
-        viewModel.scannedTexts = [.init(text: "test", isSelected: false)]
-
-        // When
-        viewModel.addImage(from: .siteMediaLibrary)
-        waitUntil {
-            viewModel.imageState == .success(image)
-        }
-
-        // Then
-        XCTAssertNil(viewModel.textDetectionErrorMessage)
-    }
-
     func test_textDetectionErrorMessage_is_reset_when_image_is_loaded_again() throws {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -192,6 +192,55 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: Text detection failure
+
+    func test_details_from_previous_scan_are_reset_when_no_text_is_detected() throws {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let imageTextScanner = MockImageTextScanner(result: .success([]))
+        let viewModel = AddProductFromImageViewModel(siteID: 123,
+                                                     source: .productsTab,
+                                                     stores: stores,
+                                                     imageTextScanner: imageTextScanner,
+                                                     analytics: analytics,
+                                                     onAddImage: { _ in image })
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.scannedTexts.isEmpty)
+        XCTAssertTrue(viewModel.name.isEmpty)
+        XCTAssertTrue(viewModel.description.isEmpty)
+    }
+
+    func test_details_from_previous_scan_are_reset_when_text_detection_fails() throws {
+        // Given
+        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        let error = NSError(domain: "test", code: 10000)
+        let imageTextScanner = MockImageTextScanner(result: .failure(error))
+        let viewModel = AddProductFromImageViewModel(siteID: 123,
+                                                     source: .productsTab,
+                                                     stores: stores,
+                                                     imageTextScanner: imageTextScanner,
+                                                     analytics: analytics,
+                                                     onAddImage: { _ in image })
+
+        // When
+        viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(image)
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.scannedTexts.isEmpty)
+        XCTAssertTrue(viewModel.name.isEmpty)
+        XCTAssertTrue(viewModel.description.isEmpty)
+    }
+
     // MARK: `textDetectionErrorMessage`
 
     func test_textDetectionErrorMessage_is_nil_initially() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -226,7 +226,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
                        "No text detected. Please select another packaging photo or enter product details manually.")
     }
 
-    func test_textDetectionErrorMessage_has_correct_string_value_when_no_text_detection_fails() throws {
+    func test_textDetectionErrorMessage_has_correct_string_value_when_text_detection_fails() throws {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let error = NSError(domain: "test", code: 10000)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -197,9 +197,9 @@ final class AddProductFromImageViewModelTests: XCTestCase {
     func test_details_from_previous_scan_are_reset_when_new_image_selected() throws {
         // Given
         let firstImage = MediaPickerImage(image: UIImage.emailImage,
-                                          source: .media(media: .fake().copy(mediaID: 1)))
+                                          source: .media(media: .fake()))
         let secondImage = MediaPickerImage(image: UIImage.calendar,
-                                           source: .media(media: .fake().copy(mediaID: 2)))
+                                           source: .media(media: .fake()))
         var imageToReturn: MediaPickerImage? = firstImage
         let imageTextScanner = MockImageTextScanner(result: .success(["test"]))
         mockGenerateProductDetails(result: .success(.init(name: "Name",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -296,16 +296,23 @@ final class AddProductFromImageViewModelTests: XCTestCase {
                        "An error occurred while scanning the photo. Please select another packaging photo or enter product details manually.")
     }
 
-    func test_textDetectionErrorMessage_is_reset_when_image_is_loaded_again() throws {
+    func test_textDetectionErrorMessage_is_reset_when_image_with_text_is_loaded_again() throws {
         // Given
+        let firstImage = MediaPickerImage(image: UIImage.emailImage,
+                                          source: .media(media: .fake()))
+        let secondImage = MediaPickerImage(image: UIImage.calendar,
+                                           source: .media(media: .fake()))
+
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
+        var imageToReturn: MediaPickerImage? = image
+
         let imageTextScanner = MockImageTextScanner(result: .success([]))
         let viewModel = AddProductFromImageViewModel(siteID: 123,
                                                      source: .productsTab,
                                                      stores: stores,
                                                      imageTextScanner: imageTextScanner,
                                                      analytics: analytics,
-                                                     onAddImage: { _ in image })
+                                                     onAddImage: { _ in imageToReturn })
 
         // When
         viewModel.addImage(from: .siteMediaLibrary)
@@ -317,7 +324,13 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.textDetectionErrorMessage, "No text detected. Please select another packaging photo or enter product details manually.")
 
         // When
+        imageTextScanner.result = .success(["test"])
+        imageToReturn = secondImage
+
         viewModel.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            viewModel.imageState == .success(secondImage)
+        }
 
         // Then
         XCTAssertNil(viewModel.textDetectionErrorMessage)


### PR DESCRIPTION
Closes: #10293 
Closes: #10302 

## Description

When we cannot detect text from a new scan, show an error message and also reset scanned and generated texts from the previous image.

## Testing instructions
- Since the feature is now under A/B test, please enable it by returning `true` in `AddProductFromImageEligibilityChecker`.
- Log in to a WPCom store and select the Products tab.
- Select the "+" button to add a new product.
- Select the manual option if the store has no product.
- Select Simple physical product in the product type action sheet.
- Notice the product details from image form is displayed.
- Select an image with text in it.
- Wait for AI generation to auto till name and description fields. 
- Now select an image without any text in it.
- Observe that you see the message `No text detected. Please select another packaging photo or enter product details manually.` when no text is detected from the image.
- Validate that the scanned and generated texts from the previous image are cleared.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/20a48ca6-fff5-49f0-ad9b-ef1dce42d19f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
