### PR TITLE
Track path and entity name in API JSON parsing error events `api_json_parsing_error`

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		02AAD53F250092A400BA1E26 /* product-add-or-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AAD53E250092A300BA1E26 /* product-add-or-delete.json */; };
 		02AAFCD22A132C1D00F05E60 /* DotcomSitePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AAFCD12A132C1D00F05E60 /* DotcomSitePlugin.swift */; };
 		02AAFCD42A13517800F05E60 /* dotcom-plugins.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AAFCD32A13517800F05E60 /* dotcom-plugins.json */; };
+		02AD47702A6EB71100E652D6 /* URLRequestConvertible+Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AD476F2A6EB71100E652D6 /* URLRequestConvertible+Path.swift */; };
+		02AD47722A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AD47712A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift */; };
 		02AF07EA27492DBC00B2D81E /* WordPressMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AF07E927492DBC00B2D81E /* WordPressMedia.swift */; };
 		02AF07EC27492FDD00B2D81E /* media-library-from-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */; };
 		02AF07EE27493AE700B2D81E /* media-upload-to-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AF07ED27493AE700B2D81E /* media-upload-to-wordpress-site.json */; };
@@ -1035,6 +1037,8 @@
 		02AAD53E250092A300BA1E26 /* product-add-or-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-add-or-delete.json"; sourceTree = "<group>"; };
 		02AAFCD12A132C1D00F05E60 /* DotcomSitePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotcomSitePlugin.swift; sourceTree = "<group>"; };
 		02AAFCD32A13517800F05E60 /* dotcom-plugins.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "dotcom-plugins.json"; sourceTree = "<group>"; };
+		02AD476F2A6EB71100E652D6 /* URLRequestConvertible+Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequestConvertible+Path.swift"; sourceTree = "<group>"; };
+		02AD47712A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequestConvertible+PathTests.swift"; sourceTree = "<group>"; };
 		02AF07E927492DBC00B2D81E /* WordPressMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMedia.swift; sourceTree = "<group>"; };
 		02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library-from-wordpress-site.json"; sourceTree = "<group>"; };
 		02AF07ED27493AE700B2D81E /* media-upload-to-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-upload-to-wordpress-site.json"; sourceTree = "<group>"; };
@@ -2963,6 +2967,7 @@
 				DE2E8EB0295464C5002E4B14 /* URLRequest+Request.swift */,
 				EE62EE62295AD45E009C965B /* String+URL.swift */,
 				DE2D642729F0E85600F3659B /* Mapper+DataEnvelope.swift */,
+				02AD476F2A6EB71100E652D6 /* URLRequestConvertible+Path.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2977,6 +2982,7 @@
 				0212683424C046CB00F8A892 /* MockNetwork+Path.swift */,
 				CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */,
 				EE62EE64295AD46D009C965B /* String+URLTests.swift */,
+				02AD47712A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3797,6 +3803,7 @@
 			files = (
 				74ABA1CF213F1D1600FFAD30 /* TopEarnerStatsItem.swift in Sources */,
 				FE28F6E6268429B6004465C7 /* UserRemote.swift in Sources */,
+				02AD47702A6EB71100E652D6 /* URLRequestConvertible+Path.swift in Sources */,
 				7452387421124B7700A973CD /* AnyDecodable.swift in Sources */,
 				DE4D23B829B5F909003A4B5D /* Announcement.swift in Sources */,
 				CEF88DAD233E95B000BED485 /* OrderRefundCondensed.swift in Sources */,
@@ -4249,6 +4256,7 @@
 				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
 				DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */,
 				EEFAA581295D78E9003583BE /* AuthenticatedRESTRequestTests.swift in Sources */,
+				02AD47722A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift in Sources */,
 				CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */,
 				FE28F6EC268436C9004465C7 /* UserRemoteTests.swift in Sources */,
 				DE74F29E27E0A6800002FE59 /* SiteSettingMapperTests.swift in Sources */,

--- a/Networking/Networking/Extensions/URLRequestConvertible+Path.swift
+++ b/Networking/Networking/Extensions/URLRequestConvertible+Path.swift
@@ -1,0 +1,15 @@
+import Foundation
+import protocol Alamofire.URLRequestConvertible
+
+extension URLRequestConvertible {
+    /// Path of a network request in `Remote` for analyzing the decoding errors.
+    var pathForAnalytics: String? {
+        if let jetpackRequest = self as? JetpackRequest {
+            return jetpackRequest.path
+        } else if let dotcomRequest = self as? DotcomRequest {
+            return dotcomRequest.path
+        } else {
+            return nil
+        }
+    }
+}

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -65,6 +65,7 @@ public class Remote: NSObject {
                         continuation.resume(returning: document)
                     } catch {
                         self.handleResponseError(error: error, for: request)
+                        self.handleDecodingError(error: error, for: request, entityName: "\(T.self)")
                         continuation.resume(throwing: error)
                     }
                 case .failure(let error):
@@ -103,7 +104,7 @@ public class Remote: NSObject {
                 completion(parsed, nil)
             } catch {
                 self.handleResponseError(error: error, for: request)
-                self.handleDecodingError(error: error, for: request)
+                self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
                 DDLogError("<> Mapping Error: \(error)")
                 completion(nil, error)
             }
@@ -136,7 +137,7 @@ public class Remote: NSObject {
                     completion(.success(parsed))
                 } catch {
                     self.handleResponseError(error: error, for: request)
-                    self.handleDecodingError(error: error, for: request)
+                    self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
                     DDLogError("<> Mapping Error: \(error)")
                     completion(.failure(error))
                 }
@@ -179,7 +180,7 @@ public class Remote: NSObject {
                     self?.handleResponseError(error: dotcomError, for: request)
                 }
                 if let decodingError = result.failure as? DecodingError {
-                    self?.handleDecodingError(error: decodingError, for: request)
+                    self?.handleDecodingError(error: decodingError, for: request, entityName: "\(M.Output.self)")
                 }
             })
             .eraseToAnyPublisher()
@@ -218,7 +219,7 @@ public class Remote: NSObject {
                                                 completion(.success(parsed))
                                             } catch {
                                                 self.handleResponseError(error: error, for: request)
-                                                self.handleDecodingError(error: error, for: request)
+                                                self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
                                                 DDLogError("<> Mapping Error: \(error)")
                                                 completion(.failure(error))
                                             }
@@ -247,7 +248,7 @@ public class Remote: NSObject {
                     } catch {
                         DDLogError("<> Mapping Error: \(error)")
                         self.handleResponseError(error: error, for: request)
-                        self.handleDecodingError(error: error, for: request)
+                        self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
                         continuation.resume(throwing: error)
                     }
                 case .failure(let error):
@@ -282,11 +283,11 @@ private extension Remote {
 
     /// Handles decoding errors when parsing the response data fails.
     ///
-    func handleDecodingError(error: Error, for request: Request) {
+    func handleDecodingError(error: Error, for request: Request, entityName: String) {
         guard let decodingError = error as? DecodingError else {
             return
         }
-        publishJSONParsingErrorNotification(error: decodingError, path: request.pathForAnalytics)
+        publishJSONParsingErrorNotification(error: decodingError, path: request.pathForAnalytics, entityName: entityName)
     }
 
 
@@ -304,9 +305,10 @@ private extension Remote {
 
     /// Publishes a `JSON Parsing Error` Notification.
     ///
-    private func publishJSONParsingErrorNotification(error: Error, path: String?) {
+    private func publishJSONParsingErrorNotification(error: Error, path: String?, entityName: String) {
         NotificationCenter.default.post(name: .RemoteDidReceiveJSONParsingError, object: error, userInfo: [
-            JSONParsingErrorUserInfoKey.path: path
+            JSONParsingErrorUserInfoKey.path: path,
+            JSONParsingErrorUserInfoKey.entityName: entityName
         ].compactMapValues { $0 })
     }
 }
@@ -321,6 +323,7 @@ public extension Remote {
 
     enum JSONParsingErrorUserInfoKey {
         public static let path = "path"
+        public static let entityName = "entity"
     }
 }
 

--- a/Networking/NetworkingTests/Extensions/URLRequestConvertible+PathTests.swift
+++ b/Networking/NetworkingTests/Extensions/URLRequestConvertible+PathTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Networking
+
+final class URLRequestConvertible_PathTests: XCTestCase {
+    private let network = MockNetwork()
+
+    override func setUp() {
+        super.setUp()
+        network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - `pathForAnalytics`
+
+    // Example from `ProductsRemote.loadAllProducts`.
+    func test_pathForAnalytics_returns_path_of_JetpackRequest() throws {
+        // Given
+        let productsRemote = ProductsRemote(network: network)
+        productsRemote.loadAllProducts(for: 134, completion: { _ in })
+
+        // When
+        let request = try XCTUnwrap(network.requestsForResponseData.first)
+
+        // Then
+        XCTAssertEqual(request.pathForAnalytics, "products")
+        XCTAssertTrue(request is JetpackRequest)
+    }
+
+    // Example from `AccountRemote.loadSites`.
+    func test_pathForAnalytics_returns_path_of_DotcomRequest() throws {
+        // Given
+        let productsRemote = AccountRemote(network: network)
+        _ = productsRemote.loadSites()
+
+        // When
+        let request = try XCTUnwrap(network.requestsForResponseData.first)
+
+        // Then
+        XCTAssertEqual(request.pathForAnalytics, "me/sites")
+        XCTAssertTrue(request is DotcomRequest)
+    }
+
+    func test_pathForAnalytics_returns_nil_when_request_is_not_supported() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/6/rest-api/?json=true"))
+
+        // When
+        let request = URLRequest(url: url)
+
+        // Then
+        XCTAssertNil(request.pathForAnalytics)
+    }
+}

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -590,7 +590,7 @@ final class RemoteTests: XCTestCase {
         do {
             _ = try await remote.enqueue(request, mapper: mapper)
         } catch {
-            await fulfillment(of: [expectationForNotification])
+            wait(for: [expectationForNotification], timeout: Constants.expectationTimeout)
 
             // Then
             let path = try XCTUnwrap(notification?.userInfo?["path"] as? String)
@@ -620,7 +620,7 @@ final class RemoteTests: XCTestCase {
         do {
             let _: [String] = try await remote.enqueue(request)
         } catch {
-            await fulfillment(of: [expectationForNotification])
+            wait(for: [expectationForNotification], timeout: Constants.expectationTimeout)
 
             // Then
             let path = try XCTUnwrap(notification?.userInfo?["path"] as? String)
@@ -654,7 +654,7 @@ final class RemoteTests: XCTestCase {
                 promise(result)
             }
         }
-        await fulfillment(of: [expectationForNotification])
+        wait(for: [expectationForNotification], timeout: Constants.expectationTimeout)
 
         // Then
         XCTAssertTrue(result.isFailure)

--- a/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
+++ b/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
@@ -70,6 +70,7 @@ private extension TrackEventRequestNotificationHandler {
             return
         }
         let path = note.userInfo?[Remote.JSONParsingErrorUserInfoKey.path] as? String
-        analytics.track(event: .RemoteRequest.jsonParsingError(error, path: path))
+        let entityName = note.userInfo?[Remote.JSONParsingErrorUserInfoKey.entityName] as? String
+        analytics.track(event: .RemoteRequest.jsonParsingError(error, path: path, entityName: entityName))
     }
 }

--- a/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
+++ b/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import class Networking.Remote
 
 final class TrackEventRequestNotificationHandler {
 
@@ -68,6 +69,7 @@ private extension TrackEventRequestNotificationHandler {
         guard let error = note.object as? DecodingError else {
             return
         }
-        analytics.track(event: .RemoteRequest.jsonParsingError(error))
+        let path = note.userInfo?[Remote.JSONParsingErrorUserInfoKey.path] as? String
+        analytics.track(event: .RemoteRequest.jsonParsingError(error, path: path))
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2543,8 +2543,14 @@ extension WooAnalyticsEvent {
 //
 extension WooAnalyticsEvent {
     enum RemoteRequest {
-        static func jsonParsingError(_ error: Error) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .apiJSONParsingError, properties: [:], error: error)
+        enum Keys: String {
+            case path
+        }
+
+        static func jsonParsingError(_ error: Error, path: String?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .apiJSONParsingError,
+                              properties: [Keys.path.rawValue: path].compactMapValues { $0 },
+                              error: error)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2545,11 +2545,15 @@ extension WooAnalyticsEvent {
     enum RemoteRequest {
         enum Keys: String {
             case path
+            case entityName = "entity"
         }
 
-        static func jsonParsingError(_ error: Error, path: String?) -> WooAnalyticsEvent {
+        static func jsonParsingError(_ error: Error, path: String?, entityName: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .apiJSONParsingError,
-                              properties: [Keys.path.rawValue: path].compactMapValues { $0 },
+                              properties: [
+                                Keys.path.rawValue: path,
+                                Keys.entityName.rawValue: entityName
+                              ].compactMapValues { $0 },
                               error: error)
         }
     }

--- a/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
@@ -124,34 +124,39 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         assertEqual("other", actualProperties["cause"] as? String)
     }
 
-    func test_json_parsing_failed_event_is_tracked_with_nil_path_property_upon_decoding_error_when_path_is_nil() throws {
+    func test_json_parsing_failed_event_is_tracked_with_nil_properties_upon_decoding_error_when_properties_are_not_set() throws {
         // When
         let error = mockDecodingError()
         mockNotificationCenter.post(name: .RemoteDidReceiveJSONParsingError, object: error, userInfo: nil)
 
         // Then
-        let expectedEvent = WooAnalyticsEvent.RemoteRequest.jsonParsingError(error, path: nil)
+        let expectedEvent = WooAnalyticsEvent.RemoteRequest.jsonParsingError(error, path: nil, entityName: nil)
 
         XCTAssert(analyticsProvider.receivedEvents.contains(where: { $0 == expectedEvent.statName.rawValue }))
 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == expectedEvent.statName.rawValue }))
         let eventProperties = analyticsProvider.receivedProperties[indexOfEvent]
         XCTAssertNil(eventProperties["path"])
+        XCTAssertNil(eventProperties["entity"])
     }
 
     func test_json_parsing_failed_event_is_tracked_with_path_property_upon_decoding_error_when_path_is_avaiable() throws {
         // When
         let error = mockDecodingError()
-        mockNotificationCenter.post(name: .RemoteDidReceiveJSONParsingError, object: error, userInfo: ["path": "wc/test"])
+        mockNotificationCenter.post(name: .RemoteDidReceiveJSONParsingError, object: error, userInfo: [
+            "path": "wc/test",
+            "entity": "Product"
+        ])
 
         // Then
-        let expectedEvent = WooAnalyticsEvent.RemoteRequest.jsonParsingError(error, path: nil)
+        let expectedEvent = WooAnalyticsEvent.RemoteRequest.jsonParsingError(error, path: nil, entityName: nil)
 
         XCTAssert(analyticsProvider.receivedEvents.contains(where: { $0 == expectedEvent.statName.rawValue }))
 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == expectedEvent.statName.rawValue }))
         let eventProperties = analyticsProvider.receivedProperties[indexOfEvent]
         XCTAssertEqual(eventProperties["path"] as? String, "wc/test")
+        XCTAssertEqual(eventProperties["entity"] as? String, "Product")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
@@ -140,7 +140,7 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         XCTAssertNil(eventProperties["entity"])
     }
 
-    func test_json_parsing_failed_event_is_tracked_with_path_property_upon_decoding_error_when_path_is_avaiable() throws {
+    func test_json_parsing_failed_event_is_tracked_with_properties_upon_decoding_error_when_properties_are_avaiable() throws {
         // When
         let error = mockDecodingError()
         mockNotificationCenter.post(name: .RemoteDidReceiveJSONParsingError, object: error, userInfo: [


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10291 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We started tracking `api_json_parsing_error` event for decoding errors, and it'd be helpful for us to take actions better if we know which request triggers the error and the return data type. This PR added two event properties: `path` of the request, and `entity` of the expected entity type.

## How

Currently, there are 6 `enqueue` functions in `Remote` that can encounter a decoding error:

- `enqueue<T: Decodable>(_ request: Request) async throws -> T`: this wasn't tracked before 🆕 
- `enqueue<M: Mapper>(_ request: Request, mapper: M, completion: @escaping (M.Output?, Error?) -> Void)`
- `enqueue<M: Mapper>(_ request: Request, mapper: M, completion: @escaping (Result<M.Output, Error>) -> Void)`
- `enqueue<M: Mapper>(_ request: Request, mapper: M) -> AnyPublisher<Result<M.Output, Error>, Never>`
- `enqueueMultipartFormDataUpload<M: Mapper>(_ request: Request, mapper: M, multipartFormData: @escaping (MultipartFormData) -> Void, completion: @escaping (Result<M.Output, Error>) -> Void)`
- `enqueue<M: Mapper>(_ request: Request, mapper: M) async throws -> M.Output`

When calling `handleDecodingError`, two parameters were added - `Request` and the entity name either from the generic mapper output type or return type. Since it's not easy to extract the path from the request URL, an extension `URLRequestConvertible.pathForAnalytics` was created to return the path from `DotcomRequest` and `JetpackRequest` (most of the requests in `Remote` classes use these 2 requests).

These two parameters are passed to the notification's user info dictionary, and `TrackEventRequestNotificationHandler` includes these 2 parameters in the `RemoteRequest.jsonParsingError` analytics event.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: use a tool that allows editing the API response, like [Charles Proxy breakpoints](https://charlesdocsy.com/2020/05/11/breakpoints-modify-request-headers/). set a breakpoint for any requests of your choice, like the analytics requests or products requests

- Launch the app
- Trigger the API request that triggers a breakpoint in the prerequisite
- In the proxy tool, edit the response to remove a required field like `id` (if using Charles Proxy, make sure to click `Cancel` instead of `Execute` in order to edit the response). After the edit response is executed, the console should show an event like `🔵 Tracked api_json_parsing_error, properties: [AnyHashable("path"): "reports/revenue/stats", AnyHashable("entity"): "OrderStatsV4", ...]`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
