### PR TITLE
Networking: Update site model with new property `wasEcommerceTrial`

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1665,7 +1665,8 @@ extension Networking.Site {
             gmtOffset: .fake(),
             isPublic: .fake(),
             canBlaze: .fake(),
-            isAdmin: .fake()
+            isAdmin: .fake(),
+            wasEcommerceTrial: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2052,7 +2052,8 @@ extension Networking.Site {
         gmtOffset: CopiableProp<Double> = .copy,
         isPublic: CopiableProp<Bool> = .copy,
         canBlaze: CopiableProp<Bool> = .copy,
-        isAdmin: CopiableProp<Bool> = .copy
+        isAdmin: CopiableProp<Bool> = .copy,
+        wasEcommerceTrial: CopiableProp<Bool> = .copy
     ) -> Networking.Site {
         let siteID = siteID ?? self.siteID
         let name = name ?? self.name
@@ -2073,6 +2074,7 @@ extension Networking.Site {
         let isPublic = isPublic ?? self.isPublic
         let canBlaze = canBlaze ?? self.canBlaze
         let isAdmin = isAdmin ?? self.isAdmin
+        let wasEcommerceTrial = wasEcommerceTrial ?? self.wasEcommerceTrial
 
         return Networking.Site(
             siteID: siteID,
@@ -2093,7 +2095,8 @@ extension Networking.Site {
             gmtOffset: gmtOffset,
             isPublic: isPublic,
             canBlaze: canBlaze,
-            isAdmin: isAdmin
+            isAdmin: isAdmin,
+            wasEcommerceTrial: wasEcommerceTrial
         )
     }
 }

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -80,6 +80,10 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     ///
     public let isAdmin: Bool
 
+    /// Whether the site has even run an E-commerce trial plan.
+    ///
+    public let wasEcommerceTrial: Bool
+
     /// Decodable Conformance.
     ///
     public init(from decoder: Decoder) throws {
@@ -94,6 +98,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         let isAdmin = try capabilitiesContainer.decode(Bool.self, forKey: .isAdmin)
         let isJetpackThePluginInstalled = try siteContainer.decode(Bool.self, forKey: .isJetpackThePluginInstalled)
         let isJetpackConnected = try siteContainer.decode(Bool.self, forKey: .isJetpackConnected)
+        let wasEcommerceTrial = try siteContainer.decode(Bool.self, forKey: .wasEcommerceTrial)
         let optionsContainer = try siteContainer.nestedContainer(keyedBy: OptionKeys.self, forKey: .options)
         let isWordPressComStore = try optionsContainer.decode(Bool.self, forKey: .isWordPressComStore)
         let isWooCommerceActive = try optionsContainer.decode(Bool.self, forKey: .isWooCommerceActive)
@@ -124,7 +129,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                   gmtOffset: gmtOffset,
                   isPublic: isPublic,
                   canBlaze: canBlaze,
-                  isAdmin: isAdmin)
+                  isAdmin: isAdmin,
+                  wasEcommerceTrial: wasEcommerceTrial)
     }
 
     /// Designated Initializer.
@@ -147,7 +153,8 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                 gmtOffset: Double,
                 isPublic: Bool,
                 canBlaze: Bool,
-                isAdmin: Bool) {
+                isAdmin: Bool,
+                wasEcommerceTrial: Bool) {
         self.siteID = siteID
         self.name = name
         self.description = description
@@ -167,6 +174,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         self.isPublic = isPublic
         self.canBlaze = canBlaze
         self.isAdmin = isAdmin
+        self.wasEcommerceTrial = wasEcommerceTrial
     }
 }
 
@@ -200,6 +208,7 @@ private extension Site {
         case plan           = "plan"
         case isJetpackThePluginInstalled = "jetpack"
         case isJetpackConnected          = "jetpack_connection"
+        case wasEcommerceTrial           = "was_ecommerce_trial"
     }
 
     enum CapabilitiesKeys: String, CodingKey {

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -106,7 +106,8 @@ public extension WordPressSite {
               gmtOffset: Double(gmtOffset) ?? 0,
               isPublic: false,
               canBlaze: false,
-              isAdmin: false)
+              isAdmin: false,
+              wasEcommerceTrial: false)
     }
 
     struct Authentication: Decodable {

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -234,7 +234,7 @@ extension SiteRemote {
     enum SiteParameter {
         enum Fields {
             static let key = "fields"
-            static let value = "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities"
+            static let value = "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities,was_ecommerce_trial"
         }
         enum Options {
             static let key = "options"

--- a/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
@@ -48,6 +48,7 @@ final class AccountMapperTests: XCTestCase {
         XCTAssertEqual(first.isPublic, true)
         XCTAssertEqual(first.canBlaze, true)
         XCTAssertEqual(first.isAdmin, true)
+        XCTAssertTrue(first.wasEcommerceTrial)
 
         // The second site is a Jetpack CP site (connected to Jetpack without Jetpack-the-plugin).
         let second = sites!.last!
@@ -70,6 +71,7 @@ final class AccountMapperTests: XCTestCase {
         XCTAssertEqual(second.isPublic, false)
         XCTAssertEqual(second.canBlaze, false)
         XCTAssertEqual(second.isAdmin, false)
+        XCTAssertFalse(second.wasEcommerceTrial)
     }
 
     /// Verifies that the Plan field for Site is properly parsed.

--- a/Networking/NetworkingTests/Responses/sites-malformed.json
+++ b/Networking/NetworkingTests/Responses/sites-malformed.json
@@ -7,6 +7,7 @@
       "URL": "https:\/\/some-testing-url.testing.blog",
       "jetpack": true,
       "jetpack_connection": true,
+      "was_ecommerce_trial": false,
       "updates": {
         "plugins": 3,
         "themes": 1,
@@ -46,6 +47,7 @@
       },
       "jetpack": false,
       "jetpack_connection": true,
+      "was_ecommerce_trial": false,
       "options": {
         "timezone": "",
         "gmt_offset": -4,

--- a/Networking/NetworkingTests/Responses/sites.json
+++ b/Networking/NetworkingTests/Responses/sites.json
@@ -31,6 +31,7 @@
       },
       "jetpack": true,
       "jetpack_connection": true,
+      "was_ecommerce_trial": true,
       "options": {
         "timezone": "",
         "gmt_offset": 3.5,
@@ -195,6 +196,7 @@
       },
       "jetpack": false,
       "jetpack_connection": true,
+      "was_ecommerce_trial": false,
       "options": {
         "timezone": "",
         "gmt_offset": -4,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -4,7 +4,7 @@
         "method": "GET",
         "queryParameters": {
           "fields": {
-            "equalTo": "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities"
+            "equalTo": "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities,was_ecommerce_trial"
           },
           "options": {
             "equalTo": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset,jetpack_connection_active_plugins,admin_url,login_url,frame_nonce,blog_public,can_blaze"

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -46,6 +46,7 @@
                       },
                       "jetpack": true,
                       "jetpack_connection": true,
+                      "was_ecommerce_trial": false,
                       "options": {
                         "timezone": "",
                         "gmt_offset": 0,

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -51,7 +51,8 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         gmtOffset: 0,
         isPublic: true,
         canBlaze: false,
-        isAdmin: false
+        isAdmin: false,
+        wasEcommerceTrial: false
     )
 
     /// May not be needed anymore if we're not mocking the API

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -51,6 +51,7 @@ extension Storage.Site: ReadOnlyConvertible {
                     gmtOffset: gmtOffset,
                     isPublic: isPublic,
                     canBlaze: canBlaze,
-                    isAdmin: isAdmin)
+                    isAdmin: isAdmin,
+                    wasEcommerceTrial: false)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10298 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new property for the `Site` model in the Networking layer. The fields used for site info requests are also updated to include `was_ecommerce_trial` in the response.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The new field hasn't been used anywhere so just unit test and UI test passing should be sufficient.

To check that the `was_ecommerce_trial` field has been returned in the response of site info:
- Build and run the app with Proxyman opened.
- Log in to a site.
- Look into API requests and find the one with path `/me/sites`. The response should include `was_ecommerce_trial`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
