### PR TITLE
[IAP] Address dark mode in Full Feature View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/FullFeatureListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/FullFeatureListView.swift
@@ -42,7 +42,7 @@ struct FullFeatureListView: View {
                 }
             }
             .padding(.horizontal)
-            .background(Color(.white))
+            .background(Color(.systemGroupedBackground))
             .cornerRadius(Layout.featureListCornerRadius)
             VStack(alignment: .leading, spacing: Layout.featureListSpacing) {
                 Text(Localization.paymentsDisclaimerText)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10283 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
With this PR we address a dark mode issue UI issue that made text ininteligible when opening the Full Feature List view.

## Testing instructions
1. On a Free Trial site, eligible for IAP (a new site can be created in Menu > Switch Sites > Add New Site), using the app on Dark Mode, tap on `Purchase Now`:
2. Scroll below the Performance plan, tap on `View Full Feature List` button.
3. See that the view's background is dark now.

## Screenshots
| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-07-25 at 08 57 55](https://github.com/woocommerce/woocommerce-ios/assets/3812076/6fe27111-de0f-4fc6-9a48-4cbea25ee3d3) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-07-25 at 09 12 45](https://github.com/woocommerce/woocommerce-ios/assets/3812076/6bae4e20-a45a-4fff-a44a-7036cdd8ae74) | 