### PR TITLE
Update `WCPayAccount.isLive`'s expected API value to be optional based on backend implementation

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 028FA472257E110700F88A48 /* shipping-label-refund-success.json */; };
 		02935AEE29DFFA74001B793E /* site-enable-trial-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02935AEC29DFFA74001B793E /* site-enable-trial-success.json */; };
 		02935AEF29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json in Resources */ = {isa = PBXBuildFile; fileRef = 02935AED29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json */; };
+		029B86902A6FBBE000E944D1 /* wcpay-account-null-isLive.json in Resources */ = {isa = PBXBuildFile; fileRef = 029B868F2A6FBBE000E944D1 /* wcpay-account-null-isLive.json */; };
 		029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */; };
 		029BA4F4255D72EC006171FD /* ShippingLabelPrintData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */; };
 		029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */; };
@@ -1026,6 +1027,7 @@
 		028FA472257E110700F88A48 /* shipping-label-refund-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-refund-success.json"; sourceTree = "<group>"; };
 		02935AEC29DFFA74001B793E /* site-enable-trial-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-enable-trial-success.json"; sourceTree = "<group>"; };
 		02935AED29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-enable-trial-error-already-upgraded.json"; sourceTree = "<group>"; };
+		029B868F2A6FBBE000E944D1 /* wcpay-account-null-isLive.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wcpay-account-null-isLive.json"; sourceTree = "<group>"; };
 		029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemote.swift; sourceTree = "<group>"; };
 		029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintData.swift; sourceTree = "<group>"; };
 		029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintDataMapper.swift; sourceTree = "<group>"; };
@@ -2760,6 +2762,7 @@
 				3158A4A22729F42500C3CFA8 /* wcpay-account-dev-test.json */,
 				3158A4A02729F40F00C3CFA8 /* wcpay-account-live-test.json */,
 				31B8D6B326583662008E3DB2 /* wcpay-account-not-eligible.json */,
+				029B868F2A6FBBE000E944D1 /* wcpay-account-null-isLive.json */,
 				3158FE6726129CE200E566B9 /* wcpay-account-rejected-fraud.json */,
 				3158FE6B26129D2E00E566B9 /* wcpay-account-rejected-terms-of-service.json */,
 				3158FE6F26129D7500E566B9 /* wcpay-account-rejected-listed.json */,
@@ -3581,6 +3584,7 @@
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
+				029B86902A6FBBE000E944D1 /* wcpay-account-null-isLive.json in Resources */,
 				DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */,
 				74A1D263211898F000931DFA /* site-visits-day.json in Resources */,
 				31054710262E2EE400C5C02B /* wcpay-payment-intent-succeeded.json in Resources */,

--- a/Networking/Networking/Model/WCPayAccount.swift
+++ b/Networking/Networking/Model/WCPayAccount.swift
@@ -1,4 +1,4 @@
-/// Represent a WCPay accont Entity.
+/// Represent a WCPay account Entity.
 ///
 public struct WCPayAccount: Decodable {
     public static let gatewayID = "woocommerce-payments"
@@ -58,7 +58,7 @@ public struct WCPayAccount: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let status = try container.decode(WCPayAccountStatusEnum.self, forKey: .status)
-        let isLiveAccount = try container.decode(Bool.self, forKey: .isLive)
+        let isLiveAccount = try container.decodeIfPresent(Bool.self, forKey: .isLive) ?? false
         let isInTestMode = try container.decode(Bool.self, forKey: .testMode)
         let hasPendingRequirements = try container.decode(Bool.self, forKey: .hasPendingRequirements)
         let hasOverdueRequirements = try container.decode(Bool.self, forKey: .hasOverdueRequirements)

--- a/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -377,6 +377,24 @@ final class WCPayRemoteTests: XCTestCase {
         XCTAssertEqual(account.isInTestMode, true)
     }
 
+    /// Properly decodes developer account when `is_live` field is `null` wcpay-account-null-isLive
+    ///
+    func test_loadAccount_returns_account_when_is_live_field_is_null() throws {
+        let remote = WCPayRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-null-isLive")
+
+        let result = waitFor { promise in
+            remote.loadAccount(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.isLiveAccount, false)
+    }
+
     /// Verifies that loadAccount properly handles networking errors
     ///
     func test_loadAccount_properly_handles_networking_errors() throws {

--- a/Networking/NetworkingTests/Responses/wcpay-account-null-isLive.json
+++ b/Networking/NetworkingTests/Responses/wcpay-account-null-isLive.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "is_live": null,
+        "has_pending_requirements": false,
+        "has_overdue_requirements": false,
+        "current_deadline": null,
+        "status": "complete",
+        "statement_descriptor": "MY.FANCY.US.STORE",
+        "store_currencies": {
+            "default": "usd",
+            "supported": [
+                "usd"
+            ]
+        },
+        "country": "US",
+        "card_present_eligible": true,
+        "test_mode": true
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10291 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While looking at the #9 decoding error on the `is_live` field pe5pgL-3lV-p2, the WCPay [backend implementation](https://github.com/Automattic/woocommerce-payments/blob/5f390e9a93f5e96360b4acf4a99556c38c4d7766/includes/class-wc-payments-account.php#L485-L489) suggests that this field can be `null` when the account or property can't be found. The app is currently expecting this field to be non-nil, and this PR updated the API value to optional with a default value `false`. The [Stripe plugin](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/c666a7af84a0e751a7add1533450a59aa906d2ca/includes/admin/class-wc-rest-stripe-account-controller.php#L130) always returns an account with a non-nil `is_live` value.

## How

For `WCPayAccount`'s `isLiveAccount` property, it now expects the API value to be optional with a default value `false`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This isn't easily reproducible, a test case was added to simulate the API response when the field is `null`. Please feel free to do a confidence check on IPP in the app for a store with WCPay/IPP enabled.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.