### PR TITLE
[Free trial survey] Survey screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+FreeTrialSurvey.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+FreeTrialSurvey.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum FreeTrialSurvey {
+
+        private enum Key: String {
+            case source = "source"
+            case surveyOption = "survey_option"
+            case freeText = "free_text"
+        }
+
+        static func surveySent(source: FreeTrialSurveyCoordinator.Source,
+                               surveyOption: String?,
+                               freeText: String?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .freeTrialSurveySent,
+                              properties: [Key.source.rawValue: source.rawValue,
+                                           Key.surveyOption.rawValue: surveyOption,
+                                           Key.freeText.rawValue: freeText].compactMapValues { $0 })
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+FreeTrialSurvey.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+FreeTrialSurvey.swift
@@ -10,7 +10,7 @@ extension WooAnalyticsEvent {
         }
 
         static func surveySent(source: FreeTrialSurveyCoordinator.Source,
-                               surveyOption: String?,
+                               surveyOption: String,
                                freeText: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .freeTrialSurveySent,
                               properties: [Key.source.rawValue: source.rawValue,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -963,6 +963,10 @@ public enum WooAnalyticsStat: String {
     case planUpgradeSuccess = "plan_upgrade_success"
     case planUpgradeAbandoned = "plan_upgrade_abandoned"
 
+    // MARK: Free Trial Survey
+    case freeTrialSurveyDisplayed = "free_trial_survey_displayed"
+    case freeTrialSurveySent = "free_trial_survey_sent"
+
     // MARK: In-App Purchases
     case planUpgradePurchaseButtonTapped = "plan_upgrade_purchase_button_tapped"
     case planUpgradeScreenLoaded = "plan_upgrade_screen_loaded"

--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+final class FreeTrialSurveyCoordinator: Coordinator {
+    enum Source: String {
+        case freeTrialSurvey24hAfterFreeTrialSubscribed = "free_trial_survey_24h_after_free_trial_subscribed"
+    }
+
+    let navigationController: UINavigationController
+
+    private let source: Source
+    private let analytics: Analytics
+
+    init(source: Source,
+         navigationController: UINavigationController,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.source = source
+        self.navigationController = navigationController
+        self.analytics = analytics
+    }
+
+    func start() {
+        let survey = FreeTrialSurveyHostingController(viewModel: .init(source: source))
+        navigationController.present(WooNavigationController(rootViewController: survey), animated: true)
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+/// Coordinates navigation for Free trial survey
+/// 
 final class FreeTrialSurveyCoordinator: Coordinator {
     enum Source: String {
         case freeTrialSurvey24hAfterFreeTrialSubscribed = "free_trial_survey_24h_after_free_trial_subscribed"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
@@ -75,7 +75,7 @@ struct FreeTrialSurveyView: View {
             .background(Color(.systemBackground))
         }
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .cancellationAction) {
                 Button(Localization.cancel) {
                     dismissAction()
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
@@ -22,6 +22,8 @@ final class FreeTrialSurveyHostingController: UIHostingController<FreeTrialSurve
     }
 }
 
+/// View that presents a list of answers for Free trial survey
+///
 struct FreeTrialSurveyView: View {
     @ObservedObject private var viewModel: FreeTrialSurveyViewModel
     var dismissAction: () -> Void = {}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+final class FreeTrialSurveyHostingController: UIHostingController<FreeTrialSurveyView> {
+    init(viewModel: FreeTrialSurveyViewModel) {
+        super.init(rootView: FreeTrialSurveyView(viewModel: viewModel))
+        rootView.dismissAction = dismiss
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTransparentNavigationBar()
+    }
+
+    func dismiss() {
+        dismiss(animated: true)
+    }
+}
+
+struct FreeTrialSurveyView: View {
+    @ObservedObject private var viewModel: FreeTrialSurveyViewModel
+    var dismissAction: () -> Void = {}
+
+    init(viewModel: FreeTrialSurveyViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                Text(Localization.title)
+                    .fontWeight(.bold)
+                    .titleStyle()
+
+                VStack() {
+                    ForEach(viewModel.answers, id: \.self) { answer in
+                        if answer == .otherReasons {
+                            TextField(answer.text, text: $viewModel.otherReasonSpecified)
+                                .font(.body)
+                                .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
+                        } else {
+                            Button(action: {
+                                viewModel.selectAnswer(answer)
+                            }, label: {
+                                HStack {
+                                    Text(answer.text)
+                                    Spacer()
+                                }
+                            })
+                            .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedAnswer == answer))
+                        }
+                    }
+                }
+            }
+            .padding(Layout.contentPadding)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: Layout.ctaPadding) {
+                Divider()
+                    .frame(height: Layout.dividerHeight)
+                    .foregroundColor(Color(.separator))
+
+                Button(Localization.sendFeedback) {
+                    viewModel.submitFeedback()
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.horizontal, Layout.ctaPadding)
+                .disabled(!viewModel.feedbackSelected)
+            }
+            .background(Color(.systemBackground))
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(Localization.cancel) {
+                    dismissAction()
+                }
+                .buttonStyle(TextButtonStyle())
+            }
+        }
+    }
+}
+
+private extension FreeTrialSurveyView {
+    enum Layout {
+        static let dividerHeight: CGFloat = 1
+        static let contentPadding: EdgeInsets = .init(top: 40, leading: 16, bottom: 16, trailing: 16)
+        static let ctaPadding: CGFloat = 16
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Help us understand your subscription decisions. Your feedback matters.",
+            comment: "Title in Free trail survey screen."
+        )
+
+        static let sendFeedback = NSLocalizedString(
+            "Send Feedback",
+            comment: "CTA button title which sends survey feedback."
+        )
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Button to dismiss the survey screen."
+        )
+    }
+}
+
+struct FreeTrialSurveyView_Previews: PreviewProvider {
+    static var previews: some View {
+        if #available(iOS 16.0, *) {
+            NavigationStack {
+                FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed))
+            }
+        } else {
+            FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed))
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
@@ -62,7 +62,8 @@ struct FreeTrialSurveyView: View {
                                     Spacer()
                                 }
                             })
-                            .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedAnswer == answer))
+                            .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedAnswer == answer,
+                                                                        labelFont: .body))
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
@@ -26,6 +26,8 @@ final class FreeTrialSurveyHostingController: UIHostingController<FreeTrialSurve
 ///
 struct FreeTrialSurveyView: View {
     @ObservedObject private var viewModel: FreeTrialSurveyViewModel
+    @FocusState private var isOtherReasonsFocused: Bool
+
     var dismissAction: () -> Void = {}
 
     init(viewModel: FreeTrialSurveyViewModel) {
@@ -42,11 +44,17 @@ struct FreeTrialSurveyView: View {
                 VStack() {
                     ForEach(viewModel.answers, id: \.self) { answer in
                         if answer == .otherReasons {
-                            TextField(answer.text, text: $viewModel.otherReasonSpecified)
-                                .font(.body)
-                                .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
+                            TextField(answer.text, text: $viewModel.otherReasonSpecified, onEditingChanged: { focus in
+                                if focus {
+                                    viewModel.selectAnswer(.otherReasons)
+                                }
+                            })
+                            .font(.body)
+                            .textFieldStyle(RoundedBorderTextFieldStyle(focused: isOtherReasonsFocused))
+                            .focused($isOtherReasonsFocused)
                         } else {
                             Button(action: {
+                                isOtherReasonsFocused = false
                                 viewModel.selectAnswer(answer)
                             }, label: {
                                 HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+final class FreeTrialSurveyViewModel: ObservableObject {
+    @Published private(set) var selectedAnswer: SurveyAnswer?
+    @Published var otherReasonSpecified: String = ""
+
+    private let analytics: Analytics
+    private let source: FreeTrialSurveyCoordinator.Source
+
+    init(source: FreeTrialSurveyCoordinator.Source,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.source = source
+        self.analytics = analytics
+
+        $otherReasonSpecified
+            .filter { $0.isNotEmpty }
+            .map { _ in nil }
+            .assign(to: &$selectedAnswer)
+    }
+
+    var answers: [SurveyAnswer] {
+        SurveyAnswer.allCases
+    }
+
+    var feedbackSelected: Bool {
+        otherReasonSpecified.isNotEmpty || selectedAnswer != nil
+    }
+
+    func selectAnswer(_ answer: SurveyAnswer) {
+        selectedAnswer = answer
+    }
+
+    func submitFeedback() {
+        // TODO: 10266 Submit tracks
+    }
+
+    enum SurveyAnswer: String, Equatable, CaseIterable {
+        case stillExploring = "still_exploring"
+        case comparingWithOtherPlatforms = "comparing_with_other_platforms"
+        case priceIsSignificantFactor = "price_is_significant_factor"
+        case collectiveDecision = "collective_decision"
+        case otherReasons = "other_reasons"
+
+        var text: String {
+            switch self {
+            case .stillExploring:
+                return Localization.stillExploring
+            case .comparingWithOtherPlatforms:
+                return Localization.comparingWithOtherPlatforms
+            case .priceIsSignificantFactor:
+                return Localization.priceIsSignificantFactor
+            case .collectiveDecision:
+                return Localization.collectiveDecision
+            case .otherReasons:
+                return Localization.otherReasons
+            }
+        }
+
+        private enum Localization {
+            static let stillExploring = NSLocalizedString(
+                "I am still exploring and assessing the features and benefits of the app.",
+                comment: "Text for Free trial survey answer."
+            )
+            static let comparingWithOtherPlatforms = NSLocalizedString(
+                "I am evaluating and comparing your service with others on the market",
+                comment: "Text for Free trial survey answer."
+            )
+            static let priceIsSignificantFactor = NSLocalizedString(
+                "I find the price of the service to be a significant factor in my decision.",
+                comment: "Text for Free trial survey answer."
+            )
+            static let collectiveDecision = NSLocalizedString(
+                "I am part of a team, and we need to make the decision collectively.",
+                comment: "Text for Free trial survey answer."
+            )
+            static let otherReasons = NSLocalizedString(
+                "Other (please specify).",
+                comment: "Placeholder text for Free trial survey."
+            )
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+/// View model for `FreeTrialSurveyView`
+///
 final class FreeTrialSurveyViewModel: ObservableObject {
     @Published private(set) var selectedAnswer: SurveyAnswer?
     @Published var otherReasonSpecified: String = ""

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -31,7 +31,7 @@ final class FreeTrialSurveyViewModel: ObservableObject {
         // TODO: 10266 Submit tracks
     }
 
-    enum SurveyAnswer: String, Equatable, CaseIterable {
+    enum SurveyAnswer: String, CaseIterable {
         case stillExploring = "still_exploring"
         case comparingWithOtherPlatforms = "comparing_with_other_platforms"
         case priceIsSignificantFactor = "price_is_significant_factor"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -13,11 +13,6 @@ final class FreeTrialSurveyViewModel: ObservableObject {
          analytics: Analytics = ServiceLocator.analytics) {
         self.source = source
         self.analytics = analytics
-
-        $otherReasonSpecified
-            .filter { $0.isNotEmpty }
-            .map { _ in nil }
-            .assign(to: &$selectedAnswer)
     }
 
     var answers: [SurveyAnswer] {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -68,7 +68,13 @@ struct SecondaryLoadingButtonStyle: PrimitiveButtonStyle {
 struct SelectableSecondaryButtonStyle: ButtonStyle {
     /// Whether the button is selected.
     let isSelected: Bool
-    let labelFont: Font = .headline
+    let labelFont: Font
+
+    init(isSelected: Bool, labelFont: Font = .headline) {
+        self.isSelected = isSelected
+        self.labelFont = labelFont
+    }
+
     func makeBody(configuration: Configuration) -> some View {
         SelectableSecondaryButton(isSelected: isSelected, configuration: configuration, labelFont: labelFont)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2265,6 +2265,8 @@
 		EE45E2C22A42C9D80085F227 /* ProductDescriptionAITooltipUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE45E2C12A42C9D80085F227 /* ProductDescriptionAITooltipUseCaseTests.swift */; };
 		EE45E2C42A4A85350085F227 /* TooltipPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE45E2C32A4A85350085F227 /* TooltipPresenterTests.swift */; };
 		EE46CEDF29CB31DF004E4524 /* StoreOnboardingStoreDetailsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE46CEDE29CB31DF004E4524 /* StoreOnboardingStoreDetailsCoordinator.swift */; };
+		EE486DD02A7013C80079F7B8 /* FreeTrialSurveyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE486DCF2A7013C80079F7B8 /* FreeTrialSurveyCoordinator.swift */; };
+		EE486DD22A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE486DD12A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift */; };
 		EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */; };
 		EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */; };
 		EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */; };
@@ -2286,6 +2288,8 @@
 		EEB4E2DA29B5F8FC00371C3C /* CouponLineDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */; };
 		EEB4E2DC29B600B800371C3C /* CouponLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */; };
 		EEB4E2DE29B61AAD00371C3C /* CouponInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */; };
+		EEB917C82A6FE52F004D364B /* FreeTrialSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB917C72A6FE52F004D364B /* FreeTrialSurveyView.swift */; };
+		EEB917CA2A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB917C92A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift */; };
 		EEBDF7DA2A2EF69B00EFEF47 /* ShareProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */; };
 		EEBDF7DF2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7DE2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift */; };
 		EEBDF7E22A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */; };
@@ -4676,6 +4680,8 @@
 		EE45E2C12A42C9D80085F227 /* ProductDescriptionAITooltipUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAITooltipUseCaseTests.swift; sourceTree = "<group>"; };
 		EE45E2C32A4A85350085F227 /* TooltipPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPresenterTests.swift; sourceTree = "<group>"; };
 		EE46CEDE29CB31DF004E4524 /* StoreOnboardingStoreDetailsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingStoreDetailsCoordinator.swift; sourceTree = "<group>"; };
+		EE486DCF2A7013C80079F7B8 /* FreeTrialSurveyCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyCoordinator.swift; sourceTree = "<group>"; };
+		EE486DD12A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+FreeTrialSurvey.swift"; sourceTree = "<group>"; };
 		EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandler.swift; sourceTree = "<group>"; };
 		EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ApplicationPassword.swift"; sourceTree = "<group>"; };
 		EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandlerTests.swift; sourceTree = "<group>"; };
@@ -4697,6 +4703,8 @@
 		EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetailsViewModel.swift; sourceTree = "<group>"; };
 		EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetails.swift; sourceTree = "<group>"; };
 		EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponInputTransformer.swift; sourceTree = "<group>"; };
+		EEB917C72A6FE52F004D364B /* FreeTrialSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyView.swift; sourceTree = "<group>"; };
+		EEB917C92A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyViewModel.swift; sourceTree = "<group>"; };
 		EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductCoordinator.swift; sourceTree = "<group>"; };
 		EEBDF7DE2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductAIEligibilityChecker.swift; sourceTree = "<group>"; };
 		EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShareProductAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
@@ -6643,6 +6651,7 @@
 			children = (
 				26C1633B29DA2CE700E482CE /* FreeTrialSummaryView.swift */,
 				53284F5B35E9ED12097A1E88 /* FreeTrialFeatures.swift */,
+				EE486DCF2A7013C80079F7B8 /* FreeTrialSurveyCoordinator.swift */,
 			);
 			path = "Free Trial";
 			sourceTree = "<group>";
@@ -6682,6 +6691,7 @@
 		26C98F9929C18ABF00F96503 /* Free Trial */ = {
 			isa = PBXGroup;
 			children = (
+				EEB917C62A6FE4C6004D364B /* FreeTrialSurvey */,
 				26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */,
 				2631D4FD29F2141D00F13F20 /* FreeTrialBannerPresenter.swift */,
 				261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */,
@@ -7797,6 +7807,7 @@
 				0225091C2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift */,
 				DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */,
 				EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */,
+				EE486DD12A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -10621,6 +10632,15 @@
 			path = ShippingValueLocalizer;
 			sourceTree = "<group>";
 		};
+		EEB917C62A6FE4C6004D364B /* FreeTrialSurvey */ = {
+			isa = PBXGroup;
+			children = (
+				EEB917C72A6FE52F004D364B /* FreeTrialSurveyView.swift */,
+				EEB917C92A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift */,
+			);
+			path = FreeTrialSurvey;
+			sourceTree = "<group>";
+		};
 		EEBDF7D62A2EF65D00EFEF47 /* ShareProduct */ = {
 			isa = PBXGroup;
 			children = (
@@ -11868,6 +11888,7 @@
 				B6F37970293798ED00718561 /* AnalyticsHubTodayRangeData.swift in Sources */,
 				CCFBBCF629C4B9A30081B595 /* ComponentsListViewModel.swift in Sources */,
 				269098B427D2BBFC001FEB07 /* ShippingInputTransformer.swift in Sources */,
+				EE486DD02A7013C80079F7B8 /* FreeTrialSurveyCoordinator.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				45F627B6253603AE00894B86 /* Product+DownloadSettingsViewModels.swift in Sources */,
 				B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */,
@@ -11903,6 +11924,7 @@
 				DE2E8EB729547771002E4B14 /* ApplicationPasswordDisabledViewModel.swift in Sources */,
 				0259D65D2582248D003B1CD6 /* PrintShippingLabelViewController.swift in Sources */,
 				D881A31B256B5CC500FE5605 /* ULErrorViewController.swift in Sources */,
+				EEB917CA2A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift in Sources */,
 				CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */,
 				021125482577CC650075AD2A /* ShippingLabelDetailsViewModel.swift in Sources */,
 				68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */,
@@ -11921,6 +11943,7 @@
 				035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */,
 				EEB4E2DC29B600B800371C3C /* CouponLineDetails.swift in Sources */,
 				03F5CB012A0BA3D40026877A /* ModalOverlay.swift in Sources */,
+				EEB917C82A6FE52F004D364B /* FreeTrialSurveyView.swift in Sources */,
 				02C37B7D2967B72A00F0CF9E /* FreeStagingDomainView.swift in Sources */,
 				457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */,
 				D8815B0D263861A400EDAD62 /* CardPresentModalSuccess.swift in Sources */,
@@ -12688,6 +12711,7 @@
 				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,
 				CC3B35DD28E5A6EA0036B097 /* ReviewReplyViewModel.swift in Sources */,
 				DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */,
+				EE486DD22A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift in Sources */,
 				CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */,
 				77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */,
 				3F50FE4328CAEBA800C89201 /* AppLocalizedString.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10266 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

- Adds view, view model and coordinator for the Free trial survey screen.
- Adds tracks events and helper for tracking. 

Notes
- Please use SwiftUI preview to see the screen. 
- I will add unit tests in a future PR.

## Testing instructions
This screen will be presented in a future PR.  CI passing is enough for now.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/524475/a518da06-ab74-4ee4-84a8-1bcd66a86a06



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
