### PR TITLE
[IAP] Disable plan selection while purchasing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -42,16 +42,17 @@ struct OwnerUpgradesView: View {
                 VStack {
                     ForEach(upgradePlans.filter { $0.wooPlan.planFrequency == paymentFrequency }) { upgradePlan in
                         WooPlanCardView(upgradePlan: upgradePlan, selectedPlan: $selectedPlan)
-                        .accessibilityAddTraits(.isSummaryElement)
-                        .listRowSeparator(.hidden)
-                        .redacted(reason: isLoading ? .placeholder : [])
-                        .shimmering(active: isLoading)
-                        .padding(.bottom, 8)
+                            .disabled(isPurchasing)
+                            .listRowSeparator(.hidden)
+                            .redacted(reason: isLoading ? .placeholder : [])
+                            .shimmering(active: isLoading)
+                            .padding(.bottom, 8)
                     }
                     Button(Localization.allFeaturesListText) {
                         showingFullFeatureList.toggle()
                     }
                     .buttonStyle(SecondaryButtonStyle())
+                    .disabled(isPurchasing)
                     .sheet(isPresented: $showingFullFeatureList) {
                         NavigationView {
                             FullFeatureListView()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10286
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

It takes a little while after tapping `Purchase` for Apple’s In-App Purchase drawer to show up.

Previously it was possible to change your selected plan after tapping Purchase, while waiting for the IAP drawer to show, but any changes would not be reflected when the draw did appear. This was potentially confusing.

This disables plan selection and opening the all features view while waiting for Apple.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Select the `WooCommerce IAP` scheme in Xcode, and build the app
2. Switch to a store with a Woo Express free trial plan active
3. Tap `Upgrade now`
4. Select a plan
5. Tap `Purchase Essential Yearly` or equivalent
6. Quickly attempt to tap another plan or the full details button before the IAP drawer shows
7. Observe that you cannot change the selected plan while waiting for the IAP drawer

This may be easier to test with a sandbox user, because I think you get a bit longer waiting for the IAP drawer. In that case, use the WooCommerce screen and a physical device.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
