### PR TITLE
Update “manage button” logic to cover all plans

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Plan/WebPurchasesForWPComPlans.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Plan/WebPurchasesForWPComPlans.swift
@@ -54,6 +54,11 @@ extension WebPurchasesForWPComPlans: InAppPurchasesForWPComPlansProtocol {
         // Web purchases are available for everyone and every site.
         true
     }
+
+    func siteHasCurrentInAppPurchases(siteID: Int64) async -> Bool {
+        // no-op
+        false
+    }
 }
 
 private extension WebPurchasesForWPComPlans {

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
@@ -49,6 +49,10 @@ protocol InAppPurchasesForWPComPlansProtocol {
     /// Returns whether In-App Purchases are supported for the current user configuration
     ///
     func inAppPurchasesAreSupported() async -> Bool
+
+    /// Returns whether the site has any current In-App Purchases product
+    ///
+    func siteHasCurrentInAppPurchases(siteID: Int64) async -> Bool
 }
 
 final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProtocol {
@@ -100,6 +104,15 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
             stores.dispatch(InAppPurchaseAction.inAppPurchasesAreSupported(completion: { result in
                 continuation.resume(returning: result)
             }))
+        }
+    }
+
+    @MainActor
+    func siteHasCurrentInAppPurchases(siteID: Int64) async -> Bool {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(InAppPurchaseAction.siteHasCurrentInAppPurchases(siteID: siteID) { result in
+                continuation.resume(returning: result)
+            })
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -25,7 +25,7 @@ final class StorePlanSynchronizer: ObservableObject {
 
     /// Current logged-in site. `Nil` if not logged-in.
     ///
-    private var site: Site?
+    private(set) var site: Site?
 
     /// Stores manager.
     ///

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -134,7 +134,9 @@ private extension SubscriptionsViewModel {
         shouldShowFreeTrialFeatures = plan.isFreeTrial
 
         Task {
-            try await shouldRenderManageSubscriptionsButton()
+            if !plan.isFreeTrial {
+                try await shouldRenderManageSubscriptionsButton()
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockInAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockInAppPurchasesForWPComPlansManager.swift
@@ -52,6 +52,10 @@ extension MockInAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansPro
     func inAppPurchasesAreSupported() async -> Bool {
         isIAPSupported
     }
+
+    func siteHasCurrentInAppPurchases(siteID: Int64) async -> Bool {
+        userIsEntitledToPlan
+    }
 }
 
 extension MockInAppPurchasesForWPComPlansManager {

--- a/Yosemite/Yosemite/Actions/InAppPurchaseAction.swift
+++ b/Yosemite/Yosemite/Actions/InAppPurchaseAction.swift
@@ -7,4 +7,5 @@ public enum InAppPurchaseAction: Action {
     case userIsEntitledToProduct(productID: String, completion: (Result<Bool, Error>) -> Void)
     case inAppPurchasesAreSupported(completion: (Bool) -> Void)
     case retryWPComSyncForPurchasedProduct(productID: String, completion: (Result<(), Error>) -> Void)
+    case siteHasCurrentInAppPurchases(siteID: Int64, completion: (Bool) -> Void)
 }

--- a/Yosemite/Yosemite/Model/WooPlans/LegacyWooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/LegacyWooPlan.swift
@@ -136,7 +136,7 @@ public struct LegacyWooPlan: Decodable {
     }
 }
 
-public enum AvailableInAppPurchasesWPComPlans: String, CaseIterable {
+public enum AvailableInAppPurchasesWPComPlans: String {
     case essentialMonthly = "woocommerce.express.essential.monthly"
     case essentialYearly = "woocommerce.express.essential.yearly"
     case performanceMonthly = "woocommerce.express.performance.monthly"

--- a/Yosemite/Yosemite/Model/WooPlans/LegacyWooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/LegacyWooPlan.swift
@@ -136,7 +136,7 @@ public struct LegacyWooPlan: Decodable {
     }
 }
 
-public enum AvailableInAppPurchasesWPComPlans: String {
+public enum AvailableInAppPurchasesWPComPlans: String, CaseIterable {
     case essentialMonthly = "woocommerce.express.essential.monthly"
     case essentialYearly = "woocommerce.express.essential.yearly"
     case performanceMonthly = "woocommerce.express.performance.monthly"

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -278,7 +278,7 @@ private extension InAppPurchaseStore {
 
         return supportedCountriesCodes.contains(countryCode)
     }
-    
+
     /// Checks if the Site has current subscriptions via In-App Purchases
     ///
     func siteHasCurrentInAppPurchases(siteID: Int64) async -> Bool {

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -68,6 +68,10 @@ public class InAppPurchaseStore: Store {
                     completion(.failure(error))
                 }
             }
+        case .siteHasCurrentInAppPurchases(siteID: let siteID, completion: let completion):
+            Task {
+                completion(await siteHasCurrentInAppPurchases(siteID: siteID))
+            }
         }
     }
 }
@@ -273,6 +277,27 @@ private extension InAppPurchaseStore {
         }
 
         return supportedCountriesCodes.contains(countryCode)
+    }
+    
+    /// Checks if the Site has current subscriptions via In-App Purchases
+    ///
+    func siteHasCurrentInAppPurchases(siteID: Int64) async -> Bool {
+        for await transaction in Transaction.currentEntitlements {
+            switch transaction {
+            case .verified(let transaction):
+                // If we have current entitlements, we check for its transaction token, and extract the associated siteID.
+                // If this siteID matches the current siteID, then the site has current In-App Purchases.
+                guard let token = transaction.appAccountToken,
+                      let transactionSiteID = AppAccountToken.siteIDFromToken(token),
+                      transactionSiteID == siteID else {
+                    continue
+                }
+                return true
+            default:
+                break
+            }
+        }
+        return false
     }
 
     func listenForTransactions() {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/10194
Closes: https://github.com/woocommerce/woocommerce-ios/issues/9916 

## Description
This PR addresses two issues regarding the "Manage your subscription" button:
1. The button would only load for sites with a current Essential Monthly plan, since we only checked for that specific case during M1.
2. The button would load for any site that is in the same account of a merchant with an active plan, since the check was performed account-wide, without taking into account the siteID (https://github.com/woocommerce/woocommerce-ios/issues/10194)

## Changes

We add a new `siteHasCurrentInAppPurchases(siteID: Int64)` action to the `InAppPurchaseStore` which will check if there's  any `VerificationResult<Transaction>` on the user account, which represents a current In-App Purchase. 

If there is, we decode the transaction token and extract the associated SiteID with that transaction. If the current store's siteID fits the extracted siteID, then we know the current site has a subscription via IAP.

## Testing instructions
For the following Woo Express stores. go to `Menu` > `Subscriptions` and observe that:
- On a Free Trial store with no upgrades, or expired, no button is rendered.
- On a store upgraded via web, no button is rendered.
- On a store upgraded via In-App Purchases, a "Manage your subscription" button is rendered. Tapping this button will behave as before, redirecting the merchant to the App Store `https://apps.apple.com/account/subscriptions` URL

