### PR TITLE
[IAP] Apply loading state to view all features button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -52,7 +52,9 @@ struct OwnerUpgradesView: View {
                         showingFullFeatureList.toggle()
                     }
                     .buttonStyle(SecondaryButtonStyle())
-                    .disabled(isPurchasing)
+                    .disabled(isPurchasing || isLoading)
+                    .redacted(reason: isLoading ? .placeholder : [])
+                    .shimmering(active: isLoading)
                     .sheet(isPresented: $showingFullFeatureList) {
                         NavigationView {
                             FullFeatureListView()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after #10320
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The `View Full Feature List` button previously showed its label and was functional while the rest of the view was loading, which was a little strange. This PR adds the loading state to this button.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Using the WooCommerce IAP scheme, build the app on a simulator
2. Switch to a store with a Woo Express free trial
3. Tap `Upgrade now` in the banner on the My Store tab
4. Observe that the button has a loading state and does nothing when tapped
5. Observe that it shows and works when the rest of the view loads.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/13a4ee13-ed90-4e58-bf2c-09991188e14a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
