### PR TITLE
[IAP] Prevent view reload when purchase plan tapped

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
@@ -3,7 +3,6 @@ import Foundation
 enum UpgradeViewState: Equatable {
     case loading
     case loaded([WooWPComPlan])
-    case purchasing(WooWPComPlan, [WooWPComPlan])
     case waiting(WooWPComPlan)
     case completed(WooWPComPlan)
     case prePurchaseError(PrePurchaseError)
@@ -11,7 +10,7 @@ enum UpgradeViewState: Equatable {
 
     var shouldShowPlanDetailsView: Bool {
         switch self {
-        case .loading, .loaded, .purchasing, .prePurchaseError:
+        case .loading, .loaded, .prePurchaseError:
             return true
         default:
             return false
@@ -20,7 +19,7 @@ enum UpgradeViewState: Equatable {
 
     var analyticsStep: WooAnalyticsEvent.InAppPurchases.Step? {
         switch self {
-        case .loading, .purchasing:
+        case .loading:
             return nil
         case .loaded:
             return .planDetails

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -4,16 +4,16 @@ import WooFoundation
 
 struct OwnerUpgradesView: View {
     @State var upgradePlans: [WooWPComPlan]
-    @State var isPurchasing: Bool
+    @Binding var isPurchasing: Bool
     let purchasePlanAction: (WooWPComPlan) -> Void
     @State var isLoading: Bool
 
     init(upgradePlans: [WooWPComPlan],
-         isPurchasing: Bool = false,
+         isPurchasing: Binding<Bool>,
          purchasePlanAction: @escaping ((WooWPComPlan) -> Void),
          isLoading: Bool = false) {
         _upgradePlans = .init(initialValue: upgradePlans)
-        _isPurchasing = .init(initialValue: isPurchasing)
+        _isPurchasing = isPurchasing
         self.purchasePlanAction = purchasePlanAction
         _isLoading = .init(initialValue: isLoading)
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -93,16 +93,17 @@ struct UpgradesView: View {
                         .skeletonPlan(frequency: .year, shortName: "Performance"),
                         .skeletonPlan(frequency: .month, shortName: "Essential"),
                         .skeletonPlan(frequency: .month, shortName: "Performance")],
+                                      isPurchasing: .constant(false),
                                       purchasePlanAction: { _ in }, isLoading: true)
                         .accessibilityLabel(Localization.plansLoadingAccessibilityLabel)
                 case .loaded(let plans):
-                    OwnerUpgradesView(upgradePlans: plans, purchasePlanAction: { selectedPlan in
+                    OwnerUpgradesView(upgradePlans: plans,
+                                      isPurchasing: $upgradesViewModel.isPurchasing,
+                                      purchasePlanAction: { selectedPlan in
                         Task {
                             await upgradesViewModel.purchasePlan(with: selectedPlan.wpComPlan.id)
                         }
                     })
-                case .purchasing(_, let plans):
-                    OwnerUpgradesView(upgradePlans: plans, isPurchasing: true, purchasePlanAction: { _ in })
                 case .waiting(let plan):
                     ScrollView(.vertical) {
                         UpgradeWaitingView(planName: plan.wooPlan.shortName)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after: #10322
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, when the merchant tapped `Purchase Essential Monthly` or similar, we sent a new view state, `purchasing(plan, [plans])`, which set the purchasing state (i.e. spinner on the Purchase button, disabling the plan selection).

Unfortunately, this also resulted in a full view redraw, which means we lost the user’s place. If they’d selected a monthly plan, it would be hidden as the view moved back to the default yearly plans section, and any scroll position would be lost, which looked a little strange.

Here, we replace the `purchasing` state with a published property for `isPurchasing` on the view model, which is bound by the `OwnerUpgradesView` where needed. This value also lets us check whether we should advance to the waiting state after the IAP drawer is dismissed – if we’re no longer purchasing because of an error or cancellation, we shouldn’t show the waiting state.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US-based sandbox Apple ID

1. Select a store with a Woo Express free trial
2. Tap `Upgrade now` in the banner on the My Store tab
3. Select a monthly plan
4. Tap `Purchase Essential/Performance Monthly`
5. Observe that the view only updates to have a spinner in the purchase button, and does not switch back to the yearly plans
6. Tap cancel on the In App Purchase sheet when it's shown
7. Observe that the view's buttons are re-enabled, but it doesn't jump back to the yearly plans
8. Re-do a purchase, going all the way through
9. Observe that the purchase is successful.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/6c5af236-1f47-451e-bd6a-1c5b1c50a1b2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
