### PR TITLE
Local notification: Notification for Free trial survey

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -99,6 +99,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ordersWithCouponsM4:
             return true
+        case .freeTrialSurvey24hAfterFreeTrialSubscribed:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -210,4 +210,7 @@ public enum FeatureFlag: Int {
 
     /// Enables the Milestone 4 of the Orders with Coupons project: Adding discounts to products
     case ordersWithCouponsM4
+
+    /// Enables Free trial survey notificaiton
+    case freeTrialSurvey24hAfterFreeTrialSubscribed
 }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -48,6 +48,7 @@ struct LocalNotification {
                 static let oneDayAfterFreeTrialExpires = "one_day_after_free_trial_expires"
                 static let sixHoursAfterFreeTrialSubscribed = "six_hours_after_free_trial_subscribed"
                 static let twentyFourHoursAfterFreeTrialSubscribed = "twenty_four_hours_after_free_trial_subscribed"
+                static let freeTrialSurvey24hAfterFreeTrialSubscribed = "free_trial_survey_24h_after_free_trial_subscribed"
             }
             static let oneDayAfterStoreCreationNameWithoutFreeTrial = "one_day_after_store_creation_name_without_free_trial"
         }
@@ -225,6 +226,17 @@ extension LocalNotification {
             static let body = NSLocalizedString(
                 "Discover advanced features and personalized recommendations for your store! Tap to pick a plan that suits you best.",
                 comment: "Message on the local notification to remind the user to purchase a plan."
+            )
+        }
+
+        enum FreeTrialSurvey24hAfterFreeTrialSubscribed {
+            static let title = NSLocalizedString(
+                "💡Help Us Understand Your Subscription Decision",
+                comment: "Title of the local notification to ask for Free trial survey."
+            )
+            static let body = NSLocalizedString(
+                "We’re interested in your decision-making journey. Could you please tell us about your current status?",
+                comment: "Message on the local notification to ask for Free trial survey."
             )
         }
     }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -24,6 +24,7 @@ struct LocalNotification {
         case oneDayAfterFreeTrialExpires(siteID: Int64)
         case sixHoursAfterFreeTrialSubscribed(siteID: Int64)
         case twentyFourHoursAfterFreeTrialSubscribed(siteID: Int64)
+        case freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: Int64)
 
         var identifier: String {
             switch self {
@@ -39,6 +40,8 @@ struct LocalNotification {
                 return Identifier.Prefix.sixHoursAfterFreeTrialSubscribed + "\(siteID)"
             case let .twentyFourHoursAfterFreeTrialSubscribed(siteID):
                 return Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed + "\(siteID)"
+            case let .freeTrialSurvey24hAfterFreeTrialSubscribed(siteID):
+                return Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed + "\(siteID)"
             }
         }
 
@@ -63,6 +66,8 @@ struct LocalNotification {
                 return Identifier.Prefix.sixHoursAfterFreeTrialSubscribed
             } else if identifier.hasPrefix(Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed) {
                 return Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed
+            } else if identifier.hasPrefix(Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed) {
+                return Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed
             }
             return identifier
         }
@@ -143,6 +148,10 @@ extension LocalNotification {
         case .twentyFourHoursAfterFreeTrialSubscribed:
             title = Localization.TwentyFourHoursAfterFreeTrialSubscribed.title
             body = Localization.TwentyFourHoursAfterFreeTrialSubscribed.body
+
+        case .freeTrialSurvey24hAfterFreeTrialSubscribed:
+            title = Localization.FreeTrialSurvey24hAfterFreeTrialSubscribed.title
+            body = Localization.FreeTrialSurvey24hAfterFreeTrialSubscribed.body
 
         }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -351,6 +351,7 @@ private extension AppCoordinator {
         let oneDayAfterFreeTrialExpiresIdentifier = LocalNotification.Scenario.Identifier.Prefix.oneDayAfterFreeTrialExpires
         let sixHoursAfterFreeTrialSubscribed = LocalNotification.Scenario.Identifier.Prefix.sixHoursAfterFreeTrialSubscribed
         let twentyFourHoursAfterFreeTrialSubscribed = LocalNotification.Scenario.Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed
+        let freeTrialSurvey24hAfterFreeTrialSubscribed = LocalNotification.Scenario.Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed
 
         let userInfo = response.notification.request.content.userInfo
         guard response.actionIdentifier != UNNotificationDismissActionIdentifier else {
@@ -387,6 +388,11 @@ private extension AppCoordinator {
                 return
             }
             showUpgradesView(siteID: siteID)
+        case let identifier where identifier.hasPrefix(freeTrialSurvey24hAfterFreeTrialSubscribed):
+            guard response.actionIdentifier == UNNotificationDefaultActionIdentifier else {
+                return
+            }
+            showFreeTrialSurvey()
         case LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial:
             let storeNameKey = LocalNotification.UserInfoKey.storeName
             guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
@@ -403,6 +409,10 @@ private extension AppCoordinator {
 
 /// Local notification handling helper methods.
 private extension AppCoordinator {
+    func showFreeTrialSurvey() {
+        // TODO: 10266 Show free trial survey screen
+    }
+
     func showUpgradesView(siteID: Int64) {
         switchStoreUseCase.switchStore(with: siteID) { [weak self] _ in
             guard let self,

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -166,6 +166,9 @@ private extension StorePlanSynchronizer {
             group.addTask { [weak self] in
                 await self?.localNotificationScheduler.cancel(scenario: .twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID))
             }
+            group.addTask { [weak self] in
+                await self?.localNotificationScheduler.cancel(scenario: .freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: siteID))
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -129,12 +129,22 @@ private extension StorePlanSynchronizer {
                                                      subscribedDate: subscribedDate)
             }
 
-            // Schedule notification only if the Free trial is subscribed less than 24 hrs ago
-            if Date().timeIntervalSince(subscribedDate) < Constants.oneDayTimeInterval {
-                let scenario = LocalNotification.Scenario.twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID)
-                schedulePostSubscriptionNotification(scenario: scenario,
-                                                     timeAfterSubscription: Constants.oneDayTimeInterval,
-                                                     subscribedDate: subscribedDate)
+            if featureFlagService.isFeatureFlagEnabled(.freeTrialSurvey24hAfterFreeTrialSubscribed) {
+                // Schedule notification only if the Free trial is subscribed less than 24 hrs ago
+                if Date().timeIntervalSince(subscribedDate) < Constants.oneDayTimeInterval {
+                    let scenario = LocalNotification.Scenario.freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: siteID)
+                    schedulePostSubscriptionNotification(scenario: scenario,
+                                                         timeAfterSubscription: Constants.oneDayTimeInterval,
+                                                         subscribedDate: subscribedDate)
+                }
+            } else { // TODO: 10266 Safely remove
+                // Schedule notification only if the Free trial is subscribed less than 24 hrs ago
+                if Date().timeIntervalSince(subscribedDate) < Constants.oneDayTimeInterval {
+                    let scenario = LocalNotification.Scenario.twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID)
+                    schedulePostSubscriptionNotification(scenario: scenario,
+                                                         timeAfterSubscription: Constants.oneDayTimeInterval,
+                                                         subscribedDate: subscribedDate)
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -44,15 +44,18 @@ final class StorePlanSynchronizer: ObservableObject {
     private var subscriptions: Set<AnyCancellable> = []
 
     private let inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol
+    private let featureFlagService: FeatureFlagService
 
     init(stores: StoresManager = ServiceLocator.stores,
          timeZone: TimeZone = .current,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
-         inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
+         inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager(),
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.stores = stores
         self.localNotificationScheduler = .init(pushNotesManager: pushNotesManager, stores: stores)
         self.timeZone = timeZone
         self.inAppPurchaseManager = inAppPurchaseManager
+        self.featureFlagService = featureFlagService
 
         stores.site.sink { [weak self] site in
             guard let self else { return }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -27,6 +27,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShareProductAIEnabled: Bool
     private let isJustInTimeMessagesOnDashboardEnabled: Bool
     private let isFreeTrialInAppPurchasesUpgradeM2: Bool
+    private let isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -52,7 +53,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
          isJustInTimeMessagesOnDashboardEnabled: Bool = false,
-         isFreeTrialInAppPurchasesUpgradeM2: Bool = false) {
+         isFreeTrialInAppPurchasesUpgradeM2: Bool = false,
+         isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -78,6 +80,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isBlazeEnabled = isBlazeEnabled
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.isJustInTimeMessagesOnDashboardEnabled = isJustInTimeMessagesOnDashboardEnabled
+        self.isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled = isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -130,6 +133,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isJustInTimeMessagesOnDashboardEnabled
         case .freeTrialInAppPurchasesUpgradeM2:
             return isFreeTrialInAppPurchasesUpgradeM2
+        case .freeTrialSurvey24hAfterFreeTrialSubscribed:
+            return isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -110,4 +110,21 @@ final class LocalNotificationTests: XCTestCase {
         assertEqual(expectedBody, notification.body)
         XCTAssertNil(notification.actions)
     }
+
+    func test_freeTrialSurvey24hAfterFreeTrialSubscribed_scenario_returns_correct_notification_contents() throws {
+        // Given
+        let scenario = LocalNotification.Scenario.freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: 123)
+        let testName = "Miffy"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
+
+        // When
+        let notification = LocalNotification(scenario: scenario, stores: stores)
+
+        // Then
+        let expectedTitle = LocalNotification.Localization.FreeTrialSurvey24hAfterFreeTrialSubscribed.title
+        let expectedBody = LocalNotification.Localization.FreeTrialSurvey24hAfterFreeTrialSubscribed.body
+        assertEqual(expectedTitle, notification.title)
+        assertEqual(expectedBody, notification.body)
+        XCTAssertNil(notification.actions)
+    }
 }


### PR DESCRIPTION
Part of: #10266 

## Description

Schedules a notification 24 hours after the Free trial subscription. We will be displaying the survey screen in a future PR. 

## Testing instructions
- Build and run the app on a physical device for easy testing.
- Create a new store with a free trial subscription.
- When the store creation completes, notice in Xcode console: 
```
Tracked local_notification_scheduled, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("is_iap_available"): true, AnyHashable("type"): "free_trial_survey_24h_after_free_trial_subscribed", AnyHashable("blog_id"): 12345]
```
- Open the device Settings app to switch to 23h58m after the time of the store creation.
- After 2 minutes, a notification asking for purchasing a plan should be displayed.
- Tap the notification, the app should be opened. Notice in Xcode console: 
```
Tracked local_notification_tapped, properties: [AnyHashable("blog_id"): 12345, AnyHashable("is_iap_available"): true, AnyHashable("is_wpcom_store"): true, AnyHashable("type"): "free_trial_survey_24h_after_free_trial_subscribed"]
```

## Screenshots
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/d67f2569-9176-48bb-a792-58ee4733c618" width="320"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
