### PR TITLE
[Free trial survey] Show survey upon tapping local notification

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+FreeTrialSurvey.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+FreeTrialSurvey.swift
@@ -9,6 +9,11 @@ extension WooAnalyticsEvent {
             case freeText = "free_text"
         }
 
+        static func surveyDisplayed(source: FreeTrialSurveyCoordinator.Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .freeTrialSurveyDisplayed,
+                              properties: [Key.source.rawValue: source.rawValue])
+        }
+
         static func surveySent(source: FreeTrialSurveyCoordinator.Source,
                                surveyOption: String,
                                freeText: String?) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
@@ -21,7 +21,7 @@ final class FreeTrialSurveyCoordinator: Coordinator {
     }
 
     func start() {
-        analytics.track(event: .FreeTrialSurvey.surveyDisplayed(source: .freeTrialSurvey24hAfterFreeTrialSubscribed))
+        analytics.track(event: .FreeTrialSurvey.surveyDisplayed(source: source))
 
         let survey = FreeTrialSurveyHostingController(viewModel: .init(source: source,
                                                                        onClose: { [weak self] in

--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
@@ -26,9 +26,6 @@ final class FreeTrialSurveyCoordinator: Coordinator {
         let survey = FreeTrialSurveyHostingController(viewModel: .init(source: source,
                                                                        onClose: { [weak self] in
             self?.navigationController.dismiss(animated: true)
-        },
-                                                                       onSubmit: { [weak self] in
-            self?.navigationController.dismiss(animated: true)
         }))
         navigationController.present(WooNavigationController(rootViewController: survey), animated: true)
     }

--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSurveyCoordinator.swift
@@ -21,7 +21,15 @@ final class FreeTrialSurveyCoordinator: Coordinator {
     }
 
     func start() {
-        let survey = FreeTrialSurveyHostingController(viewModel: .init(source: source))
+        analytics.track(event: .FreeTrialSurvey.surveyDisplayed(source: .freeTrialSurvey24hAfterFreeTrialSubscribed))
+
+        let survey = FreeTrialSurveyHostingController(viewModel: .init(source: source,
+                                                                       onClose: { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+        },
+                                                                       onSubmit: { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+        }))
         navigationController.present(WooNavigationController(rootViewController: survey), animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -32,6 +32,7 @@ final class AppCoordinator {
     private var localNotificationResponsesSubscription: AnyCancellable?
     private var isLoggedIn: Bool = false
     private var storeCreationCoordinator: StoreCreationCoordinator?
+    private var freeTrialSurveyCoorindator: FreeTrialSurveyCoordinator?
 
     /// Checks on whether the Apple ID credential is valid when the app is logged in and becomes active.
     ///
@@ -410,7 +411,14 @@ private extension AppCoordinator {
 /// Local notification handling helper methods.
 private extension AppCoordinator {
     func showFreeTrialSurvey() {
-        // TODO: 10266 Show free trial survey screen
+        guard let navigationController = self.window.rootViewController?.topmostPresentedViewController as? UINavigationController else {
+            return
+        }
+
+        let coordinator = FreeTrialSurveyCoordinator(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                     navigationController: navigationController)
+        freeTrialSurveyCoorindator = coordinator
+        coordinator.start()
     }
 
     func showUpgradesView(siteID: Int64) {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -411,7 +411,7 @@ private extension AppCoordinator {
 /// Local notification handling helper methods.
 private extension AppCoordinator {
     func showFreeTrialSurvey() {
-        guard let navigationController = self.window.rootViewController?.topmostPresentedViewController as? UINavigationController else {
+        guard let navigationController = getNavigationController() else {
             return
         }
 
@@ -437,18 +437,7 @@ private extension AppCoordinator {
             return
         }
 
-        // Fetch the navigation controller for store selected or not selected cases
-        guard let navigationController: UINavigationController = {
-            // If logged in with a valid store, tab bar will have a viewcontroller selected.
-            if let navigationController = tabBarController.selectedViewController as? UINavigationController {
-                return navigationController
-            } // If logged in with no valid stores, store picker will be displayed.
-            else if let navigationController = window.rootViewController?.topmostPresentedViewController as? UINavigationController {
-                return navigationController
-            } else {
-                return nil
-            }
-        }() else {
+        guard let navigationController = getNavigationController() else {
             return
         }
 
@@ -471,6 +460,25 @@ private extension AppCoordinator {
                                                    pushNotesManager: pushNotesManager)
         self.storeCreationCoordinator = coordinator
         coordinator.start()
+    }
+
+    func getNavigationController() -> UINavigationController? {
+        // Fetch the navigation controller for store selected or not selected cases
+        guard let navigationController: UINavigationController = {
+            // If logged in with a valid store, tab bar will have a viewcontroller selected.
+            if let navigationController = tabBarController.selectedViewController as? UINavigationController {
+                return navigationController
+            } // If logged in with no valid stores, store picker will be displayed.
+            else if let navigationController = window.rootViewController?.topmostPresentedViewController as? UINavigationController {
+                return navigationController
+            } else {
+                return nil
+            }
+        }() else {
+            return nil
+        }
+
+        return navigationController
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 final class FreeTrialSurveyHostingController: UIHostingController<FreeTrialSurveyView> {
     init(viewModel: FreeTrialSurveyViewModel) {
         super.init(rootView: FreeTrialSurveyView(viewModel: viewModel))
-        rootView.dismissAction = dismiss
     }
 
     @available(*, unavailable)
@@ -16,10 +15,6 @@ final class FreeTrialSurveyHostingController: UIHostingController<FreeTrialSurve
 
         configureTransparentNavigationBar()
     }
-
-    func dismiss() {
-        dismiss(animated: true)
-    }
 }
 
 /// View that presents a list of answers for Free trial survey
@@ -27,8 +22,6 @@ final class FreeTrialSurveyHostingController: UIHostingController<FreeTrialSurve
 struct FreeTrialSurveyView: View {
     @ObservedObject private var viewModel: FreeTrialSurveyViewModel
     @FocusState private var isOtherReasonsFocused: Bool
-
-    var dismissAction: () -> Void = {}
 
     init(viewModel: FreeTrialSurveyViewModel) {
         self.viewModel = viewModel
@@ -88,7 +81,7 @@ struct FreeTrialSurveyView: View {
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button(Localization.cancel) {
-                    dismissAction()
+                    viewModel.onClose()
                 }
                 .buttonStyle(TextButtonStyle())
             }
@@ -125,10 +118,10 @@ struct FreeTrialSurveyView_Previews: PreviewProvider {
     static var previews: some View {
         if #available(iOS 16.0, *) {
             NavigationStack {
-                FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed))
+                FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed, onClose: {}, onSubmit: {}))
             }
         } else {
-            FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed))
+            FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed, onClose: {}, onSubmit: {}))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyView.swift
@@ -118,10 +118,10 @@ struct FreeTrialSurveyView_Previews: PreviewProvider {
     static var previews: some View {
         if #available(iOS 16.0, *) {
             NavigationStack {
-                FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed, onClose: {}, onSubmit: {}))
+                FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed, onClose: {}))
             }
         } else {
-            FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed, onClose: {}, onSubmit: {}))
+            FreeTrialSurveyView(viewModel: .init(source: .freeTrialSurvey24hAfterFreeTrialSubscribed, onClose: {}))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -28,7 +28,15 @@ final class FreeTrialSurveyViewModel: ObservableObject {
     }
 
     var feedbackSelected: Bool {
-        otherReasonSpecified.isNotEmpty || selectedAnswer != nil
+        guard let selectedAnswer else {
+            return false
+        }
+
+        if selectedAnswer == .otherReasons {
+            return otherReasonSpecified.isNotEmpty
+        }
+
+        return true
     }
 
     func selectAnswer(_ answer: SurveyAnswer) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -5,20 +5,16 @@ import SwiftUI
 final class FreeTrialSurveyViewModel: ObservableObject {
     @Published private(set) var selectedAnswer: SurveyAnswer?
     @Published var otherReasonSpecified: String = ""
-    /// Triggered when the user taps Cancel.
+    /// Triggered when the user taps Cancel or Submits the survey.
     let onClose: () -> Void
-    /// Triggered when the survey is submitted.
-    let onSubmit: () -> Void
 
     private let analytics: Analytics
     private let source: FreeTrialSurveyCoordinator.Source
 
     init(source: FreeTrialSurveyCoordinator.Source,
          onClose: @escaping () -> Void,
-         onSubmit: @escaping () -> Void,
          analytics: Analytics = ServiceLocator.analytics) {
         self.onClose = onClose
-        self.onSubmit = onSubmit
         self.source = source
         self.analytics = analytics
     }
@@ -51,7 +47,7 @@ final class FreeTrialSurveyViewModel: ObservableObject {
         analytics.track(event: .FreeTrialSurvey.surveySent(source: source,
                                                            surveyOption: selectedAnswer.rawValue,
                                                            freeText: otherReasonSpecified))
-        onSubmit()
+        onClose()
     }
 
     enum SurveyAnswer: String, CaseIterable {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -5,12 +5,20 @@ import SwiftUI
 final class FreeTrialSurveyViewModel: ObservableObject {
     @Published private(set) var selectedAnswer: SurveyAnswer?
     @Published var otherReasonSpecified: String = ""
+    /// Triggered when the user taps Cancel.
+    let onClose: () -> Void
+    /// Triggered when the survey is submitted.
+    let onSubmit: () -> Void
 
     private let analytics: Analytics
     private let source: FreeTrialSurveyCoordinator.Source
 
     init(source: FreeTrialSurveyCoordinator.Source,
+         onClose: @escaping () -> Void,
+         onSubmit: @escaping () -> Void,
          analytics: Analytics = ServiceLocator.analytics) {
+        self.onClose = onClose
+        self.onSubmit = onSubmit
         self.source = source
         self.analytics = analytics
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -44,7 +44,14 @@ final class FreeTrialSurveyViewModel: ObservableObject {
     }
 
     func submitFeedback() {
-        // TODO: 10266 Submit tracks
+        guard let selectedAnswer else {
+            return
+        }
+
+        analytics.track(event: .FreeTrialSurvey.surveySent(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                           surveyOption: selectedAnswer.rawValue,
+                                                           freeText: otherReasonSpecified))
+        onSubmit()
     }
 
     enum SurveyAnswer: String, CaseIterable {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -46,7 +46,7 @@ final class FreeTrialSurveyViewModel: ObservableObject {
 
         analytics.track(event: .FreeTrialSurvey.surveySent(source: source,
                                                            surveyOption: selectedAnswer.rawValue,
-                                                           freeText: otherReasonSpecified))
+                                                           freeText: otherReasonSpecified.isNotEmpty ? otherReasonSpecified : nil))
         onClose()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -48,7 +48,7 @@ final class FreeTrialSurveyViewModel: ObservableObject {
             return
         }
 
-        analytics.track(event: .FreeTrialSurvey.surveySent(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+        analytics.track(event: .FreeTrialSurvey.surveySent(source: source,
                                                            surveyOption: selectedAnswer.rawValue,
                                                            freeText: otherReasonSpecified))
         onSubmit()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2275,6 +2275,7 @@
 		EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6B2AD029DC522300048A8F /* StoreCreationProgressView.swift */; };
 		EE6B2AD329DD285A00048A8F /* StoreCreationProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */; };
 		EE6F08662A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */; };
+		EE6F08682A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F08672A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift */; };
 		EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */; };
 		EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */; };
 		EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */; };
@@ -4692,6 +4693,7 @@
 		EE6B2AD029DC522300048A8F /* StoreCreationProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressView.swift; sourceTree = "<group>"; };
 		EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModel.swift; sourceTree = "<group>"; };
 		EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyViewModelTests.swift; sourceTree = "<group>"; };
+		EE6F08672A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyCoordinatorTests.swift; sourceTree = "<group>"; };
 		EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdaterTests.swift; sourceTree = "<group>"; };
 		EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthentication.swift; sourceTree = "<group>"; };
 		EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModelTests.swift; sourceTree = "<group>"; };
@@ -10625,6 +10627,7 @@
 			isa = PBXGroup;
 			children = (
 				EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */,
+				EE6F08672A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift */,
 			);
 			path = FreeTrialSurvey;
 			sourceTree = "<group>";
@@ -13196,6 +13199,7 @@
 				D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */,
 				02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */,
 				31F635DC273AF0B100E14F10 /* VersionHelpersTests.swift in Sources */,
+				EE6F08682A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift in Sources */,
 				EEADF626281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift in Sources */,
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2274,6 +2274,7 @@
 		EE5A0A1C2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */; };
 		EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6B2AD029DC522300048A8F /* StoreCreationProgressView.swift */; };
 		EE6B2AD329DD285A00048A8F /* StoreCreationProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */; };
+		EE6F08662A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */; };
 		EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */; };
 		EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */; };
 		EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */; };
@@ -4690,6 +4691,7 @@
 		EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+LocalNotification.swift"; sourceTree = "<group>"; };
 		EE6B2AD029DC522300048A8F /* StoreCreationProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressView.swift; sourceTree = "<group>"; };
 		EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModel.swift; sourceTree = "<group>"; };
+		EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyViewModelTests.swift; sourceTree = "<group>"; };
 		EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdaterTests.swift; sourceTree = "<group>"; };
 		EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthentication.swift; sourceTree = "<group>"; };
 		EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModelTests.swift; sourceTree = "<group>"; };
@@ -6374,6 +6376,7 @@
 		261F1A7A29C2B081001D9861 /* Free Trial */ = {
 			isa = PBXGroup;
 			children = (
+				EE6F08642A718DE000AA9B88 /* FreeTrialSurvey */,
 				261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */,
 			);
 			path = "Free Trial";
@@ -10618,6 +10621,14 @@
 			path = me;
 			sourceTree = "<group>";
 		};
+		EE6F08642A718DE000AA9B88 /* FreeTrialSurvey */ = {
+			isa = PBXGroup;
+			children = (
+				EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */,
+			);
+			path = FreeTrialSurvey;
+			sourceTree = "<group>";
+		};
 		EE94258D29DDA4300063B499 /* Progress */ = {
 			isa = PBXGroup;
 			children = (
@@ -13121,6 +13132,7 @@
 				E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */,
 				0298431225936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift in Sources */,
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,
+				EE6F08662A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift in Sources */,
 				02D7E7CC2A4CE5060003049A /* LocalAnnouncementsProviderTests.swift in Sources */,
 				020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */,
 				0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -528,7 +528,7 @@ final class AppCoordinatorTests: XCTestCase {
         }
     }
 
-    func test_UpgradesHostingController_is_shown_when_tapping_twentyFourHoursAfterFreeTrialSubscribed_notification_if_freeTrialIAP_available() throws {
+    func test_FreeTrialSurveyHostingController_is_shown_when_tapping_freeTrialSurvey24hAfterFreeTrialSubscribed_notification() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
@@ -542,13 +542,14 @@ final class AppCoordinatorTests: XCTestCase {
         // When
         let response = try XCTUnwrap(MockNotificationResponse(
             actionIdentifier: UNNotificationDefaultActionIdentifier,
-            requestIdentifier: LocalNotification.Scenario.twentyFourHoursAfterFreeTrialSubscribed(siteID: siteID).identifier)
+            requestIdentifier: LocalNotification.Scenario.freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: siteID).identifier)
         )
         pushNotesManager.sendLocalNotificationResponse(response)
 
         // Then
         waitUntil {
-            self.window.rootViewController?.topmostPresentedViewController is UpgradesHostingController
+            let navigationController = self.window.rootViewController?.topmostPresentedViewController as? WooNavigationController
+            return navigationController?.topViewController is FreeTrialSurveyHostingController
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyCoordinatorTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import WooCommerce
+
+final class FreeTrialSurveyCoordinatorTests: XCTestCase {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+
+        super.tearDown()
+    }
+
+    func test_it_tracks_correct_event_upon_start() throws {
+        // Given
+        let navigationController = WooNavigationController(rootViewController: .init())
+        let sut = FreeTrialSurveyCoordinator(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                     navigationController: navigationController,
+                                                     analytics: analytics)
+
+        // When
+        sut.start()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "free_trial_survey_displayed" }))
+
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "free_trial_survey_24h_after_free_trial_subscribed")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -155,6 +155,23 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         XCTAssertEqual(properties["free_text"] as? String, "Need time to decide")
     }
 
+    func test_submitFeedback_method_does_not_track_free_text_if_it_is_empty() throws {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 analytics: analytics)
+        viewModel.selectAnswer(.comparingWithOtherPlatforms)
+        viewModel.otherReasonSpecified = ""
+
+        // When
+        viewModel.submitFeedback()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "free_trial_survey_sent" }))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertNil(properties["free_text"])
+    }
+
     func test_onClose_is_fired_when_submitting_feedback() {
         var onCloseFired = false
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -19,6 +19,8 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: `answers`
+
     func test_answers_has_correct_values() {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
@@ -28,5 +30,155 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.answers, FreeTrialSurveyViewModel.SurveyAnswer.allCases)
+    }
+
+    // MARK: `selectAnswer(:)`
+
+    func test_selectAnswer_method_updates_selectedAnswer() {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+        // When
+        viewModel.selectAnswer(.collectiveDecision)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedAnswer, .collectiveDecision)
+    }
+
+    // MARK: `feedbackSelected`
+
+    func test_feedbackSelected_is_false_initially() {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+
+        // Then
+        XCTAssertFalse(viewModel.feedbackSelected)
+    }
+
+    func test_feedbackSelected_is_true_when_answer_is_selected() {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+        // When
+        viewModel.selectAnswer(.collectiveDecision)
+
+        // Then
+        XCTAssertTrue(viewModel.feedbackSelected)
+    }
+
+    func test_feedbackSelected_is_false_when_otherReasons_is_selected_and_otherReasonSpecified_is_empty() {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+        // When
+        viewModel.selectAnswer(.otherReasons)
+        viewModel.otherReasonSpecified = ""
+
+        // Then
+        XCTAssertFalse(viewModel.feedbackSelected)
+    }
+
+    func test_feedbackSelected_is_true_when_otherReasons_is_selected_and_otherReasonSpecified_is_empty() {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+        // When
+        viewModel.selectAnswer(.otherReasons)
+        viewModel.otherReasonSpecified = "Need time to decide"
+
+        // Then
+        XCTAssertTrue(viewModel.feedbackSelected)
+    }
+
+    // MARK: `submitFeedback`
+
+    func test_submitFeedback_method_tracks_correct_event_when_selected_a_given_answer() throws {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+        viewModel.selectAnswer(.comparingWithOtherPlatforms)
+
+        // When
+        viewModel.submitFeedback()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "free_trial_survey_sent" }))
+
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "free_trial_survey_24h_after_free_trial_subscribed")
+        XCTAssertEqual(properties["survey_option"] as? String, "comparing_with_other_platforms")
+    }
+
+    func test_submitFeedback_method_tracks_correct_event_when_entered_otherReasons() throws {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+        viewModel.selectAnswer(.otherReasons)
+        viewModel.otherReasonSpecified = "Need time to decide"
+
+        // When
+        viewModel.submitFeedback()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "free_trial_survey_sent" }))
+
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "free_trial_survey_24h_after_free_trial_subscribed")
+        XCTAssertEqual(properties["survey_option"] as? String, "other_reasons")
+        XCTAssertEqual(properties["free_text"] as? String, "Need time to decide")
+    }
+
+    func test_submitFeedback_method_tracks_free_text_even_when_selected_a_given_answer() throws {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+        viewModel.selectAnswer(.comparingWithOtherPlatforms)
+        viewModel.otherReasonSpecified = "Need time to decide"
+
+        // When
+        viewModel.submitFeedback()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "free_trial_survey_sent" }))
+
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "free_trial_survey_24h_after_free_trial_subscribed")
+        XCTAssertEqual(properties["survey_option"] as? String, "comparing_with_other_platforms")
+        XCTAssertEqual(properties["free_text"] as? String, "Need time to decide")
+    }
+
+    func test_onSubmit_is_fired_when_submitting_feedback() {
+        var onSubmitFired = false
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {
+            onSubmitFired = true
+        },
+                                                 analytics: analytics)
+        viewModel.selectAnswer(.comparingWithOtherPlatforms)
+        viewModel.otherReasonSpecified = "Need time to decide"
+
+        // When
+        viewModel.submitFeedback()
+
+        // Then
+        XCTAssertTrue(onSubmitFired)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -25,7 +25,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
 
         // Then
@@ -38,7 +37,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
         // When
         viewModel.selectAnswer(.collectiveDecision)
@@ -53,7 +51,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
 
         // Then
@@ -64,7 +61,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
         // When
         viewModel.selectAnswer(.collectiveDecision)
@@ -77,7 +73,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
         // When
         viewModel.selectAnswer(.otherReasons)
@@ -91,7 +86,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
         // When
         viewModel.selectAnswer(.otherReasons)
@@ -107,7 +101,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
         viewModel.selectAnswer(.comparingWithOtherPlatforms)
 
@@ -126,7 +119,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
         viewModel.selectAnswer(.otherReasons)
         viewModel.otherReasonSpecified = "Need time to decide"
@@ -147,7 +139,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         // Given
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  analytics: analytics)
         viewModel.selectAnswer(.comparingWithOtherPlatforms)
         viewModel.otherReasonSpecified = "Need time to decide"
@@ -164,12 +155,11 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         XCTAssertEqual(properties["free_text"] as? String, "Need time to decide")
     }
 
-    func test_onSubmit_is_fired_when_submitting_feedback() {
-        var onSubmitFired = false
+    func test_onClose_is_fired_when_submitting_feedback() {
+        var onCloseFired = false
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
-                                                 onClose: {},
-                                                 onSubmit: {
-            onSubmitFired = true
+                                                 onClose: {
+            onCloseFired = true
         },
                                                  analytics: analytics)
         viewModel.selectAnswer(.comparingWithOtherPlatforms)
@@ -179,6 +169,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         viewModel.submitFeedback()
 
         // Then
-        XCTAssertTrue(onSubmitFired)
+        XCTAssertTrue(onCloseFired)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import WooCommerce
+
+final class FreeTrialSurveyViewModelTests: XCTestCase {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+
+        super.tearDown()
+    }
+
+    func test_answers_has_correct_values() {
+        // Given
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 analytics: analytics)
+
+        // Then
+        XCTAssertEqual(viewModel.answers, FreeTrialSurveyViewModel.SurveyAnswer.allCases)
+    }
+}


### PR DESCRIPTION
Part of: #10266

## Description
Displays the survey screen upon tapping local notification. 

Changes
- Show survey screen upon tapping survey local notification.
- Unit tests for view model and coordinator. 
- Track events upon showing and submitting survey. 

## Testing instructions
- Build and run the app on a physical device for easy testing.
- Create a new store with a free trial subscription.
- Open the device Settings app to switch to 23h58m after the time of the store creation.
- After 2 minutes, a notification asking for a survey should be displayed.
- Tap the notification, the app should be opened. 
- Observe that the free trial survey screen is presented and the following event is tracked.
```
🔵 Tracked free_trial_survey_displayed, properties: [AnyHashable("blog_id"): 12345, AnyHashable("is_wpcom_store"): true, AnyHashable("source"): "free_trial_survey_24h_after_free_trial_subscribed"]
```
- Selecting an option from the survey and submitting the survey should track the following event
```
🔵 Tracked free_trial_survey_sent, properties: [AnyHashable("source"): "free_trial_survey_24h_after_free_trial_subscribed", AnyHashable("blog_id"): 123456, AnyHashable("survey_option"): "<option>", AnyHashable("is_wpcom_store"): true, AnyHashable("free_text"): "<TextEntered>"]
```

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/f93926ff-487d-4f83-b5f4-2117da8e09b8" width="320"/>

https://github.com/woocommerce/woocommerce-ios/assets/524475/5956e991-b756-4258-9829-a95d4ca4a098


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
