### PR TITLE
Create test order: update logic for entry point

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -325,6 +325,7 @@ extension OrderListViewController {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         delegate?.orderListViewControllerWillSynchronizeOrders(self)
         NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
+        viewModel.onPullToRefresh()
         syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
             sender.endRefreshing()
         }
@@ -613,13 +614,7 @@ private extension OrderListViewController {
     ///
     func noOrdersAvailableConfig() -> EmptyStateViewController.Config {
 
-        /// If site is launched, show entry point to creating test orders.
-        if  ServiceLocator.featureFlagService.isFeatureFlagEnabled(.createTestOrder),
-            let site = ServiceLocator.stores.sessionManager.defaultSite,
-            site.isPublic,
-            let url = URL(string: site.url),
-            UIApplication.shared.canOpenURL(url) {
-
+        if viewModel.shouldEnableTestOrder, let url = viewModel.siteURL {
             return .withButton(message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                                image: .emptyOrdersImage,
                                details: Localization.createTestOrderDetail,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -28,6 +28,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isJustInTimeMessagesOnDashboardEnabled: Bool
     private let isFreeTrialInAppPurchasesUpgradeM2: Bool
     private let isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool
+    private let isCreateTestOrderEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -54,7 +55,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isShareProductAIEnabled: Bool = false,
          isJustInTimeMessagesOnDashboardEnabled: Bool = false,
          isFreeTrialInAppPurchasesUpgradeM2: Bool = false,
-         isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool = false) {
+         isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool = false,
+         isCreateTestOrderEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -81,6 +83,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.isJustInTimeMessagesOnDashboardEnabled = isJustInTimeMessagesOnDashboardEnabled
         self.isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled = isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled
+        self.isCreateTestOrderEnabled = isCreateTestOrderEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -135,6 +138,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isFreeTrialInAppPurchasesUpgradeM2
         case .freeTrialSurvey24hAfterFreeTrialSubscribed:
             return isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled
+        case .createTestOrder:
+            return isCreateTestOrderEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -885,7 +885,7 @@ final class OrderListViewModelTests: XCTestCase {
     }
 
     // MARK: - `shouldEnableTestOrder`
-    func test_shouldEnableTestOrder_returns_true_when_site_is_public_and_has_at_published_product_and_set_up_payment() {
+    func test_shouldEnableTestOrder_returns_true_when_site_is_public_and_has_a_published_product_and_set_up_payment() {
         // Given
         let siteID: Int64 = 123
         let site = Site.fake().copy(siteID: siteID, url: "https://example.com", isPublic: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -883,6 +883,87 @@ final class OrderListViewModelTests: XCTestCase {
         // Then
         assertEqual(nil, feedbackStatus)
     }
+
+    // MARK: - `shouldEnableTestOrder`
+    func test_shouldEnableTestOrder_returns_true_when_site_is_public_and_has_at_published_product_and_set_up_payment() {
+        // Given
+        let siteID: Int64 = 123
+        let site = Site.fake().copy(siteID: siteID, url: "https://example.com", isPublic: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
+        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(siteID: siteID, statusKey: "publish"))
+        storageManager.insertSamplePaymentGateway(readOnlyGateway: PaymentGateway.fake().copy(siteID: siteID, enabled: true))
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil,
+                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+
+        // When
+        let isEnabled = viewModel.shouldEnableTestOrder
+
+        // Then
+        XCTAssertTrue(isEnabled)
+    }
+
+    func test_shouldEnableTestOrder_returns_false_when_site_is_not_public() {
+        // Given
+        let siteID: Int64 = 123
+        let site = Site.fake().copy(siteID: siteID, url: "https://example.com", isPublic: false)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
+        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(siteID: siteID, statusKey: "publish"))
+        storageManager.insertSamplePaymentGateway(readOnlyGateway: PaymentGateway.fake().copy(siteID: siteID, enabled: true))
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil,
+                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+
+        // When
+        let isEnabled = viewModel.shouldEnableTestOrder
+
+        // Then
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_shouldEnableTestOrder_returns_false_when_site_has_no_published_product() {
+        // Given
+        let siteID: Int64 = 123
+        let site = Site.fake().copy(siteID: siteID, url: "https://example.com", isPublic: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
+        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(siteID: siteID, statusKey: "draft"))
+        storageManager.insertSamplePaymentGateway(readOnlyGateway: PaymentGateway.fake().copy(siteID: siteID, enabled: true))
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil,
+                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+
+        // When
+        let isEnabled = viewModel.shouldEnableTestOrder
+
+        // Then
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_shouldEnableTestOrder_returns_false_when_site_has_no_payment_gateway() {
+        // Given
+        let siteID: Int64 = 123
+        let site = Site.fake().copy(siteID: siteID, url: "https://example.com", isPublic: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
+        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(siteID: siteID, statusKey: "publish"))
+        storageManager.insertSamplePaymentGateway(readOnlyGateway: PaymentGateway.fake().copy(siteID: siteID, enabled: false))
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil,
+                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+
+        // When
+        let isEnabled = viewModel.shouldEnableTestOrder
+
+        // Then
+        XCTAssertFalse(isEnabled)
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10292 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In a recent discussion (p1690378034787739/1689926465.212349-slack-C0354HSNUJH), we decided to only show the entry point to test order if a site satisfies all the following conditions:
- Site has been launched
- Site has published at least 1 product
- Site has set up at least 1 payment method.

This PR updates the logic check for the entry point by updating `OrderListViewModel` to get details about the site's payment gateways and published products to determine whether the entry point to test order should be enabled.

For simplicity, I didn't make this check reactive - any update to payment gateways and products needs to be fetched through pull-to-refresh. Otherwise, the logic would require listening to Core Data changes and updating to how the empty state is configured on the order list.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store without any orders. The empty order list should not show the entry point to test order.
- Set up at least one payment method for the site in wp-admin > WooCommerce > Settings > Payments.
- Create a product on the web or the app.
- Launch the store.
- Refresh the order list, the entry point to test order should now be available on the empty order list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| When not all conditions are met | When all conditions are met |
| ----- | ----- | 
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/66d03d5b-0731-4b6b-ab58-c367ce9c903b" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/6bb3591c-508b-4f44-9b7b-c1c4a818e6eb" width=320 /> |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.