### PR TITLE
Test order: Add analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+TestOrder.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+TestOrder.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum TestOrder {
+        enum Keys {
+            static let isWooExpressStore = "is_wooexpress_store"
+        }
+
+        /// Tracked when the entry point to test order is displayed on the empty state of order list.
+        /// - Parameters:
+        ///     - isWooExpressStore: whether the current store is running a WooExpress plan.
+        ///
+        static func entryPointDisplayed(isWooExpressStore: Bool) -> WooAnalyticsEvent {
+            .init(statName: .orderListTestOrderDisplayed, properties: [
+                Keys.isWooExpressStore: isWooExpressStore
+            ])
+        }
+
+        /// Tracked when the CTA to try test order is tapped on the empty order list screen.
+        /// - Parameters:
+        ///     - isWooExpressStore: whether the current store is running a WooExpress plan.
+        ///
+        static func tryTestOrderTapped(isWooExpressStore: Bool) -> WooAnalyticsEvent {
+            .init(statName: .orderListTryTestOrderTapped, properties: [
+                Keys.isWooExpressStore: isWooExpressStore
+            ])
+        }
+
+        /// Tracked when the CTA to start test order is tapped on the test order screen.
+        /// - Parameters:
+        ///     - isWooExpressStore: whether the current store is running a WooExpress plan.
+        ///
+        static func testOrderStarted(isWooExpressStore: Bool) -> WooAnalyticsEvent {
+            .init(statName: .testOrderStartTapped, properties: [
+                Keys.isWooExpressStore: isWooExpressStore
+            ])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -363,6 +363,12 @@ public enum WooAnalyticsStat: String {
     case orderDetailEditFlowFailed = "order_detail_edit_flow_failed"
     case orderDetailPaymentLinkShared = "order_detail_payment_link_shared"
 
+    // MARK: Test order
+    //
+    case orderListTestOrderDisplayed = "order_list_test_order_displayed"
+    case orderListTryTestOrderTapped = "order_list_try_test_order_tapped"
+    case testOrderStartTapped = "test_order_start_tapped"
+
     // MARK: Order Data/Action Events
     //
     case orderOpen = "order_open"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -614,15 +614,19 @@ private extension OrderListViewController {
     ///
     func noOrdersAvailableConfig() -> EmptyStateViewController.Config {
 
+        let analytics = ServiceLocator.analytics
         if viewModel.shouldEnableTestOrder, let url = viewModel.siteURL {
+
+            analytics.track(event: .TestOrder.entryPointDisplayed(isWooExpressStore: viewModel.isWooExpressStore))
             return .withButton(message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                                image: .emptyOrdersImage,
                                details: Localization.createTestOrderDetail,
                                buttonTitle: Localization.tryTestOrder,
                                onTap: { [weak self] _ in
                 guard let self else { return }
+                analytics.track(event: .TestOrder.tryTestOrderTapped(isWooExpressStore: viewModel.isWooExpressStore))
                 let hostingController = CreateTestOrderHostingController {
-                    // TODO: analytics
+                    analytics.track(event: .TestOrder.testOrderStarted(isWooExpressStore: self.viewModel.isWooExpressStore))
                     UIApplication.shared.open(url)
                 }
                 self.present(UINavigationController(rootViewController: hostingController), animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -624,7 +624,7 @@ private extension OrderListViewController {
                                buttonTitle: Localization.tryTestOrder,
                                onTap: { [weak self] _ in
                 guard let self else { return }
-                analytics.track(event: .TestOrder.tryTestOrderTapped(isWooExpressStore: viewModel.isWooExpressStore))
+                analytics.track(event: .TestOrder.tryTestOrderTapped(isWooExpressStore: self.viewModel.isWooExpressStore))
                 let hostingController = CreateTestOrderHostingController {
                     analytics.track(event: .TestOrder.testOrderStarted(isWooExpressStore: self.viewModel.isWooExpressStore))
                     UIApplication.shared.open(url)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -52,6 +52,12 @@ final class OrderListViewModel {
         return site.isPublic && hasAnyPaymentGateways && hasAnyPublishedProducts
     }
 
+    /// Whether the current store is running on an WooExpress plan.
+    ///
+    var isWooExpressStore: Bool {
+        stores.sessionManager.defaultSite?.wasEcommerceTrial ?? false
+    }
+
     /// Filters applied to the order list.
     ///
     private(set) var filters: FilterOrderListViewModel.Filters? {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2108,6 +2108,7 @@
 		DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */; };
 		DE621F6A29D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE621F6929D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift */; };
 		DE653EAD2A70D09F00937C78 /* CreateTestOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE653EAC2A70D09F00937C78 /* CreateTestOrderView.swift */; };
+		DE653EAF2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */; };
 		DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
@@ -4526,6 +4527,7 @@
 		DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerViewModelTests.swift; sourceTree = "<group>"; };
 		DE621F6929D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+JetpackSetup.swift"; sourceTree = "<group>"; };
 		DE653EAC2A70D09F00937C78 /* CreateTestOrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTestOrderView.swift; sourceTree = "<group>"; };
+		DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+TestOrder.swift"; sourceTree = "<group>"; };
 		DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordDisabledViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
@@ -7810,6 +7812,7 @@
 				DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */,
 				EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */,
 				EE486DD12A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift */,
+				DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -12064,6 +12067,7 @@
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSourceProtocol.swift in Sources */,
+				DE653EAF2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
 				7E7C5F7A2719A8F900315B61 /* EditProductCategoryListViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10292 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking events for the test order feature:



Event | Properties | Triggers
-- | -- | --
*_order_list_test_order_displayed | is_wooexpress_store: true \| false | When the empty state with CTA to create test order is displayed.
*_order_list_try_test_order_tapped | is_wooexpress_store: true \| false | When the Try test order button is tapped on the empty order list screen.
*_test_order_start_tapped | is_wooexpress_store: true \| false | When the Start test order button is tapped on the create test order screen.



## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store without any orders. The empty order list should not show the entry point to test order.
- Set up at least one payment method for the site in wp-admin > WooCommerce > Settings > Payments.
- Create a product on the web or the app.
- Launch the store.
- Refresh the order list, the entry point to test order should now be available on the empty order list.
- Notice in Xcode console: `🔵 Tracked order_list_test_order_displayed` with correct properties for your test site.
- Tap the Try a test order CTA. Notice in Xcode console: `🔵 Tracked order_list_try_test_order_tapped` with correct properties for your test site.
- On the presented test order screen, tap the Start test order CTA. Notice in Xcode console: `🔵 Tracked test_order_start_tapped` with correct properties for your test site.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
