### PR TITLE
[Free trial survey] Notify after 3 days if still exploring

### DIFF
--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -25,6 +25,7 @@ struct LocalNotification {
         case sixHoursAfterFreeTrialSubscribed(siteID: Int64)
         case twentyFourHoursAfterFreeTrialSubscribed(siteID: Int64)
         case freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: Int64)
+        case threeDaysAfterStillExploring(siteID: Int64)
 
         var identifier: String {
             switch self {
@@ -42,6 +43,8 @@ struct LocalNotification {
                 return Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed + "\(siteID)"
             case let .freeTrialSurvey24hAfterFreeTrialSubscribed(siteID):
                 return Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed + "\(siteID)"
+            case let .threeDaysAfterStillExploring(siteID):
+                return Identifier.Prefix.threeDaysAfterStillExploring + "\(siteID)"
             }
         }
 
@@ -52,6 +55,7 @@ struct LocalNotification {
                 static let sixHoursAfterFreeTrialSubscribed = "six_hours_after_free_trial_subscribed"
                 static let twentyFourHoursAfterFreeTrialSubscribed = "twenty_four_hours_after_free_trial_subscribed"
                 static let freeTrialSurvey24hAfterFreeTrialSubscribed = "free_trial_survey_24h_after_free_trial_subscribed"
+                static let threeDaysAfterStillExploring = "three_days_after_still_exploring"
             }
             static let oneDayAfterStoreCreationNameWithoutFreeTrial = "one_day_after_store_creation_name_without_free_trial"
         }
@@ -68,6 +72,8 @@ struct LocalNotification {
                 return Identifier.Prefix.twentyFourHoursAfterFreeTrialSubscribed
             } else if identifier.hasPrefix(Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed) {
                 return Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed
+            } else if identifier.hasPrefix(Identifier.Prefix.threeDaysAfterStillExploring) {
+                return Identifier.Prefix.threeDaysAfterStillExploring
             }
             return identifier
         }
@@ -153,6 +159,9 @@ extension LocalNotification {
             title = Localization.FreeTrialSurvey24hAfterFreeTrialSubscribed.title
             body = Localization.FreeTrialSurvey24hAfterFreeTrialSubscribed.body
 
+        case .threeDaysAfterStillExploring:
+            title = Localization.ThreeDaysAfterStillExploring.title
+            body = Localization.ThreeDaysAfterStillExploring.body
         }
 
         self.init(title: title,

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -248,5 +248,16 @@ extension LocalNotification {
                 comment: "Message on the local notification to ask for Free trial survey."
             )
         }
+
+        enum ThreeDaysAfterStillExploring {
+            static let title = NSLocalizedString(
+                "🧭 Still Exploring WooCommerce?",
+                comment: "Title of the local notification to remind after three days."
+            )
+            static let body = NSLocalizedString(
+                "No rush, take your time! If you have any questions or need assistance, we're always here to help. Happy exploring!",
+                comment: "Message on the local notification to remind after three days."
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -53,11 +53,11 @@ final class FreeTrialSurveyViewModel: ObservableObject {
         guard let selectedAnswer else {
             return
         }
-        
+
         if selectedAnswer == .stillExploring {
             scheduleLocalNotificationAfterThreeDays()
         }
-        
+
         analytics.track(event: .FreeTrialSurvey.surveySent(source: source,
                                                            surveyOption: selectedAnswer.rawValue,
                                                            freeText: otherReasonSpecified.isNotEmpty ? otherReasonSpecified : nil))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -53,7 +53,11 @@ final class FreeTrialSurveyViewModel: ObservableObject {
         guard let selectedAnswer else {
             return
         }
-
+        
+        if selectedAnswer == .stillExploring {
+            scheduleLocalNotificationAfterThreeDays()
+        }
+        
         analytics.track(event: .FreeTrialSurvey.surveySent(source: source,
                                                            surveyOption: selectedAnswer.rawValue,
                                                            freeText: otherReasonSpecified.isNotEmpty ? otherReasonSpecified : nil))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 /// View model for `FreeTrialSurveyView`
 ///
@@ -10,13 +11,22 @@ final class FreeTrialSurveyViewModel: ObservableObject {
 
     private let analytics: Analytics
     private let source: FreeTrialSurveyCoordinator.Source
+    private let inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol
+    private let localNotificationScheduler: LocalNotificationScheduler
+    private let stores: StoresManager
 
     init(source: FreeTrialSurveyCoordinator.Source,
          onClose: @escaping () -> Void,
-         analytics: Analytics = ServiceLocator.analytics) {
-        self.onClose = onClose
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
+         inAppPurchaseManager: InAppPurchasesForWPComPlansProtocol = InAppPurchasesForWPComPlansManager()) {
         self.source = source
+        self.onClose = onClose
+        self.stores = stores
         self.analytics = analytics
+        self.localNotificationScheduler = .init(pushNotesManager: pushNotesManager, stores: stores)
+        self.inAppPurchaseManager = inAppPurchaseManager
     }
 
     var answers: [SurveyAnswer] {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -169,6 +169,9 @@ private extension StorePlanSynchronizer {
             group.addTask { [weak self] in
                 await self?.localNotificationScheduler.cancel(scenario: .freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: siteID))
             }
+            group.addTask { [weak self] in
+                await self?.localNotificationScheduler.cancel(scenario: .threeDaysAfterStillExploring(siteID: siteID))
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -80,11 +80,7 @@ final class LocalNotificationTests: XCTestCase {
     func test_sixHoursAfterFreeTrialSubscribed_scenario_returns_correct_notification_contents() throws {
         // Given
         let scenario = LocalNotification.Scenario.sixHoursAfterFreeTrialSubscribed(siteID: 123)
-        let testName = "Miffy"
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
-
-        // When
-        let notification = LocalNotification(scenario: scenario, stores: stores)
+        let notification = LocalNotification(scenario: scenario)
 
         // Then
         let expectedTitle = LocalNotification.Localization.SixHoursAfterFreeTrialSubscribed.title
@@ -97,11 +93,7 @@ final class LocalNotificationTests: XCTestCase {
     func test_twentyFourHoursAfterFreeTrialSubscribed_scenario_returns_correct_notification_contents() throws {
         // Given
         let scenario = LocalNotification.Scenario.twentyFourHoursAfterFreeTrialSubscribed(siteID: 123)
-        let testName = "Miffy"
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
-
-        // When
-        let notification = LocalNotification(scenario: scenario, stores: stores)
+        let notification = LocalNotification(scenario: scenario)
 
         // Then
         let expectedTitle = LocalNotification.Localization.TwentyFourHoursAfterFreeTrialSubscribed.title
@@ -114,11 +106,7 @@ final class LocalNotificationTests: XCTestCase {
     func test_freeTrialSurvey24hAfterFreeTrialSubscribed_scenario_returns_correct_notification_contents() throws {
         // Given
         let scenario = LocalNotification.Scenario.freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: 123)
-        let testName = "Miffy"
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
-
-        // When
-        let notification = LocalNotification(scenario: scenario, stores: stores)
+        let notification = LocalNotification(scenario: scenario)
 
         // Then
         let expectedTitle = LocalNotification.Localization.FreeTrialSurvey24hAfterFreeTrialSubscribed.title
@@ -131,11 +119,7 @@ final class LocalNotificationTests: XCTestCase {
     func test_threeDaysAfterStillExploring_scenario_returns_correct_notification_contents() throws {
         // Given
         let scenario = LocalNotification.Scenario.threeDaysAfterStillExploring(siteID: 123)
-        let testName = "Miffy"
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
-
-        // When
-        let notification = LocalNotification(scenario: scenario, stores: stores)
+        let notification = LocalNotification(scenario: scenario)
 
         // Then
         let expectedTitle = LocalNotification.Localization.ThreeDaysAfterStillExploring.title

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -127,4 +127,21 @@ final class LocalNotificationTests: XCTestCase {
         assertEqual(expectedBody, notification.body)
         XCTAssertNil(notification.actions)
     }
+
+    func test_threeDaysAfterStillExploring_scenario_returns_correct_notification_contents() throws {
+        // Given
+        let scenario = LocalNotification.Scenario.threeDaysAfterStillExploring(siteID: 123)
+        let testName = "Miffy"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
+
+        // When
+        let notification = LocalNotification(scenario: scenario, stores: stores)
+
+        // Then
+        let expectedTitle = LocalNotification.Localization.ThreeDaysAfterStillExploring.title
+        let expectedBody = LocalNotification.Localization.ThreeDaysAfterStillExploring.body
+        assertEqual(expectedTitle, notification.title)
+        assertEqual(expectedBody, notification.body)
+        XCTAssertNil(notification.actions)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+@testable import Yosemite
 
 final class FreeTrialSurveyViewModelTests: XCTestCase {
     private var analyticsProvider: MockAnalyticsProvider!
@@ -187,5 +188,66 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(onCloseFired)
+    }
+
+    // MARK: Local notification after three days
+
+    func test_threeDaysAfterStillExploring_local_notification_is_scheduled_if_submitted_answer_is_stillExploring() throws {
+        // Given
+        let sessionManager = SessionManager.testingInstance
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        let sampleSiteID: Int64 = 123
+        let site = Site.fake().copy(siteID: sampleSiteID)
+        sessionManager.defaultSite = site
+
+        let pushNotesManager = MockPushNotificationsManager()
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 stores: stores,
+                                                 analytics: analytics,
+                                                 pushNotesManager: pushNotesManager,
+                                                 inAppPurchaseManager: MockInAppPurchasesForWPComPlansManager(isIAPSupported: true))
+
+        // When
+        viewModel.selectAnswer(.stillExploring)
+        viewModel.submitFeedback()
+
+        // Then
+        waitUntil(timeout: 3) {
+            pushNotesManager.requestedLocalNotificationsIfNeeded.isNotEmpty
+        }
+        let ids = pushNotesManager.requestedLocalNotificationsIfNeeded.map(\.scenario.identifier)
+        let expectedID = LocalNotification.Scenario.Identifier.Prefix.threeDaysAfterStillExploring + "\(sampleSiteID)"
+        XCTAssertTrue(ids.contains(expectedID))
+    }
+
+    func test_threeDaysAfterStillExploring_local_notification_is_not_scheduled_if_submitted_answer_is_not_stillExploring() throws {
+        // Given
+        let sessionManager = SessionManager.testingInstance
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        let sampleSiteID: Int64 = 123
+        let site = Site.fake().copy(siteID: sampleSiteID)
+        sessionManager.defaultSite = site
+
+        let pushNotesManager = MockPushNotificationsManager()
+        let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
+                                                 onClose: {},
+                                                 onSubmit: {},
+                                                 stores: stores,
+                                                 analytics: analytics,
+                                                 pushNotesManager: pushNotesManager,
+                                                 inAppPurchaseManager: MockInAppPurchasesForWPComPlansManager(isIAPSupported: true))
+
+        // When
+        viewModel.selectAnswer(.collectiveDecision)
+        viewModel.submitFeedback()
+
+        // Then
+        let ids = pushNotesManager.requestedLocalNotificationsIfNeeded.map(\.scenario.identifier)
+        let expectedID = LocalNotification.Scenario.Identifier.Prefix.threeDaysAfterStillExploring + "\(sampleSiteID)"
+        XCTAssertFalse(ids.contains(expectedID))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -194,12 +194,8 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
 
     func test_threeDaysAfterStillExploring_local_notification_is_scheduled_if_submitted_answer_is_stillExploring() throws {
         // Given
-        let sessionManager = SessionManager.testingInstance
-        let stores = MockStoresManager(sessionManager: sessionManager)
-
         let sampleSiteID: Int64 = 123
-        let site = Site.fake().copy(siteID: sampleSiteID)
-        sessionManager.defaultSite = site
+        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: Site.fake().copy(siteID: sampleSiteID)))
 
         let pushNotesManager = MockPushNotificationsManager()
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
@@ -224,12 +220,8 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
 
     func test_threeDaysAfterStillExploring_local_notification_is_not_scheduled_if_submitted_answer_is_not_stillExploring() throws {
         // Given
-        let sessionManager = SessionManager.testingInstance
-        let stores = MockStoresManager(sessionManager: sessionManager)
-
         let sampleSiteID: Int64 = 123
-        let site = Site.fake().copy(siteID: sampleSiteID)
-        sessionManager.defaultSite = site
+        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: Site.fake().copy(siteID: sampleSiteID)))
 
         let pushNotesManager = MockPushNotificationsManager()
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -204,7 +204,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         let pushNotesManager = MockPushNotificationsManager()
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  stores: stores,
                                                  analytics: analytics,
                                                  pushNotesManager: pushNotesManager,
@@ -235,7 +234,6 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
         let pushNotesManager = MockPushNotificationsManager()
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,
                                                  onClose: {},
-                                                 onSubmit: {},
                                                  stores: stores,
                                                  analytics: analytics,
                                                  pushNotesManager: pushNotesManager,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -303,8 +303,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         let secondImage = MediaPickerImage(image: UIImage.calendar,
                                            source: .media(media: .fake()))
 
-        let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
-        var imageToReturn: MediaPickerImage? = image
+        var imageToReturn: MediaPickerImage? = firstImage
 
         let imageTextScanner = MockImageTextScanner(result: .success([]))
         let viewModel = AddProductFromImageViewModel(siteID: 123,
@@ -317,7 +316,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         // When
         viewModel.addImage(from: .siteMediaLibrary)
         waitUntil {
-            viewModel.imageState == .success(image)
+            viewModel.imageState == .success(firstImage)
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/StorePlanSynchronizerTests.swift
@@ -345,8 +345,9 @@ final class StorePlanSynchronizerTests: XCTestCase {
             /// - 6 hrs after trial subscription
             /// - 24 hrs after trial subscription
             /// - Free trial survey 24 hrs after trial subscription
+            /// - 3 days after answering "Still exploring" in Free trial survey
             /// Update this number based on the number of notifications we support.
-            pushNotesManager.canceledLocalNotificationScenarios.count == 5
+            pushNotesManager.canceledLocalNotificationScenarios.count == 6
         }
 
         // No local notifications scheduling requested for a non free trial plan


### PR DESCRIPTION
Part of: #10266

## Description

Schedules a local notification after three days if user submits "Still exploring" answer in the Free trial survey. 

## Testing instructions
- Build and run the app on a physical device for easy testing.
- Create a new store with a free trial subscription.
- Open the device Settings app to switch to 23h58m after the time of the store creation.
- After 2 minutes, a notification asking for a survey should be displayed.
- Tap the notification, the app should be opened. 
- Observe that the free trial survey screen is presented.
- Selecting "I am still exploring and assessing the features and benefits of the app." option from the survey and submitting the survey should track the following event
```
🔵 Tracked local_notification_scheduled, properties: [AnyHashable("blog_id"): 12345, AnyHashable("is_iap_available"): true, AnyHashable("type"): "three_days_after_still_exploring", AnyHashable("is_wpcom_store"): true]
```
- Open the device Settings app to switch to 2d23h58m after the current time
- After 2 minutes, a notification to remind about the Free trial will be displayed. (Ref screenshot)
- Tapping on the notification will launch the app and following even will be tracked.
```
🔵 Tracked local_notification_tapped, properties: [AnyHashable("blog_id"): 12345, AnyHashable("type"): "three_days_after_still_exploring", AnyHashable("is_iap_available"): true, AnyHashable("is_wpcom_store"): true]
```

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/598ed33d-dbe0-4577-8c4f-7d586cd14690" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
