### PR TITLE
Data/track order event properties for extensions

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -512,10 +512,12 @@ extension WooAnalyticsEvent {
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
             let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
+            let redeemedWithGiftCard = order.appliedGiftCards.isNotEmpty
             return WooAnalyticsEvent(statName: .orderOpen, properties: ["id": order.orderID,
                                                                         "status": order.status.rawValue,
                                                                         "custom_fields_count": Int64(order.customFields.count),
-                                                                        "custom_fields_size": Int64(customFieldsSize)])
+                                                                        "custom_fields_size": Int64(customFieldsSize),
+                                                                        "redeemed_gift_card": redeemedWithGiftCard])
         }
 
         static func orderAddNew() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -524,6 +524,14 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderAddNew, properties: [:])
         }
 
+        static func orderProductsLoaded(order: Order, products: [Product]) -> WooAnalyticsEvent {
+            let productIDs = order.items.map { $0.productID }
+            let productTypes = productIDs.compactMap { productID in
+                products.first(where: { $0.productID == productID })?.productType.rawValue
+            }.uniqued().joined(separator: ",")
+            return WooAnalyticsEvent(statName: .orderProductsLoaded, properties: ["product_types": productTypes])
+        }
+
         static func orderAddNewFromBarcodeScanningTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderListProductBarcodeScanningTapped, properties: [:])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -513,12 +513,10 @@ extension WooAnalyticsEvent {
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
             let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
-            let redeemedWithGiftCard = order.appliedGiftCards.isNotEmpty
             return WooAnalyticsEvent(statName: .orderOpen, properties: ["id": order.orderID,
                                                                         "status": order.status.rawValue,
                                                                         "custom_fields_count": Int64(order.customFields.count),
-                                                                        "custom_fields_size": Int64(customFieldsSize),
-                                                                        "redeemed_gift_card": redeemedWithGiftCard])
+                                                                        "custom_fields_size": Int64(customFieldsSize)])
         }
 
         static func orderAddNew() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -387,8 +387,9 @@ extension WooAnalyticsEvent {
 extension WooAnalyticsEvent {
     /// Namespace
     enum ProductDetail {
-        static func loaded(hasLinkedProducts: Bool) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productDetailLoaded, properties: ["has_linked_products": hasLinkedProducts])
+        static func loaded(hasLinkedProducts: Bool, hasMinMaxQuantityRules: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailLoaded, properties: ["has_linked_products": hasLinkedProducts,
+                                                                           "has_minmax_quantity_rules": hasMinMaxQuantityRules])
         }
 
         /// Tracks when the merchant previews a product draft.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -367,6 +367,7 @@ public enum WooAnalyticsStat: String {
     //
     case orderOpen = "order_open"
     case orderAddNew = "orders_add_new"
+    case orderProductsLoaded = "order_products_loaded"
     case orderNotesLoaded = "order_notes_loaded"
     case orderNoteAdd = "order_note_add"
     case orderNoteAddSuccess = "order_note_add_success"

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -215,7 +215,9 @@ extension OrderDetailsViewModel {
                     group.leave()
                 }
                 guard let self else { return }
-                ServiceLocator.analytics.track(event: .Orders.orderProductsLoaded(order: self.order, products: self.products))
+                ServiceLocator.analytics.track(event: .Orders.orderProductsLoaded(order: self.order,
+                                                                                  products: self.products,
+                                                                                  addOnGroups: self.dataSource.addOnGroups))
             }
 
             group.enter()

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -210,8 +210,12 @@ extension OrderDetailsViewModel {
             guard let self = self else { return }
 
             group.enter()
-            self.syncProducts { _ in
-                group.leave()
+            self.syncProducts { [weak self] _ in
+                defer {
+                    group.leave()
+                }
+                guard let self else { return }
+                ServiceLocator.analytics.track(event: .Orders.orderProductsLoaded(order: self.order, products: self.products))
             }
 
             group.enter()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -590,7 +590,9 @@ extension ProductFormViewModel {
 extension ProductFormViewModel {
     func trackProductFormLoaded() {
         let hasLinkedProducts = product.upsellIDs.isNotEmpty || product.crossSellIDs.isNotEmpty
-        analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts))
+        let hasMinMaxQuantityRules = product.hasQuantityRules
+        analytics.track(event: WooAnalyticsEvent.ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts,
+                                                                      hasMinMaxQuantityRules: hasMinMaxQuantityRules))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -80,6 +80,7 @@ final class OrderSearchUICommand: SearchUICommand {
         let detailsViewController = OrderDetailsViewController(viewModel: viewModel)
 
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: model))
     }
 
     /// Removes the `#` from the start of the search keyword, if present.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10337 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To better prioritize the extensions we want to support in the app, it'd be great to understand how often they are used in the orders/products viewed by the merchants. The top priority extensions sorted by active stores count in the last 30 days that also use mobile:

- WooCommerce Product Add-ons: how many opened orders have line items with product add-ons - `order_products_loaded.has_addons` (new event & property) when the order's products are synced
- WooCommerce Product Bundles: how many opened orders have line items with a bundle product - `order_products_loaded.product_types: comma-delimited list string` (new event & property) when the order's products are synced
- WooCommerce Subscriptions: how many opened orders have line items with a subscription product - same as above
- WooCommerce Gift Cards: how many opened orders include a gift card redemption - ✅  `order_details_gift_card_shown` when gift card is shown in order details
- WooCommerce Min/Max Quantities: how many opened products include min/max quantity rules - `product_detail_loaded.has_minmax_quantity_rules` (existing event, new property) when a product is loaded

While testing the `order_open` event, I noticed that it wasn't tracked when tapping on an order from the order search screen. Now it should be tracked in the PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### `order_products_loaded` event (new)

- Go to the orders tab
- Tap on an order that includes at least one subscription product --> an event `order_products_loaded` should be tracked with the subscription product type in the `product_types` property (e.g. `variable-subscription`)
- Tap on an order that includes at least one bundle product --> an event `order_products_loaded` should be tracked with the `bundle` product type in the `product_types` property
- Tap on an order that includes at least one product with add-ons --> an event `order_products_loaded` should be tracked with `has_addons: true`
- Tap on an order that doesn't include any product with add-ons --> an event `order_products_loaded` should be tracked with `has_addons: false`

### `product_detail_loaded` event

- Go to the products tab
- Tap on a product with min/max quantity rules --> an event `product_detail_loaded` should be tracked with `has_minmax_quantity_rules: true`
- Tap on a product without min/max quantity rules --> an event `product_detail_loaded` should be tracked with `has_minmax_quantity_rules: false`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
