### PR TITLE
Product description AI: Make product name field more prominent

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Local notifications: Add a reminder to purchase a plan is scheduled 6hr after a free trial subscription. [https://github.com/woocommerce/woocommerce-ios/pull/10268]
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
 - [*] Photo -> Product: Reset details from previous image when new image is selected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
+- [*] Product description AI: the AI sheet has been improved with the product name field made more prominent. [https://github.com/woocommerce/woocommerce-ios/pull/10333]
 
 14.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -180,10 +180,10 @@ struct ProductDescriptionGenerationView: View {
     private var nameTextField: some View {
         if #available(iOS 16.0, *) {
             TextField(Localization.productNamePlaceholder, text: $viewModel.name, axis: .vertical)
-                .subheadlineStyle()
+                .bodyStyle()
         } else {
             TextField(Localization.productNamePlaceholder, text: $viewModel.name)
-                .subheadlineStyle()
+                .bodyStyle()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -26,7 +26,7 @@ final class ProductDescriptionGenerationHostingController: UIHostingController<P
 struct ProductDescriptionGenerationView: View {
     @ObservedObject private var viewModel: ProductDescriptionGenerationViewModel
     @State private var copyTextNotice: Notice?
-    @FocusState private var isFeaturesFieldInFocus: Bool
+    @FocusState private var focusedField: Field?
 
     init(viewModel: ProductDescriptionGenerationViewModel) {
         self.viewModel = viewModel
@@ -44,8 +44,10 @@ struct ProductDescriptionGenerationView: View {
                     .padding(Layout.productNamePadding)
                     .overlay(
                         RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                            .stroke(Color(viewModel.missingName ? .error : .divider))
+                            .stroke(Color(viewModel.missingName ? .error :
+                                          focusedField == .name ? .accent : .divider))
                     )
+                    .focused($focusedField, equals: .name)
 
                 // Since there is no placeholder support in `TextEditor`, a workaround is to
                 // use a ZStack with an optional `Text` on top that passes through the gestures.
@@ -58,10 +60,10 @@ struct ProductDescriptionGenerationView: View {
                         .frame(minHeight: Layout.minimuEditorSize, maxHeight: .infinity)
                         .overlay(
                             RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                                .stroke(Color(isFeaturesFieldInFocus ? .accent :
-                                              viewModel.missingFeatures ? .error : .separator))
+                                .stroke(Color(viewModel.missingFeatures ? .error :
+                                              focusedField == .features ? .accent : .separator))
                         )
-                        .focused($isFeaturesFieldInFocus)
+                        .focused($focusedField, equals: .features)
 
                     if viewModel.features.isEmpty {
                         Text(Localization.productDescriptionPlaceholder)
@@ -118,6 +120,7 @@ struct ProductDescriptionGenerationView: View {
                         // CTA to regenerate description.
                         Button {
                             viewModel.generateDescription()
+                            focusedField = nil
                         } label: {
                             if viewModel.isGenerationInProgress {
                                 ActivityIndicator(isAnimating: .constant(true), style: .medium)
@@ -141,6 +144,7 @@ struct ProductDescriptionGenerationView: View {
                         // CTA to generate text for the first pass.
                         Button {
                             viewModel.generateDescription()
+                            focusedField = nil
                         } label: {
                             Label {
                                 Text(Localization.generateText)
@@ -186,6 +190,11 @@ private extension ProductDescriptionGenerationView {
         static let productFeaturesInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
         static let productFeaturesPlaceholderInsets: EdgeInsets = .init(top: 18, leading: 16, bottom: 18, trailing: 16)
         static let suggestedTextInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+    }
+
+    enum Field: Equatable {
+        case name
+        case features
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -26,8 +26,6 @@ final class ProductDescriptionGenerationHostingController: UIHostingController<P
 struct ProductDescriptionGenerationView: View {
     @ObservedObject private var viewModel: ProductDescriptionGenerationViewModel
     @State private var copyTextNotice: Notice?
-    @State private var missingName: Bool = false
-    @State private var missingFeatures: Bool = false
     @FocusState private var isFeaturesFieldInFocus: Bool
 
     init(viewModel: ProductDescriptionGenerationViewModel) {
@@ -46,7 +44,7 @@ struct ProductDescriptionGenerationView: View {
                     .padding(Layout.productNamePadding)
                     .overlay(
                         RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                            .stroke(Color(missingName ? .error : .divider))
+                            .stroke(Color(viewModel.missingName ? .error : .divider))
                     )
 
                 // Since there is no placeholder support in `TextEditor`, a workaround is to
@@ -61,7 +59,7 @@ struct ProductDescriptionGenerationView: View {
                         .overlay(
                             RoundedRectangle(cornerRadius: Layout.cornerRadius)
                                 .stroke(Color(isFeaturesFieldInFocus ? .accent :
-                                              missingFeatures ? .error : .separator))
+                                              viewModel.missingFeatures ? .error : .separator))
                         )
                         .focused($isFeaturesFieldInFocus)
 
@@ -142,12 +140,6 @@ struct ProductDescriptionGenerationView: View {
                     } else {
                         // CTA to generate text for the first pass.
                         Button {
-                            guard viewModel.name.isNotEmpty else {
-                                return missingName = true
-                            }
-                            guard viewModel.features.isNotEmpty else {
-                                return missingFeatures = true
-                            }
                             viewModel.generateDescription()
                         } label: {
                             Label {
@@ -168,12 +160,6 @@ struct ProductDescriptionGenerationView: View {
             }.padding(insets: Layout.insets)
         }
         .notice($copyTextNotice, autoDismiss: true)
-        .onChange(of: viewModel.name) { _ in
-            missingName = false
-        }
-        .onChange(of: viewModel.features) { _ in
-            missingFeatures = false
-        }
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -21,6 +21,12 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
     /// Whether feedback banner for the generated text should be displayed.
     @Published private(set) var shouldShowFeedbackView = false
 
+    /// Whether product name is missing
+    @Published private(set) var missingName: Bool = false
+
+    /// Whether product features are missing
+    @Published private(set) var missingFeatures: Bool = false
+
     let isProductNameEditable: Bool
 
     private let siteID: Int64
@@ -50,10 +56,24 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
         self.onApply = onApply
         self.isProductNameEditable = name.isEmpty
         self.delayBeforeDismissingFeedbackBanner = delayBeforeDismissingFeedbackBanner
+
+        // resets `missingName` upon any changes to `name`
+        $name.map { _ in false }
+            .assign(to: &$missingName)
+
+        // resets `missingFeatures` upon any changes to `features`
+        $features.map { _ in false }
+            .assign(to: &$missingFeatures)
     }
 
     /// Generates product description async.
     func generateDescription() {
+        guard name.isNotEmpty else {
+            return missingName = true
+        }
+        guard features.isNotEmpty else {
+            return missingFeatures = true
+        }
         analytics.track(event: .ProductFormAI.productDescriptionAIGenerateButtonTapped(isRetry: suggestedText?.isNotEmpty == true))
 
         isGenerationInProgress = true

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -21,11 +21,6 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
     /// Whether feedback banner for the generated text should be displayed.
     @Published private(set) var shouldShowFeedbackView = false
 
-    /// Whether the text generation CTA is enabled.
-    var isGenerationEnabled: Bool {
-        name.isNotEmpty && features.isNotEmpty
-    }
-
     let isProductNameEditable: Bool
 
     private let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -4,10 +4,18 @@ import Yosemite
 /// View model for `ProductDescriptionGenerationView`.
 final class ProductDescriptionGenerationViewModel: ObservableObject {
     /// Product name, editable.
-    @Published var name: String
+    @Published var name: String {
+        didSet {
+            missingName = false
+        }
+    }
 
     /// Product features, editable. The default value is the pre-existing product description.
-    @Published var features: String
+    @Published var features: String {
+        didSet {
+            missingFeatures = false
+        }
+    }
 
     /// AI-generated product description.
     @Published private(set) var suggestedText: String?
@@ -56,14 +64,6 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
         self.onApply = onApply
         self.isProductNameEditable = name.isEmpty
         self.delayBeforeDismissingFeedbackBanner = delayBeforeDismissingFeedbackBanner
-
-        // resets `missingName` upon any changes to `name`
-        $name.map { _ in false }
-            .assign(to: &$missingName)
-
-        // resets `missingFeatures` upon any changes to `features`
-        $features.map { _ in false }
-            .assign(to: &$missingFeatures)
     }
 
     /// Generates product description async.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
@@ -54,6 +54,8 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.suggestedText)
 
         // When
+        viewModel.name = "Kitkat"
+        viewModel.features = "Chocolate, sweet"
         viewModel.generateDescription()
 
         // Then
@@ -71,6 +73,8 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "", stores: stores, onApply: { _ in })
 
         // When
+        viewModel.name = "Kitkat"
+        viewModel.features = "Chocolate, sweet"
         viewModel.generateDescription()
 
         // Then
@@ -87,6 +91,8 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "", stores: stores, onApply: { _ in })
 
         // When
+        viewModel.name = "Kitkat"
+        viewModel.features = "Chocolate, sweet"
         viewModel.generateDescription()
 
         // Then
@@ -130,6 +136,8 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isGenerationInProgress)
 
         // When
+        viewModel.name = "Kitkat"
+        viewModel.features = "Chocolate, sweet"
         viewModel.generateDescription()
 
         // Then
@@ -383,6 +391,55 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         let failureEventProperties = analyticsProvider.receivedProperties[failureEventIndex]
         XCTAssertEqual(failureEventProperties["error_code"] as? String, "500")
         XCTAssertEqual(failureEventProperties["error_domain"] as? String, "Test")
+    }
+
+    // MARK: - `missingName` & `missingFeatures`
+
+    func test_missingName_is_updated_correctly() {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6,
+                                                              name: "",
+                                                              description: "",
+                                                              stores: stores,
+                                                              analytics: analytics,
+                                                              onApply: { _ in })
+        XCTAssertFalse(viewModel.missingName)
+
+        // When
+        viewModel.generateDescription()
+
+        // Then
+        XCTAssertTrue(viewModel.missingName)
+
+        // When
+        viewModel.name = "Test"
+
+        // Then
+        XCTAssertFalse(viewModel.missingName)
+    }
+
+    func test_missingFeatures_is_updated_correctly() {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6,
+                                                              name: "",
+                                                              description: "",
+                                                              stores: stores,
+                                                              analytics: analytics,
+                                                              onApply: { _ in })
+        XCTAssertFalse(viewModel.missingFeatures)
+
+        // When
+        viewModel.name = "Test"
+        viewModel.generateDescription()
+
+        // Then
+        XCTAssertTrue(viewModel.missingFeatures)
+
+        // When
+        viewModel.features = "Test description"
+
+        // Then
+        XCTAssertFalse(viewModel.missingFeatures)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
@@ -136,32 +136,6 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isGenerationInProgress)
     }
 
-    // MARK: - `isGenerationEnabled`
-
-    func test_isGenerationEnabled_is_false_when_product_name_is_empty() throws {
-        // Given
-        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "a product", onApply: { _ in })
-
-        // Then
-        XCTAssertFalse(viewModel.isGenerationEnabled)
-    }
-
-    func test_isGenerationEnabled_is_false_when_product_description_is_empty() throws {
-        // Given
-        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "Woo plate", description: "", onApply: { _ in })
-
-        // Then
-        XCTAssertFalse(viewModel.isGenerationEnabled)
-    }
-
-    func test_isGenerationEnabled_is_true_when_product_name_and_description_are_not_empty() throws {
-        // Given
-        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "Woo", description: "a product", onApply: { _ in })
-
-        // Then
-        XCTAssertTrue(viewModel.isGenerationEnabled)
-    }
-
     // MARK: - `shouldShowFeedbackView`
     func test_shouldShowFeedbackView_is_true_after_generating_a_description() {
         // Given


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10317 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the product description AI sheet to show a border around the product name field and improve error handling. When the product name or features are missing, the relevant field shows a red border to attract the user's attention.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store.
- Navigate to the Product tab and select the "+" button to add a product.
- Tap Write with AI on the product form.
- On the product description AI sheet, notice that the product name field now has a border around it.
- Tap Write with AI button on the sheet, notice that the product name field is red if it's empty.
- Enter something in the name field and tap Write with AI. Notice that the features field is now red.
- Enter something in the features field and tap Write with AI. The content generation should then be triggered.
- Navigate back to the product list and select an existing product.
- Tap Write with AI - the product name field should be disabled, only the features field is required.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/5533851/b8535e3e-ac15-4093-8e5b-ad9aa94476fa





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
