### PR TITLE
Analytics: Track was_ecommerce_trial as a default property

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Local notifications: Add a reminder to purchase a plan is scheduled 6hr after a free trial subscription. [https://github.com/woocommerce/woocommerce-ios/pull/10268]
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
+- [Internal] New default property `was_ecommerce_trial` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10343]
 - [*] Photo -> Product: Reset details from previous image when new image is selected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
 - [**] Store creation: US users can upgrade to a choice of plans for their store via In-App Purchase [https://github.com/woocommerce/woocommerce-ios/pull/10340]
 

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -242,6 +242,7 @@ private extension WooAnalytics {
         let site = ServiceLocator.stores.sessionManager.defaultSite
         updatedProperties[PropertyKeys.blogIDKey] = site?.siteID
         updatedProperties[PropertyKeys.wpcomStoreKey] = site?.isWordPressComStore
+        updatedProperties[PropertyKeys.wooExpressStoreKey] = site?.wasEcommerceTrial
         return updatedProperties
     }
 
@@ -284,5 +285,6 @@ private extension WooAnalytics {
         static let propertyKeyTimeInApp = "time_in_app"
         static let blogIDKey            = "blog_id"
         static let wpcomStoreKey        = "is_wpcom_store"
+        static let wooExpressStoreKey   = "is_wooexpress_store"
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -242,7 +242,7 @@ private extension WooAnalytics {
         let site = ServiceLocator.stores.sessionManager.defaultSite
         updatedProperties[PropertyKeys.blogIDKey] = site?.siteID
         updatedProperties[PropertyKeys.wpcomStoreKey] = site?.isWordPressComStore
-        updatedProperties[PropertyKeys.wooExpressStoreKey] = site?.wasEcommerceTrial
+        updatedProperties[PropertyKeys.ecommerceTrialKey] = site?.wasEcommerceTrial
         return updatedProperties
     }
 
@@ -285,6 +285,6 @@ private extension WooAnalytics {
         static let propertyKeyTimeInApp = "time_in_app"
         static let blogIDKey            = "blog_id"
         static let wpcomStoreKey        = "is_wpcom_store"
-        static let wooExpressStoreKey   = "is_wooexpress_store"
+        static let ecommerceTrialKey    = "was_ecommerce_trial"
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+TestOrder.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+TestOrder.swift
@@ -2,38 +2,22 @@ import Foundation
 
 extension WooAnalyticsEvent {
     enum TestOrder {
-        enum Keys {
-            static let isWooExpressStore = "is_wooexpress_store"
-        }
 
         /// Tracked when the entry point to test order is displayed on the empty state of order list.
-        /// - Parameters:
-        ///     - isWooExpressStore: whether the current store is running a WooExpress plan.
-        ///
-        static func entryPointDisplayed(isWooExpressStore: Bool) -> WooAnalyticsEvent {
-            .init(statName: .orderListTestOrderDisplayed, properties: [
-                Keys.isWooExpressStore: isWooExpressStore
-            ])
+        static func entryPointDisplayed() -> WooAnalyticsEvent {
+            .init(statName: .orderListTestOrderDisplayed, properties: [:])
         }
 
         /// Tracked when the CTA to try test order is tapped on the empty order list screen.
-        /// - Parameters:
-        ///     - isWooExpressStore: whether the current store is running a WooExpress plan.
         ///
-        static func tryTestOrderTapped(isWooExpressStore: Bool) -> WooAnalyticsEvent {
-            .init(statName: .orderListTryTestOrderTapped, properties: [
-                Keys.isWooExpressStore: isWooExpressStore
-            ])
+        static func tryTestOrderTapped() -> WooAnalyticsEvent {
+            .init(statName: .orderListTryTestOrderTapped, properties: [:])
         }
 
         /// Tracked when the CTA to start test order is tapped on the test order screen.
-        /// - Parameters:
-        ///     - isWooExpressStore: whether the current store is running a WooExpress plan.
         ///
-        static func testOrderStarted(isWooExpressStore: Bool) -> WooAnalyticsEvent {
-            .init(statName: .testOrderStartTapped, properties: [
-                Keys.isWooExpressStore: isWooExpressStore
-            ])
+        static func testOrderStarted() -> WooAnalyticsEvent {
+            .init(statName: .testOrderStartTapped, properties: [:])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -617,16 +617,16 @@ private extension OrderListViewController {
         let analytics = ServiceLocator.analytics
         if viewModel.shouldEnableTestOrder, let url = viewModel.siteURL {
 
-            analytics.track(event: .TestOrder.entryPointDisplayed(isWooExpressStore: viewModel.isWooExpressStore))
+            analytics.track(event: .TestOrder.entryPointDisplayed())
             return .withButton(message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                                image: .emptyOrdersImage,
                                details: Localization.createTestOrderDetail,
                                buttonTitle: Localization.tryTestOrder,
                                onTap: { [weak self] _ in
                 guard let self else { return }
-                analytics.track(event: .TestOrder.tryTestOrderTapped(isWooExpressStore: self.viewModel.isWooExpressStore))
+                analytics.track(event: .TestOrder.tryTestOrderTapped())
                 let hostingController = CreateTestOrderHostingController {
-                    analytics.track(event: .TestOrder.testOrderStarted(isWooExpressStore: self.viewModel.isWooExpressStore))
+                    analytics.track(event: .TestOrder.testOrderStarted())
                     UIApplication.shared.open(url)
                 }
                 self.present(UINavigationController(rootViewController: hostingController), animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -52,12 +52,6 @@ final class OrderListViewModel {
         return site.isPublic && hasAnyPaymentGateways && hasAnyPublishedProducts
     }
 
-    /// Whether the current store is running on an WooExpress plan.
-    ///
-    var isWooExpressStore: Bool {
-        stores.sessionManager.defaultSite?.wasEcommerceTrial ?? false
-    }
-
     /// Filters applied to the order list.
     ///
     private(set) var filters: FilterOrderListViewModel.Filters? {

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -28,6 +28,7 @@ extension Storage.Site: ReadOnlyConvertible {
         isPublic = site.isPublic
         canBlaze = site.canBlaze
         isAdmin = site.isAdmin
+        wasEcommerceTrial = site.wasEcommerceTrial
     }
 
     /// Returns a ReadOnly version of the receiver.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10342 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds `was_ecommerce_trial` as a default property following the internal discussion p1690456615750299-slack-C03L1NF1EA3. A few changes were made:
- Fixed issue saving `wasEcommerceTrial` to storage.
- Added new default property in `WooAnalytics`.
- Removed `is_wooexpress_store` from the test order events.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WooExpress store (free trial or already upgraded) - notice that there's a new property `was_ecommerce_trial` in every event with value `true`.
- Switch to a self-hosted or ordinary WPCom store, `was_ecommerce_trial` should be tracked as `false`.
- Log out of the app, `was_ecommerce_trial` should not be tracked at all.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.