### PR TITLE
[Free trial survey] Release free trial survey local notification

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -100,7 +100,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .ordersWithCouponsM4:
             return true
         case .freeTrialSurvey24hAfterFreeTrialSubscribed:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .createTestOrder:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,8 @@
 - [*] Local notifications: Add a reminder to purchase a plan is scheduled 6hr after a free trial subscription. [https://github.com/woocommerce/woocommerce-ios/pull/10268]
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
 - [*] Photo -> Product: Reset details from previous image when new image is selected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
+- [*] Local notifications: Show free trial survey after 24h since subscription. [https://github.com/woocommerce/woocommerce-ios/pull/10324, https://github.com/woocommerce/woocommerce-ios/pull/10328]
+- [*] Local notifications: Add a reminder after 3 days if answered "Still Exploring" in Free trial survey. [https://github.com/woocommerce/woocommerce-ios/pull/10331]
 
 14.6
 -----


### PR DESCRIPTION
Part of: #10266

## Description
Enables the feature flag for the Free trial survey and reminder notification after 3 days

## Testing instructions
CI passing is enough.
Feel free to smoke test using the instructions from #10324  #10328 and #10331

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
