### PR TITLE
Create test order: Release feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -100,7 +100,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .ordersWithCouponsM4:
             return true
         case .freeTrialSurvey24hAfterFreeTrialSubscribed:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .betterCustomerSelectionInOrder:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -101,8 +101,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .freeTrialSurvey24hAfterFreeTrialSubscribed:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .createTestOrder:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .betterCustomerSelectionInOrder:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -214,10 +214,6 @@ public enum FeatureFlag: Int {
     /// Enables Free trial survey notificaiton
     case freeTrialSurvey24hAfterFreeTrialSubscribed
 
-    /// Shows entry point to create test order for new merchants.
-    ///
-    case createTestOrder
-
     /// Enables the improvements in the customer selection logic when creating an order
     /// 
     case betterCustomerSelectionInOrder

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
 - [Internal] New default property `was_ecommerce_trial` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10343]
 - [*] Photo -> Product: Reset details from previous image when new image is selected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
-- [*] Order list: Suggest testing orders for stores without any orders. [https://github.com/woocommerce/woocommerce-ios/pull/10329]
+- [*] Order list: Suggest testing orders for stores without any orders. [https://github.com/woocommerce/woocommerce-ios/pull/10346]
 - [*] Product description AI: the AI sheet has been improved with the product name field made more prominent. [https://github.com/woocommerce/woocommerce-ios/pull/10333]
 - [**] Store creation: US users can upgrade to a choice of plans for their store via In-App Purchase [https://github.com/woocommerce/woocommerce-ios/pull/10340]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
 - [Internal] New default property `was_ecommerce_trial` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10343]
 - [*] Photo -> Product: Reset details from previous image when new image is selected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
+- [*] Order list: Suggest testing orders for stores without any orders. [https://github.com/woocommerce/woocommerce-ios/pull/10329]
 - [**] Store creation: US users can upgrade to a choice of plans for their store via In-App Purchase [https://github.com/woocommerce/woocommerce-ios/pull/10340]
 
 14.6

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -41,8 +41,7 @@ final class OrderListViewModel {
     /// Whether the entry point to test order should be displayed on the empty state screen.
     ///
     var shouldEnableTestOrder: Bool {
-        guard featureFlagService.isFeatureFlagEnabled(.createTestOrder),
-              let site = stores.sessionManager.defaultSite,
+        guard let site = stores.sessionManager.defaultSite,
               let url = siteURL,
               UIApplication.shared.canOpenURL(url) else {
             return false

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -28,7 +28,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isJustInTimeMessagesOnDashboardEnabled: Bool
     private let isFreeTrialInAppPurchasesUpgradeM2: Bool
     private let isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool
-    private let isCreateTestOrderEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -55,8 +54,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isShareProductAIEnabled: Bool = false,
          isJustInTimeMessagesOnDashboardEnabled: Bool = false,
          isFreeTrialInAppPurchasesUpgradeM2: Bool = false,
-         isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool = false,
-         isCreateTestOrderEnabled: Bool = false) {
+         isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -83,7 +81,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.isJustInTimeMessagesOnDashboardEnabled = isJustInTimeMessagesOnDashboardEnabled
         self.isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled = isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled
-        self.isCreateTestOrderEnabled = isCreateTestOrderEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -138,8 +135,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isFreeTrialInAppPurchasesUpgradeM2
         case .freeTrialSurvey24hAfterFreeTrialSubscribed:
             return isFreeTrialSurvey24hAfterFreeTrialSubscribedEnabled
-        case .createTestOrder:
-            return isCreateTestOrderEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -895,8 +895,7 @@ final class OrderListViewModelTests: XCTestCase {
         let viewModel = OrderListViewModel(siteID: siteID,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           filters: nil,
-                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+                                           filters: nil)
 
         // When
         let isEnabled = viewModel.shouldEnableTestOrder
@@ -915,8 +914,7 @@ final class OrderListViewModelTests: XCTestCase {
         let viewModel = OrderListViewModel(siteID: siteID,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           filters: nil,
-                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+                                           filters: nil)
 
         // When
         let isEnabled = viewModel.shouldEnableTestOrder
@@ -935,8 +933,7 @@ final class OrderListViewModelTests: XCTestCase {
         let viewModel = OrderListViewModel(siteID: siteID,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           filters: nil,
-                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+                                           filters: nil)
 
         // When
         let isEnabled = viewModel.shouldEnableTestOrder
@@ -955,8 +952,7 @@ final class OrderListViewModelTests: XCTestCase {
         let viewModel = OrderListViewModel(siteID: siteID,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           filters: nil,
-                                           featureFlagService: MockFeatureFlagService(isCreateTestOrderEnabled: true))
+                                           filters: nil)
 
         // When
         let isEnabled = viewModel.shouldEnableTestOrder


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10292 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the feature flag for `createTestOrder` to enable it on the app.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store without any orders. The empty order list should not show the entry point to test order.
- Set up at least one payment method for the site in wp-admin > WooCommerce > Settings > Payments.
- Create a product on the web or the app.
- Launch the store.
- Refresh the order list, the entry point to test order should now be available on the empty order list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
