### PR TITLE
Analytics: Track site plan info as default property

### DIFF
--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -111,6 +111,9 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         let canBlaze = try optionsContainer.decode(Bool.self, forKey: .canBlaze)
         let isPublic = optionsContainer.failsafeDecodeIfPresent(booleanForKey: .isPublic) ?? false
 
+        let planContainer = try siteContainer.nestedContainer(keyedBy: PlanInfo.self, forKey: .plan)
+        let plan = try planContainer.decode(String.self, forKey: .slug)
+
         self.init(siteID: siteID,
                   name: name,
                   description: description,
@@ -119,7 +122,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                   loginURL: loginURL,
                   isSiteOwner: isSiteOwner,
                   frameNonce: frameNonce,
-                  plan: String(), // Not created on init. Added in supplementary API request.
+                  plan: plan,
                   isJetpackThePluginInstalled: isJetpackThePluginInstalled,
                   isJetpackConnected: isJetpackConnected,
                   isWooCommerceActive: isWooCommerceActive,
@@ -209,6 +212,10 @@ private extension Site {
         case isJetpackThePluginInstalled = "jetpack"
         case isJetpackConnected          = "jetpack_connection"
         case wasEcommerceTrial           = "was_ecommerce_trial"
+    }
+
+    enum PlanInfo: String, CodingKey {
+        case slug = "product_slug"
     }
 
     enum CapabilitiesKeys: String, CodingKey {

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -234,7 +234,7 @@ extension SiteRemote {
     enum SiteParameter {
         enum Fields {
             static let key = "fields"
-            static let value = "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities,was_ecommerce_trial"
+            static let value = "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities,was_ecommerce_trial,plan"
         }
         enum Options {
             static let key = "options"

--- a/Networking/NetworkingTests/Mapper/SiteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteListMapperTests.swift
@@ -5,12 +5,15 @@ final class SiteListMapperTests: XCTestCase {
 
     /// `sites-malformed.json` contains a correct site and a site without options(malformed)
     ///
-    func test_malformed_sites_are_evicted_from_site_list() {
+    func test_malformed_sites_are_evicted_from_site_list() throws {
         // Given
         let sites = mapLoadMalformedSiteListResponse()
 
         // Then
         XCTAssertEqual(sites.count, 1)
+        let site = try XCTUnwrap(sites.first)
+        XCTAssertFalse(site.wasEcommerceTrial)
+        XCTAssertEqual(site.plan, "business-bundle")
     }
 }
 

--- a/Networking/NetworkingTests/Responses/sites-malformed.json
+++ b/Networking/NetworkingTests/Responses/sites-malformed.json
@@ -48,6 +48,10 @@
       "jetpack": false,
       "jetpack_connection": true,
       "was_ecommerce_trial": false,
+      "plan": {
+          "product_id": 1008,
+          "product_slug": "business-bundle"
+      },
       "options": {
         "timezone": "",
         "gmt_offset": -4,

--- a/Networking/NetworkingTests/Responses/sites.json
+++ b/Networking/NetworkingTests/Responses/sites.json
@@ -32,6 +32,10 @@
       "jetpack": true,
       "jetpack_connection": true,
       "was_ecommerce_trial": true,
+      "plan": {
+          "product_id": 1008,
+          "product_slug": "business-bundle"
+      },
       "options": {
         "timezone": "",
         "gmt_offset": 3.5,
@@ -197,6 +201,10 @@
       "jetpack": false,
       "jetpack_connection": true,
       "was_ecommerce_trial": false,
+      "plan": {
+          "product_id": 1008,
+          "product_slug": "business-bundle"
+      },
       "options": {
         "timezone": "",
         "gmt_offset": -4,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 14.8
 -----
-
+- [Internal] New default property `plan` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10356]
 
 14.7
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -243,6 +243,7 @@ private extension WooAnalytics {
         updatedProperties[PropertyKeys.blogIDKey] = site?.siteID
         updatedProperties[PropertyKeys.wpcomStoreKey] = site?.isWordPressComStore
         updatedProperties[PropertyKeys.ecommerceTrialKey] = site?.wasEcommerceTrial
+        updatedProperties[PropertyKeys.planKey] = site?.plan
         return updatedProperties
     }
 
@@ -286,5 +287,6 @@ private extension WooAnalytics {
         static let blogIDKey            = "blog_id"
         static let wpcomStoreKey        = "is_wpcom_store"
         static let ecommerceTrialKey    = "was_ecommerce_trial"
+        static let planKey              = "plan"
     }
 }

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -4,7 +4,7 @@
         "method": "GET",
         "queryParameters": {
           "fields": {
-            "equalTo": "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities,was_ecommerce_trial"
+            "equalTo": "ID,name,description,URL,options,jetpack,jetpack_connection,capabilities,was_ecommerce_trial,plan"
           },
           "options": {
             "equalTo": "timezone,is_wpcom_store,woocommerce_is_active,gmt_offset,jetpack_connection_active_plugins,admin_url,login_url,frame_nonce,blog_public,can_blaze"

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -44,6 +44,10 @@
                         "view_stats": true,
                         "activate_plugins": false
                       },
+                      "plan": {
+                          "product_id": 1003,
+                          "product_slug": "value_bundle"
+                      },
                       "jetpack": true,
                       "jetpack_connection": true,
                       "was_ecommerce_trial": false,

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.Site: ReadOnlyConvertible {
         loginURL = site.loginURL
         isSiteOwner = site.isSiteOwner
         frameNonce = site.frameNonce
-//        plan = site.plan // We're not assigning the plan here because it's not sent on the intial API request.
+        plan = site.plan
         isJetpackThePluginInstalled = site.isJetpackThePluginInstalled
         isJetpackConnected = site.isJetpackConnected
         isWooCommerceActive = NSNumber(booleanLiteral: site.isWooCommerceActive)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10355 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR add site plan info as default property for all tracked events.

Since we already have `plan` property for `Site` in both Networking and Storage, the changes only include decoding plan info, mapping the attribute in storage, and track it as default property in `WooAnalytics`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build and log in to the app.
- Switch between different sites, notice that site plan is tracked correctly in all logged-in events.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
