### PR TITLE
Store creation: Remove feature flag `storeCreationMVP`

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -31,8 +31,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .inAppPurchases:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .storeCreationMVP:
-            return true
         case .storeCreationM2:
             return true
         case .storeCreationM2WithInAppPurchasesEnabled:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -68,10 +68,6 @@ public enum FeatureFlag: Int {
     ///
     case tapToPayBadge
 
-    /// Store creation MVP.
-    ///
-    case storeCreationMVP
-
     /// Store creation milestone 2. https://wp.me/pe5sF9-I3
     ///
     case storeCreationM2

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -181,7 +181,7 @@ final class StorePickerViewController: UIViewController {
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.viewModel = StorePickerViewModel(configuration: configuration)
-        self.isStoreCreationEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
+        self.isStoreCreationEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationM2)
         super.init(nibName: Self.nibName, bundle: nil)
     }
 
@@ -341,7 +341,6 @@ private extension StorePickerViewController {
                 return false
             }()
             return (appleIDCredentialChecker.hasAppleUserID()
-                    || featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
                     || featureFlagService.isFeatureFlagEnabled(.storeCreationM2)) && hasEmptyStores
         }()
         if isCloseAccountButtonVisible {
@@ -685,7 +684,7 @@ private extension StorePickerViewController {
     /// or the add store action sheet for simplified login.
     ///
     @IBAction private func addStoreWasPressed() {
-        if featureFlagService.isFeatureFlagEnabled(.storeCreationMVP) {
+        if featureFlagService.isFeatureFlagEnabled(.storeCreationM2) {
             ServiceLocator.analytics.track(.sitePickerAddStoreTapped)
             presentAddStoreActionSheet(from: addStoreButton)
         } else {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -57,7 +57,7 @@ final class NotWPAccountViewModel: ULErrorViewModel {
             isSecondaryButtonHidden = false
 
             primaryButtonTitle = Localization.createAnAccount
-            isPrimaryButtonHidden = !featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
+            isPrimaryButtonHidden = !featureFlagService.isFeatureFlagEnabled(.storeCreationM2)
         }
     }
 

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -7,7 +7,7 @@ extension WordPressAuthenticator {
     static func initializeWithCustomConfigs(dotcomAuthScheme: String = ApiCredentials.dotcomAuthScheme,
                                             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
-        let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
+        let isStoreCreationEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationM2)
         let isManualErrorHandlingEnabled = featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
@@ -30,7 +30,7 @@ extension WordPressAuthenticator {
                                                                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen:
                                                                     isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen,
                                                                 enableWPComLoginOnlyInPrologue: false,
-                                                                enableSiteCreation: isStoreCreationMVPEnabled,
+                                                                enableSiteCreation: isStoreCreationEnabled,
                                                                 enableSocialLogin: true,
                                                                 emphasizeEmailForWPComPassword: true,
                                                                 wpcomPasswordInstructions:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -355,7 +355,6 @@ private extension SettingsViewModel {
                 return nil
             }
             guard appleIDCredentialChecker.hasAppleUserID()
-                    || featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
                     || featureFlagService.isFeatureFlagEnabled(.storeCreationM2) else {
                 return nil
             }

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -112,7 +112,7 @@ final class NotWPAccountViewModelTests: XCTestCase {
 
     func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_store_creation_is_on() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: true)
+        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
                                               featureFlagService: featureFlagService)
         // Then
@@ -121,7 +121,7 @@ final class NotWPAccountViewModelTests: XCTestCase {
 
     func test_primary_button_is_hidden_for_invalidWPComEmail_from_wpCom_error_when_store_creation_is_off() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: false)
+        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: false)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
                                               featureFlagService: featureFlagService)
         // Then

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -7,7 +7,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isUpdateOrderOptimisticallyOn: Bool
     private let shippingLabelsOnboardingM1: Bool
     private let isLoginPrologueOnboardingEnabled: Bool
-    private let isStoreCreationMVPEnabled: Bool
     private let isStoreCreationM2Enabled: Bool
     private let isStoreCreationM2WithInAppPurchasesEnabled: Bool
     private let isStoreCreationM3ProfilerEnabled: Bool
@@ -34,7 +33,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
          isLoginPrologueOnboardingEnabled: Bool = false,
-         isStoreCreationMVPEnabled: Bool = true,
          isStoreCreationM2Enabled: Bool = false,
          isStoreCreationM2WithInAppPurchasesEnabled: Bool = false,
          isStoreCreationM3ProfilerEnabled: Bool = false,
@@ -60,7 +58,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.isLoginPrologueOnboardingEnabled = isLoginPrologueOnboardingEnabled
-        self.isStoreCreationMVPEnabled = isStoreCreationMVPEnabled
         self.isStoreCreationM2Enabled = isStoreCreationM2Enabled
         self.isStoreCreationM2WithInAppPurchasesEnabled = isStoreCreationM2WithInAppPurchasesEnabled
         self.isStoreCreationM3ProfilerEnabled = isStoreCreationM3ProfilerEnabled
@@ -95,8 +92,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return shippingLabelsOnboardingM1
         case .loginPrologueOnboarding:
             return isLoginPrologueOnboardingEnabled
-        case .storeCreationMVP:
-            return isStoreCreationMVPEnabled
         case .storeCreationM2:
             return isStoreCreationM2Enabled
         case .storeCreationM2WithInAppPurchasesEnabled:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -168,7 +168,7 @@ final class SettingsViewModelTests: XCTestCase {
     func test_closeAccount_section_is_hidden_when_apple_id_does_not_exist_and_store_creation_features_disabled() {
         // Given
         let appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: false)
-        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: false, isStoreCreationM2Enabled: false)
+        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: false)
         let viewModel = SettingsViewModel(stores: stores,
                                           storageManager: storageManager,
                                           featureFlagService: featureFlagService,
@@ -184,7 +184,7 @@ final class SettingsViewModelTests: XCTestCase {
     func test_closeAccount_section_is_hidden_when_authenticated_without_wpcom() {
         // Given
         let appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: false)
-        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: true, isStoreCreationM2Enabled: true)
+        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
         let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
         let stores = DefaultStoresManager(sessionManager: sessionManager)
         let viewModel = SettingsViewModel(stores: stores,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10327 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We have shipped M2 for store creation for a while and will not get back to web store creation. This PR cleans up the code by removing the stale feature flag `storeCreationMVP` and replacing the checks for this flag with `storeCreationM2`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build, run, and log out of the app if needed.
- On the prologue screen, notice that both CTA is available as before: Log In and Get Started.
- Select Get Started and tap Log In.
- Enter an email address that is not associated to any WP site.
- See the error screen about incorrect email address > the CTA to Create an account should be available.

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/720b900a-b7b2-49e4-8172-d117011de776" width=320 />

- Navigate back and enter the correct email address to finish login.
- After successfully logging in, switch to the Menu tab and open the site picker.
- Scroll to the bottom and select Add a Store > Create a new store. The store creation flow should start as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
