### PR TITLE
Store creation: Remove feature flag for free trial

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -67,8 +67,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productBundles:
             return true
-        case .freeTrial:
-            return true
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
         case .compositeProducts:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -148,10 +148,6 @@ public enum FeatureFlag: Int {
     ///
     case productBundles
 
-    /// Enables conditional behaviour when a site has a free trial plan.
-    ///
-    case freeTrial
-
     /// Enables manual error handling for site credential login.
     ///
     case manualErrorHandlingForSiteCredentialLogin

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -504,8 +504,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
     // Navigate to store creation
     func showSiteCreation(in navigationController: UINavigationController) {
-        let isFreeTrialEnabled = featureFlagService.isFeatureFlagEnabled(.freeTrial)
-        analytics.track(event: .StoreCreation.loginPrologueCreateSiteTapped(isFreeTrial: isFreeTrialEnabled))
+        analytics.track(event: .StoreCreation.loginPrologueCreateSiteTapped(isFreeTrial: true))
 
         let coordinator = LoggedOutStoreCreationCoordinator(source: .prologue,
                                                             navigationController: navigationController)

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -45,7 +45,6 @@ final class StoreCreationCoordinator: Coordinator {
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
     private let featureFlagService: FeatureFlagService
     private let localNotificationScheduler: LocalNotificationScheduler
-    private var jetpackCheckRetryInterval: TimeInterval = 10
 
     private weak var storeCreationProgressViewModel: StoreCreationProgressViewModel?
     private var statusChecker: StoreCreationStatusChecker?
@@ -626,7 +625,7 @@ private extension StoreCreationCoordinator {
     func showInProgressView(from navigationController: UINavigationController,
                             viewProperties: InProgressViewProperties) {
         let approxSecondsToWaitForNetworkRequest = 10.0
-        let viewModel = StoreCreationProgressViewModel(estimatedTimePerProgress: jetpackCheckRetryInterval + approxSecondsToWaitForNetworkRequest)
+        let viewModel = StoreCreationProgressViewModel(estimatedTimePerProgress: Constants.jetpackCheckRetryInterval + approxSecondsToWaitForNetworkRequest)
         let storeCreationProgressView = StoreCreationProgressHostingViewController(viewModel: viewModel)
         navigationController.isNavigationBarHidden = true
         self.storeCreationProgressViewModel = viewModel
@@ -904,6 +903,8 @@ private extension StoreCreationCoordinator {
         enum LocalNotificationScenario {
             static let storeCreationComplete: LocalNotification.Scenario = .storeCreationComplete
         }
+
+        static let jetpackCheckRetryInterval: TimeInterval = 10
     }
 
     /// Error scenarios when purchasing a WPCOM plan.

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -13,7 +13,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isDomainSettingsEnabled: Bool
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
-    private let isFreeTrial: Bool
     private let jetpackSetupWithApplicationPassword: Bool
     private let isTapToPayOnIPhoneMilestone2On: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
@@ -39,7 +38,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
-         isFreeTrial: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          isTapToPayOnIPhoneMilestone2On: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
@@ -104,8 +102,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isSupportRequestEnabled
         case .dashboardOnboarding:
             return isDashboardStoreOnboardingEnabled
-        case .freeTrial:
-            return isFreeTrial
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
         case .tapToPayOnIPhoneMilestone2:

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -62,7 +62,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
-        self.isFreeTrial = isFreeTrial
         self.isFreeTrialInAppPurchasesUpgradeM2 = isFreeTrialInAppPurchasesUpgradeM2
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isTapToPayOnIPhoneMilestone2On = isTapToPayOnIPhoneMilestone2On

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -334,7 +334,6 @@ final class HubMenuViewModelTests: XCTestCase {
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         featureFlagService: featureFlagService,
                                          stores: stores)
         viewModel.setupMenuElements()
 
@@ -352,7 +351,6 @@ final class HubMenuViewModelTests: XCTestCase {
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         featureFlagService: featureFlagService,
                                          stores: stores)
         viewModel.setupMenuElements()
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -327,8 +327,6 @@ final class HubMenuViewModelTests: XCTestCase {
 
     func test_menuElements_include_subscriptions_on_wp_com_sites() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isFreeTrial: true)
-
         let sessionManager = SessionManager.testingInstance
         sessionManager.defaultSite = Site.fake().copy(isWordPressComStore: true)
         let stores = MockStoresManager(sessionManager: sessionManager)
@@ -347,8 +345,6 @@ final class HubMenuViewModelTests: XCTestCase {
 
     func test_menuElements_does_not_include_subscriptions_on_self_hosted_sites() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isFreeTrial: true)
-
         let sessionManager = SessionManager.testingInstance
         sessionManager.defaultSite = Site.fake().copy(isWordPressComStore: false)
         let stores = MockStoresManager(sessionManager: sessionManager)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10327
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To clean up the logic for store creation and improve readability, we are removing stale feature flags and enabling active ones by default. 

Since we are enabling free trial for all users, this PR removes the `freeTrial` feature flag and enable all related code path by default. The old flow with domain picker is permanently removed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to the app and navigate to the store picker.
- Select Add a store > Create a new store.
- The store creation flow with free trial should work as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/f4d950d3-b61c-4c16-abb1-7396c891680a



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
