### PR TITLE
Store creation: Remove web store creation

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -63,9 +63,6 @@ class AuthenticationManager: Authentication {
     private var siteCredentialLoginUseCase: SiteCredentialLoginUseCase?
 
     /// Injected for unit test purposes
-    private let purchasesManager: InAppPurchasesForWPComPlansProtocol?
-
-    /// Injected for unit test purposes
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol?
 
     init(stores: StoresManager = ServiceLocator.stores,
@@ -73,14 +70,12 @@ class AuthenticationManager: Authentication {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          analytics: Analytics = ServiceLocator.analytics,
          abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider(),
-         purchasesManager: InAppPurchasesForWPComPlansProtocol? = nil,
          switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil) {
         self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
         self.analytics = analytics
         self.abTestVariationProvider = abTestVariationProvider
-        self.purchasesManager = purchasesManager
         self.switchStoreUseCase = switchStoreUseCase
     }
 
@@ -534,8 +529,7 @@ private extension AuthenticationManager {
             // not have any existing stores
             let coordinator = StoreCreationCoordinator(source: .loggedOut(source: storeCreationSource),
                                                        navigationController: navigationController,
-                                                       featureFlagService: featureFlagService,
-                                                       purchasesManager: purchasesManager)
+                                                       featureFlagService: featureFlagService)
             self.storeCreationCoordinator = coordinator
             coordinator.start()
             return

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -159,7 +159,7 @@ private extension StoreCreationCoordinator {
                 /// Before enabling it again, make sure the onboarding questions are properly sent on the trial flow around line `343`.
                 /// Ref: https://github.com/woocommerce/woocommerce-ios/issues/9326#issuecomment-1490012032
                 ///
-                self?.showCategoryQuestion(from: navigationController, storeName: storeName, planToPurchase: planToPurchase)
+                self?.showCategoryQuestion(from: navigationController, storeName: storeName)
             } else {
                 self?.showFreeTrialSummaryView(from: navigationController, storeName: storeName, profilerData: nil)
             }
@@ -360,16 +360,15 @@ private extension StoreCreationCoordinator {
 private extension StoreCreationCoordinator {
     @MainActor
     func showCategoryQuestion(from navigationController: UINavigationController,
-                              storeName: String,
-                              planToPurchase: WPComPlanProduct) {
+                              storeName: String) {
         let questionController = StoreCreationCategoryQuestionHostingController(viewModel:
                 .init(storeName: storeName) { [weak self] category in
                     guard let self else { return }
-                    self.showSellingStatusQuestion(from: navigationController, storeName: storeName, category: category, planToPurchase: planToPurchase)
+                    self.showSellingStatusQuestion(from: navigationController, storeName: storeName, category: category)
                 } onSkip: { [weak self] in
                     guard let self else { return }
                     self.analytics.track(event: .StoreCreation.siteCreationProfilerQuestionSkipped(step: .profilerCategoryQuestion))
-                    self.showSellingStatusQuestion(from: navigationController, storeName: storeName, category: nil, planToPurchase: planToPurchase)
+                    self.showSellingStatusQuestion(from: navigationController, storeName: storeName, category: nil)
                 })
         navigationController.pushViewController(questionController, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerCategoryQuestion))
@@ -378,8 +377,7 @@ private extension StoreCreationCoordinator {
     @MainActor
     func showSellingStatusQuestion(from navigationController: UINavigationController,
                                    storeName: String,
-                                   category: StoreCreationCategoryAnswer?,
-                                   planToPurchase: WPComPlanProduct) {
+                                   category: StoreCreationCategoryAnswer?) {
         let questionController = StoreCreationSellingStatusQuestionHostingController(storeName: storeName) { [weak self] sellingStatus in
             guard let self else { return }
             if sellingStatus?.sellingStatus == .alreadySellingOnline && sellingStatus?.sellingPlatforms?.isEmpty == true {
@@ -388,16 +386,14 @@ private extension StoreCreationCoordinator {
             self.showStoreCountryQuestion(from: navigationController,
                                           storeName: storeName,
                                           category: category,
-                                          sellingStatus: sellingStatus,
-                                          planToPurchase: planToPurchase)
+                                          sellingStatus: sellingStatus)
         } onSkip: { [weak self] in
             guard let self else { return }
             self.analytics.track(event: .StoreCreation.siteCreationProfilerQuestionSkipped(step: .profilerSellingStatusQuestion))
             self.showStoreCountryQuestion(from: navigationController,
                                           storeName: storeName,
                                           category: category,
-                                          sellingStatus: nil,
-                                          planToPurchase: planToPurchase)
+                                          sellingStatus: nil)
         }
         navigationController.pushViewController(questionController, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerSellingStatusQuestion))
@@ -407,8 +403,7 @@ private extension StoreCreationCoordinator {
     func showStoreCountryQuestion(from navigationController: UINavigationController,
                                   storeName: String,
                                   category: StoreCreationCategoryAnswer?,
-                                  sellingStatus: StoreCreationSellingStatusAnswer?,
-                                  planToPurchase: WPComPlanProduct) {
+                                  sellingStatus: StoreCreationSellingStatusAnswer?) {
         let questionController = StoreCreationCountryQuestionHostingController(viewModel:
                 .init(storeName: storeName) { [weak self] countryCode in
                     guard let self else { return }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -597,43 +597,6 @@ private extension StoreCreationCoordinator {
     }
 
     enum Localization {
-        static var domainSelectorTitle: String {
-            NSLocalizedString("Choose a domain", comment: "Title of the domain selector in the store creation flow.")
-        }
-        static var domainSelectorSubtitle: String {
-            NSLocalizedString(
-                "This is where people will find you on the Internet. You can add another domain later.",
-                comment: "Subtitle of the domain selector in the store creation flow.")
-        }
-
-        enum WaitingForIAPEligibility {
-            static let title = NSLocalizedString(
-                "We are getting ready for your store creation",
-                comment: "Title of the in-progress view when waiting for the in-app purchase status before the store creation flow."
-            )
-            static let message = NSLocalizedString(
-                "Please remain connected.",
-                comment: "Message of the in-progress view when waiting for the in-app purchase status before the store creation flow."
-            )
-        }
-
-        enum IAPIneligibleAlert {
-            static let notSupportedMessage = NSLocalizedString(
-                "We're sorry, but store creation is not currently available in your country in the app.",
-                comment: "Message of the alert when the user cannot create a store because their App Store country is not supported."
-            )
-            static let productNotEligibleMessage = NSLocalizedString(
-                "Sorry, but you can only create one store. Your account is already associated with an active store.",
-                comment: "Message of the alert when the user cannot create a store because they already created one before."
-            )
-            static let defaultMessage = NSLocalizedString(
-                "We're sorry, but store creation is not currently available in the app.",
-                comment: "Message of the alert when the user cannot create a store for some reason."
-            )
-            static let dismissActionTitle = NSLocalizedString("OK",
-                                                             comment: "Button title to cancel the alert when the user cannot create a store.")
-        }
-
         enum DiscardChangesAlert {
             static let title = NSLocalizedString("Do you want to leave?",
                                                  comment: "Title of the alert when the user dismisses the store creation flow.")
@@ -658,23 +621,6 @@ private extension StoreCreationCoordinator {
             )
         }
 
-        enum PlanPurchaseErrorAlert {
-            static let title = NSLocalizedString("Issue purchasing the plan",
-                                                 comment: "Title of the alert when the WPCOM plan cannot be purchased in the store creation flow.")
-            static let defaultErrorMessage = NSLocalizedString(
-                "Please try again and make sure you are signed in to an App Store account eligible for purchase.",
-                comment: "Message of the alert when the WPCOM plan cannot be purchased in the store creation flow."
-            )
-            static let webPurchaseErrorMessage = NSLocalizedString(
-                "Please try again, or exit the screen and check back on your store if you previously left the checkout screen while payment is in progress.",
-                comment: "Message of the alert when the WPCOM plan cannot be purchased in a webview in the store creation flow."
-            )
-            static let cancelActionTitle = NSLocalizedString(
-                "OK",
-                comment: "Button title to dismiss the alert when the WPCOM plan cannot be purchased in the store creation flow."
-            )
-        }
-
         enum WaitingForJetpackSite {
             static let title = NSLocalizedString(
                 "Creating your store",
@@ -685,24 +631,10 @@ private extension StoreCreationCoordinator {
     }
 
     enum Constants {
-        // TODO: 8108 - update the identifier to production value when it's ready
-        static let iapPlanIdentifier = "debug.woocommerce.ecommerce.monthly"
-        static let webPlanIdentifier = "1021"
-
         /// Local notification scenarios during store creation.
         enum LocalNotificationScenario {
             static let storeCreationComplete: LocalNotification.Scenario = .storeCreationComplete
         }
-    }
-
-    /// Error scenarios when purchasing a WPCOM plan.
-    enum PlanPurchaseError: Error {
-        /// The user is not eligible for In-App Purchases.
-        case iapNotSupported
-        /// There is no matching product to purchase.
-        case noMatchingProduct
-        /// The user is already entitled to the product, and cannot purchase it anymore.
-        case productNotEligible
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -64,9 +64,8 @@ final class StoreCreationCoordinator: Coordinator {
     func start() {
         Task { @MainActor in
             let storeCreationNavigationController = WooNavigationController()
-            await presentStoreCreation(viewController: storeCreationNavigationController)
-
             startStoreCreation(from: storeCreationNavigationController)
+            await presentStoreCreation(viewController: storeCreationNavigationController)
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -91,23 +91,6 @@ final class StoreCreationCoordinator: Coordinator {
 }
 
 private extension StoreCreationCoordinator {
-    func startStoreCreationM1() {
-        observeSiteURLsFromStoreCreation()
-
-        let viewModel = StoreCreationWebViewModel { [weak self] result in
-            self?.handleStoreCreationResult(result)
-        }
-        possibleSiteURLsFromStoreCreation = []
-        let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
-        webViewController.addCloseNavigationBarButton(target: self, action: #selector(handleStoreCreationCloseAction))
-        let webNavigationController = WooNavigationController(rootViewController: webViewController)
-        // Disables interactive dismissal of the store creation modal.
-        webNavigationController.isModalInPresentation = true
-
-        Task { @MainActor in
-            await presentStoreCreation(viewController: webNavigationController)
-        }
-    }
 
     @MainActor
     func startStoreCreation(from navigationController: UINavigationController) {
@@ -164,36 +147,6 @@ private extension StoreCreationCoordinator {
                 }
             }
         }
-    }
-
-    @MainActor
-    func createIAPEligibilityInProgressView() -> UIViewController {
-        InProgressViewController(viewProperties:
-                .init(title: Localization.WaitingForIAPEligibility.title,
-                      message: Localization.WaitingForIAPEligibility.message),
-                                 hidesNavigationBar: true)
-    }
-
-    /// Shows UI when the user is not eligible for store creation.
-    func showIneligibleUI(from navigationController: UINavigationController, error: Error) {
-        let message: String
-        switch error {
-        case PlanPurchaseError.iapNotSupported:
-            message = Localization.IAPIneligibleAlert.notSupportedMessage
-        case PlanPurchaseError.productNotEligible:
-            message = Localization.IAPIneligibleAlert.productNotEligibleMessage
-        default:
-            message = Localization.IAPIneligibleAlert.defaultMessage
-        }
-
-        let alert = UIAlertController(title: nil,
-                                      message: message,
-                                      preferredStyle: .alert)
-        alert.view.tintColor = .text
-
-        alert.addCancelActionWithTitle(Localization.IAPIneligibleAlert.dismissActionTitle) { _ in }
-
-        navigationController.present(alert, animated: true)
     }
 
     /// Shows an alert with default error message

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -44,7 +44,6 @@ final class StoreCreationCoordinator: Coordinator {
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         purchasesManager: InAppPurchasesForWPComPlansProtocol? = nil,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.source = source
         self.navigationController = navigationController

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -24,7 +24,6 @@ final class AppCoordinator {
     private let pushNotesManager: PushNotesManager
     private let featureFlagService: FeatureFlagService
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol
-    private let purchasesManager: InAppPurchasesForWPComPlansProtocol?
     private let upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator
 
     private var storePickerCoordinator: StorePickerCoordinator?
@@ -47,7 +46,6 @@ final class AppCoordinator {
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         purchasesManager: InAppPurchasesForWPComPlansProtocol? = nil,
          upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator()) {
         self.window = window
         self.tabBarController = {
@@ -65,7 +63,6 @@ final class AppCoordinator {
         self.loggedOutAppSettings = loggedOutAppSettings
         self.pushNotesManager = pushNotesManager
         self.featureFlagService = featureFlagService
-        self.purchasesManager = purchasesManager
         self.switchStoreUseCase = SwitchStoreUseCase(stores: stores, storageManager: storageManager)
         self.upgradesViewPresentationCoordinator = upgradesViewPresentationCoordinator
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
@@ -456,7 +453,6 @@ private extension AppCoordinator {
                                                    storageManager: storageManager,
                                                    stores: stores,
                                                    featureFlagService: featureFlagService,
-                                                   purchasesManager: purchasesManager,
                                                    pushNotesManager: pushNotesManager)
         self.storeCreationCoordinator = coordinator
         coordinator.start()

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -625,8 +625,7 @@ final class AppCoordinatorTests: XCTestCase {
                                           stores: stores,
                                           authenticationManager: authenticationManager,
                                           pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService,
-                                          purchasesManager: WebPurchasesForWPComPlans(stores: stores))
+                                          featureFlagService: featureFlagService)
 
         let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
         let identifier = LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial
@@ -669,8 +668,7 @@ final class AppCoordinatorTests: XCTestCase {
                                           stores: stores,
                                           authenticationManager: authenticationManager,
                                           pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService,
-                                          purchasesManager: WebPurchasesForWPComPlans(stores: stores))
+                                          featureFlagService: featureFlagService)
 
         let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
         let identifier = LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial
@@ -707,7 +705,6 @@ private extension AppCoordinatorTests {
                          loggedOutAppSettings: LoggedOutAppSettingsProtocol = MockLoggedOutAppSettings(),
                          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
                          featureFlagService: FeatureFlagService = MockFeatureFlagService(),
-                         purchasesManager: InAppPurchasesForWPComPlansProtocol? = nil,
                          upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator()
     ) -> AppCoordinator {
         return AppCoordinator(window: window ?? self.window,
@@ -719,7 +716,6 @@ private extension AppCoordinatorTests {
                               loggedOutAppSettings: loggedOutAppSettings,
                               pushNotesManager: pushNotesManager,
                               featureFlagService: featureFlagService,
-                              purchasesManager: purchasesManager ?? nil,
                               upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -539,8 +539,7 @@ final class AuthenticationManagerTests: XCTestCase {
 
         let manager = AuthenticationManager(stores: stores,
                                             storageManager: storage,
-                                            featureFlagService: featureFlagService,
-                                            purchasesManager: WebPurchasesForWPComPlans(stores: stores))
+                                            featureFlagService: featureFlagService)
 
         let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false)
         let credentials = AuthenticatorCredentials(wpcom: wpcomCredentials, wporg: nil)
@@ -580,7 +579,6 @@ final class AuthenticationManagerTests: XCTestCase {
         let manager = AuthenticationManager(stores: stores,
                                             storageManager: storage,
                                             featureFlagService: featureFlagService,
-                                            purchasesManager: WebPurchasesForWPComPlans(stores: stores),
                                             switchStoreUseCase: switchStoreUseCase)
 
         let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false)
@@ -620,7 +618,6 @@ final class AuthenticationManagerTests: XCTestCase {
         let manager = AuthenticationManager(stores: stores,
                                             storageManager: storage,
                                             featureFlagService: featureFlagService,
-                                            purchasesManager: WebPurchasesForWPComPlans(stores: stores),
                                             switchStoreUseCase: switchStoreUseCase)
 
         let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false)

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
@@ -23,63 +23,10 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Presentation in different states for store creation M1
-
-    func test_AuthenticatedWebViewController_is_presented_when_navigationController_is_presenting_another_view_with_storeCreationM2_disabled() throws {
+    func test_StoreNameFormHostingController_is_presented_upon_start() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: false)
         let coordinator = StoreCreationCoordinator(source: .storePicker,
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService)
-        waitFor { promise in
-            self.navigationController.present(.init(), animated: false) {
-                promise(())
-            }
-        }
-        XCTAssertNotNil(navigationController.presentedViewController)
-
-        // When
-        coordinator.start()
-
-        // Then
-        waitUntil {
-            self.navigationController.presentedViewController is WooNavigationController
-        }
-        let storeCreationNavigationController = try XCTUnwrap(navigationController.presentedViewController as? UINavigationController)
-        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: AuthenticatedWebViewController.self)
-    }
-
-    func test_AuthenticatedWebViewController_is_presented_when_navigationController_is_showing_another_view_with_storeCreationM2_disabled() throws {
-        // Given
-        navigationController.show(.init(), sender: nil)
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: false)
-        let coordinator = StoreCreationCoordinator(source: .loggedOut(source: .loginEmailError),
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService)
-        XCTAssertNotNil(navigationController.topViewController)
-        XCTAssertNil(navigationController.presentedViewController)
-
-        // When
-        coordinator.start()
-
-        // Then
-        waitUntil {
-            self.navigationController.presentedViewController is WooNavigationController
-        }
-        let storeCreationNavigationController = try XCTUnwrap(navigationController.presentedViewController as? UINavigationController)
-        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: AuthenticatedWebViewController.self)
-    }
-
-    // MARK: - Presentation in different states for store creation M2
-
-    func test_StoreNameFormHostingController_is_presented_when_navigationController_is_presenting_another_view_with_iap_enabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true,
-                                                        isStoreCreationM2WithInAppPurchasesEnabled: true)
-        let coordinator = StoreCreationCoordinator(source: .storePicker,
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0))
+                                                   navigationController: navigationController)
         waitFor { promise in
             self.navigationController.present(.init(), animated: false) {
                 promise(())
@@ -96,15 +43,11 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         }
     }
 
-    func test_StoreNameFormHostingController_is_presented_when_navigationController_is_showing_another_view_with_iap_enabled() throws {
+    func test_StoreNameFormHostingController_is_presented_when_navigationController_is_showing_another_view() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true,
-                                                        isStoreCreationM2WithInAppPurchasesEnabled: true)
         navigationController.show(.init(), sender: nil)
         let coordinator = StoreCreationCoordinator(source: .loggedOut(source: .loginEmailError),
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0))
+                                                   navigationController: navigationController)
         XCTAssertNotNil(navigationController.topViewController)
         XCTAssertNil(navigationController.presentedViewController)
 
@@ -114,122 +57,6 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         // Then
         waitUntil {
             (self.navigationController.presentedViewController as? UINavigationController)?.topViewController is StoreNameFormHostingController
-        }
-    }
-
-    func test_UIAlertController_is_presented_when_iap_is_not_supported_with_iap_enabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true,
-                                                        isStoreCreationM2WithInAppPurchasesEnabled: true)
-        let coordinator = StoreCreationCoordinator(source: .storePicker,
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService,
-                                                   purchasesManager: MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0,
-                                                                                                            isIAPSupported: false))
-        waitFor { promise in
-            self.navigationController.present(.init(), animated: false) {
-                promise(())
-            }
-        }
-        XCTAssertNotNil(navigationController.presentedViewController)
-
-        // When
-        coordinator.start()
-
-        // Then
-        waitUntil {
-            self.navigationController.presentedViewController is UIAlertController
-        }
-    }
-
-    func test_StoreNameFormHostingController_is_presented_when_navigationController_is_presenting_another_view_with_iap_disabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true,
-                                                        isStoreCreationM2WithInAppPurchasesEnabled: false)
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
-            if case let .loadPlan(_, completion) = action {
-                completion(.success(.init(productID: 1021, name: "", formattedPrice: "")))
-            }
-        }
-        let coordinator = StoreCreationCoordinator(source: .storePicker,
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService,
-                                                   purchasesManager: WebPurchasesForWPComPlans(stores: stores))
-        waitFor { promise in
-            self.navigationController.present(.init(), animated: false) {
-                promise(())
-            }
-        }
-        XCTAssertNotNil(navigationController.presentedViewController)
-
-        // When
-        coordinator.start()
-
-        // Then
-        waitUntil {
-            (self.navigationController.presentedViewController as? WooNavigationController)?.topViewController is StoreNameFormHostingController
-        }
-    }
-
-    func test_InProgressViewController_is_first_presented_when_fetching_iap_products() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        // 6 seconds = 6_000_000_000 nanoseconds.
-        let purchasesManager = MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 6_000_000_000)
-        let coordinator = StoreCreationCoordinator(source: .storePicker,
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService,
-                                                   purchasesManager: purchasesManager)
-
-        // When
-        coordinator.start()
-
-        // Then
-        waitUntil(timeout: 5) {
-            (self.navigationController.presentedViewController as? WooNavigationController)?.topViewController is InProgressViewController
-        }
-    }
-
-    func test_AuthenticatedWebViewController_is_presented_when_no_matching_iap_product() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        let purchasesManager = MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0,
-                                            plans: [
-                                                MockInAppPurchasesForWPComPlansManager.Plan(displayName: "",
-                                                                        description: "",
-                                                                        id: "random.id",
-                                                                        displayPrice: "$25")
-                                            ])
-        let coordinator = StoreCreationCoordinator(source: .storePicker,
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService,
-                                                   purchasesManager: purchasesManager)
-
-        // When
-        coordinator.start()
-
-        // Then
-        waitUntil {
-            (self.navigationController.presentedViewController as? WooNavigationController)?.topViewController is AuthenticatedWebViewController
-        }
-    }
-
-    func test_AuthenticatedWebViewController_is_presented_when_user_is_already_entitled_to_iap_product() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
-        let purchasesManager = MockInAppPurchasesForWPComPlansManager(fetchPlansDelayInNanoseconds: 0, userIsEntitledToPlan: true)
-        let coordinator = StoreCreationCoordinator(source: .storePicker,
-                                                   navigationController: navigationController,
-                                                   featureFlagService: featureFlagService,
-                                                   purchasesManager: purchasesManager)
-
-        // When
-        coordinator.start()
-
-        // Then
-        waitUntil {
-            (self.navigationController.presentedViewController as? WooNavigationController)?.topViewController is AuthenticatedWebViewController
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

⚠️ Make sure that #10358 is reviewed and merged first.
Part of #10327
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Since we are using the native store creation flow with free trial by default now, we should remove the code path for the web view solution to make code more readable. This PR removes all logic related to the web view flow and IAP checks to keep one single code path for store creation.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to the app.
- Switch to the Menu tab and open the store picker.
- Select Add a store > Create a new store.
- The store creation flow should work as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/woocommerce/woocommerce-ios/assets/5533851/f4d950d3-b61c-4c16-abb1-7396c891680a

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
