### PR TITLE
Test order: Fix incorrect page number for synching products on the order list screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -243,7 +243,7 @@ final class OrderListViewModel {
 
         /// syncs first published product
         stores.dispatch(ProductAction.synchronizeProducts(siteID: siteID,
-                                                          pageNumber: 0,
+                                                          pageNumber: Store.Default.firstPageNumber,
                                                           pageSize: 1,
                                                           stockStatus: nil,
                                                           productStatus: .published,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10359
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the incorrect page number when syncing products on the order list screen for test order. To avoid the same mistake, the fix uses a shared constant instead.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to the app.
- Navigate to the Orders tab.
- Pull to refresh the list. In Proxyman, notice that the request to path `/wc/v3/products&_method=get` has query `page` equal to 1 and the response succeeds with code 200.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
