### PR TITLE
[IAP] Improve voiceover on woo express plans screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 14.8
 -----
-
+- [*] Store creation: Improvements to the Upgrades screen accessibility [https://github.com/woocommerce/woocommerce-ios/pull/10363]
 
 14.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Upgrades/FullFeatureListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/FullFeatureListView.swift
@@ -15,6 +15,7 @@ struct FullFeatureListView: View {
                         .bold()
                         .padding(.top)
                         .padding(.bottom)
+                        .accessibilityAddTraits(.isHeader)
                     ForEach(featureList.essentialFeatures, id: \.self) { feature in
                         Text(feature)
                             .font(.body)
@@ -26,6 +27,8 @@ struct FullFeatureListView: View {
                             Image(systemName: "star.fill")
                                 .foregroundColor(.withColorStudio(name: .wooCommercePurple, shade: .shade50))
                                 .font(.footnote)
+                                .accessibilityRemoveTraits([.isImage])
+                                .accessibilityLabel(Localization.performanceOnlyText)
                         }
                     }
                     Divider()
@@ -39,6 +42,7 @@ struct FullFeatureListView: View {
                     .foregroundColor(.withColorStudio(name: .wooCommercePurple, shade: .shade50))
                     .padding(.bottom)
                     .renderedIf(featureList.performanceFeatures.isNotEmpty)
+                    .accessibilityHidden(true)
                 }
             }
             .padding(.horizontal)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/WooPlanCardView.swift
@@ -18,7 +18,6 @@ struct WooPlanCardView: View {
                     Text(upgradePlan.wooPlan.shortName)
                         .font(.title2)
                         .bold()
-                        .accessibilityAddTraits(.isHeader)
 
                     Spacer()
 
@@ -27,8 +26,12 @@ struct WooPlanCardView: View {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .foregroundStyle(isSelected ? Color.withColorStudio(name: .wooCommercePurple, shade: .shade50) : Color(.systemGray4))
                         .font(.system(size: Layout.checkImageSize))
-
                 }
+                .accessibilityElement()
+                .accessibilityLabel(upgradePlan.wooPlan.shortName)
+                .accessibilityAddTraits([.isHeader, .isButton])
+                .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+
                 Text(upgradePlan.wooPlan.planDescription)
                     .font(.subheadline)
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
During testing of M2 of Project Pineapple (Woo Express plans sold by In-App Purchase) a few issues were found when navigating the new screens in VoiceOver.

1. It wasn't clear that plans could be selected, or which plan was selected
2. Heading navigation was not working in the Full Feature List
3. The `Performance plan only` stars in the full feature list were unclear via VoiceOver.

This PR resolves these issues by adding accessibility traits, labels, and grouping certain elements.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Testing navigation on the Upgrades screen
Switch to a store with an active Woo Express free trial
Use VoiceOver to navigate through the app

1. Tap `Upgrade now` on the banner on the My Store screen
2. Use the VoiceOver rotor to select Heading navigation
3. Swipe down with one finger to move to the next heading
4. Double tap to select a plan
5. Observe that the plan names and prices are headings
6. Observe that the checkbox is not individually announced as "Circle" or "Circle, checked"
7. Instead, the heading is announced as a button, and "Selected" on the selected plan.

### Testing the Full Feature List

1. Swipe right repeatedly until you reach the `Full feature list` button – double tap to activate the button
2. Swipe down/up to navigate between headings – observe that you can go to each
3. Swipe right to navigate through features – observe that the star images are not announced as "Image, favourite" but as "performance plan only"
4. Observe that the legend for the stars is not announced at all

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/135bf013-d4da-4701-8297-481e2cfc9da2



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
