### PR TITLE
[Better Customer Selection] Add selected customer information to the order

### DIFF
--- a/Networking/Networking/Model/Customer.swift
+++ b/Networking/Networking/Model/Customer.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents a Customer entity:
 /// https://woocommerce.github.io/woocommerce-rest-api-docs/#customer-properties
 ///
-public struct Customer: Codable, GeneratedCopiable, GeneratedFakeable {
+public struct Customer: Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     /// The siteID for the customer
     public let siteID: Int64
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorView.swift
@@ -6,9 +6,10 @@ import SwiftUI
 ///
 struct CustomerSelectorView: UIViewControllerRepresentable {
     let siteID: Int64
+    let onCustomerSelected: (Customer) -> Void
 
     func makeUIViewController(context: Context) -> WooNavigationController {
-        let viewController = CustomerSelectorViewController(siteID: siteID)
+        let viewController = CustomerSelectorViewController(siteID: siteID, onCustomerSelected: onCustomerSelected)
 
         let navigationController = WooNavigationController(rootViewController: viewController)
         return navigationController

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -122,8 +122,8 @@ private extension CustomerSelectorViewController {
             comment: "Title of the order customer selection screen."
         )
 
-        static let genericAddCustomerError = NSLocalizedString("Failed to fetch the customer data. Please try again.",
-                                                                comment: "Error message in the Add Customer to order screen " +
-                                                                "when getting the customer information")
+        static let genericAddCustomerError = NSLocalizedString(
+            "Failed to fetch the customer data. Please try again.",
+            comment: "Error message in the Add Customer to order screen when getting the customer information")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -11,6 +11,10 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
     private let onCustomerSelected: (Customer) -> Void
     private let viewModel: CustomerSelectorViewModel
 
+    /// Notice presentation handler
+    ///
+    private var noticePresenter: NoticePresenter = DefaultNoticePresenter()
+
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(style: .medium)
         indicator.hidesWhenStopped = true
@@ -96,10 +100,21 @@ private extension CustomerSelectorViewController {
 
     func onCustomerTapped(_ customer: Customer) {
         activityIndicator.startAnimating()
-        viewModel.onCustomerSelected(customer, onCompletion: { [weak self] in
+        viewModel.onCustomerSelected(customer, onCompletion: { [weak self] result in
             self?.activityIndicator.stopAnimating()
-            self?.dismiss(animated: true)
+
+            switch result {
+            case .success(()):
+                self?.dismiss(animated: true)
+            case .failure(_):
+                self?.showErrorNotice()
+            }
         })
+    }
+
+    func showErrorNotice() {
+        noticePresenter.presentingViewController = self
+        noticePresenter.enqueue(notice: Notice(title: Localization.genericAddCustomerError, feedbackType: .error))
     }
 }
 
@@ -109,6 +124,10 @@ private extension CustomerSelectorViewController {
             "Add customer details",
             comment: "Title of the order customer selection screen."
         )
+
+        static let genericAddCustomerError = NSLocalizedString("Failed to fetch the customer data. Please try again.",
+                                                                comment: "Error message in the Add Customer to order screen " +
+                                                                "when getting the customer information")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -8,11 +8,17 @@ import Yosemite
 final class CustomerSelectorViewController: UIViewController, GhostableViewController {
     private var searchViewController: UIViewController?
     private let siteID: Int64
+    private let onCustomerSelected: (Customer) -> Void
+    private let viewModel: CustomerSelectorViewModel
 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: TitleAndSubtitleAndStatusTableViewCell.self))
 
-    init(siteID: Int64) {
+    init(siteID: Int64,
+         onCustomerSelected: @escaping (Customer) -> Void) {
+
+        viewModel = CustomerSelectorViewModel(siteID: siteID, onCustomerSelected: onCustomerSelected)
         self.siteID = siteID
+        self.onCustomerSelected = onCustomerSelected
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -72,7 +78,11 @@ private extension CustomerSelectorViewController {
         self.searchViewController = searchViewController
     }
 
-    func onCustomerTapped(_ customer: Customer) {}
+    func onCustomerTapped(_ customer: Customer) {
+        viewModel.onCustomerSelected(customer, onCompletion: { [weak self] in
+            self?.dismiss(animated: true)
+        })
+    }
 }
 
 private extension CustomerSelectorViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -26,7 +26,6 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
 
     init(siteID: Int64,
          onCustomerSelected: @escaping (Customer) -> Void) {
-
         viewModel = CustomerSelectorViewModel(siteID: siteID, onCustomerSelected: onCustomerSelected)
         self.siteID = siteID
         self.onCustomerSelected = onCustomerSelected
@@ -49,13 +48,11 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
 
 private extension CustomerSelectorViewController {
     func loadCustomersContent() {
-        ServiceLocator.stores.dispatch(CustomerAction.synchronizeLightCustomersData(siteID: siteID,
-                                                                                    pageNumber: Constants.firstPageNumber,
-                                                                                    pageSize: Constants.pageSize, onCompletion: { [weak self] result in
+        viewModel.loadCustomersListData(onCompletion: { [weak self] result in
             self?.removeGhostContent()
             self?.addSearchViewController()
             self?.configureActivityIndicator()
-        }))
+        })
     }
 
     func configureNavigation() {
@@ -128,10 +125,5 @@ private extension CustomerSelectorViewController {
         static let genericAddCustomerError = NSLocalizedString("Failed to fetch the customer data. Please try again.",
                                                                 comment: "Error message in the Add Customer to order screen " +
                                                                 "when getting the customer information")
-    }
-
-    enum Constants {
-        static let pageSize = 25
-        static let firstPageNumber = 1
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -11,6 +11,13 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
     private let onCustomerSelected: (Customer) -> Void
     private let viewModel: CustomerSelectorViewModel
 
+    private lazy var activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
+
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: TitleAndSubtitleAndStatusTableViewCell.self))
 
     init(siteID: Int64,
@@ -43,6 +50,7 @@ private extension CustomerSelectorViewController {
                                                                                     pageSize: Constants.pageSize, onCompletion: { [weak self] result in
             self?.removeGhostContent()
             self?.addSearchViewController()
+            self?.configureActivityIndicator()
         }))
     }
 
@@ -53,6 +61,14 @@ private extension CustomerSelectorViewController {
                                                             style: .plain,
                                                             target: self,
                                                             action: #selector(presentNewCustomerDetailsFlow))
+    }
+
+    func configureActivityIndicator() {
+        view.addSubview(activityIndicator)
+        NSLayoutConstraint.activate([
+            view.centerXAnchor.constraint(equalTo: activityIndicator.centerXAnchor),
+            view.centerYAnchor.constraint(equalTo: activityIndicator.centerYAnchor)
+        ])
     }
 
     @objc func cancelWasPressed() {
@@ -79,7 +95,9 @@ private extension CustomerSelectorViewController {
     }
 
     func onCustomerTapped(_ customer: Customer) {
+        activityIndicator.startAnimating()
         viewModel.onCustomerSelected(customer, onCompletion: { [weak self] in
+            self?.activityIndicator.stopAnimating()
             self?.dismiss(animated: true)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -101,9 +101,9 @@ private extension CustomerSelectorViewController {
             self?.activityIndicator.stopAnimating()
 
             switch result {
-            case .success(()):
+            case .success:
                 self?.dismiss(animated: true)
-            case .failure(_):
+            case .failure:
                 self?.showErrorNotice()
             }
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
@@ -15,11 +15,11 @@ final class CustomerSelectorViewModel {
         self.onCustomerSelected = onCustomerSelected
     }
 
-    func onCustomerSelected(_ customer: Customer, onCompletion: @escaping () -> Void) {
+    func onCustomerSelected(_ customer: Customer, onCompletion: @escaping (Result<(), Error>) -> Void) {
         guard customer.customerID != 0 else {
             // The customer is not registered, we won't get any further information. Dismiss and return data
             onCustomerSelected(customer)
-            onCompletion()
+            onCompletion(.success(()))
 
             return
         }
@@ -28,8 +28,9 @@ final class CustomerSelectorViewModel {
             switch result {
             case .success(let customer):
                 self?.onCustomerSelected(customer)
-                onCompletion()
-            case .failure(_):
+                onCompletion(.success(()))
+            case .failure(let error):
+                onCompletion(.failure(error))
                 break
             }
         }))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
@@ -16,6 +16,14 @@ final class CustomerSelectorViewModel {
     }
 
     func onCustomerSelected(_ customer: Customer, onCompletion: @escaping () -> Void) {
+        guard customer.customerID != 0 else {
+            // The customer is not registered, we won't get any further information. Dismiss and return data
+            onCustomerSelected(customer)
+            onCompletion()
+
+            return
+        }
+        // Get the full data about that customer
         stores.dispatch(CustomerAction.retrieveCustomer(siteID: siteID, customerID: customer.customerID, onCompletion: { [weak self] result in
             switch result {
             case .success(let customer):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
@@ -8,8 +8,8 @@ final class CustomerSelectorViewModel {
     private let onCustomerSelected: (Customer) -> Void
 
     init(siteID: Int64,
-         onCustomerSelected: @escaping (Customer) -> Void,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         onCustomerSelected: @escaping (Customer) -> Void) {
         self.siteID = siteID
         self.stores = stores
         self.onCustomerSelected = onCustomerSelected
@@ -18,7 +18,7 @@ final class CustomerSelectorViewModel {
     /// Loads the customer list data, a lighter version of the model without all the information
     ///
     func loadCustomersListData(onCompletion: @escaping (Result<(), Error>) -> Void) {
-        ServiceLocator.stores.dispatch(CustomerAction.synchronizeLightCustomersData(siteID: siteID,
+        stores.dispatch(CustomerAction.synchronizeLightCustomersData(siteID: siteID,
                                                                                     pageNumber: Constants.firstPageNumber,
                                                                                     pageSize: Constants.pageSize, onCompletion: onCompletion))
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
@@ -15,6 +15,16 @@ final class CustomerSelectorViewModel {
         self.onCustomerSelected = onCustomerSelected
     }
 
+    /// Loads the customer list data, a lighter version of the model without all the information
+    ///
+    func loadCustomersListData(onCompletion: @escaping (Result<(), Error>) -> Void) {
+        ServiceLocator.stores.dispatch(CustomerAction.synchronizeLightCustomersData(siteID: siteID,
+                                                                                    pageNumber: Constants.firstPageNumber,
+                                                                                    pageSize: Constants.pageSize, onCompletion: onCompletion))
+    }
+
+    /// Loads the whole customer information and calls the completion closures
+    ///
     func onCustomerSelected(_ customer: Customer, onCompletion: @escaping (Result<(), Error>) -> Void) {
         guard customer.customerID != 0 else {
             // The customer is not registered, we won't get any further information. Dismiss and return data
@@ -34,5 +44,12 @@ final class CustomerSelectorViewModel {
                 break
             }
         }))
+    }
+}
+
+private extension CustomerSelectorViewModel {
+    enum Constants {
+        static let pageSize = 25
+        static let firstPageNumber = 1
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Yosemite
+
+final class CustomerSelectorViewModel {
+    private let stores: StoresManager
+    private let siteID: Int64
+
+    private let onCustomerSelected: (Customer) -> Void
+
+    init(siteID: Int64,
+         onCustomerSelected: @escaping (Customer) -> Void,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+        self.onCustomerSelected = onCustomerSelected
+    }
+
+    func onCustomerSelected(_ customer: Customer, onCompletion: @escaping () -> Void) {
+        stores.dispatch(CustomerAction.retrieveCustomer(siteID: siteID, customerID: customer.customerID, onCompletion: { [weak self] result in
+            switch result {
+            case .success(let customer):
+                self?.onCustomerSelected(customer)
+                onCompletion()
+            case .failure(_):
+                break
+            }
+        }))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -19,7 +19,7 @@ struct OrderCustomerSection: View {
                 NavigationView {
                     if viewModel.shouldShowCustomerSelectorScreen {
                         CustomerSelectorView(siteID: viewModel.siteID) { customer in
-                            viewModel.addCustomerToOrder(customer: customer)
+                            viewModel.addCustomerAddressToOrder(customer: customer)
                         }
                     } else {
                         EditOrderAddressForm(dismiss: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -18,7 +18,9 @@ struct OrderCustomerSection: View {
             .sheet(isPresented: $showAddressForm) {
                 NavigationView {
                     if viewModel.shouldShowCustomerSelectorScreen {
-                        CustomerSelectorView(siteID: viewModel.siteID)
+                        CustomerSelectorView(siteID: viewModel.siteID) { customer in
+                            viewModel.addCustomerToOrder(customer: customer)
+                        }
                     } else {
                         EditOrderAddressForm(dismiss: {
                             showAddressForm.toggle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -511,14 +511,15 @@ final class EditableOrderViewModel: ObservableObject {
                                                                addressData: .init(billingAddress: orderSynchronizer.order.billingAddress,
                                                                                   shippingAddress: orderSynchronizer.order.shippingAddress),
                                                                onAddressUpdate: { [weak self] updatedAddressData in
-            let input = Self.createAddressesInput(from: updatedAddressData)
+            let input = Self.createAddressesInputIfPossible(billingAddress: updatedAddressData.billingAddress,
+                                                            shippingAddress: updatedAddressData.shippingAddress)
             self?.orderSynchronizer.setAddresses.send(input)
             self?.trackCustomerDetailsAdded()
         })
     }
 
     func addCustomerToOrder(customer: Customer) {
-        let input = Self.createAddressesInput(from: customer)
+        let input = Self.createAddressesInputIfPossible(billingAddress: customer.billing, shippingAddress: customer.shipping)
         orderSynchronizer.setAddresses.send(input)
     }
 
@@ -1188,19 +1189,11 @@ private extension EditableOrderViewModel {
                                                                         errorDescription: error.localizedDescription))
     }
 
-    /// Creates an `OrderSyncAddressesInput` type from a `NewOrderAddressData` type.
-    /// Expects `billing` and `shipping` addresses to exists together,
+    /// Creates an `OrderSyncAddressesInput` type if the given data exists, otherwise returns nil
     ///
-    static func createAddressesInput(from data: CreateOrderAddressFormViewModel.NewOrderAddressData) -> OrderSyncAddressesInput? {
-        guard let billingAddress = data.billingAddress, let shippingAddress = data.shippingAddress else {
-            return nil
-        }
-        return OrderSyncAddressesInput(billing: billingAddress, shipping: shippingAddress)
-    }
-
-    static func createAddressesInput(from customer: Customer) -> OrderSyncAddressesInput? {
-        guard let billingAddress = customer.billing,
-                let shippingAddress = customer.shipping else {
+    static func createAddressesInputIfPossible(billingAddress: Address?, shippingAddress: Address?)  -> OrderSyncAddressesInput? {
+        guard let billingAddress = billingAddress,
+                let shippingAddress = shippingAddress else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -518,9 +518,10 @@ final class EditableOrderViewModel: ObservableObject {
         })
     }
 
-    func addCustomerToOrder(customer: Customer) {
+    func addCustomerAddressToOrder(customer: Customer) {
         let input = Self.createAddressesInputIfPossible(billingAddress: customer.billing, shippingAddress: customer.shipping)
         orderSynchronizer.setAddresses.send(input)
+        resetAddressForm()
     }
 
     /// Updates the order creation draft with the current set customer note.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -517,6 +517,11 @@ final class EditableOrderViewModel: ObservableObject {
         })
     }
 
+    func addCustomerToOrder(customer: Customer) {
+        let input = Self.createAddressesInput(from: customer)
+        orderSynchronizer.setAddresses.send(input)
+    }
+
     /// Updates the order creation draft with the current set customer note.
     ///
     func updateCustomerNote() {
@@ -1190,6 +1195,15 @@ private extension EditableOrderViewModel {
         guard let billingAddress = data.billingAddress, let shippingAddress = data.shippingAddress else {
             return nil
         }
+        return OrderSyncAddressesInput(billing: billingAddress, shipping: shippingAddress)
+    }
+
+    static func createAddressesInput(from customer: Customer) -> OrderSyncAddressesInput? {
+        guard let billingAddress = customer.billing,
+                let shippingAddress = customer.shipping else {
+            return nil
+        }
+
         return OrderSyncAddressesInput(billing: billingAddress, shipping: shippingAddress)
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1654,6 +1654,7 @@
 		B958A7D628B5310100823EEF /* URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7D428B5302500823EEF /* URLOpener.swift */; };
 		B958A7D828B5316A00823EEF /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7D728B5316A00823EEF /* MockURLOpener.swift */; };
 		B958B4DA2983E3F40010286B /* OrderDurationRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */; };
+		B95A45E92A77AE2C0073A91F /* CustomerSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95A45E82A77AE2C0073A91F /* CustomerSelectorViewModel.swift */; };
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
 		B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */; };
@@ -4065,6 +4066,7 @@
 		B958A7D428B5302500823EEF /* URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLOpener.swift; sourceTree = "<group>"; };
 		B958A7D728B5316A00823EEF /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDurationRecorder.swift; sourceTree = "<group>"; };
+		B95A45E82A77AE2C0073A91F /* CustomerSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSelectorViewModel.swift; sourceTree = "<group>"; };
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineViewModel.swift; sourceTree = "<group>"; };
@@ -8061,6 +8063,7 @@
 				68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */,
 				B95700AB2A72C1E4001BADF2 /* CustomerSelectorViewController.swift */,
 				B95700AD2A72C39C001BADF2 /* CustomerSelectorView.swift */,
+				B95A45E82A77AE2C0073A91F /* CustomerSelectorViewModel.swift */,
 			);
 			path = CustomerSection;
 			sourceTree = "<group>";
@@ -11757,6 +11760,7 @@
 				020732042988AB7B000A53C2 /* DomainContactInfoForm.swift in Sources */,
 				DE2FE595292737330018040A /* JetpackSetupView.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
+				B95A45E92A77AE2C0073A91F /* CustomerSelectorViewModel.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				CCF4346E290AE1F900B4475A /* ProductsOnboardingAnnouncementCardViewModel.swift in Sources */,
 				0217399E2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1655,6 +1655,7 @@
 		B958A7D828B5316A00823EEF /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7D728B5316A00823EEF /* MockURLOpener.swift */; };
 		B958B4DA2983E3F40010286B /* OrderDurationRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */; };
 		B95A45E92A77AE2C0073A91F /* CustomerSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95A45E82A77AE2C0073A91F /* CustomerSelectorViewModel.swift */; };
+		B95A45EC2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95A45EB2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift */; };
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
 		B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */; };
@@ -4067,6 +4068,7 @@
 		B958A7D728B5316A00823EEF /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDurationRecorder.swift; sourceTree = "<group>"; };
 		B95A45E82A77AE2C0073A91F /* CustomerSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSelectorViewModel.swift; sourceTree = "<group>"; };
+		B95A45EB2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSelectorViewModelTests.swift; sourceTree = "<group>"; };
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineViewModel.swift; sourceTree = "<group>"; };
@@ -8842,6 +8844,14 @@
 			path = DurationRecorder;
 			sourceTree = "<group>";
 		};
+		B95A45EA2A77D78F0073A91F /* CustomerSection */ = {
+			isa = PBXGroup;
+			children = (
+				B95A45EB2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift */,
+			);
+			path = CustomerSection;
+			sourceTree = "<group>";
+		};
 		B99686E12A13C8D200D1AF62 /* ScanToPay */ = {
 			isa = PBXGroup;
 			children = (
@@ -9019,6 +9029,7 @@
 		CCB366AD274518CD007D437A /* Order Creation */ = {
 			isa = PBXGroup;
 			children = (
+				B95A45EA2A77D78F0073A91F /* CustomerSection */,
 				B9FECD832A6043E5003D98B7 /* ProductsSection */,
 				CCB366AE274518EC007D437A /* EditableOrderViewModelTests.swift */,
 				CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */,
@@ -12983,6 +12994,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				45C8B2692316B2440002FA77 /* BillingAddressTableViewCellTests.swift in Sources */,
+				B95A45EC2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift in Sources */,
 				3178C1FD26409360000D771A /* BluetoothCardReaderSettingsConnectedViewModelTests.swift in Sources */,
 				02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */,
 				B63AAF4B254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModelTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class CustomerSelectorViewModelTests: XCTestCase {
+    var viewModel: CustomerSelectorViewModel!
+    var stores: MockStoresManager!
+
+    let sampleSiteID: Int64 = 123
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .testingInstance)
+    }
+
+    func test_loadCustomersListData_calls_to_synchronizeLightCustomersData() {
+        // Given
+        let viewModel = CustomerSelectorViewModel(siteID: sampleSiteID, stores: stores) { _ in }
+
+        var passedSiteID: Int64?
+        var passedPageNumber: Int?
+        var passedPageSize: Int?
+
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            switch action {
+            case let .synchronizeLightCustomersData(siteID, pageNumber, pageSize, onCompletion):
+                passedSiteID = siteID
+                passedPageNumber = pageNumber
+                passedPageSize = pageSize
+                onCompletion(.success(()))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        waitForExpectation { expectation in
+            viewModel.loadCustomersListData() { _ in
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(passedSiteID, sampleSiteID)
+        XCTAssertEqual(passedPageNumber, 1)
+        XCTAssertEqual(passedPageSize, 25)
+    }
+
+    func test_loadCustomersListData_calls_to_synchronizeLightCustomersData_and_passes_error() {
+        // Given
+        let viewModel = CustomerSelectorViewModel(siteID: sampleSiteID, stores: stores) { _ in }
+        let error = NSError(domain: "Test", code: -1001)
+
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            switch action {
+            case let .synchronizeLightCustomersData(_, _, _, onCompletion):
+                onCompletion(.failure(error))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        var passedError: NSError?
+        waitForExpectation { expectation in
+            viewModel.loadCustomersListData() { result in
+                if case let .failure(error) = result {
+                    passedError = error as NSError
+
+                }
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(passedError, error)
+    }
+
+    func test_onCustomerSelected_when_customerID_is_0_passes_customer_and_finishes_succesfully() {
+        // Given
+        var passedCustomer: Customer?
+        let viewModel = CustomerSelectorViewModel(siteID: sampleSiteID, stores: stores) { customer in
+            passedCustomer = customer
+        }
+
+        // When
+        let notRegisteredCustomer = Customer.fake().copy(customerID: 0)
+
+        var returnedResult: (Result<(), any Error>)?
+        waitForExpectation { expectation in
+            viewModel.onCustomerSelected(notRegisteredCustomer) { result in
+                returnedResult = result
+                expectation.fulfill()
+            }
+        }
+
+        guard case .success(()) = returnedResult else {
+            XCTFail()
+
+            return
+        }
+
+        XCTAssertEqual(passedCustomer, notRegisteredCustomer)
+    }
+
+    func test_onCustomerSelected_when_customerID_is_not_0_retrieves_customer_full_data_and_finishes_succesfully() {
+        // Given
+        var passedCustomer: Customer?
+        let viewModel = CustomerSelectorViewModel(siteID: sampleSiteID, stores: stores) { customer in
+            passedCustomer = customer
+        }
+
+        let returnedCustomer = Customer.fake().copy(customerID: 23, lastName: "Testion")
+
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            switch action {
+            case let .retrieveCustomer(_, _, onCompletion):
+                onCompletion(.success(returnedCustomer))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        let registeredCustomer = Customer.fake().copy(customerID: 23)
+
+        var returnedResult: (Result<(), any Error>)?
+        waitForExpectation { expectation in
+            viewModel.onCustomerSelected(registeredCustomer) { result in
+                returnedResult = result
+                expectation.fulfill()
+            }
+        }
+
+        guard case .success(()) = returnedResult else {
+            XCTFail()
+
+            return
+        }
+
+        XCTAssertEqual(passedCustomer, returnedCustomer)
+    }
+
+    func test_onCustomerSelected_calls_to_retrieveCustomer_and_passes_error() {
+        // Given
+        let viewModel = CustomerSelectorViewModel(siteID: sampleSiteID, stores: stores) { _ in }
+        let error = NSError(domain: "Test", code: -1001)
+
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            switch action {
+            case let .retrieveCustomer(_, _, onCompletion):
+                onCompletion(.failure(error))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        let registeredCustomer = Customer.fake().copy(customerID: 23)
+        var passedError: NSError?
+        waitForExpectation { expectation in
+            viewModel.onCustomerSelected(registeredCustomer) { result in
+                if case let .failure(error) = result {
+                    passedError = error as NSError
+
+                }
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(passedError, error)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1330,6 +1330,25 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.discardOrder()
     }
 
+    func test_addCustomerAddressToOrder_resets_addressFormViewModel_with_new_data() {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let customer = Customer.fake().copy(
+            email: "scrambled@scrambled.com",
+            firstName: "Johnny",
+            lastName: "Appleseed",
+            billing: sampleAddress1(),
+            shipping: sampleAddress2()
+        )
+
+        viewModel.addCustomerAddressToOrder(customer: customer)
+
+        // Then
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.firstName, customer.firstName)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.lastName, customer.lastName)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.email, customer.email)
+    }
+
     func test_resetAddressForm_discards_pending_address_field_changes() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)

--- a/Yosemite/Yosemite/Model/Storage/Customer+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Customer+ReadOnlyConvertible.swift
@@ -73,6 +73,15 @@ extension Storage.Customer: ReadOnlyConvertible {
             firstName = nameComponents.count > 1 ? nameComponents.dropLast().joined(separator: " ") : nameComponents.first
             lastName = nameComponents.count > 1 ? nameComponents.last : nil
         }
+
+        // Reuse information for addresses
+        shippingFirstName = firstName
+        shippingLastName = lastName
+        shippingEmail = email
+
+        billingFirstName = firstName
+        billingLastName = lastName
+        shippingEmail = email
     }
 
     /// Returns a ReadOnly (`Networking.Customer`) version of the `Storage.Customer`
@@ -91,11 +100,7 @@ extension Storage.Customer: ReadOnlyConvertible {
 
     /// Helpers
     private func createReadOnlyBillingAddress() -> Yosemite.Address? {
-        guard let billingCountry = billingCountry else {
-            return nil
-        }
-
-        return Address(firstName: billingFirstName ?? "",
+        Address(firstName: billingFirstName ?? "",
                        lastName: billingLastName ?? "",
                        company: billingCompany ?? "",
                        address1: billingAddress1 ?? "",
@@ -103,18 +108,14 @@ extension Storage.Customer: ReadOnlyConvertible {
                        city: billingCity ?? "",
                        state: billingState ?? "",
                        postcode: billingPostcode ?? "",
-                       country: billingCountry,
+                       country: billingCountry ?? "",
                        phone: billingPhone,
                        email: billingEmail
         )
     }
 
     private func createReadOnlyShippingAddress() -> Yosemite.Address? {
-        guard let shippingCountry = shippingCountry else {
-            return nil
-        }
-
-        return Address(firstName: shippingFirstName ?? "",
+        Address(firstName: shippingFirstName ?? "",
                        lastName: shippingLastName ?? "",
                        company: shippingCompany ?? "",
                        address1: shippingAddress1 ?? "",
@@ -122,7 +123,7 @@ extension Storage.Customer: ReadOnlyConvertible {
                        city: shippingCity ?? "",
                        state: shippingState ?? "",
                        postcode: shippingPostcode ?? "",
-                       country: shippingCountry,
+                       country: shippingCountry ?? "",
                        phone: shippingPhone,
                        email: shippingEmail
         )

--- a/Yosemite/Yosemite/Model/Storage/Customer+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Customer+ReadOnlyConvertible.swift
@@ -81,7 +81,7 @@ extension Storage.Customer: ReadOnlyConvertible {
 
         billingFirstName = firstName
         billingLastName = lastName
-        shippingEmail = email
+        billingEmail = email
     }
 
     /// Returns a ReadOnly (`Networking.Customer`) version of the `Storage.Customer`


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10349 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we pass the selected customer from the list to the order. As when showing the list we don't load all the customers information, we retrieve it here once it's selected, if the user is registered. if the user is not registered we pass it directly as there's no more information to load. 

When the user is not registered and we don't have all the information available, we follow the logic we had until now and set the pending fields empty. To let that happen we had to remove the requirement of address country being not nil from `Customer+ReadOnlyConvertible` so the Customer model object can be generated.

Apart from that, most of the changes are related to wiring the selector customer to the order, through closures and functions. 

## Changes

- Add the light customer data to the addresses in `Customer+ReadOnlyConvertible` and remove country requirements.
- Create `CustomerSelectorViewModel`. Move the customer list loading logic.
- Retrieve the full customer information once it's selected if it's registered. Show an error if that request fails.
- Wire the selected customer from `CustomerSelectorViewModel` to `EditableOrderViewModel`.
- Add the necessary logic to the `EditableOrderViewModel` to handle this case.
- Add Unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Enable the feature flag `betterCustomerSelectionInOrder` in the `DefaultFeatureFlagService`

### Registered user:

1. Go to Orders
2. Tap on + to create a new order.
3. Tap on + Add Customer Details
4. Selected a registered users. 
5. The Customer list selector is dismissed and the information is added to the order.

https://github.com/woocommerce/woocommerce-ios/assets/1864060/fb1b776d-0e05-487d-81fb-9be011d618d9

### Not registered user:

1. Go to Orders
2. Tap on + to create a new order.
3. Tap on + Add Customer Details
4. Selected a not registered user. 
5. The Customer list selector is dismissed and the information is added to the order. But still not visible in the order details. Create the order, and tap View Billing Information. See that the not registered user email is there.

https://github.com/woocommerce/woocommerce-ios/assets/1864060/d1c8d0fe-4e0b-47db-983f-a75834e7803c

### Error when retrieving a customer:

Make the `onCustomerSelected` fail, for instance by adding `onCompletion(.failure(NSError(domain: "Test", code: -1001)))` on the `onCustomerSelected` function of `CustomerSelectorViewModel`.

1. Go to Orders
2. Tap on + to create a new order.
3. Tap on + Add Customer Details
4. Selected a user.
5. The Error notice is shown and you stay in the Customer Selector Screen.

https://github.com/woocommerce/woocommerce-ios/assets/1864060/7667c7a1-794f-4ebf-be1e-390e58766228

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
