### PR TITLE
Add banner to purchase a paid plan for WooExpress sites with expired plan

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,9 +3,10 @@
 14.8
 -----
 - [*] Store creation: Improvements to the Upgrades screen accessibility [https://github.com/woocommerce/woocommerce-ios/pull/10363]
+- [*] Stores with expired WooExpress plans can now be upgraded within the app (if eligible for IAP) via a new banner. [https://github.com/woocommerce/woocommerce-ios/pull/10369]
 - [Internal] New default property `plan` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10356]
 - [Internal] Google sign in now defaults to bypassing the Google SDK [https://github.com/woocommerce/woocommerce-ios/pull/10341]
-
+ 
 14.7
 -----
 - [*] Local notifications: Add a reminder to purchase a plan is scheduled 6hr after a free trial subscription. [https://github.com/woocommerce/woocommerce-ios/pull/10268]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -166,7 +166,7 @@ final class DashboardViewController: UIViewController {
         observeAddProductTrigger()
         observeOnboardingVisibility()
         observeBlazeBannerVisibility()
-        configurestorePlanBannerPresenter()
+        configureStorePlanBannerPresenter()
         presentPrivacyBannerIfNeeded()
 
         Task { @MainActor in
@@ -374,7 +374,7 @@ private extension DashboardViewController {
         view.pinSubviewToSafeArea(stackView)
     }
 
-    func configurestorePlanBannerPresenter() {
+    func configureStorePlanBannerPresenter() {
         self.storePlanBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: stackView,
                                                                   siteID: siteID) { [weak self] bannerHeight in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -129,7 +129,7 @@ final class DashboardViewController: UIViewController {
 
     /// Free trial banner presentation handler.
     ///
-    private var freeTrialBannerPresenter: FreeTrialBannerPresenter?
+    private var freeTrialBannerPresenter: StorePlanBannerPresenter?
 
     /// Presenter for the privacy choices banner
     ///
@@ -375,7 +375,7 @@ private extension DashboardViewController {
     }
 
     func configureFreeTrialBannerPresenter() {
-        self.freeTrialBannerPresenter =  FreeTrialBannerPresenter(viewController: self,
+        self.freeTrialBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: stackView,
                                                                   siteID: siteID) { [weak self] bannerHeight in
             self?.containerView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bannerHeight, right: 0)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -129,7 +129,7 @@ final class DashboardViewController: UIViewController {
 
     /// Free trial banner presentation handler.
     ///
-    private var freeTrialBannerPresenter: StorePlanBannerPresenter?
+    private var storePlanBannerPresenter: StorePlanBannerPresenter?
 
     /// Presenter for the privacy choices banner
     ///
@@ -166,7 +166,7 @@ final class DashboardViewController: UIViewController {
         observeAddProductTrigger()
         observeOnboardingVisibility()
         observeBlazeBannerVisibility()
-        configureFreeTrialBannerPresenter()
+        configurestorePlanBannerPresenter()
         presentPrivacyBannerIfNeeded()
 
         Task { @MainActor in
@@ -179,7 +179,7 @@ final class DashboardViewController: UIViewController {
         // Reset title to prevent it from being empty right after login
         configureTitle()
 
-        freeTrialBannerPresenter?.reloadBannerVisibility()
+        storePlanBannerPresenter?.reloadBannerVisibility()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -374,8 +374,8 @@ private extension DashboardViewController {
         view.pinSubviewToSafeArea(stackView)
     }
 
-    func configureFreeTrialBannerPresenter() {
-        self.freeTrialBannerPresenter =  StorePlanBannerPresenter(viewController: self,
+    func configurestorePlanBannerPresenter() {
+        self.storePlanBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: stackView,
                                                                   siteID: siteID) { [weak self] bannerHeight in
             self?.containerView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bannerHeight, right: 0)
@@ -750,7 +750,7 @@ private extension DashboardViewController {
                                                                      site: site,
                                                                      onUpgradePlan: { [weak self] in
             guard let self else { return }
-            self.freeTrialBannerPresenter?.reloadBannerVisibility()
+            self.storePlanBannerPresenter?.reloadBannerVisibility()
         },
                                                                      shareFeedbackAction: { [weak self] in
             // Present survey

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -127,7 +127,7 @@ final class DashboardViewController: UIViewController {
     private var subscriptions = Set<AnyCancellable>()
     private var navbarObserverSubscription: AnyCancellable?
 
-    /// Free trial banner presentation handler.
+    /// Store plan banner presentation handler.
     ///
     private var storePlanBannerPresenter: StorePlanBannerPresenter?
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBanner.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
-/// Hosting controller for `FreeTrialBanner`.
+/// Hosting controller for `StorePlanBanner`.
 ///
-final class FreeTrialBannerHostingViewController: UIHostingController<FreeTrialBanner> {
+final class StorePlanBannerHostingViewController: UIHostingController<StorePlanBanner> {
     /// Designated initializer.
     ///
     init(actionText: String, mainText: String, onLearnMoreTapped: @escaping () -> Void) {
-        super.init(rootView: FreeTrialBanner(actionText: actionText,
+        super.init(rootView: StorePlanBanner(actionText: actionText,
                                              mainText: mainText,
                                              onLearnMoreTapped: onLearnMoreTapped))
     }
@@ -18,9 +18,9 @@ final class FreeTrialBannerHostingViewController: UIHostingController<FreeTrialB
     }
 }
 
-/// Free Trial Banner. To be used inside the Dashboard.
+/// Store Plan Banner. To be used inside the Dashboard.
 ///
-struct FreeTrialBanner: View {
+struct StorePlanBanner: View {
 
     /// Text to be rendered as the banner action button
     ///
@@ -63,7 +63,7 @@ struct FreeTrialBanner: View {
 }
 
 // MARK: Definitions
-extension FreeTrialBanner {
+extension StorePlanBanner {
     enum Layout {
         static let spacing: CGFloat = 6.0
     }
@@ -73,9 +73,9 @@ extension FreeTrialBanner {
     }
 }
 
-struct FreeTrial_Preview: PreviewProvider {
+struct StorePlanBanner_Preview: PreviewProvider {
     static var previews: some View {
-        FreeTrialBanner(actionText: "Upgrade now", mainText: "Your Free trial has ended", onLearnMoreTapped: { })
+        StorePlanBanner(actionText: "Upgrade now", mainText: "Your Free trial has ended", onLearnMoreTapped: { })
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
@@ -24,7 +24,7 @@ final class StorePlanBannerPresenter {
 
     /// Holds a reference to the Free Trial Banner view, Needed to be able to remove it when required.
     ///
-    private var freeTrialBanner: UIView?
+    private var storePlanBanner: UIView?
 
     /// Observable subscription store.
     ///
@@ -57,8 +57,8 @@ final class StorePlanBannerPresenter {
     /// Bring banner (if visible) to the front. Useful when some content has hidden it.
     ///
     func bringBannerToFront() {
-        guard let containerView, let freeTrialBanner else { return }
-        containerView.bringSubviewToFront(freeTrialBanner)
+        guard let containerView, let storePlanBanner else { return }
+        containerView.bringSubviewToFront(storePlanBanner)
     }
 }
 
@@ -67,22 +67,29 @@ private extension StorePlanBannerPresenter {
     /// Observe the store plan and add or remove the banner as appropriate
     ///
     private func observeStorePlan() {
-        ServiceLocator.storePlanSynchronizer.$planState.sink { [weak self] planState in
-            guard let self else { return }
-            switch planState {
-            case .loaded(let plan) where plan.isFreeTrial:
-                // Only add the banner for the free trial plan
-                let bannerViewModel = FreeTrialBannerViewModel(sitePlan: plan)
-                Task { @MainActor in
-                    await self.addBanner(contentText: bannerViewModel.message)
+        ServiceLocator.storePlanSynchronizer.$planState
+            .withLatestFrom(ServiceLocator.stores.site)
+            .sink { [weak self] planState, site in
+                guard let self else { return }
+                switch planState {
+                case .loaded(let plan) where plan.isFreeTrial:
+                    // Add the banner for the free trial plan
+                    let bannerViewModel = FreeTrialBannerViewModel(sitePlan: plan)
+                    Task { @MainActor in
+                        await self.addBanner(contentText: bannerViewModel.message)
+                    }
+                case .loaded(let plan) where plan.isFreePlan && site?.wasEcommerceTrial == true:
+                    // Show plan expired banner for sites with expired WooExpress plans
+                    Task { @MainActor in
+                        await self.addBanner(contentText: Localization.expiredPlan)
+                    }
+                case .loading, .failed:
+                    break // `.loading` and `.failed` should not change the banner visibility
+                default:
+                    self.removeBanner() // All other states should remove the banner
                 }
-            case .loading, .failed:
-                break // `.loading` and `.failed` should not change the banner visibility
-            default:
-                self.removeBanner() // All other states should remove the banner
             }
-        }
-        .store(in: &subscriptions)
+            .store(in: &subscriptions)
     }
 
     /// Hide the banner when there is no internet connection.
@@ -120,38 +127,38 @@ private extension StorePlanBannerPresenter {
         guard let containerView else { return }
 
         // Remove any previous banner.
-        freeTrialBanner?.removeFromSuperview()
+        storePlanBanner?.removeFromSuperview()
 
         let bannerActionText = await setupBannerText()
 
-        let freeTrialViewController = FreeTrialBannerHostingViewController(actionText: bannerActionText, mainText: contentText) { [weak self] in
+        let storePlanViewController = StorePlanBannerHostingViewController(actionText: bannerActionText, mainText: contentText) { [weak self] in
             self?.showUpgradesView()
         }
-        freeTrialViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        storePlanViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
-        containerView.addSubview(freeTrialViewController.view)
+        containerView.addSubview(storePlanViewController.view)
         NSLayoutConstraint.activate([
-            freeTrialViewController.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            freeTrialViewController.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            freeTrialViewController.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+            storePlanViewController.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            storePlanViewController.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            storePlanViewController.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
         // Let consumers know that the layout has been updated so their content is not hidden by the `freeTrialViewController`.
         DispatchQueue.main.async {
-            self.onLayoutUpdated(freeTrialViewController.view.frame.size.height)
+            self.onLayoutUpdated(storePlanViewController.view.frame.size.height)
         }
 
-        // Store a reference to it to manipulate it later in `removeFreeTrialBanner`.
-        freeTrialBanner = freeTrialViewController.view
+        // Store a reference to it to manipulate it later in `removeBanner`.
+        storePlanBanner = storePlanViewController.view
     }
 
     /// Removes the Free Trial Banner from the container view..
     ///
     func removeBanner() {
-        guard let freeTrialBanner else { return }
-        freeTrialBanner.removeFromSuperview()
+        guard let storePlanBanner else { return }
+        storePlanBanner.removeFromSuperview()
         onLayoutUpdated(.zero)
-        self.freeTrialBanner = nil
+        self.storePlanBanner = nil
     }
 
     /// Shows a view for the merchant to upgrade their site's plan.
@@ -167,5 +174,6 @@ private extension StorePlanBannerPresenter {
     enum Localization {
         static let learnMore = NSLocalizedString("Learn more", comment: "Title on the button to learn more about the free trial plan.")
         static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")
+        static let expiredPlan = NSLocalizedString("Your last plan has ended", comment: "Title on the banner when the site's WooExpress plan has expired")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
@@ -184,6 +184,6 @@ private extension StorePlanBannerPresenter {
     enum Localization {
         static let learnMore = NSLocalizedString("Learn more", comment: "Title on the button to learn more about the free trial plan.")
         static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")
-        static let expiredPlan = NSLocalizedString("Your last plan has ended", comment: "Title on the banner when the site's WooExpress plan has expired")
+        static let expiredPlan = NSLocalizedString("Your site plan has ended", comment: "Title on the banner when the site's WooExpress plan has expired")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
@@ -184,6 +184,6 @@ private extension StorePlanBannerPresenter {
     enum Localization {
         static let learnMore = NSLocalizedString("Learn more", comment: "Title on the button to learn more about the free trial plan.")
         static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")
-        static let expiredPlan = NSLocalizedString("Your site plan has ended", comment: "Title on the banner when the site's WooExpress plan has expired")
+        static let expiredPlan = NSLocalizedString("Your site plan has ended.", comment: "Title on the banner when the site's WooExpress plan has expired")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
@@ -3,10 +3,10 @@ import Combine
 import UIKit
 import protocol Experiments.FeatureFlagService
 
-/// Presents or hides the free trial banner at the bottom of the screen.
+/// Presents or hides the store plan info banner at the bottom of the screen.
 /// Internally uses the `storePlanSynchronizer` to know when to present or hide the banner.
 ///
-final class FreeTrialBannerPresenter {
+final class StorePlanBannerPresenter {
     /// View controller used to present any action needed by the free trial banner.
     ///
     private weak var viewController: UIViewController?
@@ -62,7 +62,7 @@ final class FreeTrialBannerPresenter {
     }
 }
 
-private extension FreeTrialBannerPresenter {
+private extension StorePlanBannerPresenter {
 
     /// Observe the store plan and add or remove the banner as appropriate
     ///
@@ -163,7 +163,7 @@ private extension FreeTrialBannerPresenter {
     }
 }
 
-private extension FreeTrialBannerPresenter {
+private extension StorePlanBannerPresenter {
     enum Localization {
         static let learnMore = NSLocalizedString("Learn more", comment: "Title on the button to learn more about the free trial plan.")
         static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -123,7 +123,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     /// Free trial banner presentation handler.
     ///
-    private var freeTrialBannerPresenter: FreeTrialBannerPresenter?
+    private var freeTrialBannerPresenter: StorePlanBannerPresenter?
 
     /// Notice presentation handler
     ///
@@ -310,7 +310,7 @@ private extension OrderListViewController {
     }
 
     func configureFreeTrialBannerPresenter() {
-        self.freeTrialBannerPresenter =  FreeTrialBannerPresenter(viewController: self,
+        self.freeTrialBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: view,
                                                                   siteID: siteID) { [weak self] bannerHeight in
             self?.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bannerHeight, right: 0)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -168,7 +168,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureViewModel()
         configureSyncingCoordinator()
 
-        configurestorePlanBannerPresenter()
+        configureStorePlanBannerPresenter()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -309,7 +309,7 @@ private extension OrderListViewController {
         tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
     }
 
-    func configurestorePlanBannerPresenter() {
+    func configureStorePlanBannerPresenter() {
         self.storePlanBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: view,
                                                                   siteID: siteID) { [weak self] bannerHeight in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -123,7 +123,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     /// Free trial banner presentation handler.
     ///
-    private var freeTrialBannerPresenter: StorePlanBannerPresenter?
+    private var storePlanBannerPresenter: StorePlanBannerPresenter?
 
     /// Notice presentation handler
     ///
@@ -168,7 +168,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureViewModel()
         configureSyncingCoordinator()
 
-        configureFreeTrialBannerPresenter()
+        configurestorePlanBannerPresenter()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -309,8 +309,8 @@ private extension OrderListViewController {
         tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
     }
 
-    func configureFreeTrialBannerPresenter() {
-        self.freeTrialBannerPresenter =  StorePlanBannerPresenter(viewController: self,
+    func configurestorePlanBannerPresenter() {
+        self.storePlanBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: view,
                                                                   siteID: siteID) { [weak self] bannerHeight in
             self?.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bannerHeight, right: 0)
@@ -584,7 +584,7 @@ private extension OrderListViewController {
         childController.didMove(toParent: self)
 
         // Make sure the banner is on top of the empty state view
-        freeTrialBannerPresenter?.bringBannerToFront()
+        storePlanBannerPresenter?.bringBannerToFront()
     }
 
     func removeEmptyViewController() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -121,7 +121,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     ///
     private var inPersonPaymentsSurveyVariation: SurveyViewController.Source?
 
-    /// Free trial banner presentation handler.
+    /// Store plan banner presentation handler.
     ///
     private var storePlanBannerPresenter: StorePlanBannerPresenter?
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -184,7 +184,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     /// Free trial banner presentation handler.
     ///
-    private var freeTrialBannerPresenter: FreeTrialBannerPresenter?
+    private var freeTrialBannerPresenter: StorePlanBannerPresenter?
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -702,7 +702,7 @@ private extension ProductsViewController {
     }
 
     func configureFreeTrialBannerPresenter() {
-        self.freeTrialBannerPresenter =  FreeTrialBannerPresenter(viewController: self,
+        self.freeTrialBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: view,
                                                                   siteID: siteID) { [weak self] bannerHeight in
             self?.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bannerHeight, right: 0)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -223,7 +223,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         configureHiddenScrollView()
         configureToolbar()
         configureSyncingCoordinator()
-        configurestorePlanBannerPresenter()
+        configureStorePlanBannerPresenter()
         registerTableViewCells()
 
         observeBlazeBannerVisibility()
@@ -701,7 +701,7 @@ private extension ProductsViewController {
         toolbar.isHidden = filters.numberOfActiveFilters == 0 ? isEmpty : false
     }
 
-    func configurestorePlanBannerPresenter() {
+    func configureStorePlanBannerPresenter() {
         self.storePlanBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: view,
                                                                   siteID: siteID) { [weak self] bannerHeight in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -184,7 +184,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
 
     /// Free trial banner presentation handler.
     ///
-    private var freeTrialBannerPresenter: StorePlanBannerPresenter?
+    private var storePlanBannerPresenter: StorePlanBannerPresenter?
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -223,7 +223,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         configureHiddenScrollView()
         configureToolbar()
         configureSyncingCoordinator()
-        configureFreeTrialBannerPresenter()
+        configurestorePlanBannerPresenter()
         registerTableViewCells()
 
         observeBlazeBannerVisibility()
@@ -701,8 +701,8 @@ private extension ProductsViewController {
         toolbar.isHidden = filters.numberOfActiveFilters == 0 ? isEmpty : false
     }
 
-    func configureFreeTrialBannerPresenter() {
-        self.freeTrialBannerPresenter =  StorePlanBannerPresenter(viewController: self,
+    func configurestorePlanBannerPresenter() {
+        self.storePlanBannerPresenter =  StorePlanBannerPresenter(viewController: self,
                                                                   containerView: view,
                                                                   siteID: siteID) { [weak self] bannerHeight in
             self?.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bannerHeight, right: 0)
@@ -1114,7 +1114,7 @@ private extension ProductsViewController {
         emptyStateViewController.configure(config)
 
         // Make sure the banner is on top of the empty state view
-        freeTrialBannerPresenter?.bringBannerToFront()
+        storePlanBannerPresenter?.bringBannerToFront()
     }
 
     func createFilterConfig() ->  EmptyStateViewController.Config {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -182,7 +182,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
     ///
     @Published private var dataLoadingError: Error?
 
-    /// Free trial banner presentation handler.
+    /// Store plan banner presentation handler.
     ///
     private var storePlanBannerPresenter: StorePlanBannerPresenter?
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/StorePlanSynchronizer.swift
@@ -71,8 +71,9 @@ final class StorePlanSynchronizer: ObservableObject {
             return
         }
 
-        // If the site is not a WPCom store set the state to `.unavailable`
-        guard site.isWordPressComStore else {
+        // If the site is not a WPCom store and has never run a trial WooExpress plan,
+        // set the state to `.unavailable`
+        guard site.isWordPressComStore || site.wasEcommerceTrial else {
             planState = .unavailable
             return
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -743,7 +743,7 @@
 		26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */; };
 		2631D4F829ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4F729ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift */; };
 		2631D4FA29ED108400F13F20 /* WPComPlanNameSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */; };
-		2631D4FE29F2141D00F13F20 /* FreeTrialBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4FD29F2141D00F13F20 /* FreeTrialBannerPresenter.swift */; };
+		2631D4FE29F2141D00F13F20 /* StorePlanBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */; };
 		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
@@ -3152,7 +3152,7 @@
 		26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaInsetsKey.swift; sourceTree = "<group>"; };
 		2631D4F729ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPlanNameSanitizer.swift; sourceTree = "<group>"; };
 		2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPlanNameSanitizer.swift; sourceTree = "<group>"; };
-		2631D4FD29F2141D00F13F20 /* FreeTrialBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerPresenter.swift; sourceTree = "<group>"; };
+		2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenter.swift; sourceTree = "<group>"; };
 		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
 		263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerViewModel.swift; sourceTree = "<group>"; };
@@ -6710,7 +6710,7 @@
 			children = (
 				EEB917C62A6FE4C6004D364B /* FreeTrialSurvey */,
 				26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */,
-				2631D4FD29F2141D00F13F20 /* FreeTrialBannerPresenter.swift */,
+				2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */,
 				261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */,
 			);
 			path = "Free Trial";
@@ -12929,7 +12929,7 @@
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
 				B94403C9289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift in Sources */,
 				7E7C5F872719A93C00315B61 /* ProductCategoryListViewController.swift in Sources */,
-				2631D4FE29F2141D00F13F20 /* FreeTrialBannerPresenter.swift in Sources */,
+				2631D4FE29F2141D00F13F20 /* StorePlanBannerPresenter.swift in Sources */,
 				DEC51B06276B3F3C009F3DF4 /* Int64+Helpers.swift in Sources */,
 				02BE9CC029C05CFD00292333 /* SitePreviewView.swift in Sources */,
 				D8B4D5EE26C2C26C00F34E94 /* InPersonPaymentsStripeAcountReviewView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -844,7 +844,7 @@
 		26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E926E8FD3900C7BB0F /* LazyView.swift */; };
 		26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */; };
 		26C98F9829C1247000F96503 /* WPComSitePlan+FreeTrial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */; };
-		26C98F9B29C18ACE00F96503 /* FreeTrialBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */; };
+		26C98F9B29C18ACE00F96503 /* StorePlanBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C98F9A29C18ACE00F96503 /* StorePlanBanner.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
@@ -3246,7 +3246,7 @@
 		26C6E8E926E8FD3900C7BB0F /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyNavigationLink.swift; sourceTree = "<group>"; };
 		26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPComSitePlan+FreeTrial.swift"; sourceTree = "<group>"; };
-		26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBanner.swift; sourceTree = "<group>"; };
+		26C98F9A29C18ACE00F96503 /* StorePlanBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBanner.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
@@ -6709,7 +6709,7 @@
 			isa = PBXGroup;
 			children = (
 				EEB917C62A6FE4C6004D364B /* FreeTrialSurvey */,
-				26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */,
+				26C98F9A29C18ACE00F96503 /* StorePlanBanner.swift */,
 				2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */,
 				261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */,
 			);
@@ -12759,7 +12759,7 @@
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
 				0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */,
 				02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */,
-				26C98F9B29C18ACE00F96503 /* FreeTrialBanner.swift in Sources */,
+				26C98F9B29C18ACE00F96503 /* StorePlanBanner.swift in Sources */,
 				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				68E674AB2A4DAB8C0034BA1E /* CompletedUpgradeView.swift in Sources */,
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10298
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As discussed in pe5sF9-1JH-p2, when a store plan expires, after 8 days the site gets reverted to a simple site and the app is no longer usable. To mitigate this issue, we should detect these cases and let users upgrade their plans in the app. 

Previously, we added an alert with a CTA to upgrade plans if this happens in #10059 - but this alert can be dismissed. For a more persistent solution, we should make use of the existing free trial banner to display something similar on the app.

This PR makes use of the existing `FreeTrialBannerPresenter` by renaming it to `StorePlanBannerPresenter` to be more generic and catching the case where a store plan is reverted to simple while it is recognized as having run a free trial WooExpress plan in the past. We only support upgrading for WooExpress stores for now since IAP hasn't been implemented to support regular WPCom plans.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to an expired WooExpress site.
- Expired sites are not accessible on the store picker as we are filtering them out. Build and run the code from [this diff](https://github.com/woocommerce/woocommerce-ios/compare/try/allow-ineligible-sites-in-picker?expand=1) to get access to those sites.
- In the store picker, select the expired WooExpress site and tap Continue. 
- You should be navigate to the dashboard screen with the banner saying the past plan has ended.
- The banner CTA should display "Learn More" if your account is ineligible for IAP, or "Upgrade" otherwise.

Please feel free to test with other sites to make sure that the new banner is only available for sites with expired WooExpress plans, and the free trial banner is still displayed for free trial stores.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/b3334d0a-e2c3-4e5a-8680-c1bf9c619c99" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.