### PR TITLE
[Better Customer Selection] Add/Edit Customer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorView.swift
@@ -6,10 +6,11 @@ import SwiftUI
 ///
 struct CustomerSelectorView: UIViewControllerRepresentable {
     let siteID: Int64
+    let addressFormViewModel: CreateOrderAddressFormViewModel
     let onCustomerSelected: (Customer) -> Void
 
     func makeUIViewController(context: Context) -> WooNavigationController {
-        let viewController = CustomerSelectorViewController(siteID: siteID, onCustomerSelected: onCustomerSelected)
+        let viewController = CustomerSelectorViewController(siteID: siteID, addressFormViewModel: addressFormViewModel, onCustomerSelected: onCustomerSelected)
 
         let navigationController = WooNavigationController(rootViewController: viewController)
         return navigationController

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -82,7 +82,7 @@ private extension CustomerSelectorViewController {
 
     @objc func presentNewCustomerDetailsFlow() {
         let editOrderAddressForm = EditOrderAddressForm(dismiss: { [weak self] in
-                                                            self?.dismiss(animated: true, completion: {
+                                                            self?.dismiss(animated: true, completion: { [weak self] in
                                                                 self?.dismiss(animated: true)
                                                             })
                                                         },

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import WordPressUI
 import UIKit
 import Yosemite
@@ -10,6 +11,7 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
     private let siteID: Int64
     private let onCustomerSelected: (Customer) -> Void
     private let viewModel: CustomerSelectorViewModel
+    private let addressFormViewModel: CreateOrderAddressFormViewModel
 
     /// Notice presentation handler
     ///
@@ -25,9 +27,11 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: TitleAndSubtitleAndStatusTableViewCell.self))
 
     init(siteID: Int64,
+         addressFormViewModel: CreateOrderAddressFormViewModel,
          onCustomerSelected: @escaping (Customer) -> Void) {
         viewModel = CustomerSelectorViewModel(siteID: siteID, onCustomerSelected: onCustomerSelected)
         self.siteID = siteID
+        self.addressFormViewModel = addressFormViewModel
         self.onCustomerSelected = onCustomerSelected
 
         super.init(nibName: nil, bundle: nil)
@@ -76,7 +80,19 @@ private extension CustomerSelectorViewController {
         dismiss(animated: true)
     }
 
-    @objc func presentNewCustomerDetailsFlow() {}
+    @objc func presentNewCustomerDetailsFlow() {
+        let editOrderAddressForm = EditOrderAddressForm(dismiss: { [weak self] in
+                                                            self?.dismiss(animated: true, completion: {
+                                                                self?.dismiss(animated: true)
+                                                            })
+                                                        },
+                                                        showSearchButton: false,
+                                                        viewModel: addressFormViewModel)
+        let rootViewController = UIHostingController(rootView: editOrderAddressForm)
+        let navigationController = WooNavigationController(rootViewController: rootViewController)
+
+        present(navigationController, animated: true, completion: nil)
+    }
 
     func addSearchViewController() {
         let searchViewController = SearchViewController(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -83,6 +83,7 @@ private extension CustomerSelectorViewController {
     @objc func presentNewCustomerDetailsFlow() {
         let editOrderAddressForm = EditOrderAddressForm(dismiss: { [weak self] in
                                                             self?.dismiss(animated: true, completion: { [weak self] in
+                                                                // Dismiss this view too
                                                                 self?.dismiss(animated: true)
                                                             })
                                                         },

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -18,7 +18,7 @@ struct OrderCustomerSection: View {
             .sheet(isPresented: $showAddressForm) {
                 NavigationView {
                     if viewModel.shouldShowCustomerSelectorScreen {
-                        CustomerSelectorView(siteID: viewModel.siteID) { customer in
+                        CustomerSelectorView(siteID: viewModel.siteID, addressFormViewModel: addressFormViewModel) { customer in
                             viewModel.addCustomerAddressToOrder(customer: customer)
                         }
                     } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -17,14 +17,17 @@ struct OrderCustomerSection: View {
         OrderCustomerSectionContent(viewModel: viewModel.customerDataViewModel, showAddressForm: $showAddressForm)
             .sheet(isPresented: $showAddressForm) {
                 NavigationView {
-                    if viewModel.shouldShowCustomerSelectorScreen {
+                    switch viewModel.customerNavigationScreen {
+                    case .form:
+                        EditOrderAddressForm(dismiss: {
+                                                showAddressForm.toggle()
+                                             },
+                                             showSearchButton: viewModel.shouldShowSearchButtonInOrderAddressForm,
+                                             viewModel: addressFormViewModel)
+                    case .selector:
                         CustomerSelectorView(siteID: viewModel.siteID, addressFormViewModel: addressFormViewModel) { customer in
                             viewModel.addCustomerAddressToOrder(customer: customer)
                         }
-                    } else {
-                        EditOrderAddressForm(dismiss: {
-                            showAddressForm.toggle()
-                        }, viewModel: addressFormViewModel)
                     }
                 }
                 .discardChangesPrompt(canDismiss: !addressFormViewModel.hasPendingChanges,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -35,6 +35,13 @@ final class EditableOrderViewModel: ObservableObject {
         }
     }
 
+    /// Encapsulates the type of screen that should be shown when navigating to Customer Details
+    ///
+    enum CustomerNavigationScreen {
+        case form
+        case selector
+    }
+
     /// Current flow. For editing stores existing order state prior to applying any edits.
     ///
     let flow: Flow
@@ -67,11 +74,19 @@ final class EditableOrderViewModel: ObservableObject {
         featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) && flow == .creation
     }
 
-    var shouldShowCustomerSelectorScreen: Bool {
-        featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder) &&
-        // If there are no addresses added 
+    /// Indicates the customer details screen to be shown. If there's no address added show the customer selector, otherwise the form so it can be edited
+    ///
+    var customerNavigationScreen: CustomerNavigationScreen {
+        let shouldShowSelector = featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder) &&
+        // If there are no addresses added
         orderSynchronizer.order.billingAddress == nil &&
         orderSynchronizer.order.shippingAddress == nil
+
+        return shouldShowSelector ? .selector : .form
+    }
+
+    var shouldShowSearchButtonInOrderAddressForm: Bool {
+        !featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder)
     }
 
     /// Indicates whether adding a product to the order via SKU scanning is enabled

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -68,7 +68,10 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     var shouldShowCustomerSelectorScreen: Bool {
-        featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder)
+        featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder) &&
+        // If there are no addresses added 
+        orderSynchronizer.order.billingAddress == nil &&
+        orderSynchronizer.order.shippingAddress == nil
     }
 
     /// Indicates whether adding a product to the order via SKU scanning is enabled

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -84,6 +84,10 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
     ///
     var dismiss: (() -> Void) = {}
 
+    /// Shows the search button on the navigation bar
+    /// 
+    var showSearchButton = true
+
     /// View Model for the view
     ///
     @ObservedObject private(set) var viewModel: ViewModel
@@ -150,13 +154,17 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                     viewModel.userDidCancelFlow()
                 })
             }
-            ToolbarItem(placement: .automatic) {
-                Button(action: {
-                    showingCustomerSearch = true
-                }, label: {
-                    Image(systemName: "magnifyingglass")
-                })
+
+            ToolbarItemGroup(placement: .automatic) {
+                if showSearchButton {
+                    Button(action: {
+                        showingCustomerSearch = true
+                    }, label: {
+                        Image(systemName: "magnifyingglass")
+                    })
+                }
             }
+
             ToolbarItem(placement: .confirmationAction) {
                 navigationBarTrailingItem()
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1353,7 +1353,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                stores: stores,
-                                               featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))
+                                               featureFlagService: MockFeatureFlagService(betterCustomerSelectionInOrder: true))
         let customer = Customer.fake().copy(
             email: "scrambled@scrambled.com",
             firstName: "Johnny",
@@ -1365,16 +1365,16 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.addCustomerAddressToOrder(customer: customer)
 
         // Then
-        XCTAssertFalse(viewModel.customerNavigationScreen == .form)
+        XCTAssertTrue(viewModel.customerNavigationScreen == .form)
     }
 
     func test_addCustomerAddressToOrder_when_feature_flag_is_enabled_and_no_customer_is_added_then_shows_the_selector() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                stores: stores,
-                                               featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))
+                                               featureFlagService: MockFeatureFlagService(betterCustomerSelectionInOrder: true))
         // Then
-        XCTAssertFalse(viewModel.customerNavigationScreen == .selector)
+        XCTAssertTrue(viewModel.customerNavigationScreen == .selector)
     }
 
     func test_resetAddressForm_discards_pending_address_field_changes() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1349,7 +1349,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.addressFormViewModel.fields.email, customer.email)
     }
 
-    func test_addCustomerAddressToOrder_when_feature_flag_is_enabled_then_does_not_show_customer_selector_anymore() {
+    func test_addCustomerAddressToOrder_when_feature_flag_is_enabled_and_a_customer_was_added_then_shows_the_form() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                stores: stores,
@@ -1365,7 +1365,16 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.addCustomerAddressToOrder(customer: customer)
 
         // Then
-        XCTAssertFalse(viewModel.shouldShowCustomerSelectorScreen)
+        XCTAssertFalse(viewModel.customerNavigationScreen == .form)
+    }
+
+    func test_addCustomerAddressToOrder_when_feature_flag_is_enabled_and_no_customer_is_added_then_shows_the_selector() {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))
+        // Then
+        XCTAssertFalse(viewModel.customerNavigationScreen == .selector)
     }
 
     func test_resetAddressForm_discards_pending_address_field_changes() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1349,6 +1349,25 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.addressFormViewModel.fields.email, customer.email)
     }
 
+    func test_addCustomerAddressToOrder_when_feature_flag_is_enabled_then_does_not_show_customer_selector_anymore() {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))
+        let customer = Customer.fake().copy(
+            email: "scrambled@scrambled.com",
+            firstName: "Johnny",
+            lastName: "Appleseed",
+            billing: sampleAddress1(),
+            shipping: sampleAddress2()
+        )
+
+        viewModel.addCustomerAddressToOrder(customer: customer)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowCustomerSelectorScreen)
+    }
+
     func test_resetAddressForm_discards_pending_address_field_changes() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10311 and #10310
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR the users can add a new customer by opening the form from the customer selector list. Furthermore, once it's added, they can edit it from the Order Details.

## Changes
- Pass the `CreateOrderAddressFormViewModel` to the `CustomerSelectorViewController`
- Open `EditOrderAddressForm` from the `CustomerSelectorViewController` with it
- Make the search button optional in `EditOrderAddressForm`
- Open the customer selector or form from the Order Details depending on whether the order has a customer added or not
- Add Unit tests

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Enable the feature flag betterCustomerSelectionInOrder in the DefaultFeatureFlagService

1. Go to orders
2. Tap on +
3. Tap on + Add Customer Details
4. Fill out the form and tap Done
Make sure that the details are added to the order, and you can edit them whenever you want by tapping Edit on the customer details section (See Video)


https://github.com/woocommerce/woocommerce-ios/assets/1864060/850671d9-0cb9-4680-8f1a-538e64e1e5dd


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See Video above


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
