### PR TITLE
Sentry: Disable tracking HTTP client errors and app hangs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,9 +27,9 @@ def aztec
 end
 
 def tracks
-  pod 'Automattic-Tracks-iOS', '~> 2.2'
+#  pod 'Automattic-Tracks-iOS', '~> 2.2'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
-  # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
+   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => '1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f'
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -28,8 +28,8 @@ end
 
 def tracks
 #  pod 'Automattic-Tracks-iOS', '~> 2.2'
-  # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
-   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => '1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f'
+   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
+#   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -77,7 +77,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, commit `1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f`)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, branch `trunk`)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -132,7 +132,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
-    :commit: 1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f
+    :branch: trunk
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   WordPressAuthenticator:
     :branch: trunk
@@ -140,7 +140,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
-    :commit: 1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f
+    :commit: aad902bf945e7528a00ba5b9c5640974d58ff2fd
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   WordPressAuthenticator:
     :commit: bfdfde6fcd9a0faf0509db8380aa208e6d093a08
@@ -183,6 +183,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 17343446f03e7f6b12a818bd4c6920cdecb14415
+PODFILE CHECKSUM: 1e30ee7ea7eaa2f5c59e5cc4a272570a13c1d32a
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - AppAuth/Core (1.6.1)
   - AppAuth/ExternalUserAgent (1.6.1):
     - AppAuth/Core
-  - Automattic-Tracks-iOS (2.2.0):
+  - Automattic-Tracks-iOS (2.3.0):
     - Sentry (~> 8.0)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
@@ -28,12 +28,12 @@ PODS:
   - Kingfisher (7.6.2)
   - NSObject-SafeExpectations (0.0.6)
   - "NSURL+IDN (0.4)"
-  - Sentry (8.8.0):
-    - Sentry/Core (= 8.8.0)
-    - SentryPrivate (= 8.8.0)
-  - Sentry/Core (8.8.0):
-    - SentryPrivate (= 8.8.0)
-  - SentryPrivate (8.8.0)
+  - Sentry (8.9.2):
+    - Sentry/Core (= 8.9.2)
+    - SentryPrivate (= 8.9.2)
+  - Sentry/Core (8.9.2):
+    - SentryPrivate (= 8.9.2)
+  - SentryPrivate (8.9.2)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
   - StripeTerminal (2.19.1)
@@ -77,7 +77,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (~> 2.2)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, commit `1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f`)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -99,7 +99,6 @@ SPEC REPOS:
   trunk:
     - Alamofire
     - AppAuth
-    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - GoogleSignIn
     - Gridicons
@@ -132,11 +131,17 @@ SPEC REPOS:
     - ZendeskSupportSDK
 
 EXTERNAL SOURCES:
+  Automattic-Tracks-iOS:
+    :commit: 1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   WordPressAuthenticator:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
+  Automattic-Tracks-iOS:
+    :commit: 1d3bb8030b3aed54c2b24c18fb95f3945ac63f9f
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   WordPressAuthenticator:
     :commit: bfdfde6fcd9a0faf0509db8380aa208e6d093a08
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
@@ -144,7 +149,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: e48b432bb4ba88b10cb2bcc50d7f3af21e78b9c2
-  Automattic-Tracks-iOS: a1b020ab02f0e5a39c5d4e6870a498273f286158
+  Automattic-Tracks-iOS: 310a9b65615d03db838fad6e58823effb4f385bf
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
@@ -154,8 +159,8 @@ SPEC CHECKSUMS:
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
-  Sentry: 927dfb29d18a14d924229a59cc2ad149f43349f2
-  SentryPrivate: 4350d865f898224ab9fa02b37d6ee7fbb623f47e
+  Sentry: 4fe92c018ba6ed61ce1fc652dd1ccac34505a4c6
+  SentryPrivate: b58fc25b3a0ac7e3d4ec229be63d583e3314a47a
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 93e18a93c6f92e51ceedc5b78ab3075327075a80
@@ -178,6 +183,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 33119766b8581a4e76206f345a770ca2c617f78d
+PODFILE CHECKSUM: 17343446f03e7f6b12a818bd4c6920cdecb14415
 
 COCOAPODS: 1.12.1

--- a/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
+++ b/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
@@ -90,6 +90,9 @@ class WCCrashLoggingDataProvider: CrashLoggingDataProvider {
 
     let featureFlagService: FeatureFlagService
 
+    let enableAppHangTracking = false
+    let enableCaptureFailedRequests = false
+
     /// Tracks if the component has been initialized.
     ///
     private var hasBeenInitialized = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10372 
Please also review https://github.com/Automattic/Automattic-Tracks-iOS/pull/261.
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `Automattic-Tracks-iOS` and adds configs to disable HTTP client error and app hang tracking on Sentry. The purpose is to stop reports of these errors bloating up Sentry report list - we'll find better ways to keep track of the issues. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
It's not straightforward to check that these errors are not tracked from debug builds. You can use breakpoints to ensure that the options are delivered to `Automattic-Tracks-iOS`'s `CrashLogging` file successfully.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
