### PR TITLE
[Beta fix] Remove IAP M2 from 14.7 🛑 Do Not Merge

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -96,7 +96,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .shareProductAI:
             return true
         case .freeTrialInAppPurchasesUpgradeM2:
-            return true
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ordersWithCouponsM4:
             return true
         case .freeTrialSurvey24hAfterFreeTrialSubscribed:

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,3 +1,3 @@
-Exciting news for new store owners! Firstly, you can now easily upgrade to all available plans. Secondly, gain hands-on experience in managing orders by creating test orders directly within the app!
+Exciting news for new store owners! You can now gain hands-on experience in managing orders by creating test orders directly within the app!
 
 And that's not all—our latest update also includes improvements to the product description AI. Give it a try if you haven't already!


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We may decide to pull IAP from the 14.7 release before we ship this release. See {p91TBi-aAI-p2#comment-11560} for context.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Run a release build on a simulator
Switch to a store with an active Woo Express free trial
Tap `Upgrade now`
Observe that only the Essential Monthly plan is available


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
