### PR TITLE
[Profiler] Cleanup feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -31,8 +31,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .inAppPurchases:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .storeCreationM3Profiler:
-            return true
         case .justInTimeMessagesOnDashboard:
             return true
         case .IPPInAppFeedbackBanner:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -68,10 +68,6 @@ public enum FeatureFlag: Int {
     ///
     case tapToPayBadge
 
-    /// Store creation milestone 3 - profiler questions
-    ///
-    case storeCreationM3Profiler
-
     /// Just In Time Messages on Dashboard
     ///
     case justInTimeMessagesOnDashboard

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -76,17 +76,8 @@ private extension StoreCreationCoordinator {
         // Disables interactive dismissal of the store creation modal.
         navigationController.isModalInPresentation = true
 
-        let isProfilerEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationM3Profiler)
         let continueAfterEnteringStoreName = { [weak self] storeName in
-            if isProfilerEnabled {
-                /// `storeCreationM3Profiler` is currently disabled.
-                /// Before enabling it again, make sure the onboarding questions are properly sent on the trial flow around line `343`.
-                /// Ref: https://github.com/woocommerce/woocommerce-ios/issues/9326#issuecomment-1490012032
-                ///
-                self?.showCategoryQuestion(from: navigationController, storeName: storeName)
-            } else {
-                self?.showFreeTrialSummaryView(from: navigationController, storeName: storeName, profilerData: nil)
-            }
+            self?.showCategoryQuestion(from: navigationController, storeName: storeName)
         }
         let storeNameForm = StoreNameFormHostingController(prefillStoreName: prefillStoreName) { [weak self] storeName in
             self?.scheduleLocalNotificationToSubscribeFreeTrial(storeName: storeName)

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
@@ -42,8 +42,7 @@ struct StoreCreationSummaryViewModel {
     /// Optional category name from the previous profiler question.
     let categoryName: String?
     /// Country code for the store location.
-    /// `nil` only when the `storeCreationM3Profiler` feature flag is disabled.
-    let countryCode: SiteAddress.CountryCode?
+    let countryCode: SiteAddress.CountryCode
 }
 
 /// Displays a summary of the store creation flow with the store information (e.g. store name, store slug).
@@ -165,7 +164,7 @@ private extension StoreCreationSummaryView {
 private extension StoreCreationSummaryViewModel {
     /// Text for the store country label.
     var country: String? {
-        countryCode.map { [$0.readableCountry, $0.flagEmoji].compactMap { $0 }.joined(separator: " ") }
+        [countryCode.readableCountry, countryCode.flagEmoji].compactMap { $0 }.joined(separator: " ")
     }
 }
 
@@ -182,7 +181,7 @@ struct StoreCreationSummaryView_Previews: PreviewProvider {
                 .init(storeName: "Fruity shop",
                       storeSlug: "fruityshop.com",
                       categoryName: "Arts and Crafts",
-                      countryCode: nil),
+                      countryCode: .UG),
                                  onContinueToPayment: {},
                                  onSupport: {})
         .preferredColorScheme(.dark)

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -581,7 +581,6 @@ final class AppCoordinatorTests: XCTestCase {
     func test_store_creation_flow_starts_upon_tapping_oneDayAfterStoreCreationNameWithoutFreeTrial_notification_when_valid_store_is_selected_already() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM3ProfilerEnabled: true)
 
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
@@ -598,8 +597,7 @@ final class AppCoordinatorTests: XCTestCase {
         let coordinator = makeCoordinator(window: window,
                                           stores: stores,
                                           authenticationManager: authenticationManager,
-                                          pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService)
+                                          pushNotesManager: pushNotesManager)
 
         let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
         let identifier = LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial
@@ -629,7 +627,6 @@ final class AppCoordinatorTests: XCTestCase {
     func test_store_creation_flow_starts_upon_tapping_oneDayAfterStoreCreationNameWithoutFreeTrial_notification_when_no_valid_store_available() throws {
         // Given
         let pushNotesManager = MockPushNotificationsManager()
-        let featureFlagService = MockFeatureFlagService(isStoreCreationM3ProfilerEnabled: true)
         // Authenticates the app without selecting a site, so that the store picker is shown.
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
         sessionManager.defaultStoreID = nil
@@ -639,8 +636,7 @@ final class AppCoordinatorTests: XCTestCase {
         let coordinator = makeCoordinator(window: window,
                                           stores: stores,
                                           authenticationManager: authenticationManager,
-                                          pushNotesManager: pushNotesManager,
-                                          featureFlagService: featureFlagService)
+                                          pushNotesManager: pushNotesManager)
 
         let notificationUserInfo = [LocalNotification.UserInfoKey.storeName: "sampleStoreName"]
         let identifier = LocalNotification.Scenario.Identifier.oneDayAfterStoreCreationNameWithoutFreeTrial

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -7,7 +7,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isUpdateOrderOptimisticallyOn: Bool
     private let shippingLabelsOnboardingM1: Bool
     private let isLoginPrologueOnboardingEnabled: Bool
-    private let isStoreCreationM3ProfilerEnabled: Bool
     private let isDomainSettingsEnabled: Bool
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
@@ -30,7 +29,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
          isLoginPrologueOnboardingEnabled: Bool = false,
-         isStoreCreationM3ProfilerEnabled: Bool = false,
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
@@ -52,7 +50,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.isLoginPrologueOnboardingEnabled = isLoginPrologueOnboardingEnabled
-        self.isStoreCreationM3ProfilerEnabled = isStoreCreationM3ProfilerEnabled
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
@@ -83,8 +80,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return shippingLabelsOnboardingM1
         case .loginPrologueOnboarding:
             return isLoginPrologueOnboardingEnabled
-        case .storeCreationM3Profiler:
-            return isStoreCreationM3ProfilerEnabled
         case .domainSettings:
             return isDomainSettingsEnabled
         case .supportRequests:


### PR DESCRIPTION
Part of: #10376

## Description

Cleans up by removing `storeCreationM3Profiler` feature flag which is already always `true`. Cleaning up allows us to introduce another feature flag for [Optimize profiler question](https://github.com/woocommerce/woocommerce-ios/issues/10374) work. 

## Testing instructions
- Log in to the app.
- Switch to the Menu tab and open the store picker.
- Select Add a store > Create a new store.
- The profiler questions flow should be presented after entering store name. 

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/24a8aed4-5368-4892-b9e2-c506a067647e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.