### PR TITLE
Product list filter: add extension product types

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Stores with expired WooExpress plans can now be upgraded within the app (if eligible for IAP) via a new banner. [https://github.com/woocommerce/woocommerce-ios/pull/10369]
 - [Internal] New default property `plan` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10356]
 - [Internal] Google sign in now defaults to bypassing the Google SDK [https://github.com/woocommerce/woocommerce-ios/pull/10341]
+- [*] Product list filter (Products tab and order creation > add products > filter): product types from extensions supported in the app are now available for product filtering - subscription, variable subscription, bundle, and composite. [https://github.com/woocommerce/woocommerce-ios/pull/10382]
  
 14.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -137,7 +137,7 @@ extension FilterProductListViewModel.ProductListFilter {
                                        listSelectorConfig: .staticOptions(options: options),
                                        selectedValue: filters.productStatus)
         case .productType:
-            let options: [ProductType?] = [nil, .simple, .variable, .grouped, .affiliate]
+            let options: [ProductType?] = [nil, .simple, .variable, .grouped, .affiliate, .subscription, .variableSubscription, .bundle, .composite]
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: options),
                                        selectedValue: filters.productType)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -236,6 +236,14 @@ private extension ProductStore {
                                excludedProductIDs: excludedProductIDs) { [weak self] result in
                                 switch result {
                                 case .failure(let error):
+                                    if let productType,
+                                        let error = error as? DotcomError,
+                                        case let .unknown(code, message) = error,
+                                        code == "rest_invalid_param",
+                                        message == "Invalid parameter(s): type",
+                                        ProductType.coreTypes.contains(productType) == false {
+                                        return onCompletion(.success(false))
+                                    }
                                     onCompletion(.failure(error))
                                 case .success(let products):
                                     guard let self = self else {
@@ -1143,4 +1151,8 @@ public struct ProductDetailsFromScannedTexts: Equatable, Decodable {
         self.description = description
         self.language = language
     }
+}
+
+private extension ProductType {
+    static let coreTypes: Set<ProductType> = [.simple, .variable, .grouped, .affiliate]
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -33,6 +33,9 @@ final class MockProductsRemote {
     /// The results to return based on the given site ID in `updateProductImages`
     private var updateProductImagesResultsBySiteID = [ResultKey: Result<Product, Error>]()
 
+    /// The results to return based on the given site ID in `loadAllProducts`
+    private var loadAllProductsResultsBySiteID = [Int64: Result<[Product], Error>]()
+
     /// The number of times that `loadProduct()` was invoked.
     private(set) var invocationCountOfLoadProduct: Int = 0
 
@@ -67,6 +70,12 @@ final class MockProductsRemote {
     func whenUpdatingProductImages(siteID: Int64, productID: Int64, thenReturn result: Result<Product, Error>) {
         let key = ResultKey(siteID: siteID, productIDs: [productID])
         updateProductImagesResultsBySiteID[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `loadAllProducts()` is called.
+    ///
+    func whenLoadingAllProducts(siteID: Int64, thenReturn result: Result<[Product], Error>) {
+        loadAllProductsResultsBySiteID[siteID] = result
     }
 }
 
@@ -147,7 +156,11 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                          order: ProductsRemote.Order,
                          excludedProductIDs: [Int64],
                          completion: @escaping (Result<[Product], Error>) -> Void) {
-        // no-op
+        if let result = loadAllProductsResultsBySiteID[siteID] {
+            completion(result)
+        } else {
+            XCTFail("\(String(describing: self)) Could not find Result for \(siteID)")
+        }
     }
 
     func searchProducts(for siteID: Int64,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10381
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In Android, we're already showing the product types from extensions supported in the app (readonly for now - subscription, composite, bundle). For sites that don't have the extensions, the results will be empty but we are also considering promoting/upselling the extensions on the empty state UI from the idea post pe5pgL-2tE-p2.

## How

In the filter product list view model, `.subscription, .variableSubscription, .bundle, .composite` were added to the product type options. Since an error is returned from the products API request when a site doesn't have the extension, this particular error is handled in the app so that no error banner is shown in this case.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Stores with subscription/bundle/composite products extension support

- Log in to a store with at least one of the subscription/bundle/composite products extensions
- Go to the Products tab
- Tap `Filter`
- Tap `Product Type` --> the options should now include `Subscription`, `Variable Subscription`, `Bundle`, and `Composite`
- Tap on one of the extension product types supported on the site --> the results should be shown
- Go to the Orders tab
- Tap `+` on the top right
- Tap `Add Products`
- Tap `Filter`
- Tap `Product Type` --> the options should now include `Subscription`, `Variable Subscription`, `Bundle`, and `Composite`
- Tap on one of the extension product types supported on the site --> the results should be shown

### Stores without subscription/bundle/composite products extension support

- Log in to a store without the subscription/bundle/composite products extensions
- Go to the Products tab
- Tap `Filter`
- Tap `Product Type` --> the options should now include `Subscription`, `Variable Subscription`, `Bundle`, and `Composite`
- Tap on one of the extension product types supported on the site --> empty results should be shown without an error banner
- Go to the Orders tab
- Tap `+` on the top right
- Tap `Add Products`
- Tap `Filter`
- Tap `Product Type` --> the options should now include `Subscription`, `Variable Subscription`, `Bundle`, and `Composite`
- Tap on one of the extension product types --> empty results should be shown without an error notice

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screenshot - iPhone 14 Plus - 2023-08-02 at 14 16 36](https://github.com/woocommerce/woocommerce-ios/assets/1945542/4fb65f65-d4b4-4acb-ad77-50fae0348f41) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-03 at 11 12 54](https://github.com/woocommerce/woocommerce-ios/assets/1945542/865b517d-4952-4a75-a26f-bcecd49e3a2d)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
