### PR TITLE
RequirementsChecker: navigate to IAP for sites with expired WooExpress plans

### DIFF
--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -199,7 +199,7 @@ public extension Site {
     /// Whether the site has been reverted to a simple site
     ///
     var isSimpleSite: Bool {
-        plan == "free_plan"
+        plan == WooConstants.freePlanSlug
     }
 }
 

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -195,6 +195,12 @@ public extension Site {
         /// hence not a Jetpack site.
         siteID == WooConstants.placeholderSiteID
     }
+
+    /// Whether the site has been reverted to a simple site
+    ///
+    var isSimpleSite: Bool {
+        plan == "free_plan"
+    }
 }
 
 /// Defines all of the Site CodingKeys.

--- a/Networking/Networking/Settings/WooConstants.swift
+++ b/Networking/Networking/Settings/WooConstants.swift
@@ -9,4 +9,7 @@ public enum WooConstants {
     /// Keychain Access's Service Name
     ///
     public static let keychainServiceName = "com.automattic.woocommerce"
+
+    /// Slug of the free plan
+    static let freePlanSlug = "free_plan"
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [Internal] Native store creation flow with free trial is enabled by default - all code for the old flows have been removed. [https://github.com/woocommerce/woocommerce-ios/pull/10362]
 - [*] Store creation: Improvements to the Upgrades screen accessibility [https://github.com/woocommerce/woocommerce-ios/pull/10363]
 - [*] Stores with expired WooExpress plans can now be upgraded within the app (if eligible for IAP) via a new banner. [https://github.com/woocommerce/woocommerce-ios/pull/10369]
+- [*] The expired site plan should navigate to IAP for sites with expired WooExpress plans (if eligible for IAP). [https://github.com/woocommerce/woocommerce-ios/pull/10384]
 - [Internal] New default property `plan` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10356]
 - [Internal] Google sign in now defaults to bypassing the Google SDK [https://github.com/woocommerce/woocommerce-ios/pull/10341]
  

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -40,19 +40,14 @@ final class RequirementsChecker {
     /// in order to determine if the site is running on an expired plan.
     ///
     func checkSiteEligibility(for site: Site, onCompletion: ((Result<RequirementCheckResult, Error>) -> Void)? = nil) {
+        guard !site.isSimpleSite else {
+            onCompletion?(.success(.expiredWPComPlan))
+            return
+        }
         Task { @MainActor in
             do {
                 let result = try await checkMinimumWooVersion(for: site)
-                guard case .invalidWCVersion = result else {
-                    onCompletion?(.success(result))
-                    return
-                }
-
-                if site.isSimpleSite {
-                    onCompletion?(.success(.expiredWPComPlan))
-                } else {
-                    onCompletion?(.success(.invalidWCVersion))
-                }
+                onCompletion?(.success(result))
             } catch {
                 onCompletion?(.failure(error))
             }

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -40,6 +40,7 @@ final class RequirementsChecker {
     /// in order to determine if the site is running on an expired plan.
     ///
     func checkSiteEligibility(for site: Site, onCompletion: ((Result<RequirementCheckResult, Error>) -> Void)? = nil) {
+        /// When a site plan expires, after 8 days the site is reverted to a simple site.
         guard !site.isSimpleSite else {
             onCompletion?(.success(.expiredWPComPlan))
             return

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -48,8 +48,7 @@ final class RequirementsChecker {
                     return
                 }
 
-                let siteExpired = await checkIfWPComSitePlanExpired(for: site.siteID)
-                if siteExpired {
+                if site.isSimpleSite {
                     onCompletion?(.success(.expiredWPComPlan))
                 } else {
                     onCompletion?(.success(.invalidWCVersion))
@@ -79,7 +78,7 @@ final class RequirementsChecker {
             case .success(.invalidWCVersion):
                 self?.displayWCVersionAlert()
             case .success(.expiredWPComPlan):
-                self?.displayWPComPlanUpgradeAlert(siteID: site.siteID)
+                self?.displayWPComPlanUpgradeAlert(for: site)
             default:
                 break
             }
@@ -91,26 +90,6 @@ final class RequirementsChecker {
 // MARK: - Private helpers
 //
 private extension RequirementsChecker {
-    @MainActor
-    func checkIfWPComSitePlanExpired(for siteID: Int64) async -> Bool {
-        await withCheckedContinuation { continuation in
-            stores.dispatch(PaymentAction.loadSiteCurrentPlan(siteID: siteID) { result in
-                switch result {
-                case .success(let plan):
-                    // When a plan expired, the site gets reverted to a simple site with plan ID "1"
-                    continuation.resume(returning: plan.isFreePlan)
-                case .failure(LoadSiteCurrentPlanError.noCurrentPlan):
-                    // Since this is a WPCom store, if it has no plan its plan must have expired or been cancelled.
-                    // Generally, expiry is `.success(plan)` with a plan expiry date in the past, but in some cases, we just
-                    // don't get any plans marked as `current` in the plans response.
-                    continuation.resume(returning: true)
-                case .failure(let error):
-                    continuation.resume(returning: false)
-                    DDLogError("⛔️ Error synchronizing WPCom plan: \(error)")
-                }
-            })
-        }
-    }
 
     /// Display the WC version alert
     ///
@@ -121,18 +100,19 @@ private extension RequirementsChecker {
         baseViewController?.present(fancyAlert, animated: true)
     }
 
-    func displayWPComPlanUpgradeAlert(siteID: Int64) {
+    func displayWPComPlanUpgradeAlert(for site: Site) {
         guard let baseViewController else {
             return
         }
-        UIAlertController.presentExpiredWPComPlanAlert(from: baseViewController) { [weak self] in
-            guard let self else { return }
-            /// Since we cannot tell if the site is eligible for upgrading with IAP,
-            /// it's safer to navigate to the plans page just in case the site is not suitable
-            /// for upgrading WooExpress plans (e.g: expired Business plan).
-            /// Please place IAP here if we have a solution to check the case.
-            let controller = UpgradePlanCoordinatingController(siteID: siteID, source: .expiredWPComPlanAlert)
-            self.baseViewController?.present(controller, animated: true)
+        UIAlertController.presentExpiredWPComPlanAlert(from: baseViewController) {
+            if site.wasEcommerceTrial {
+                /// If site once ran a trial WooExpress plan, attempt show IAP if possible.
+                UpgradesViewPresentationCoordinator().presentUpgrades(for: site.siteID, from: baseViewController)
+            } else {
+                /// If the site never ran a WooExpress plan, show the appropriate plans on the web.
+                let controller = UpgradePlanCoordinatingController(siteID: site.siteID, source: .expiredWPComPlanAlert)
+                baseViewController.present(controller, animated: true)
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
@@ -6,7 +6,7 @@ import WordPressUI
 @MainActor
 final class RequirementsCheckerTests: XCTestCase {
 
-    private let freePlan = "free-plan"
+    private let freePlan = "free_plan"
     private var viewController: UINavigationController!
 
     override func setUp() {
@@ -30,17 +30,8 @@ final class RequirementsCheckerTests: XCTestCase {
     func test_checkSiteEligibility_returns_expiredWPComPlan_if_plan_expired() {
         // Given
         let site = Site.fake().copy(siteID: 123, plan: freePlan, wasEcommerceTrial: false)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
         let checker = RequirementsChecker(stores: stores)
-
-        stores.whenReceivingAction(ofType: SettingAction.self) { action in
-            switch action {
-            case .retrieveSiteAPI(_, let completion):
-                completion(.success(SiteAPI(siteID: site.siteID, namespaces: [])))
-            default:
-                break
-            }
-        }
 
         // When
         var checkResult: RequirementCheckResult?
@@ -63,7 +54,7 @@ final class RequirementsCheckerTests: XCTestCase {
     func test_checkSiteEligibility_returns_validWCVersion_if_highest_Woo_version_is_3() {
         // Given
         let site = Site.fake().copy(siteID: 123)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
         let checker = RequirementsChecker(stores: stores)
 
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
@@ -96,7 +87,7 @@ final class RequirementsCheckerTests: XCTestCase {
     func test_checkSiteEligibility_returns_invalidWCVersion_if_highest_Woo_version_is_not_3() {
         // Given
         let site = Site.fake().copy(siteID: 123)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
         let checker = RequirementsChecker(stores: stores)
 
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
@@ -137,7 +128,7 @@ final class RequirementsCheckerTests: XCTestCase {
     func test_checkSiteEligibility_returns_failure_if_site_setting_check_fails() {
         // Given
         let site = Site.fake().copy(siteID: 123)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
         let checker = RequirementsChecker(stores: stores)
 
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
@@ -194,11 +185,10 @@ final class RequirementsCheckerTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
         let checker = RequirementsChecker(stores: stores, baseViewController: viewController)
 
-        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
             switch action {
-            case .loadSiteCurrentPlan(_, let completion):
-                let sitePlan = WPComSitePlan(id: self.freePlan, hasDomainCredit: false)
-                completion(.success(sitePlan))
+            case .retrieveSiteAPI(_, let completion):
+                completion(.success(SiteAPI(siteID: site.siteID, namespaces: [])))
             default:
                 break
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10383 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the `RequirementsChecker` file with the latest updates in #10298:
- With the new fields `plan` and `wasEcommerceTrial` in the `Site` model, we no longer need to fetch site plan separately. The method `checkIfWPComSitePlanExpired` hence was removed.
- The `displayWPComPlanUpgradeAlert` method is updated to make sure that we are showing IAP for sites with expired WooExpress plans if possible (or subscription list otherwise). For sites with expired regular WPCom plans, we are still showing the plans page in web view since the subscription page doesn't show any useful info for these sites.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
 Expired sites are not accessible on the store picker as we are filtering them out. Build and run the code from [this diff](https://github.com/woocommerce/woocommerce-ios/compare/try/allow-ineligible-sites-in-picker?expand=1) to get access to those sites.
- In the store picker, select the expired WooExpress site and tap Continue. 
- You should be navigated to the dashboard screen with an alert saying the site plan has expired.
- If the site ran a WooExpress plan before, the Upgrade button should navigate to the IAP screen if your account is eligible for IAP.
- If the site never ran a WooExpress plan before, the Upgrade button should navigate to the web view with appropriate plans to purchase.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Expired WooExpress plan | Expired regular WPCom plan |
| ----- | ----- |
| https://github.com/woocommerce/woocommerce-ios/assets/5533851/09a12465-d1f3-4f90-bc93-76f849138a4c | https://github.com/woocommerce/woocommerce-ios/assets/5533851/6d8365eb-14c9-4b03-94e2-14ffc602b125 |





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
