### PR TITLE
[Profiler] Challenges question screen UI

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -190,6 +190,7 @@ extension WooAnalyticsEvent.StoreCreation {
         case profilerSellingStatusQuestion = "store_profiler_commerce_journey"
         case profilerSellingPlatformsQuestion = "store_profiler_ecommerce_platforms"
         case profilerCountryQuestion = "store_profiler_country"
+        case profilerChallengesQuestion = "store_profiler_challenges"
         case domainPicker = "domain_picker"
         case storeSummary = "store_summary"
         case planPurchase = "plan_purchase"

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionOptions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension StoreCreationChallengesQuestionViewModel {
     // TODO: 10386 Align with Android and send these via tracks
-    enum Challenge: String, Equatable {
+    enum Challenge: String, CaseIterable {
         case settingUpTheOnlineStore = "setting-up-the-online-store"
         case findingCustomers = "finding-customers"
         case managingInventory = "managing-inventory"
@@ -11,13 +11,7 @@ extension StoreCreationChallengesQuestionViewModel {
     }
 
     var challenges: [Challenge] {
-        [
-            .settingUpTheOnlineStore,
-            .findingCustomers,
-            .managingInventory,
-            .shippingAndLogistics,
-            .other
-        ]
+        Challenge.allCases
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionOptions.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension StoreCreationChallengesQuestionViewModel {
+    // TODO: 10386 Align with Android and send these via tracks
+    enum Challenge: String, Equatable {
+        case settingUpTheOnlineStore = "setting-up-the-online-store"
+        case findingCustomers = "finding-customers"
+        case managingInventory = "managing-inventory"
+        case shippingAndLogistics = "shipping-and-logistics"
+        case other = "other"
+    }
+
+    var challenges: [Challenge] {
+        [
+            .settingUpTheOnlineStore,
+            .findingCustomers,
+            .managingInventory,
+            .shippingAndLogistics,
+            .other
+        ]
+    }
+}
+
+extension StoreCreationChallengesQuestionViewModel.Challenge {
+    var name: String {
+        switch self {
+        case .settingUpTheOnlineStore:
+            return NSLocalizedString("Setting up the online store", comment: "Challenge option in the store creation challenges question.")
+        case .findingCustomers:
+            return NSLocalizedString("Finding customers", comment: "Challenge option in the store creation challenges question.")
+        case .managingInventory:
+            return NSLocalizedString("Managing inventory", comment: "Challenge option in the store creation challenges question.")
+        case .shippingAndLogistics:
+            return NSLocalizedString("Shipping and logistics", comment: "Challenge option in the store creation challenges question.")
+        case .other:
+            return NSLocalizedString("Other", comment: "Challenge option in the store creation challenges question.")
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Hosting controller that wraps the `StoreCreationChallengesQuestionView`.
+final class StoreCreationChallengesQuestionHostingController: UIHostingController<StoreCreationChallengesQuestionView> {
+    init(viewModel: StoreCreationChallengesQuestionViewModel) {
+        super.init(rootView: StoreCreationChallengesQuestionView(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTransparentNavigationBar()
+    }
+}
+
+/// Shows the store challenges question in the store creation flow.
+struct StoreCreationChallengesQuestionView: View {
+    @ObservedObject private var viewModel: StoreCreationChallengesQuestionViewModel
+
+    init(viewModel: StoreCreationChallengesQuestionViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        OptionalStoreCreationProfilerQuestionView(viewModel: viewModel) {
+            VStack(alignment: .leading, spacing: 16) {
+                ForEach(viewModel.challenges, id: \.self) { challenge in
+                    Button(action: {
+                        viewModel.didTapChallenge(challenge)
+                    }, label: {
+                        HStack {
+                            Text(challenge.name)
+                            Spacer()
+                        }
+                    })
+                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedChallenges.contains(where: { $0 == challenge })))
+                }
+            }
+        }
+    }
+}
+
+struct StoreCreationChallengesQuestionView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreCreationChallengesQuestionView(viewModel: .init(onContinue: { _ in },
+                                                             onSkip: {}))
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionViewModel.swift
@@ -1,0 +1,74 @@
+import Combine
+import Foundation
+
+/// Necessary data from the answer of the store creation challenges question.
+struct StoreCreationChallengesAnswer: Equatable {
+    /// Display name of the selected challenge.
+    let name: String
+    /// Raw value of the challenge to be sent to the backend.
+    let value: String
+}
+
+/// View model for `StoreCreationChallengesQuestionView`, an optional profiler question about challenges in the store creation flow.
+@MainActor
+final class StoreCreationChallengesQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
+    typealias Answer = StoreCreationChallengesAnswer
+
+    let topHeader = Localization.topHeader
+
+    let title = Localization.title
+
+    let subtitle = Localization.subtitle
+
+    @Published private(set) var selectedChallenges: [Challenge] = []
+
+    private let onContinue: ([Answer]) -> Void
+    private let onSkip: () -> Void
+
+    init(onContinue: @escaping ([Answer]) -> Void,
+         onSkip: @escaping () -> Void) {
+        self.onContinue = onContinue
+        self.onSkip = onSkip
+    }
+}
+
+extension StoreCreationChallengesQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
+    func continueButtonTapped() async {
+        guard selectedChallenges.isNotEmpty else {
+            return onSkip()
+        }
+
+        onContinue(selectedChallenges.map { .init(name: $0.name, value: $0.rawValue) })
+    }
+
+    func skipButtonTapped() {
+        onSkip()
+    }
+}
+
+extension StoreCreationChallengesQuestionViewModel {
+    func didTapChallenge(_ challenge: Challenge) {
+        if let alreadySelectedIndex = selectedChallenges.firstIndex(of: challenge) {
+            selectedChallenges.remove(at: alreadySelectedIndex)
+        } else {
+            selectedChallenges.append(challenge)
+        }
+    }
+}
+
+private extension StoreCreationChallengesQuestionViewModel {
+    enum Localization {
+        static let topHeader = NSLocalizedString(
+            "About you",
+            comment: "Top header text of the store creation profiler question about the challenges."
+        )
+        static let title = NSLocalizedString(
+            "What challenges you in starting or running an online Store?",
+            comment: "Title of the store creation profiler question about the challenges."
+        )
+        static let subtitle = NSLocalizedString(
+            "Choose your concerns or difficulties below. You can select more than one option.",
+            comment: "Subtitle of the store creation profiler question about the challenges."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -244,6 +244,20 @@ private extension StoreCreationCoordinator {
 
 private extension StoreCreationCoordinator {
     @MainActor
+    func showChallengesQuestion(from navigationController: UINavigationController) {
+        let questionController = StoreCreationChallengesQuestionHostingController(viewModel:
+                .init { _ in
+                    // TODO: 10376 - Navigate to features selection and pass the selected challenges
+                } onSkip: { [weak self] in
+                    guard let self else { return }
+                    self.analytics.track(event: .StoreCreation.siteCreationProfilerQuestionSkipped(step: .profilerChallengesQuestion))
+                    // TODO: 10376 - Navigate to features selection
+                })
+        navigationController.pushViewController(questionController, animated: true)
+        analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerChallengesQuestion))
+    }
+
+    @MainActor
     func showCategoryQuestion(from navigationController: UINavigationController,
                               storeName: String) {
         let questionController = StoreCreationCategoryQuestionHostingController(viewModel:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2308,6 +2308,10 @@
 		EEC5E01129A70CC300416CAC /* StoreSetupProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */; };
 		EECB7EE02862115C0028C888 /* MockProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */; };
 		EECB7EE62864647F0028C888 /* ProductImagesProductIDUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB7EE52864647F0028C888 /* ProductImagesProductIDUpdater.swift */; };
+		EED028642A7AB51500C5DE03 /* StoreCreationChallengesQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED028632A7AB51500C5DE03 /* StoreCreationChallengesQuestionView.swift */; };
+		EED028662A7AB53900C5DE03 /* StoreCreationChallengesQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED028652A7AB53900C5DE03 /* StoreCreationChallengesQuestionViewModel.swift */; };
+		EED028682A7AB56600C5DE03 /* StoreCreationChallengesQuestionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED028672A7AB56600C5DE03 /* StoreCreationChallengesQuestionOptions.swift */; };
+		EED0286A2A7B640300C5DE03 /* StoreCreationChallengesQuestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED028692A7B640300C5DE03 /* StoreCreationChallengesQuestionViewModelTests.swift */; };
 		EEEA41F22869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */; };
 		EEEDA916290A799E004B001D /* WordPressAuthenticator+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEDA915290A799E004B001D /* WordPressAuthenticator+Internal.swift */; };
 		F997170523DBB97500592D8E /* WooCommerceScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997170423DBB97500592D8E /* WooCommerceScreenshots.swift */; };
@@ -4730,6 +4734,10 @@
 		EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSetupProgressView.swift; sourceTree = "<group>"; };
 		EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImageUploader.swift; sourceTree = "<group>"; };
 		EECB7EE52864647F0028C888 /* ProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
+		EED028632A7AB51500C5DE03 /* StoreCreationChallengesQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationChallengesQuestionView.swift; sourceTree = "<group>"; };
+		EED028652A7AB53900C5DE03 /* StoreCreationChallengesQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationChallengesQuestionViewModel.swift; sourceTree = "<group>"; };
+		EED028672A7AB56600C5DE03 /* StoreCreationChallengesQuestionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationChallengesQuestionOptions.swift; sourceTree = "<group>"; };
+		EED028692A7B640300C5DE03 /* StoreCreationChallengesQuestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationChallengesQuestionViewModelTests.swift; sourceTree = "<group>"; };
 		EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
 		EEEDA915290A799E004B001D /* WordPressAuthenticator+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAuthenticator+Internal.swift"; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
@@ -4861,9 +4869,10 @@
 				0201E4262945B01800C793C7 /* StoreCreationProfilerQuestionView.swift */,
 				0201E42C2946C23600C793C7 /* OptionalStoreCreationProfilerQuestionView.swift */,
 				027CB046295D7EF400F98F7C /* RequiredStoreCreationProfilerQuestionView.swift */,
-				0201E42E2946F9F400C793C7 /* Category */,
 				020DD0AD294A069500727BEF /* Selling Status */,
+				0201E42E2946F9F400C793C7 /* Category */,
 				026D4655295D7A380037F59A /* Country */,
+				EED028622A7AB4C800C5DE03 /* Challenges */,
 			);
 			path = Profiler;
 			sourceTree = "<group>";
@@ -4885,6 +4894,7 @@
 				028A4654295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift */,
 				026D464F295C08CA0037F59A /* StoreCreationSellingPlatformsQuestionViewModelTests.swift */,
 				022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */,
+				EED028692A7B640300C5DE03 /* StoreCreationChallengesQuestionViewModelTests.swift */,
 			);
 			path = Profiler;
 			sourceTree = "<group>";
@@ -10707,6 +10717,16 @@
 			path = FirstProductCreated;
 			sourceTree = "<group>";
 		};
+		EED028622A7AB4C800C5DE03 /* Challenges */ = {
+			isa = PBXGroup;
+			children = (
+				EED028632A7AB51500C5DE03 /* StoreCreationChallengesQuestionView.swift */,
+				EED028652A7AB53900C5DE03 /* StoreCreationChallengesQuestionViewModel.swift */,
+				EED028672A7AB56600C5DE03 /* StoreCreationChallengesQuestionOptions.swift */,
+			);
+			path = Challenges;
+			sourceTree = "<group>";
+		};
 		F4B77A83B2A3D94EA331691B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -11776,6 +11796,7 @@
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				CCF4346E290AE1F900B4475A /* ProductsOnboardingAnnouncementCardViewModel.swift in Sources */,
 				0217399E2772FB7E0084CD89 /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
+				EED028642A7AB51500C5DE03 /* StoreCreationChallengesQuestionView.swift in Sources */,
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,
 				EEB4E2DE29B61AAD00371C3C /* CouponInputTransformer.swift in Sources */,
 				035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */,
@@ -12219,6 +12240,7 @@
 				B9E4364C287587D300883CFA /* FeatureAnnouncementCardView.swift in Sources */,
 				267F60132A0C24D700CD1E4E /* PrivacyBannerViewController.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
+				EED028682A7AB56600C5DE03 /* StoreCreationChallengesQuestionOptions.swift in Sources */,
 				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
@@ -12525,6 +12547,7 @@
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
 				02BA53432A380D7D0069224D /* ProductDescriptionAICoordinator.swift in Sources */,
+				EED028662A7AB53900C5DE03 /* StoreCreationChallengesQuestionViewModel.swift in Sources */,
 				FE28F7122684CA29004465C7 /* RoleErrorViewController.swift in Sources */,
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,
 				31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */,
@@ -13139,6 +13162,7 @@
 				02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */,
 				45C8B25B231521510002FA77 /* CustomerNoteTableViewCellTests.swift in Sources */,
 				B5980A6721AC91AA00EBF596 /* BundleWooTests.swift in Sources */,
+				EED0286A2A7B640300C5DE03 /* StoreCreationChallengesQuestionViewModelTests.swift in Sources */,
 				02CA3C9A29F8EB6A0079E2FF /* BottomSheetPresenterTests.swift in Sources */,
 				026D4A24280461960090164F /* LegacyCollectOrderPaymentUseCaseTests.swift in Sources */,
 				D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
@@ -81,23 +81,4 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
             viewModel.skipButtonTapped()
         }
     }
-
-    func test_challenges_are_in_the_expected_order() throws {
-        // Given
-        let viewModel = StoreCreationChallengesQuestionViewModel(onContinue: { _ in },
-                                                               onSkip: {})
-
-        // When
-        let challenges = viewModel.challenges
-
-        // Then
-        XCTAssertEqual(challenges,
-                       [
-                        .settingUpTheOnlineStore,
-                        .findingCustomers,
-                        .managingInventory,
-                        .shippingAndLogistics,
-                        .other
-                       ])
-    }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
@@ -82,7 +82,7 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
         }
     }
 
-    func test_categories_are_in_the_expected_order() throws {
+    func test_challenges_are_in_the_expected_order() throws {
         // Given
         let viewModel = StoreCreationChallengesQuestionViewModel(onContinue: { _ in },
                                                                onSkip: {})

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
@@ -35,7 +35,7 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedChallenges, [.managingInventory])
     }
 
-    func test_continueButtonTapped_invokes_onContinue_after_selecting_a_challenge() throws {
+    func test_continueButtonTapped_invokes_onContinue_after_selecting_challenges() throws {
         let answer = waitFor { promise in
             // Given
             let viewModel = StoreCreationChallengesQuestionViewModel(onContinue: { answer in
@@ -44,6 +44,8 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
                                                                    onSkip: {})
             // When
             viewModel.didTapChallenge(.shippingAndLogistics)
+            viewModel.didTapChallenge(.managingInventory)
+
             Task { @MainActor in
                 await viewModel.continueButtonTapped()
             }
@@ -51,7 +53,9 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(answer, [.init(name: StoreCreationChallengesQuestionViewModel.Challenge.shippingAndLogistics.name,
-                                     value: "shipping-and-logistics")])
+                                     value: "shipping-and-logistics"),
+                                .init(name: StoreCreationChallengesQuestionViewModel.Challenge.managingInventory.name,
+                                                             value: "managing-inventory")])
     }
 
     func test_continueButtonTapped_invokes_onSkip_without_selecting_a_challenge() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import WooCommerce
+
+@MainActor
+final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
+    func test_didTapChallenge_adds_challenge_to_selectedChallenges() throws {
+        // Given
+        let viewModel = StoreCreationChallengesQuestionViewModel(onContinue: { _ in },
+                                                               onSkip: {})
+
+        // When
+        viewModel.didTapChallenge(.shippingAndLogistics)
+        viewModel.didTapChallenge(.managingInventory)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedChallenges, [.shippingAndLogistics, .managingInventory])
+    }
+
+    func test_didTapChallenge_removes_challenge_from_selectedChallenges_if_already_selected() throws {
+        // Given
+        let viewModel = StoreCreationChallengesQuestionViewModel(onContinue: { _ in },
+                                                               onSkip: {})
+
+        // When
+        viewModel.didTapChallenge(.shippingAndLogistics)
+        viewModel.didTapChallenge(.managingInventory)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedChallenges, [.shippingAndLogistics, .managingInventory])
+
+        // When
+        viewModel.didTapChallenge(.shippingAndLogistics)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedChallenges, [.managingInventory])
+    }
+
+    func test_continueButtonTapped_invokes_onContinue_after_selecting_a_challenge() throws {
+        let answer = waitFor { promise in
+            // Given
+            let viewModel = StoreCreationChallengesQuestionViewModel(onContinue: { answer in
+                promise(answer)
+            },
+                                                                   onSkip: {})
+            // When
+            viewModel.didTapChallenge(.shippingAndLogistics)
+            Task { @MainActor in
+                await viewModel.continueButtonTapped()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(answer, [.init(name: StoreCreationChallengesQuestionViewModel.Challenge.shippingAndLogistics.name,
+                                     value: "shipping-and-logistics")])
+    }
+
+    func test_continueButtonTapped_invokes_onSkip_without_selecting_a_challenge() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = StoreCreationChallengesQuestionViewModel(    onContinue: { _ in },
+                                                                   onSkip: {
+                // Then
+                promise(())
+            })
+            // When
+            Task { @MainActor in
+                await viewModel.continueButtonTapped()
+            }
+        }
+    }
+
+    func test_skipButtonTapped_invokes_onSkip() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = StoreCreationChallengesQuestionViewModel(    onContinue: { _ in },
+                                                                   onSkip: {
+                // Then
+                promise(())
+            })
+            // When
+            viewModel.skipButtonTapped()
+        }
+    }
+
+    func test_categories_are_in_the_expected_order() throws {
+        // Given
+        let viewModel = StoreCreationChallengesQuestionViewModel(onContinue: { _ in },
+                                                               onSkip: {})
+
+        // When
+        let challenges = viewModel.challenges
+
+        // Then
+        XCTAssertEqual(challenges,
+                       [
+                        .settingUpTheOnlineStore,
+                        .findingCustomers,
+                        .managingInventory,
+                        .shippingAndLogistics,
+                        .other
+                       ])
+    }
+}


### PR DESCRIPTION
Part of: #10376

## Description
Adds UI code for store creation profiler challenges screen.

## Testing instructions
CI passing is sufficient. We will use this screen in a future PR.

## Screenshots
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-03 at 10 54 49](https://github.com/woocommerce/woocommerce-ios/assets/524475/dba95721-d42b-43cb-b675-a65a5245b8ce)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
