### PR TITLE
Track product list filter tapped/applied events for all sources

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductListFilter.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductListFilter.swift
@@ -1,0 +1,39 @@
+extension WooAnalyticsEvent {
+    enum ProductListFilter {
+        /// Event property keys.
+        private enum Key {
+            static let source = "source"
+            static let filters = "filters"
+        }
+
+        /// Tracked when the user taps on the button to filter products.
+        /// - Parameter source: Source of the product list filter.
+        static func productListViewFilterOptionsTapped(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productListViewFilterOptionsTapped,
+                              properties: [Key.source: source.rawValue])
+        }
+
+        /// Tracked when the user taps on the button to show products after the filters screen.
+        /// - Parameter source: Source of the product list filter.
+        /// - Parameter filters: Filters for the products.
+        static func productFilterListShowProductsButtonTapped(source: Source, filters: FilterProductListViewModel.Filters) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productFilterListShowProductsButtonTapped,
+                              properties: [Key.source: source.rawValue,
+                                           Key.filters: filters.analyticsDescription])
+        }
+    }
+}
+
+extension WooAnalyticsEvent.ProductListFilter {
+    /// Trigger of the product list filter. The raw value is the event property value.
+    enum Source: String {
+        /// From the products tab.
+        case productsTab = "products_tab"
+        /// From order form > add products.
+        case orderForm = "order_form"
+        /// From coupon form > products.
+        case couponForm = "coupon_form"
+        /// From coupon form > usage restrictions > exclude products.
+        case couponRestrictions = "coupon_restrictions"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -298,6 +298,7 @@ struct AddEditCoupon: View {
             }
             .sheet(isPresented: $showingSelectProducts) {
                 ProductSelectorNavigationView(configuration: .productsForCoupons,
+                                              source: .couponForm,
                                               isPresented: $showingSelectProducts,
                                               viewModel: viewModel.productSelectorViewModel)
                     .onDisappear {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -155,6 +155,7 @@ struct CouponRestrictions: View {
             .ignoresSafeArea(.container, edges: [.horizontal])
             .sheet(isPresented: $showingExcludeProducts) {
                 ProductSelectorNavigationView(configuration: .excludedProductsForCoupons,
+                                              source: .couponRestrictions,
                                               isPresented: $showingExcludeProducts,
                                               viewModel: viewModel.productSelectorViewModel)
                     .onDisappear {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -299,6 +299,7 @@ private struct ProductsSection: View {
                     }, content: {
                         ProductSelectorNavigationView(
                             configuration: ProductSelectorView.Configuration.addProductToOrder(),
+                            source: .orderForm,
                             isPresented: $showAddProduct,
                             viewModel: viewModel.createProductSelectorViewModelWithOrderItemsSelected())
                         .onDisappear {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
@@ -3,13 +3,16 @@ import SwiftUI
 /// `ProductSelectorView` wrapped in a SwiftUI navigation view.
 struct ProductSelectorNavigationView: View {
     private let configuration: ProductSelectorView.Configuration
+    private let source: ProductSelectorView.Source
     @Binding private var isPresented: Bool
     private let viewModel: ProductSelectorViewModel
 
     init(configuration: ProductSelectorView.Configuration,
+         source: ProductSelectorView.Source,
          isPresented: Binding<Bool>,
          viewModel: ProductSelectorViewModel) {
         self.configuration = configuration
+        self.source = source
         self._isPresented = isPresented
         self.viewModel = viewModel
     }
@@ -17,6 +20,7 @@ struct ProductSelectorNavigationView: View {
     var body: some View {
         NavigationView {
             ProductSelectorView(configuration: configuration,
+                                source: source,
                                 isPresented: $isPresented,
                                 viewModel: viewModel)
         }
@@ -33,6 +37,6 @@ struct ProductSelectorNavigationView_Previews: PreviewProvider {
             cancelButtonTitle: "Close",
             productRowAccessibilityHint: "Add product to order",
             variableProductRowAccessibilityHint: "Open variation list")
-        ProductSelectorNavigationView(configuration: configuration, isPresented: .constant(true), viewModel: viewModel)
+        ProductSelectorNavigationView(configuration: configuration, source: .orderForm, isPresented: .constant(true), viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -4,8 +4,15 @@ import Yosemite
 /// View showing a list of products to select.
 ///
 struct ProductSelectorView: View {
+    enum Source {
+        case orderForm
+        case couponForm
+        case couponRestrictions
+    }
 
     let configuration: Configuration
+
+    let source: Source
 
     /// Defines whether the view is presented.
     ///
@@ -69,6 +76,7 @@ struct ProductSelectorView: View {
 
                 Button(viewModel.filterButtonTitle) {
                     showingFilters.toggle()
+                    ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: source.filterAnalyticsSource))
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
@@ -161,6 +169,8 @@ struct ProductSelectorView: View {
         .sheet(isPresented: $showingFilters) {
             FilterListView(viewModel: viewModel.filterListViewModel) { filters in
                 viewModel.updateFilters(filters)
+                ServiceLocator.analytics.track(event: .ProductListFilter
+                    .productFilterListShowProductsButtonTapped(source: source.filterAnalyticsSource, filters: filters))
             } onClearAction: {
                 // no-op
             } onDismissAction: {
@@ -237,6 +247,19 @@ private extension ProductSelectorView {
     }
 }
 
+private extension ProductSelectorView.Source {
+    var filterAnalyticsSource: WooAnalyticsEvent.ProductListFilter.Source {
+        switch self {
+            case .orderForm:
+                return .orderForm
+            case .couponForm:
+                return .couponForm
+            case .couponRestrictions:
+                return .couponRestrictions
+        }
+    }
+}
+
 struct AddProduct_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ProductSelectorViewModel(siteID: 123)
@@ -245,6 +268,6 @@ struct AddProduct_Previews: PreviewProvider {
             cancelButtonTitle: "Close",
             productRowAccessibilityHint: "Add product to order",
             variableProductRowAccessibilityHint: "Open variation list")
-        ProductSelectorView(configuration: configuration, isPresented: .constant(true), viewModel: viewModel)
+        ProductSelectorView(configuration: configuration, source: .orderForm, isPresented: .constant(true), viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1071,10 +1071,10 @@ private extension ProductsViewController {
     }
 
     @objc func filterButtonTapped() {
-        ServiceLocator.analytics.track(.productListViewFilterOptionsTapped)
+        ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: .productsTab))
         let viewModel = FilterProductListViewModel(filters: filters, siteID: siteID)
         let filterProductListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in
-            ServiceLocator.analytics.track(.productFilterListShowProductsButtonTapped, withProperties: ["filters": filters.analyticsDescription])
+            ServiceLocator.analytics.track(event: .ProductListFilter.productFilterListShowProductsButtonTapped(source: .productsTab, filters: filters))
             self?.filters = filters
         }, onClearAction: {
             ServiceLocator.analytics.track(.productFilterListClearMenuButtonTapped)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
+		0210D8692A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0210D8682A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift */; };
 		0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252725773F220075AD2A /* Models+Copiable.generated.swift */; };
 		0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */; };
 		0211254125778BDF0075AD2A /* ShippingLabelDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211253F25778BDF0075AD2A /* ShippingLabelDetailsViewController.swift */; };
@@ -2487,6 +2488,7 @@
 		020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
+		0210D8682A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductListFilter.swift"; sourceTree = "<group>"; };
 		0211252725773F220075AD2A /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
 		0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAggregateOrderItem.swift; sourceTree = "<group>"; };
 		0211253F25778BDF0075AD2A /* ShippingLabelDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelDetailsViewController.swift; sourceTree = "<group>"; };
@@ -7844,6 +7846,7 @@
 				EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */,
 				EE486DD12A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift */,
 				DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */,
+				0210D8682A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -12269,6 +12272,7 @@
 				45FDDD65267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift in Sources */,
 				45DB70662614CE3F0064A6CF /* Decimal+Helpers.swift in Sources */,
 				0379C51727BFCE9800A7E284 /* WCPayCardBrand+icons.swift in Sources */,
+				0210D8692A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift in Sources */,
 				B958A7C728B3D44A00823EEF /* UniversalLinkRouter.swift in Sources */,
 				02E8B17C23E2C78A00A43403 /* ProductImageStatus.swift in Sources */,
 				03F5CB832A0C3A1A0026877A /* AnimatedPlaceholder.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We currently track the product list filter tapped/applied events only from the products tab, while the filter CTA is also in the order form, coupon form, and coupon restrictions form. In order to better understand the usage of product list filter in the order form for the extensions project, we'd like to track the same events in the order form > add products. Since the UI component is shared with the coupon form, the events are also tracked for the coupon use cases.

## How

`WooAnalyticsEvent.ProductListFilter` extension was added for the product list filter tapped & applied events. The filter CTA in the product selector for order & coupon forms is in `ProductSelectorView` SwiftUI view, and a new `Source` enum was created that is then mapped to the analytics source value when tracking the 2 events.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Products tab

- Go to the products tab
- Tap `Filter` --> the console should show `🔵 Tracked product_list_view_filter_options_tapped, properties: [AnyHashable("source"): "products_tab", ...]`
- Add some filters if needed
- Tap `Show Products` --> the console should show `🔵 Tracked product_filter_list_show_products_button_tapped, properties: [AnyHashable("source"): "products_tab", AnyHashable("filters"): "*", ...]` and the filtered products should be shown

### Products tab

- Go to the orders tab
- Tap `+` in the navigation bar
- Tap `Add Products`
- Tap `Filter` --> the console should show `🔵 Tracked product_list_view_filter_options_tapped, properties: [AnyHashable("source"): "order_form", ...]`
- Add some filters if needed
- Tap `Show Products` --> the console should show `🔵 Tracked product_filter_list_show_products_button_tapped, properties: [AnyHashable("source"): "order_form", AnyHashable("filters"): "*", ...]` and the filtered products should be shown

---
- [x] @jaclync tests the coupon form CTA
- [x] @jaclync tests the coupon restrictions CTA
- [ ] @jaclync registers the new event properties

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
