### PR TITLE
Product description AI: Show product name as text when not editable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -36,18 +36,23 @@ struct ProductDescriptionGenerationView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: Layout.defaultSpacing) {
 
-                Text(Localization.title)
-                    .headlineStyle()
+                VStack(alignment: .leading, spacing: Layout.titleAndProductNameSpacing) {
+                    Text(Localization.title)
+                        .headlineStyle()
+                    Text(viewModel.name)
+                        .subheadlineStyle()
+                        .renderedIf(viewModel.isProductNameEditable == false)
+                }
 
                 nameTextField
-                    .disabled(viewModel.isProductNameEditable == false)
                     .padding(Layout.productNamePadding)
                     .overlay(
                         RoundedRectangle(cornerRadius: Layout.cornerRadius)
                             .stroke(Color(viewModel.missingName ? .error :
-                                          focusedField == .name ? .accent : .divider))
+                                            focusedField == .name ? .accent : .divider))
                     )
                     .focused($focusedField, equals: .name)
+                    .renderedIf(viewModel.isProductNameEditable)
 
                 // Since there is no placeholder support in `TextEditor`, a workaround is to
                 // use a ZStack with an optional `Text` on top that passes through the gestures.
@@ -183,6 +188,7 @@ private extension ProductDescriptionGenerationView {
     enum Layout {
         static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
         static let defaultSpacing: CGFloat = 16
+        static let titleAndProductNameSpacing: CGFloat = 3
         static let minimuNameEditorSize: CGFloat = 30
         static let minimuEditorSize: CGFloat = 76
         static let cornerRadius: CGFloat = 8


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10407 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a quick update to display product name in the description AI sheet as a text instead of text field when it's not editable.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store.
- Navigate to the Products tab and tap "+" to create a new product.
- Select Write with AI and notice the product name displayed in a text field.
- Publish a new product or open an existing product.
- Select Write with AI and notice the product name displayed in a normal text.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| When editable | When not editable |
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/9b4a61ce-c0be-477f-bb31-fc66863dc3e6" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/730974e7-811d-43a5-af64-cdf63d308c23" width=320 /> |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
