### PR TITLE
[Better Customer Selection] Add pagination to search

### DIFF
--- a/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
+++ b/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
@@ -12,13 +12,20 @@ public class WCAnalyticsCustomerRemote: Remote {
     ///     - pageSize: Number of customers to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func searchCustomers(for siteID: Int64, name: String, filter: String, completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
-        // If there's no search term, we can exit and avoid the HTTP request
-        if name == "" {
-            return
-        }
+    public func searchCustomers(for siteID: Int64,
+                                pageNumber: Int = 1,
+                                pageSize: Int = 25,
+                                keyword: String,
+                                filter: String,
+                                completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.search: keyword,
+            ParameterKey.searchBy: filter
+        ]
 
-        enqueueRequest(with: ["search": name, "searchby": filter], siteID: siteID, completion: completion)
+        enqueueRequest(with: parameters, siteID: siteID, completion: completion)
     }
 
     /// Loads a paginated list of customers
@@ -68,6 +75,7 @@ private extension WCAnalyticsCustomerRemote {
         static let orderBy     = "orderby"
         static let order       = "order"
         static let search      = "search"
+        static let searchBy    = "searchby"
         static let filterEmpty = "filter_empty"
     }
 }

--- a/Networking/NetworkingTests/Remote/WCAnalyticsCustomerRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCAnalyticsCustomerRemoteTests.swift
@@ -33,22 +33,32 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
     func test_WCAnalyticsCustomerRemote_when_calls_searchCustomers_then_returns_parsed_customers_successfully() throws {
         // Given
         let filter = "all"
+        let pageNumber = 1
+        let pageSize = 25
         network.simulateResponse(requestUrlSuffix: "customers", filename: "wc-analytics-customers")
 
         // When
         let result = waitFor { promise in
-            self.remote.searchCustomers(for: self.sampleSiteID, name: self.sampleCustomerName, filter: filter) { result in
+            self.remote.searchCustomers(for: self.sampleSiteID,
+                                        pageNumber: pageNumber,
+                                        pageSize: pageSize,
+                                        keyword: self.sampleCustomerName,
+                                        filter: filter) { result in
                 promise(result)
             }
         }
 
         // Then
         let customers = try XCTUnwrap(result.get())
-        let hasSearchParameter = network.queryParameters?.contains(where: { $0 == "search=John" }) ?? false
+        let hasSearchParameter = network.queryParameters?.contains(where: { $0 == "search=\(sampleCustomerName)" }) ?? false
         let hasSearchByParameter = network.queryParameters?.contains(where: { $0 == "searchby=\(filter)" }) ?? false
+        let hasPageNumberParameter = network.queryParameters?.contains(where: { $0 == "page=\(pageNumber)" }) ?? false
+        let hasPageSizeParameter = network.queryParameters?.contains(where: { $0 == "per_page=\(pageSize)" }) ?? false
 
         XCTAssertTrue(hasSearchParameter)
         XCTAssertTrue(hasSearchByParameter)
+        XCTAssertTrue(hasPageNumberParameter)
+        XCTAssertTrue(hasPageSizeParameter)
 
         assertParsedResultsAreCorrect(with: customers)
     }
@@ -90,7 +100,7 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            self.remote.searchCustomers(for: self.sampleSiteID, name: self.sampleCustomerName, filter: "all") { result in
+            self.remote.searchCustomers(for: self.sampleSiteID, pageNumber: 1, pageSize: 25, keyword: self.sampleCustomerName, filter: "all") { result in
                 promise(result)
             }
         }
@@ -106,7 +116,7 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            self.remote.searchCustomers(for: self.sampleSiteID, name: self.sampleCustomerName, filter: "all") { result in
+            self.remote.searchCustomers(for: self.sampleSiteID, pageNumber: 1, pageSize: 25, keyword: self.sampleCustomerName, filter: "all") { result in
                 promise(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -216,6 +216,8 @@ private extension CustomerSearchUICommand {
         // and retrieve only light data when searching.
         //
         return CustomerAction.searchCustomers(siteID: siteID,
+                                              pageNumber: pageNumber,
+                                              pageSize: pageSize,
                                               keyword: keyword,
                                               retrieveFullCustomersData: !featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder),
                                               filter: searchFilter) { result in

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -26,6 +26,8 @@ public enum CustomerAction: Action {
     /// Searches for Customers by keyword. Currently, only searches by name.
     ///
     ///- `siteID`: The site for which we will perform the search.
+    ///- `pageNumber`: The number of the page you want to load.
+    ///- `pageSize`: The size of the page you want to load.
     ///- `keyword`: Keyword to perform the search.
     ///- `filter`: Filter to perform the search.
     ///- `retrieveFullCustomersData`: If `true`, retrieves all customers data one by one after the search request. It will be removed once
@@ -35,6 +37,8 @@ public enum CustomerAction: Action {
     ///     - `result.failure(Error)`: Error fetching data
     case searchCustomers(
         siteID: Int64,
+        pageNumber: Int,
+        pageSize: Int,
         keyword: String,
         retrieveFullCustomersData: Bool,
         filter: CustomerSearchFilter,

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -47,8 +47,20 @@ public final class CustomerStore: Store {
             return
         }
         switch action {
-        case .searchCustomers(siteID: let siteID, keyword: let keyword, let retrieveFullCustomersData, filter: let filter, onCompletion: let onCompletion):
-            searchCustomers(for: siteID, keyword: keyword, retrieveFullCustomersData: retrieveFullCustomersData, filter: filter, onCompletion: onCompletion)
+        case .searchCustomers(siteID: let siteID,
+                              pageNumber: let pageNumber,
+                              pageSize: let pageSize,
+                              keyword: let keyword,
+                              retrieveFullCustomersData: let retrieveFullCustomersData,
+                              filter: let filter,
+                              onCompletion: let onCompletion):
+            searchCustomers(for: siteID,
+                            pageNumber: pageNumber,
+                            pageSize: pageSize,
+                            keyword: keyword,
+                            retrieveFullCustomersData: retrieveFullCustomersData,
+                            filter: filter,
+                            onCompletion: onCompletion)
         case .retrieveCustomer(siteID: let siteID, customerID: let customerID, onCompletion: let onCompletion):
             retrieveCustomer(for: siteID, with: customerID, onCompletion: onCompletion)
         case .synchronizeLightCustomersData(siteID: let siteID, pageNumber: let pageNumber, pageSize: let pageSize, onCompletion: let onCompletion):
@@ -67,11 +79,17 @@ public final class CustomerStore: Store {
     ///
     func searchCustomers(
         for siteID: Int64,
+        pageNumber: Int,
+        pageSize: Int,
         keyword: String,
         retrieveFullCustomersData: Bool,
         filter: CustomerSearchFilter,
         onCompletion: @escaping (Result<(), Error>) -> Void) {
-            wcAnalyticsCustomerRemote.searchCustomers(for: siteID, name: keyword, filter: filter.rawValue) { [weak self] result in
+            wcAnalyticsCustomerRemote.searchCustomers(for: siteID,
+                                                      pageNumber: pageNumber,
+                                                      pageSize: pageSize,
+                                                      keyword: keyword,
+                                                      filter: filter.rawValue) { [weak self] result in
                 guard let self else { return }
                 switch result {
                 case .success(let customers):

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -137,6 +137,8 @@ final class CustomerStoreTests: XCTestCase {
         let result = waitFor { promise in
             let action = CustomerAction.searchCustomers(
                 siteID: self.dummySiteID,
+                pageNumber: 1,
+                pageSize: 25,
                 keyword: self.dummyKeyword,
                 retrieveFullCustomersData: true,
                 filter: .name) { result in
@@ -161,6 +163,8 @@ final class CustomerStoreTests: XCTestCase {
         // When
         let response = waitFor { promise in
             let action = CustomerAction.searchCustomers(siteID: self.dummySiteID,
+                                                        pageNumber: 1,
+                                                        pageSize: 25,
                                                         keyword: self.dummyKeyword,
                                                         retrieveFullCustomersData: true,
                                                         filter: .name) { result in
@@ -214,6 +218,8 @@ final class CustomerStoreTests: XCTestCase {
         // When
         () = waitFor { promise in
             let action = CustomerAction.searchCustomers(siteID: self.dummySiteID,
+                                                        pageNumber: 1,
+                                                        pageSize: 25,
                                                         keyword: self.dummyKeyword,
                                                         retrieveFullCustomersData: true,
                                                         filter: .name) { result in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10380 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add pagination to the customer search so the results can be shown in batches, lowering the request latency.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With the `betterCustomerSelectionInOrder` feature flag enabled in orders:

1. Go to orders
2. Tap on + to create a new order
3. Tap on + Add customer Details
4. Enter a search term that returns a paginated list with several pages, e.g. only "a"
5. Check that the shown list is paginated and loads the second page (See video)


https://github.com/woocommerce/woocommerce-ios/assets/1864060/233acf15-5ced-49ad-867b-86458e10aa31

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See video above


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
