### PR TITLE
[Better Customer Selection] Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -383,6 +383,7 @@ public enum WooAnalyticsStat: String {
     case orderCreationFailed = "order_creation_failed"
     case orderCreationCustomerAdded = "order_creation_customer_added"
     case orderCreationCustomerSearch = "order_creation_customer_search"
+    case orderCreationCustomerAddManuallyTapped = "order_creation_customer_add_manually_tapped"
     case orderCreationProductSelectorItemSelected = "order_creation_product_selector_item_selected"
     case orderCreationProductSelectorItemUnselected = "order_creation_product_selector_item_unselected"
     case orderCreationProductSelectorConfirmButtonTapped = "order_creation_product_selector_confirm_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -161,6 +161,7 @@ final class CustomerSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Customer, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
+        analytics.track(.orderCreationCustomerAdded)
         onDidSelectSearchResult(model)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -182,6 +182,7 @@ private extension CustomerSearchUICommand {
             details: Localization.emptyDefaultStateMessage,
             buttonTitle: Localization.emptyDefaultStateActionTitle
         ) { [weak self] _ in
+            self?.analytics.track(.orderCreationCustomerAddManuallyTapped)
             self?.onAddCustomerDetailsManually?()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -246,10 +246,6 @@ open class AddressFormViewModel: ObservableObject {
     ///
     let stores: StoresManager
 
-    /// Analytics center.
-    ///
-    let analytics: Analytics
-
     /// Whether the Done button in the navigation bar is always enabled.
     ///
     private let isDoneButtonAlwaysEnabled: Bool
@@ -264,8 +260,7 @@ open class AddressFormViewModel: ObservableObject {
          secondaryAddress: Address? = nil,
          isDoneButtonAlwaysEnabled: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
 
         self.originalAddress = address
@@ -281,7 +276,6 @@ open class AddressFormViewModel: ObservableObject {
 
         self.storageManager = storageManager
         self.stores = stores
-        self.analytics = analytics
 
         // Listen only to the first emitted event.
         onLoadTrigger.first().sink { [weak self] in
@@ -422,7 +416,6 @@ open class AddressFormViewModel: ObservableObject {
     /// Fills Order AddressFormFields with Customer details
     ///
     func customerSelectedFromSearch(customer: Customer) {
-        analytics.track(.orderCreationCustomerAdded)
         fillCustomerFields(customer: customer)
         let addressesDiffer = customer.billing != customer.shipping
         showDifferentAddressForm = addressesDiffer

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -246,6 +246,10 @@ open class AddressFormViewModel: ObservableObject {
     ///
     let stores: StoresManager
 
+    /// Analytics center.
+    ///
+    let analytics: Analytics
+
     /// Whether the Done button in the navigation bar is always enabled.
     ///
     private let isDoneButtonAlwaysEnabled: Bool
@@ -260,7 +264,8 @@ open class AddressFormViewModel: ObservableObject {
          secondaryAddress: Address? = nil,
          isDoneButtonAlwaysEnabled: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
 
         self.originalAddress = address
@@ -276,6 +281,7 @@ open class AddressFormViewModel: ObservableObject {
 
         self.storageManager = storageManager
         self.stores = stores
+        self.analytics = analytics
 
         // Listen only to the first emitted event.
         onLoadTrigger.first().sink { [weak self] in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -701,25 +701,6 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         assertEqual(analyticsProvider.receivedProperties.first?["subject"] as? String, "billing_address")
     }
 
-    func test_view_model_when_customerSelectedFromSearch_then_tracks_orderCreationCustomerAdded() {
-        // Given
-        let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .billing, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
-        let customer = Customer.fake().copy(
-            email: "scrambled@scrambled.com",
-            firstName: "Johnny",
-            lastName: "Appleseed",
-            billing: sampleAddressWithEmptyNullableFields(),
-            shipping: sampleAddressWithEmptyNullableFields()
-        )
-
-        // When
-        viewModel.customerSelectedFromSearch(customer: customer)
-
-        // Then
-        XCTAssert(analyticsProvider.receivedEvents.contains("order_creation_customer_added"))
-    }
-
     func test_view_model_fires_error_notice_when_providing_an_invalid_email() {
         // Given
         let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .billing)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Customer/CustomerSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Customer/CustomerSearchUICommandTests.swift
@@ -74,6 +74,19 @@ final class CustomerSearchUICommandTests: XCTestCase {
         XCTAssert(analyticsProvider.receivedEvents.contains("order_creation_customer_search"))
     }
 
+    func test_didSelectSearchResult_then_tracks_orderCreationCustomerAdded_event() {
+        // Given
+        let command = CustomerSearchUICommand(
+            siteID: sampleSiteID,
+            analytics: analytics) { _ in }
+
+        // When
+        command.didSelectSearchResult(model: Customer.fake(), from: UIViewController(), reloadData: {}, updateActionButton: {})
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains("order_creation_customer_added"))
+    }
+
     func test_synchronizeModels_when_better_customer_selection_is_enabled_and_keyword_is_empty_then_calls_synchronizeAllLightCustomersDataAction() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10314 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add tracking for the better customer selection events.

## Changes
- Track event when the user taps on Add Details Manually
- Track event when the user selects a customer from the search list. Remove that event tracking implementation from `AddressFormViewModel` to avoid sending duplicated events.
- Unit Tests

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With the betterCustomerSelectionInOrder feature flag enabled in orders, and a client with older Woo version:

1. Go to orders
2. Tap on + to create a new order
3. Tap on + Add customer Details
4. Tap on the Add customer details Manually button

This event should be tracked:

`🔵 Tracked order_creation_customer_add_manually_tapped, properties: [AnyHashable("plan"): "business-bundle", AnyHashable("was_ecommerce_trial"): false, AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true]`

5. Search for a customer and select it. This event should be tracked:

`🔵 Tracked order_creation_customer_added, properties: [AnyHashable("plan"): "business-bundle", AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true, AnyHashable("was_ecommerce_trial"): false]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
