### PR TITLE
[Better Customer Selection] Fix Search Logic issues

### DIFF
--- a/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
+++ b/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
@@ -18,12 +18,9 @@ public class WCAnalyticsCustomerRemote: Remote {
                                 keyword: String,
                                 filter: String,
                                 completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
-        let parameters = [
-            ParameterKey.page: String(pageNumber),
-            ParameterKey.perPage: String(pageSize),
-            ParameterKey.search: keyword,
-            ParameterKey.searchBy: filter
-        ]
+        var parameters = coreRequestParameters(from: pageNumber, pageSize: pageSize)
+        parameters[ParameterKey.search] = keyword
+        parameters[ParameterKey.searchBy] = filter
 
         enqueueRequest(with: parameters, siteID: siteID, completion: completion)
     }
@@ -34,18 +31,19 @@ public class WCAnalyticsCustomerRemote: Remote {
                                 pageNumber: Int = 1,
                                 pageSize: Int = 25,
                                 completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
-        let parameters = [
-            ParameterKey.page: String(pageNumber),
+        enqueueRequest(with: coreRequestParameters(from: pageNumber, pageSize: pageSize), siteID: siteID, completion: completion)
+    }
+}
+
+private extension WCAnalyticsCustomerRemote {
+    func coreRequestParameters(from pageNumber: Int = 1, pageSize: Int = 25) -> [String: Any] {
+        [ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.orderBy: "name",
             ParameterKey.order: "asc",
-            ParameterKey.filterEmpty: "email",
-        ]
-
-        enqueueRequest(with: parameters, siteID: siteID, completion: completion)
+            ParameterKey.filterEmpty: "email"]
     }
-
-    private func enqueueRequest(with parameters: [String: Any], siteID: Int64, completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
+    func enqueueRequest(with parameters: [String: Any], siteID: Int64, completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
         let path = "customers"
         let request = JetpackRequest(
             wooApiVersion: .wcAnalytics,

--- a/Networking/NetworkingTests/Remote/WCAnalyticsCustomerRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCAnalyticsCustomerRemoteTests.swift
@@ -54,11 +54,15 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
         let hasSearchByParameter = network.queryParameters?.contains(where: { $0 == "searchby=\(filter)" }) ?? false
         let hasPageNumberParameter = network.queryParameters?.contains(where: { $0 == "page=\(pageNumber)" }) ?? false
         let hasPageSizeParameter = network.queryParameters?.contains(where: { $0 == "per_page=\(pageSize)" }) ?? false
+        let hasOrderByParameter = network.queryParameters?.contains(where: { $0 == "orderby=name" }) ?? false
+        let hasOrderParameter = network.queryParameters?.contains(where: { $0 == "order=asc" }) ?? false
 
         XCTAssertTrue(hasSearchParameter)
         XCTAssertTrue(hasSearchByParameter)
         XCTAssertTrue(hasPageNumberParameter)
         XCTAssertTrue(hasPageSizeParameter)
+        XCTAssertTrue(hasOrderByParameter)
+        XCTAssertTrue(hasOrderParameter)
 
         assertParsedResultsAreCorrect(with: customers)
     }

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -98,7 +98,7 @@ public final class CustomerStore: Store {
                     } else {
                         self.upsertCustomersAndSave(siteID: siteID,
                                              readOnlyCustomers: customers,
-                                             shouldDeleteExistingCustomers: true,
+                                             shouldDeleteExistingCustomers: pageNumber == 1,
                                              keyword: keyword,
                                              in: self.sharedDerivedStorage,
                                              onCompletion: {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix two issues happening with the customer search requests:

- Only remove previous customer search results on the first-page number request, as we don't want to delete results for previous search pages.
- Request search results ordered by ascending name, as we do when loading the full list of customers. Filter by email as well.  Not adding these parameters ends up receiving unexpected results from the backend, that breaks our pagination syncing logic i.e., duplicated results.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With the betterCustomerSelectionInOrder feature flag enabled in orders, and a store with many customers:

1. Go to orders
2. Tap on + to create a new order
3. Tap on + Add customer Details
4. Enter a search term that returns a paginated list with several pages, e.g. only "a"
5. Check that the shown list is paginated and loads multiple pages (See video)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

Only two pages are loaded:

https://github.com/woocommerce/woocommerce-ios/assets/1864060/5fec2e21-a5f7-4fc9-b927-22bdc98021df

### After

Multiple pages are loaded:


https://github.com/woocommerce/woocommerce-ios/assets/1864060/89d023ce-1fd9-46c4-a76b-3b3d41402a79


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
