### PR TITLE
Telemetry: track & send installation date

### DIFF
--- a/Networking/Networking/Remote/TelemetryRemote.swift
+++ b/Networking/Networking/Remote/TelemetryRemote.swift
@@ -11,7 +11,8 @@ public class TelemetryRemote: Remote {
     /// - Parameters:
     ///   - siteID: Site for which we'll fetch the API settings.
     ///   - versionString: App version to report.
-    ///   - installationDate: App installation date if available. If the date is unavailable (e.g. for earlier app versions), the date parameter is not included.
+    ///   - installationDate: App installation date if available. If the date is unavailable (e.g. for earlier app versions), the date
+    ///     parameter is not included.
     ///   - completion: Closure to be executed upon completion.
     ///
     public func sendTelemetry(for siteID: Int64, versionString: String, installationDate: Date?, completion: @escaping (Result<Void, Error>) -> Void) {

--- a/Networking/Networking/Remote/TelemetryRemote.swift
+++ b/Networking/Networking/Remote/TelemetryRemote.swift
@@ -11,14 +11,14 @@ public class TelemetryRemote: Remote {
     /// - Parameters:
     ///   - siteID: Site for which we'll fetch the API settings.
     ///   - versionString: App version to report.
-    ///   - installationDate: App installation date.
+    ///   - installationDate: App installation date if available. If the date is unavailable (e.g. for earlier app versions), the date parameter is not included.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func sendTelemetry(for siteID: Int64, versionString: String, installationDate: Date, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func sendTelemetry(for siteID: Int64, versionString: String, installationDate: Date?, completion: @escaping (Result<Void, Error>) -> Void) {
         let path = "tracker"
         let parameters = ["platform": "ios",
-                          "version": versionString ,
-                          "installation_date": installationDate.ISO8601Format()] as [String: Any]
+                          "version": versionString,
+                          "installation_date": installationDate?.ISO8601Format()].compactMapValues { $0 } as [String: Any]
         let request = JetpackRequest(wooApiVersion: .wcTelemetry,
                                      method: .post,
                                      siteID: siteID,

--- a/Networking/Networking/Remote/TelemetryRemote.swift
+++ b/Networking/Networking/Remote/TelemetryRemote.swift
@@ -11,11 +11,14 @@ public class TelemetryRemote: Remote {
     /// - Parameters:
     ///   - siteID: Site for which we'll fetch the API settings.
     ///   - versionString: App version to report.
+    ///   - installationDate: App installation date.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func sendTelemetry(for siteID: Int64, versionString: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func sendTelemetry(for siteID: Int64, versionString: String, installationDate: Date, completion: @escaping (Result<Void, Error>) -> Void) {
         let path = "tracker"
-        let parameters = ["platform": "ios", "version": versionString]
+        let parameters = ["platform": "ios",
+                          "version": versionString ,
+                          "installation_date": installationDate.ISO8601Format()] as [String: Any]
         let request = JetpackRequest(wooApiVersion: .wcTelemetry,
                                      method: .post,
                                      siteID: siteID,

--- a/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
+++ b/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
@@ -21,6 +21,8 @@ extension MockNetwork {
 
         if let dotcomRequest = request as? DotcomRequest {
             return dotcomRequest.parameters
+        } else if let jetpackRequest = request as? JetpackRequest {
+            return jetpackRequest.parameters
         }
 
         let parameters = urlComponents.queryItems

--- a/Networking/NetworkingTests/Remote/TelemetryRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/TelemetryRemoteTests.swift
@@ -29,7 +29,7 @@ final class TelemetryRemoteTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2") { result in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: nil) { result in
                 promise(result)
             }
         }
@@ -47,7 +47,7 @@ final class TelemetryRemoteTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2") { result in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: nil) { result in
                 promise(result)
             }
         }
@@ -65,7 +65,7 @@ final class TelemetryRemoteTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2") { result in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: nil) { result in
                 promise(result)
             }
         }
@@ -82,12 +82,48 @@ final class TelemetryRemoteTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2") { result in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: nil) { result in
                 promise(result)
             }
         }
 
         // Then
         XCTAssertTrue(result.isFailure)
+    }
+
+    // MARK: - `installation_date` parameter
+
+    func test_sendTelemetry_includes_installation_date_parameter_in_ISO8601_format() throws {
+        // Given
+        let remote = TelemetryRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "tracker", filename: "null-data")
+        // Tuesday, August 8, 2023 3:49:57 AM
+        let installationDate = Date(timeIntervalSince1970: 1691466597)
+
+        // When
+        waitFor { promise in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: installationDate) { result in
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertEqual(network.queryParametersDictionary?["installation_date"] as? String, "2023-08-08T03:49:57Z")
+    }
+
+    func test_sendTelemetry_does_not_include_installation_date_parameter_when_installationDate_is_nil() throws {
+        // Given
+        let remote = TelemetryRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "tracker", filename: "null-data")
+
+        // When
+        waitFor { promise in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: nil) { result in
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertNil(network.queryParametersDictionary?["installation_date"])
     }
 }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -479,6 +479,7 @@ private extension AppDelegate {
             // First run after a fresh install
             ServiceLocator.analytics.track(.applicationInstalled,
                                            withProperties: ["after_abtest_setup": true])
+            UserDefaults.standard[.installationDate] = Date()
         } else if versionOfLastRun != currentVersion {
             // App was upgraded
             ServiceLocator.analytics.track(.applicationUpgraded, withProperties: ["previous_version": versionOfLastRun ?? String()])

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -19,6 +19,7 @@ extension UserDefaults {
         case deviceToken
         case errorLoginSiteAddress
         case hasFinishedOnboarding
+        case installationDate
         case userOptedInAnalytics
         case userOptedInCrashLogging = "userOptedInCrashlytics"
         case versionOfLastRun

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -488,7 +488,9 @@ private extension DefaultStoresManager {
             guard let self = self else { return }
 
             if isAvailable {
-                self.sendTelemetry(siteID: siteID, telemetryLastReportedTime: telemetryLastReportedTime)
+                self.sendTelemetry(siteID: siteID,
+                                   telemetryLastReportedTime: telemetryLastReportedTime,
+                                   installationDate: self.defaults.object(forKey: .installationDate))
             }
         }
         dispatch(checkAvailabilityAction)
@@ -496,10 +498,11 @@ private extension DefaultStoresManager {
 
     /// Sends telemetry data
     ///
-    func sendTelemetry(siteID: Int64, telemetryLastReportedTime: Date?) {
+    func sendTelemetry(siteID: Int64, telemetryLastReportedTime: Date?, installationDate: Date?) {
         let action = TelemetryAction.sendTelemetry(siteID: siteID,
                                                    versionString: UserAgent.bundleShortVersion,
-                                                   telemetryLastReportedTime: telemetryLastReportedTime) { [weak self] result in
+                                                   telemetryLastReportedTime: telemetryLastReportedTime,
+                                                   installationDate: installationDate) { [weak self] result in
             guard let self = self else { return }
 
             switch result {

--- a/Yosemite/Yosemite/Actions/TelemetryAction.swift
+++ b/Yosemite/Yosemite/Actions/TelemetryAction.swift
@@ -8,5 +8,5 @@ public enum TelemetryAction: Action {
 
     /// Sends data to the telemetry endpoint.
     ///
-    case sendTelemetry(siteID: Int64, versionString: String, telemetryLastReportedTime: Date?, onCompletion: (Result<Void, Error>) -> Void)
+    case sendTelemetry(siteID: Int64, versionString: String, telemetryLastReportedTime: Date?, installationDate: Date?, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/TelemetryAction.swift
+++ b/Yosemite/Yosemite/Actions/TelemetryAction.swift
@@ -8,5 +8,9 @@ public enum TelemetryAction: Action {
 
     /// Sends data to the telemetry endpoint.
     ///
-    case sendTelemetry(siteID: Int64, versionString: String, telemetryLastReportedTime: Date?, installationDate: Date?, onCompletion: (Result<Void, Error>) -> Void)
+    case sendTelemetry(siteID: Int64,
+                       versionString: String,
+                       telemetryLastReportedTime: Date?,
+                       installationDate: Date?,
+                       onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/TelemetryStore.swift
+++ b/Yosemite/Yosemite/Stores/TelemetryStore.swift
@@ -28,25 +28,29 @@ public class TelemetryStore: Store {
         }
 
         switch action {
-        case .sendTelemetry(let siteID, let versionString, let telemetryLastReportedTime, let onCompletion):
-            sendTelemetry(siteID: siteID, versionString: versionString, telemetryLastReportedTime: telemetryLastReportedTime, onCompletion: onCompletion)
+        case .sendTelemetry(let siteID, let versionString, let telemetryLastReportedTime, let installationDate, let onCompletion):
+            sendTelemetry(siteID: siteID, versionString: versionString, telemetryLastReportedTime: telemetryLastReportedTime, installationDate: installationDate, onCompletion: onCompletion)
         }
     }
 }
 
 private extension TelemetryStore {
 
-    func sendTelemetry(siteID: Int64, versionString: String, telemetryLastReportedTime: Date?, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func sendTelemetry(siteID: Int64, versionString: String, telemetryLastReportedTime: Date?, installationDate: Date?, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        guard let installationDate else {
+            return onCompletion(.failure(TelemetryError.noInstallationDate))
+        }
         if let telemetryLastReportedTime = telemetryLastReportedTime,
            Date().timeIntervalSince(telemetryLastReportedTime) < minimalIntervalBetweenReports {
             // send telemetry for same store only after timeout
             onCompletion(.failure(TelemetryError.requestThrottled))
             return
         }
-        telemetryRemote.sendTelemetry(for: siteID, versionString: versionString, completion: onCompletion)
+        telemetryRemote.sendTelemetry(for: siteID, versionString: versionString, installationDate: installationDate, completion: onCompletion)
     }
 }
 
 public enum TelemetryError: Error {
     case requestThrottled
+    case noInstallationDate
 }

--- a/Yosemite/Yosemite/Stores/TelemetryStore.swift
+++ b/Yosemite/Yosemite/Stores/TelemetryStore.swift
@@ -36,10 +36,11 @@ public class TelemetryStore: Store {
 
 private extension TelemetryStore {
 
-    func sendTelemetry(siteID: Int64, versionString: String, telemetryLastReportedTime: Date?, installationDate: Date?, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        guard let installationDate else {
-            return onCompletion(.failure(TelemetryError.noInstallationDate))
-        }
+    func sendTelemetry(siteID: Int64,
+                       versionString: String,
+                       telemetryLastReportedTime: Date?,
+                       installationDate: Date?,
+                       onCompletion: @escaping (Result<Void, Error>) -> Void) {
         if let telemetryLastReportedTime = telemetryLastReportedTime,
            Date().timeIntervalSince(telemetryLastReportedTime) < minimalIntervalBetweenReports {
             // send telemetry for same store only after timeout
@@ -52,5 +53,4 @@ private extension TelemetryStore {
 
 public enum TelemetryError: Error {
     case requestThrottled
-    case noInstallationDate
 }

--- a/Yosemite/Yosemite/Stores/TelemetryStore.swift
+++ b/Yosemite/Yosemite/Stores/TelemetryStore.swift
@@ -29,7 +29,11 @@ public class TelemetryStore: Store {
 
         switch action {
         case .sendTelemetry(let siteID, let versionString, let telemetryLastReportedTime, let installationDate, let onCompletion):
-            sendTelemetry(siteID: siteID, versionString: versionString, telemetryLastReportedTime: telemetryLastReportedTime, installationDate: installationDate, onCompletion: onCompletion)
+            sendTelemetry(siteID: siteID,
+                          versionString: versionString,
+                          telemetryLastReportedTime: telemetryLastReportedTime,
+                          installationDate: installationDate,
+                          onCompletion: onCompletion)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/TelemetryStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/TelemetryStoreTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 /// TelemetryStore Unit Tests
 ///
-class TelemetryStoreTests: XCTestCase {
+final class TelemetryStoreTests: XCTestCase {
 
     /// Mock Dispatcher!
     ///
@@ -40,7 +40,10 @@ class TelemetryStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = TelemetryAction.sendTelemetry(siteID: self.sampleSiteID, versionString: "1.2", telemetryLastReportedTime: nil) { result in
+            let action = TelemetryAction.sendTelemetry(siteID: self.sampleSiteID,
+                                                       versionString: "1.2",
+                                                       telemetryLastReportedTime: nil,
+                                                       installationDate: nil) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -57,7 +60,10 @@ class TelemetryStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = TelemetryAction.sendTelemetry(siteID: self.sampleSiteID, versionString: "1.2", telemetryLastReportedTime: time) { result in
+            let action = TelemetryAction.sendTelemetry(siteID: self.sampleSiteID,
+                                                       versionString: "1.2",
+                                                       telemetryLastReportedTime: time,
+                                                       installationDate: nil) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -74,7 +80,10 @@ class TelemetryStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = TelemetryAction.sendTelemetry(siteID: self.sampleSiteID, versionString: "1.2", telemetryLastReportedTime: nil) { result in
+            let action = TelemetryAction.sendTelemetry(siteID: self.sampleSiteID,
+                                                       versionString: "1.2",
+                                                       telemetryLastReportedTime: nil,
+                                                       installationDate: nil) { result in
                 promise(result)
             }
             store.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10406
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The app has been sending the app version to WCTracker via the telemetry endpoint, and now we want to also send the installation date (Anitaa's reasons in pdND4G-fl-p2#comment-181).

## How

- In the Networking layer, `installationDate: Date?` parameter was added to `TelemetryRemote.sendTelemetry` to be sent as an ISO 8601 date string. Similar in the Yosemite layer for `TelemetryAction.sendTelemetry`. It's optional for merchants who installed the app in previous versions without an installation date
- In the app layer, the installation date is tracked in UserDefaults with a new key `installationDate` [when the app is installed](https://href.li/?https://github.com/woocommerce/woocommerce-ios/blob/238e245ab3222cb49367b98c5201812ba71b924e/WooCommerce/Classes/AppDelegate.swift#L480). It's then retrieved from UserDefaults when the usage data is sent to the Telemetry endpoint

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

🗒️ Currently, the telemetry data are only sent once per day. For easier testing, you can comment out [these lines](https://github.com/woocommerce/woocommerce-ios/blob/d3797dde8d0b51a22fd7d5cbc8b405475a015293/Yosemite/Yosemite/Stores/TelemetryStore.swift#L40-L45) so that the request is always made.

### App installed from an earlier version

- Install the app from `trunk` or any other branch, if needed
- Launch the app from the PR branch
- Log in if needed
- Go to the Menu tab > Settings > Launch Wormholy Debug --> there should be a POST request to the site (`https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{{siteID}}/rest-api/`) with 200 status. After decoding the request body, it should include `path: wc-telemetry/tracker`, `platform: ios`, and `version: 14.8` without `installation_date`

### Fresh install

- Delete the app
- Install the app from the PR branch
- Log in to a store
- Go to the Menu tab > Settings > Launch Wormholy Debug --> there should be a POST request to the site (`https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{{siteID}}/rest-api/`) with 200 status. After decoding the request body, it should include `path: wc-telemetry/tracker`, `platform: ios`, `version: 14.8`, and `installation_date` like `2023-08-08T03:38:50Z`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.