### PR TITLE
[Better Customer Selection] Show ghost animation when all customers are loading

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -90,7 +90,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .ordersWithCouponsM4:
             return true
         case .betterCustomerSelectionInOrder:
-            return true
+            return false
         case .optimizeProfilerQuestions:
             return false
         default:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -164,11 +164,16 @@ final class CustomerSearchUICommand: SearchUICommand {
         let action: CustomerAction
         if featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder),
            keyword.isEmpty {
-            if pageNumber == 1 {
-                onDidStartSyncingAllCustomersFirstPage?()
-            }
+            if syncResultsWhenSearchQueryTurnsEmpty {
+                if pageNumber == 1 {
+                    onDidStartSyncingAllCustomersFirstPage?()
+                }
 
-            action = synchronizeAllLightCustomersDataAction(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+                action = synchronizeAllLightCustomersDataAction(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+            } else {
+                // As we don't have to show anything if the search query is empty, let's reset the customers database
+                action = .deleteAllCustomers(siteID: siteID, onCompletion: { onCompletion?(true) })
+            }
         } else {
             action = searchCustomersAction(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -26,9 +26,9 @@ final class CustomerSearchUICommand: SearchUICommand {
 
     var onDidSelectSearchResult: ((Customer) -> Void)
 
-    var onDidStartSyncingAllCustomers: (() -> Void)?
+    var onDidStartSyncingAllCustomersFirstPage: (() -> Void)?
 
-    var onDidFinishSyncingAllCustomers: (() -> Void)?
+    var onDidFinishSyncingAllCustomersFirstPage: (() -> Void)?
 
     var onAddCustomerDetailsManually: (() -> Void)?
 
@@ -56,8 +56,8 @@ final class CustomerSearchUICommand: SearchUICommand {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          onAddCustomerDetailsManually: (() -> Void)? = nil,
          onDidSelectSearchResult: @escaping ((Customer) -> Void),
-         onDidStartSyncingAllCustomers: (() -> Void)? = nil,
-         onDidFinishSyncingAllCustomers: (() -> Void)? = nil) {
+         onDidStartSyncingAllCustomersFirstPage: (() -> Void)? = nil,
+         onDidFinishSyncingAllCustomersFirstPage: (() -> Void)? = nil) {
         self.siteID = siteID
         self.loadResultsWhenSearchTermIsEmpty = loadResultsWhenSearchTermIsEmpty
         self.showSearchFilters = showSearchFilters
@@ -66,8 +66,8 @@ final class CustomerSearchUICommand: SearchUICommand {
         self.featureFlagService = featureFlagService
         self.onAddCustomerDetailsManually = onAddCustomerDetailsManually
         self.onDidSelectSearchResult = onDidSelectSearchResult
-        self.onDidStartSyncingAllCustomers = onDidStartSyncingAllCustomers
-        self.onDidFinishSyncingAllCustomers = onDidFinishSyncingAllCustomers
+        self.onDidStartSyncingAllCustomersFirstPage = onDidStartSyncingAllCustomersFirstPage
+        self.onDidFinishSyncingAllCustomersFirstPage = onDidFinishSyncingAllCustomersFirstPage
     }
 
     var hideCancelButton: Bool {
@@ -164,7 +164,10 @@ final class CustomerSearchUICommand: SearchUICommand {
         let action: CustomerAction
         if featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder),
            keyword.isEmpty {
-            onDidStartSyncingAllCustomers?()
+            if pageNumber == 1 {
+                onDidStartSyncingAllCustomersFirstPage?()
+            }
+
             action = synchronizeAllLightCustomersDataAction(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         } else {
             action = searchCustomersAction(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
@@ -215,7 +218,9 @@ private extension CustomerSearchUICommand {
                 DDLogError("Customer Search Failure \(error)")
             }
 
-            self?.onDidFinishSyncingAllCustomers?()
+            if pageNumber == 1 {
+                self?.onDidFinishSyncingAllCustomersFirstPage?()
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -131,12 +131,12 @@ private extension CustomerSelectorViewController {
                                              showSearchFilters: showSearchFilters,
                                              onAddCustomerDetailsManually: onAddCustomerDetailsManually,
                                              onDidSelectSearchResult: onCustomerTapped,
-                                             onDidStartSyncingAllCustomers: {
+                                             onDidStartSyncingAllCustomersFirstPage: {
                                                  Task { @MainActor [weak self] in
                                                      self?.displayGhostContent()
                                                  }
                                              },
-                                             onDidFinishSyncingAllCustomers: {
+                                             onDidFinishSyncingAllCustomersFirstPage: {
                                                  Task { @MainActor [weak self] in
                                                      self?.removeGhostContent()
                                                  }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -129,7 +129,17 @@ private extension CustomerSelectorViewController {
                                              loadResultsWhenSearchTermIsEmpty: loadResultsWhenSearchTermIsEmpty,
                                              showSearchFilters: showSearchFilters,
                                              onAddCustomerDetailsManually: onAddCustomerDetailsManually,
-                                             onDidSelectSearchResult: onCustomerTapped),
+                                             onDidSelectSearchResult: onCustomerTapped,
+                                             onDidStartSyncingAllCustomers: {
+                                                 Task { @MainActor [weak self] in
+                                                     self?.displayGhostContent()
+                                                 }
+                                             },
+                                             onDidFinishSyncingAllCustomers: {
+                                                 Task { @MainActor [weak self] in
+                                                     self?.removeGhostContent()
+                                                 }
+                                             }),
             cellType: TitleAndSubtitleAndStatusTableViewCell.self,
             cellSeparator: .none
         )

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -7,7 +7,7 @@ import Yosemite
 /// Shows a paginated and searchable list of customers, that can be selected
 ///
 final class CustomerSelectorViewController: UIViewController, GhostableViewController {
-    private var searchViewController: UIViewController?
+    private var searchViewController: SearchViewController<UnderlineableTitleAndSubtitleAndDetailTableViewCell, CustomerSearchUICommand>?
     private var emptyStateViewController: UIViewController?
     private let siteID: Int64
     private let onCustomerSelected: (Customer) -> Void
@@ -133,7 +133,10 @@ private extension CustomerSelectorViewController {
                                              onDidSelectSearchResult: onCustomerTapped,
                                              onDidStartSyncingAllCustomersFirstPage: {
                                                  Task { @MainActor [weak self] in
-                                                     self?.displayGhostContent()
+                                                     guard let searchTableView = self?.searchViewController?.tableView else {
+                                                         return
+                                                     }
+                                                     self?.displayGhostContent(over: searchTableView)
                                                  }
                                              },
                                              onDidFinishSyncingAllCustomersFirstPage: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -25,7 +25,8 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
         return indicator
     }()
 
-    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: TitleAndSubtitleAndStatusTableViewCell.self))
+    lazy var ghostTableViewController = GhostTableViewController(options:
+                                                                    GhostTableViewOptions(cellClass: UnderlineableTitleAndSubtitleAndDetailTableViewCell.self))
 
     init(siteID: Int64,
          addressFormViewModel: CreateOrderAddressFormViewModel,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
@@ -90,7 +90,7 @@ private extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
     }
 
     func configureBackground() {
-        backgroundColor = .listForeground(modal: false)
+        applyDefaultBackgroundStyle()
         selectedBackgroundView = UIView()
         selectedBackgroundView?.backgroundColor = .listBackground
     }

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -30,7 +30,7 @@ where Cell.SearchModel == Command.CellViewModel {
 
     /// TableView
     ///
-    @IBOutlet private var tableView: UITableView!
+    @IBOutlet var tableView: UITableView!
 
 
     @IBOutlet private weak var bordersView: BordersView!

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Customer/CustomerSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Customer/CustomerSearchUICommandTests.swift
@@ -87,11 +87,12 @@ final class CustomerSearchUICommandTests: XCTestCase {
         XCTAssert(analyticsProvider.receivedEvents.contains("order_creation_customer_added"))
     }
 
-    func test_synchronizeModels_when_better_customer_selection_is_enabled_and_keyword_is_empty_then_calls_synchronizeAllLightCustomersDataAction() {
+    func test_synchronizeModels_when_and_keyword_is_empty_and_loadResultsWhenSearchTermIsEmpty_is_true_then_calls_synchronizeAllLightCustomersDataAction() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         // Given
         let command = CustomerSearchUICommand(siteID: sampleSiteID,
+                                              loadResultsWhenSearchTermIsEmpty: true,
                                               stores: stores,
                                               featureFlagService: MockFeatureFlagService(betterCustomerSelectionInOrder: true)) { _ in }
 
@@ -102,6 +103,35 @@ final class CustomerSearchUICommandTests: XCTestCase {
             }
             invocationCount += 1
             onCompletion(.success(true))
+        }
+
+        // When
+        waitFor { promise in
+            command.synchronizeModels(siteID: self.sampleSiteID, keyword: "", pageNumber: 1, pageSize: 10) { _ in
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertEqual(invocationCount, 1)
+    }
+
+    func test_synchronizeModels_when_and_keyword_is_empty_and_loadResultsWhenSearchTermIsEmpty_is_false_then_calls_deleteAllCustomers() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        // Given
+        let command = CustomerSearchUICommand(siteID: sampleSiteID,
+                                              loadResultsWhenSearchTermIsEmpty: false,
+                                              stores: stores,
+                                              featureFlagService: MockFeatureFlagService(betterCustomerSelectionInOrder: true)) { _ in }
+
+        var invocationCount = 0
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case let .deleteAllCustomers(_, onCompletion) = action else {
+                return XCTFail("Unexpected action: \(action)")
+            }
+            invocationCount += 1
+            onCompletion()
         }
 
         // When

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -299,7 +299,7 @@ public extension UIColor {
         return .systemColor(.systemGray3)
     }
 
-    /// Ghost cell animation end color. `Gray-5` (Light Mode) and Gray-10 (Dark Mode)
+    /// Ghost cell animation end color. `Gray-6` (Light Mode) and `Gray-4` (Dark Mode)
     ///
     static var ghostCellAnimationEndColor: UIColor {
         return UIColor(light: .systemColor(.systemGray6),

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -303,7 +303,7 @@ public extension UIColor {
     ///
     static var ghostCellAnimationEndColor: UIColor {
         return UIColor(light: .systemColor(.systemGray6),
-                       dark: .systemColor(.systemGray5))
+                       dark: .systemColor(.systemGray4))
     }
 
     /// Rating star filled color.

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -55,4 +55,11 @@ public enum CustomerAction: Action {
         siteID: Int64,
         customerID: Int64,
         onCompletion: (Result<Customer, Error>) -> Void)
+
+
+    /// Deletes all customers for the given site
+    ///
+    ///- `siteID`: The site for which customers should be delete.
+    ///- `onCompletion`: Invoked when the operation finishes.
+    case deleteAllCustomers(siteID: Int64, onCompletion: () -> Void)
 }

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -65,6 +65,8 @@ public final class CustomerStore: Store {
             retrieveCustomer(for: siteID, with: customerID, onCompletion: onCompletion)
         case .synchronizeLightCustomersData(siteID: let siteID, pageNumber: let pageNumber, pageSize: let pageSize, onCompletion: let onCompletion):
             synchronizeLightCustomersData(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .deleteAllCustomers(siteID: let siteID, onCompletion: let onCompletion):
+            deleteAllCustomers(from: siteID, onCompletion: onCompletion)
         }
     }
 
@@ -150,6 +152,16 @@ public final class CustomerStore: Store {
             case .failure(let error):
                 onCompletion(.failure(error))
             }
+        }
+    }
+
+    func deleteAllCustomers(from siteID: Int64, onCompletion: @escaping () -> Void) {
+        sharedDerivedStorage.perform { [weak self] in
+            self?.sharedDerivedStorage.deleteCustomers(siteID: siteID)
+        }
+
+        storageManager.saveDerivedType(derivedStorage: sharedDerivedStorage) {
+            DispatchQueue.main.async(execute: onCompletion)
         }
     }
 

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -159,6 +159,16 @@ extension MockStorageManager {
         return newCoupon
     }
 
+    /// Inserts a new (Sample) Customer into the specified context.
+    ///
+    @discardableResult
+    func insertSampleCustomer(readOnlyCustomer: Customer) -> StorageCustomer {
+        let newCustomer = viewStorage.insertNewObject(ofType: StorageCustomer.self)
+        newCustomer.update(with: readOnlyCustomer)
+
+        return newCustomer
+    }
+
     /// Inserts a new (Sample) site into the specified context.
     ///
     @discardableResult

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -234,4 +234,25 @@ final class CustomerStoreTests: XCTestCase {
             request.path == "customers/0"
         }))
     }
+
+    func test_deleteAllCustomers() {
+        let customer = Customer.fake().copy(siteID: dummySiteID)
+        storageManager.insertSampleCustomer(readOnlyCustomer: customer)
+        let customersBeforeDeleting = viewStorage.allObjects(ofType: Storage.Customer.self, matching: nil, sortedBy: nil)
+
+        XCTAssertEqual(customersBeforeDeleting.count, 1)
+
+        // When
+        () = waitFor { promise in
+            let action = CustomerAction.deleteAllCustomers(siteID: self.dummySiteID) {
+                promise(())
+            }
+
+            self.dispatcher.dispatch(action)
+        }
+
+        let customersAfterDeleting = viewStorage.allObjects(ofType: Storage.Customer.self, matching: nil, sortedBy: nil)
+
+        XCTAssertEqual(customersAfterDeleting.count, 0)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10364 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With this PR we show a ghost-loading animation when the search is syncing/reset all items. While there's still a small glitch after the ghost-loading is dismissed by replacing the old search results with the new, I think this PR solution is a good trade-off, as It improves the flow: we communicate that we are loading new items. Trying to dismiss the loading animation once the UI is totally reloaded would require more effort which is not fully justified by the impact it achieves.

Furthermore, we change here the animation values of the ghost animation to make the labels lighter in dark mode, otherwise, as the color was so similar to the background, the animation was not discernable. As the other cells backgrounds are even darker, the animation is still (even more) visible elsewhere.

Apart from that, we handle the case for older Woo clients that don't support syncing all customers when the search term is empty by deleting all customers in the database, so nothing can be shown.


<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Enable the feature flag betterCustomerSelectionInOrder in DefaultFeatureFlagService

1. Go to Orders
2. Tap on + to add a new order
3. Tap on + Add Customer Details
4. Perform a search. Wait until the results are loaded
5. Reset the search by deleting the search term from the search bar. See how the ghost-loading animation is shown
6. See how the ghost-loading animation is dismissed once the results are shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/d9ea5587-64f5-4eec-ac67-19a4aaac4f92

### Ghost Animation Dark mode, Before (Not visible)

https://github.com/woocommerce/woocommerce-ios/assets/1864060/b08d7a52-1503-4c8b-a224-be06de2f2986

### Ghost Animation Dark mode, After (Visible)


https://github.com/woocommerce/woocommerce-ios/assets/1864060/47d4b2dd-d003-46e0-80f9-b213c82fba9f

### Ghost Animation Dark mode, in Coupons. (It works as expected)


https://github.com/woocommerce/woocommerce-ios/assets/1864060/37f84e09-c04e-4129-ac9c-5fb3e848d167


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
