### PR TITLE
Profiler: Split country question into 2 screens

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -21,6 +21,8 @@ final class StoreCreationCountryQuestionHostingController: UIHostingController<S
 /// Shows the store country question in the store creation flow.
 struct StoreCreationCountryQuestionView: View {
     @StateObject private var viewModel: StoreCreationCountryQuestionViewModel
+    @State private var isShowingCountryList = false
+    @State private var searchText = ""
 
     init(viewModel: StoreCreationCountryQuestionViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
@@ -28,15 +30,73 @@ struct StoreCreationCountryQuestionView: View {
 
     var body: some View {
         RequiredStoreCreationProfilerQuestionView(viewModel: viewModel) {
-            VStack(spacing: 32) {
-                if let currentCountryCode = viewModel.currentCountryCode {
-                    StoreCreationCountrySectionView(header: Localization.currentLocationHeader,
-                                                    countryCodes: [currentCountryCode],
-                                                    viewModel: viewModel)
+            VStack(alignment: .leading, spacing: 8) {
+                Button(action: {
+                    isShowingCountryList = true
+                }, label: {
+                    HStack(spacing: 16) {
+                        if let flagEmoji = viewModel.currentCountryCode?.flagEmoji {
+                            Text(flagEmoji)
+                        }
+                        Text(viewModel.currentCountryCode?.readableCountry ?? Localization.selectCountry)
+                            .bodyStyle()
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .secondaryBodyStyle()
+                    }
+                })
+                .buttonStyle(SelectableSecondaryButtonStyle(isSelected: false))
+
+                Text(Localization.preselected)
+                    .footnoteStyle()
+                    .renderedIf(viewModel.currentCountryCode != nil)
+            }
+        }
+        .sheet(isPresented: $isShowingCountryList) {
+            countryList
+        }
+    }
+
+    @ViewBuilder
+    var countryList: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 32) {
+                    TextField(text: $searchText, prompt: Text(Localization.search)) {
+                        Image(systemName: "magnifyingglass")
+                    }
+                    if searchText.isNotEmpty {
+                        let results = viewModel.countryCodes.filter {
+                            $0.readableCountry.contains(searchText)
+                        }
+                        if results.isNotEmpty {
+                            StoreCreationCountrySectionView(header: Localization.searchResults.capitalized,
+                                                            countryCodes: results,
+                                                            viewModel: viewModel)
+                        } else {
+                            Text(Localization.noResults)
+                        }
+                    } else {
+                        if let currentCountryCode = viewModel.currentCountryCode {
+                            StoreCreationCountrySectionView(header: Localization.currentLocationHeader,
+                                                            countryCodes: [currentCountryCode],
+                                                            viewModel: viewModel)
+                        }
+                        StoreCreationCountrySectionView(header: Localization.otherCountriesHeader,
+                                                        countryCodes: viewModel.countryCodes,
+                                                        viewModel: viewModel)
+                    }
                 }
-                StoreCreationCountrySectionView(header: Localization.otherCountriesHeader,
-                                                countryCodes: viewModel.countryCodes,
-                                                viewModel: viewModel)
+                .padding(16)
+            }
+            .navigationTitle(Localization.selectCountry)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        isShowingCountryList = false
+                    }
+                }
             }
         }
     }
@@ -50,6 +110,30 @@ private extension StoreCreationCountryQuestionView {
         static let otherCountriesHeader = NSLocalizedString(
             "COUNTRIES",
             comment: "Header of a list of other countries in the store creation country question.")
+        static let searchResults = NSLocalizedString(
+            "Search results",
+            comment: "Header of the search results in the store creation country question."
+        )
+        static let selectCountry = NSLocalizedString(
+            "Select country",
+            comment: "Button to open the list of country to select for store creation profiler"
+        )
+        static let preselected = NSLocalizedString(
+            "We’ve preselected your location. Please change it here if it's incorrect.",
+            comment: "Label about preselected country in the store creation country question."
+        )
+        static let search = NSLocalizedString(
+            "Search",
+            comment: "Placeholder in the country search field in store creation profiler."
+        )
+        static let noResults = NSLocalizedString(
+            "No Results",
+            comment: "Text displayed when no countries are found upon filtering the country list in store creation profiler."
+        )
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Button to dismiss the country search view in the store creation profiler"
+        )
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -47,7 +47,7 @@ struct StoreCreationCountryQuestionView: View {
 
                 Text(Localization.preselected)
                     .footnoteStyle()
-                    .renderedIf(viewModel.currentCountryCode != nil)
+                    .renderedIf(viewModel.currentCountryCode == viewModel.selectedCountryCode)
             }
         }
         .sheet(isPresented: $isShowingCountryList) {

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -30,11 +30,11 @@ struct StoreCreationCountryQuestionView: View {
 
     var body: some View {
         RequiredStoreCreationProfilerQuestionView(viewModel: viewModel) {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: Layout.mainScreenSpacing) {
                 Button(action: {
                     isShowingCountryList = true
                 }, label: {
-                    HStack(spacing: 16) {
+                    HStack(spacing: Layout.mainScreenFlagSpacing) {
                         viewModel.selectedCountryCode?.flagEmoji.map(Text.init)
                         Text(viewModel.selectedCountryCode?.readableCountry ?? Localization.selectCountry)
                             .bodyStyle()
@@ -59,7 +59,7 @@ struct StoreCreationCountryQuestionView: View {
     var countryList: some View {
         NavigationView {
             ScrollView {
-                VStack(spacing: 32) {
+                VStack(spacing: Layout.listScreenSpacing) {
                     // Search bar
                     HStack {
                         Image(systemName: "magnifyingglass")
@@ -67,9 +67,9 @@ struct StoreCreationCountryQuestionView: View {
                         TextField(Localization.search, text: $searchText)
                             .bodyStyle()
                     }
-                    .padding(8)
+                    .padding(Layout.searchBarPadding)
                     .background(
-                        RoundedRectangle(cornerRadius: 8)
+                        RoundedRectangle(cornerRadius: Layout.searchBarCornerRadius)
                             .foregroundColor(.init(uiColor: .tertiarySystemFill))
                     )
                     if searchText.isNotEmpty {
@@ -99,7 +99,7 @@ struct StoreCreationCountryQuestionView: View {
                                                         viewModel: viewModel)
                     }
                 }
-                .padding(16)
+                .padding(Layout.listScreenPadding)
             }
             .navigationTitle(Localization.selectCountry)
             .navigationBarTitleDisplayMode(.inline)
@@ -120,6 +120,14 @@ struct StoreCreationCountryQuestionView: View {
 }
 
 private extension StoreCreationCountryQuestionView {
+    enum Layout {
+        static let mainScreenSpacing: CGFloat = 12
+        static let mainScreenFlagSpacing: CGFloat = 16
+        static let listScreenSpacing: CGFloat = 32
+        static let listScreenPadding: CGFloat = 16
+        static let searchBarPadding: CGFloat = 8
+        static let searchBarCornerRadius: CGFloat = 8
+    }
     enum Localization {
         static let currentLocationHeader = NSLocalizedString(
             "CURRENT LOCATION",

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -35,10 +35,8 @@ struct StoreCreationCountryQuestionView: View {
                     isShowingCountryList = true
                 }, label: {
                     HStack(spacing: 16) {
-                        if let flagEmoji = viewModel.currentCountryCode?.flagEmoji {
-                            Text(flagEmoji)
-                        }
-                        Text(viewModel.currentCountryCode?.readableCountry ?? Localization.selectCountry)
+                        viewModel.selectedCountryCode?.flagEmoji.map(Text.init)
+                        Text(viewModel.selectedCountryCode?.readableCountry ?? Localization.selectCountry)
                             .bodyStyle()
                         Spacer()
                         Image(systemName: "chevron.right")
@@ -62,6 +60,7 @@ struct StoreCreationCountryQuestionView: View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 32) {
+                    // Search bar
                     HStack {
                         Image(systemName: "magnifyingglass")
                             .secondaryBodyStyle()
@@ -74,18 +73,22 @@ struct StoreCreationCountryQuestionView: View {
                             .foregroundColor(.init(uiColor: .tertiarySystemFill))
                     )
                     if searchText.isNotEmpty {
+                        // Search mode
                         let results = viewModel.countryCodes.filter {
                             $0.readableCountry.contains(searchText)
                         }
                         if results.isNotEmpty {
+                            // Search results
                             StoreCreationCountrySectionView(header: Localization.searchResults.uppercased(),
                                                             countryCodes: results,
                                                             viewModel: viewModel)
                         } else {
+                            // No results
                             Text(Localization.noResults)
                                 .secondaryBodyStyle()
                         }
                     } else {
+                        // Country list in normal mode
                         if let currentCountryCode = viewModel.currentCountryCode {
                             StoreCreationCountrySectionView(header: Localization.currentLocationHeader,
                                                             countryCodes: [currentCountryCode],

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -115,6 +115,9 @@ struct StoreCreationCountryQuestionView: View {
                     isShowingCountryList = false
                 }
             }
+            .onDisappear {
+                searchText = ""
+            }
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -30,7 +30,7 @@ struct StoreCreationCountryQuestionView: View {
 
     var body: some View {
         RequiredStoreCreationProfilerQuestionView(viewModel: viewModel) {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 16) {
                 Button(action: {
                     isShowingCountryList = true
                 }, label: {
@@ -62,19 +62,28 @@ struct StoreCreationCountryQuestionView: View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 32) {
-                    TextField(text: $searchText, prompt: Text(Localization.search)) {
+                    HStack {
                         Image(systemName: "magnifyingglass")
+                            .secondaryBodyStyle()
+                        TextField(Localization.search, text: $searchText)
+                            .bodyStyle()
                     }
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .foregroundColor(.init(uiColor: .tertiarySystemFill))
+                    )
                     if searchText.isNotEmpty {
                         let results = viewModel.countryCodes.filter {
                             $0.readableCountry.contains(searchText)
                         }
                         if results.isNotEmpty {
-                            StoreCreationCountrySectionView(header: Localization.searchResults.capitalized,
+                            StoreCreationCountrySectionView(header: Localization.searchResults.uppercased(),
                                                             countryCodes: results,
                                                             viewModel: viewModel)
                         } else {
                             Text(Localization.noResults)
+                                .secondaryBodyStyle()
                         }
                     } else {
                         if let currentCountryCode = viewModel.currentCountryCode {
@@ -96,6 +105,11 @@ struct StoreCreationCountryQuestionView: View {
                     Button(Localization.cancel) {
                         isShowingCountryList = false
                     }
+                }
+            }
+            .onChange(of: viewModel.selectedCountryCode) { newValue in
+                if newValue != nil {
+                    isShowingCountryList = false
                 }
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10422 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the country profiler question to split it into 2 screens: one for the detected country and one for selecting and search from the country list. Changes include only UI updates for this screen, and no new changes for the view model.

The change is applied without the check for the feature flag `optimizeProfilerQuestions` as I think it's unnecessary. Let me know if it's indeed important to apply this change only to the new flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `optimizeProfilerQuestions` if you want to see the full new flow, otherwise, test with the flag disabled to avoid creating a new free trial site.
- Log in to the app and switch to the Menu tab.
- Scroll to the bottom and select Add a store > Create a new store.
- Answer the profiler questions to reach the country question.
- Notice that only the detected country is displayed on the screen. \
- Tap the button for the country, notice that a country list is displayed.
- Search for any country, the list should be updated.
- Select any country, the screen should be dismissed and the new selected country is displayed on the screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/e708cc29-afd0-4959-ab2f-b45dfc894d25



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
