### PR TITLE
Re-Enable Shipping Zones Feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,6 +20,7 @@
 - [Internal] Shipment tracking is only enabled and synced when the order has non-virtual products.  [https://github.com/woocommerce/woocommerce-ios/pull/10288]
 - [Internal] New default property `was_ecommerce_trial` is tracked in every event for logged-in users. [https://github.com/woocommerce/woocommerce-ios/pull/10343]
 - [*] Photo -> Product: Reset details from previous image when new image is selected. [https://github.com/woocommerce/woocommerce-ios/pull/10297]
+- [**] You can now see your shipping zone list from Settings. [https://github.com/woocommerce/woocommerce-ios/pull/10258]
 - [*] Order list: Suggest testing orders for stores without any orders. [https://github.com/woocommerce/woocommerce-ios/pull/10346]
 - [*] Local notifications: Show free trial survey after 24h since subscription. [https://github.com/woocommerce/woocommerce-ios/pull/10324, https://github.com/woocommerce/woocommerce-ios/pull/10328]
 - [*] Local notifications: Add a reminder after 3 days if answered "Still Exploring" in Free trial survey. [https://github.com/woocommerce/woocommerce-ios/pull/10331]

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "cb38a32bbcc733ba03e307ca7bcae63f8c5de729",
-          "version": "0.2.2"
+          "revision": "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
+          "version": "0.2.3"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/woocommerce/woocommerce-shared.git",
         "state": {
           "branch": null,
-          "revision": "2036fc5f471f54759b88965dcf410c1fb77e4c64",
-          "version": "0.4.0"
+          "revision": "03d9c94279361e0b002055b9fff3f75ca51ed33e",
+          "version": "0.5.0"
         }
       },
       {

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
-          "version": "0.2.3"
+          "revision": "cb38a32bbcc733ba03e307ca7bcae63f8c5de729",
+          "version": "0.2.2"
         }
       },
       {
@@ -98,6 +98,15 @@
           "branch": null,
           "revision": "77c7f492f5c1c9ca159f73d18f56bbd1186390b0",
           "version": "0.3.0"
+        }
+      },
+      {
+        "package": "WooCommerceShared",
+        "repositoryURL": "https://github.com/woocommerce/woocommerce-shared.git",
+        "state": {
+          "branch": null,
+          "revision": "2036fc5f471f54759b88965dcf410c1fb77e4c64",
+          "version": "0.4.0"
         }
       },
       {

--- a/WooCommerce/Classes/Analytics/ReactNativeAnalyticsProvider.swift
+++ b/WooCommerce/Classes/Analytics/ReactNativeAnalyticsProvider.swift
@@ -1,9 +1,9 @@
 import Foundation
-// import protocol WooCommerceShared.WCRNAnalyticsProvider
+import protocol WooCommerceShared.WCRNAnalyticsProvider
 
 /// Class that provides an interface to `ReactNative` to log track events using the main app `analyticsProvider`.
 ///
-final class ReactNativeAnalyticsProvider /*: WCRNAnalyticsProvider*/ {
+final class ReactNativeAnalyticsProvider: WCRNAnalyticsProvider {
 
     /// Sends an event using `ServiceLocator.analyticsProvider`.
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -7,6 +7,7 @@ import Yosemite
 import SwiftUI
 
 import KeychainAccess
+import WooCommerceShared
 import struct Networking.ApplicationPasswordEncoder
 
 protocol SettingsViewPresenter: AnyObject {
@@ -413,25 +414,24 @@ private extension SettingsViewController {
     }
 
     func shippingZonesWasPressed() {
-        // TODO: Bring back when we found a solution for iOS 15.
-//        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-//            return DDLogError("⛔️ Cannot find SiteID to present shipping zones")
-//        }
-//
-//        let tracksProvider = ReactNativeAnalyticsProvider()
-//        let viewController: WCReactNativeViewController = {
-//
-//            if ServiceLocator.stores.isAuthenticatedWithoutWPCom {
-//                let url = ServiceLocator.stores.sessionManager.defaultSite?.url ?? ""
-//                let password = ApplicationPasswordEncoder().encodedPassword() ?? ""
-//                return WCReactNativeViewController(analyticsProvider: tracksProvider, siteUrl: url, appPassword: password)
-//            } else {
-//                let token = Keychain(service: WooConstants.keychainServiceName).currentAuthToken ?? ""
-//                return WCReactNativeViewController(analyticsProvider: tracksProvider, blogID: "\(siteID)", apiToken: token)
-//            }
-//        }()
-//
-//        show(viewController, sender: self)
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            return DDLogError("⛔️ Cannot find SiteID to present shipping zones")
+        }
+
+        let tracksProvider = ReactNativeAnalyticsProvider()
+        let viewController: WCReactNativeViewController = {
+
+            if ServiceLocator.stores.isAuthenticatedWithoutWPCom {
+                let url = ServiceLocator.stores.sessionManager.defaultSite?.url ?? ""
+                let password = ApplicationPasswordEncoder().encodedPassword() ?? ""
+                return WCReactNativeViewController(analyticsProvider: tracksProvider, siteUrl: url, appPassword: password)
+            } else {
+                let token = Keychain(service: WooConstants.keychainServiceName).currentAuthToken ?? ""
+                return WCReactNativeViewController(analyticsProvider: tracksProvider, blogID: "\(siteID)", apiToken: token)
+            }
+        }()
+
+        show(viewController, sender: self)
     }
 
     func privacyWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -280,7 +280,7 @@ private extension SettingsViewModel {
 
         // Store settings
         let storeSettingsSection: Section? = {
-            var rows: [Row] = []
+            var rows: [Row] = [.shippingZones]
 
             let site = stores.sessionManager.defaultSite
             if site?.isJetpackCPConnected == true ||

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -815,6 +815,7 @@
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
+		26A8A0BD2A68845E00FAF8BA /* WooCommerceShared in Frameworks */ = {isa = PBXBuildFile; productRef = 26A8A0BC2A68845E00FAF8BA /* WooCommerceShared */; };
 		26ABCE532518EAF300721CB0 /* IssueRefundTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ABCE522518EAF300721CB0 /* IssueRefundTableViewCell.swift */; };
 		26ABCE552518EB0600721CB0 /* IssueRefundTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26ABCE542518EB0600721CB0 /* IssueRefundTableViewCell.xib */; };
 		26AC0DD92941081500859074 /* AnalyticsHubCustomRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AC0DD82941081500859074 /* AnalyticsHubCustomRangeData.swift */; };
@@ -4828,6 +4829,7 @@
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */,
+				26A8A0BD2A68845E00FAF8BA /* WooCommerceShared in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
 				B5C3B5E520D189EA0072CB9D /* Storage.framework in Frameworks */,
 				B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */,
@@ -10960,6 +10962,7 @@
 				3FFC5EAB2851942F00563C48 /* Charts */,
 				4598298028574688003A9AFE /* Inject */,
 				DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */,
+				26A8A0BC2A68845E00FAF8BA /* WooCommerceShared */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -11131,6 +11134,7 @@
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
+				26A8A0BB2A68845E00FAF8BA /* XCRemoteSwiftPackageReference "woocommerce-shared" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -14559,6 +14563,14 @@
 				minimumVersion = 4.1.2;
 			};
 		};
+		26A8A0BB2A68845E00FAF8BA /* XCRemoteSwiftPackageReference "woocommerce-shared" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/woocommerce/woocommerce-shared.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.0;
+			};
+		};
 		3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
@@ -14635,6 +14647,11 @@
 		263E38452641FF3400260D3B /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Codegen;
+		};
+		26A8A0BC2A68845E00FAF8BA /* WooCommerceShared */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 26A8A0BB2A68845E00FAF8BA /* XCRemoteSwiftPackageReference "woocommerce-shared" */;
+			productName = WooCommerceShared;
 		};
 		3F1CA81C26C3542600228BF2 /* XCUITestHelpers */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
# Why

This PR reverts commit https://github.com/woocommerce/woocommerce-ios/commit/a5f401df7b903417cb8b5214e6548a200e465a90 which previously removed the Shipping Zones feature because it was not compatible with iOS 15.

In order for it to work, this PR also updates the `WooCoomerceShared` library to version `0.5.0` that now adds support for iOS 15.

# Screenshots

Before | After
---- | ----
<img width="907" alt="bad" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/730ede52-0731-4a26-a212-d4bee01c9237"> | <img width="459" alt="good" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/ac6d8fdc-36ae-4b5f-9fda-d6a452f8effc">

# Testing Steps

- Run this branch using an iOS 15 simulator or install the installable build on an iOS 15 device
- Launch the app and make sure it doesn't crash
- Navigate to Hub / settings / Shipping Zones and see that the list loads correctly.
