### PR TITLE
Blaze: Check for existing order to update Blaze banner visibility

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 14.9
 -----
+- [*] Only show Blaze banner on the My Store and Product List screens if the store has no existing orders. [https://github.com/woocommerce/woocommerce-ios/pull/10438]
 
 
 14.8

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -307,7 +307,7 @@ extension DashboardViewModel {
         async let isSiteEligible = blazeEligibilityChecker.isSiteEligible()
         async let storeHasPublishedProducts = (try? checkIfStoreHasProducts(siteID: siteID, status: .published)) ?? false
         async let storeHasAnyOrders = (try? checkIfStoreHasOrders(siteID: siteID)) ?? false
-        guard (await isSiteEligible, await storeHasPublishedProducts, await storeHasAnyOrders) == (true, true, false) else {
+        guard await(isSiteEligible, storeHasPublishedProducts, storeHasAnyOrders) == (true, true, false) else {
             return false
         }
         return !userDefaults.hasDismissedBlazeBanner(for: siteID)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -306,7 +306,8 @@ extension DashboardViewModel {
     private func isBlazeBannerVisible() async -> Bool {
         async let isSiteEligible = blazeEligibilityChecker.isSiteEligible()
         async let storeHasPublishedProducts = (try? checkIfStoreHasProducts(siteID: siteID, status: .published)) ?? false
-        guard (await isSiteEligible, await storeHasPublishedProducts) == (true, true) else {
+        async let storeHasAnyOrders = (try? checkIfStoreHasOrders(siteID: siteID)) ?? false
+        guard (await isSiteEligible, await storeHasPublishedProducts, await storeHasAnyOrders) == (true, true, false) else {
             return false
         }
         return !userDefaults.hasDismissedBlazeBanner(for: siteID)
@@ -321,6 +322,21 @@ extension DashboardViewModel {
                     continuation.resume(returning: hasProducts)
                 case .failure(let error):
                     DDLogError("⛔️ Dashboard — Error fetching products to show the Blaze banner: \(error)")
+                    continuation.resume(throwing: error)
+                }
+            }))
+        }
+    }
+
+    @MainActor
+    private func checkIfStoreHasOrders(siteID: Int64) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(OrderAction.checkIfStoreHasOrders(siteID: siteID, onCompletion: { result in
+                switch result {
+                case .success(let hasOrders):
+                    continuation.resume(returning: hasOrders)
+                case .failure(let error):
+                    DDLogError("⛔️ Dashboard — Error fetching order to show the Blaze banner: \(error)")
                     continuation.resume(throwing: error)
                 }
             }))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -173,7 +173,8 @@ extension ProductListViewModel {
     private func isBlazeBannerVisible() async -> Bool {
         async let isSiteEligible = blazeEligibilityChecker.isSiteEligible()
         async let storeHasPublishedProducts = (try? checkIfStoreHasProducts(siteID: siteID, status: .published)) ?? false
-        guard (await isSiteEligible, await storeHasPublishedProducts) == (true, true) else {
+        async let storeHasAnyOrders = (try? checkIfStoreHasOrders(siteID: siteID)) ?? false
+        guard await(isSiteEligible, storeHasPublishedProducts, storeHasAnyOrders) == (true, true, false) else {
             return false
         }
         return !userDefaults.hasDismissedBlazeBanner(for: siteID)
@@ -188,6 +189,21 @@ extension ProductListViewModel {
                     continuation.resume(returning: hasProducts)
                 case .failure(let error):
                     DDLogError("⛔️ Product list — Error fetching products to show the Blaze banner: \(error)")
+                    continuation.resume(throwing: error)
+                }
+            }))
+        }
+    }
+
+    @MainActor
+    private func checkIfStoreHasOrders(siteID: Int64) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(OrderAction.checkIfStoreHasOrders(siteID: siteID, onCompletion: { result in
+                switch result {
+                case .success(let hasOrders):
+                    continuation.resume(returning: hasOrders)
+                case .failure(let error):
+                    DDLogError("⛔️ Dashboard — Error fetching order to show the Blaze banner: \(error)")
                     continuation.resume(throwing: error)
                 }
             }))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import enum Networking.DotcomError
 import enum Yosemite.StatsActionV4
 import enum Yosemite.ProductAction
+import enum Yosemite.OrderAction
 import enum Yosemite.AppSettingsAction
 import enum Yosemite.JustInTimeMessageAction
 import struct Yosemite.JustInTimeMessage
@@ -633,6 +634,14 @@ final class DashboardViewModelTests: XCTestCase {
                 break
             }
         }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
         await viewModel.updateBlazeBannerVisibility()
 
         //  Then
@@ -640,7 +649,7 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     // swiftlint:disable:next line_length
-    func test_updateBlazeBannerVisibility_updates_showBlazeBanner_to_true_if_site_is_eligible_for_blaze_and_banner_is_not_dismissed_yet_and_store_has_published_products() async throws {
+    func test_updateBlazeBannerVisibility_updates_showBlazeBanner_to_true_if_site_is_eligible_for_blaze_and_banner_is_not_dismissed_yet_and_store_has_published_products_and_store_has_no_order() async throws {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let uuid = UUID().uuidString
@@ -656,6 +665,14 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
             default:
                 break
             }
@@ -682,6 +699,14 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
             default:
                 break
             }
@@ -713,6 +738,14 @@ final class DashboardViewModelTests: XCTestCase {
                 break
             }
         }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
         await viewModel.updateBlazeBannerVisibility()
 
         //  Then
@@ -739,6 +772,48 @@ final class DashboardViewModelTests: XCTestCase {
                 break
             }
         }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+        await viewModel.updateBlazeBannerVisibility()
+
+        //  Then
+        XCTAssertFalse(viewModel.showBlazeBanner)
+    }
+
+    func test_updateBlazeBannerVisibility_updates_showBlazeBanner_to_false_if_store_has_existing_orders() async throws {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           userDefaults: userDefaults,
+                                           blazeEligibilityChecker: checker)
+        XCTAssertFalse(viewModel.showBlazeBanner)
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case .checkIfStoreHasProducts(_, _, let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(true))
+            default:
+                break
+            }
+        }
         await viewModel.updateBlazeBannerVisibility()
 
         //  Then
@@ -758,6 +833,14 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -311,7 +311,7 @@ final class ProductListViewModelTests: XCTestCase {
 
     // MARK: - Blaze banner
     // swiftlint:disable:next line_length
-    func test_updateBlazeBannerVisibility_updates_shouldShowBlazeBanner_to_true_if_site_is_eligible_for_blaze_and_banner_is_not_dismissed_yet_and_site_has_published_products() async throws {
+    func test_updateBlazeBannerVisibility_updates_shouldShowBlazeBanner_to_true_if_site_is_eligible_for_blaze_and_banner_is_not_dismissed_yet_and_site_has_published_products_and_no_orders() async throws {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let uuid = UUID().uuidString
@@ -328,6 +328,14 @@ final class ProductListViewModelTests: XCTestCase {
             switch action {
             case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
             default:
                 break
             }
@@ -355,6 +363,14 @@ final class ProductListViewModelTests: XCTestCase {
             switch action {
             case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
             default:
                 break
             }
@@ -387,6 +403,14 @@ final class ProductListViewModelTests: XCTestCase {
                 break
             }
         }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
         await viewModel.updateBlazeBannerVisibility()
 
         //  Then
@@ -414,6 +438,49 @@ final class ProductListViewModelTests: XCTestCase {
                 break
             }
         }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+        await viewModel.updateBlazeBannerVisibility()
+
+        //  Then
+        XCTAssertFalse(viewModel.shouldShowBlazeBanner)
+    }
+
+    func test_updateBlazeBannerVisibility_updates_shouldShowBlazeBanner_to_false_if_store_has_existing_orders() async throws {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let uuid = UUID().uuidString
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = ProductListViewModel(siteID: sampleSiteID,
+                                             stores: stores,
+                                             userDefaults: userDefaults,
+                                             blazeEligibilityChecker: checker)
+        XCTAssertFalse(viewModel.shouldShowBlazeBanner)
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case .checkIfStoreHasProducts(_, _, let onCompletion):
+                onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(true))
+            default:
+                break
+            }
+        }
         await viewModel.updateBlazeBannerVisibility()
 
         //  Then
@@ -434,6 +501,14 @@ final class ProductListViewModelTests: XCTestCase {
             switch action {
             case .checkIfStoreHasProducts(_, _, let onCompletion):
                 onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .checkIfStoreHasOrders(_, let onCompletion):
+                onCompletion(.success(false))
             default:
                 break
             }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -109,4 +109,9 @@ public enum OrderAction: Action {
     /// Returns a publisher that emits inserted orders on the view storage context.
     ///
     case observeInsertedOrders(siteID: Int64, completion: (AnyPublisher<[Order], Never>) -> Void)
+
+    /// Checks if the store already has any orders.
+    /// Returns `false` if the store has no orders.
+    ///
+    case checkIfStoreHasOrders(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -111,7 +111,6 @@ public enum OrderAction: Action {
     case observeInsertedOrders(siteID: Int64, completion: (AnyPublisher<[Order], Never>) -> Void)
 
     /// Checks if the store already has any orders.
-    /// Returns `false` if the store has no orders.
     ///
     case checkIfStoreHasOrders(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -263,7 +263,6 @@ private extension OrderStore {
     }
 
     /// Checks if the store already has any orders.
-    /// Returns `false` if the store has no orders.
     ///
     func checkIfStoreHasOrders(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         // Check for locally stored products first.

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -273,7 +273,7 @@ private extension OrderStore {
         }
 
         // If there are no locally stored orders, then check remote.
-        remote.loadAllOrders(for: siteID, pageNumber: 1, pageSize: 1) { result in
+        remote.loadAllOrders(for: siteID, pageNumber: Default.firstPageNumber, pageSize: 1) { result in
             switch result {
             case .success(let orders):
                 onCompletion(.success(orders.isEmpty == false))

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -87,6 +87,8 @@ public class OrderStore: Store {
             deleteOrder(siteID: siteID, order: order, deletePermanently: deletePermanently, onCompletion: onCompletion)
         case let .observeInsertedOrders(siteID, completion):
             observeInsertedOrders(siteID: siteID, completion: completion)
+        case let .checkIfStoreHasOrders(siteID, completion):
+            checkIfStoreHasOrders(siteID: siteID, onCompletion: completion)
         }
     }
 }
@@ -256,6 +258,28 @@ private extension OrderStore {
                 }
             case .failure(let error):
                 onCompletion(Date().timeIntervalSince(startTime), error)
+            }
+        }
+    }
+
+    /// Checks if the store already has any orders.
+    /// Returns `false` if the store has no orders.
+    ///
+    func checkIfStoreHasOrders(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        // Check for locally stored products first.
+        let storage = storageManager.viewStorage
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        if storage.firstObject(ofType: StorageOrder.self, matching: predicate) != nil {
+            return onCompletion(.success(true))
+        }
+
+        // If there are no locally stored orders, then check remote.
+        remote.loadAllOrders(for: siteID, pageNumber: 1, pageSize: 1) { result in
+            switch result {
+            case .success(let orders):
+                onCompletion(.success(orders.isEmpty == false))
+            case .failure(let error):
+                onCompletion(.failure(error))
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10426 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the visibility check of the Blaze banners on the My Store and Product List screens. Since we want to show the banners only if a store has no orders yet, we need to take into account the existing orders in the store before displaying the banners.

Changes:
- Updated `OrderAction` and `OrderStore` to add a check for whether a store has any existing orders.
- Updated `DashboardViewModel` and `ProductListViewModel` to check for existing orders when determining the visibility of  the Blaze banners.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a public WPCom store with at least one published product but no existing order and never dismissed the Blaze banner before.
- Notice that the Blaze banner is available on the My Store and Product List screen.
- Create an order for that store.
- Notice that the Blaze banner is no longer displayed on My Store and Product List screen (pull-to-refresh to update the screens if needed).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/d4a7c7db-ce28-4412-95f1-6bb50019ed57



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
