### PR TITLE
[Better Customer Selection] Test Feedback

### DIFF
--- a/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
@@ -93,12 +93,6 @@ extension UILabel {
         textColor = .textSubtle
     }
 
-    func applyStrongCaption1Style() {
-        adjustsFontForContentSizeCategory = true
-        font = .caption1
-        textColor = .text
-    }
-
     func applyCalloutStyle() {
         adjustsFontForContentSizeCategory = true
         font = .callout

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -154,6 +154,7 @@ final class CustomerSearchUICommand: SearchUICommand {
             id: "\(model.customerID)",
             title: "\(model.firstName ?? "") \(model.lastName ?? "")",
             placeholderTitle: Localization.titleCellPlaceholder,
+            placeholderSubtitle: Localization.subtitleCellPlaceholder,
             subtitle: model.email,
             accessibilityLabel: "",
             detail: model.username ?? "",
@@ -281,6 +282,7 @@ private extension CustomerSearchUICommand {
             "We're sorry, we couldn't find results for “%@”",
             comment: "Message for empty Customers search results. %@ is a placeholder for the text entered by the user.")
         static let titleCellPlaceholder = NSLocalizedString("No name", comment: "Placeholder when there's no customer name in the list")
+        static let subtitleCellPlaceholder = NSLocalizedString("No email address", comment: "Placeholder when there's no customer email in the list")
         static let emptyDefaultStateMessage = NSLocalizedString("Search for an existing customer or",
                                                                 comment: "Message to prompt users to search for customers on the customer search screen")
         static let emptyDefaultStateActionTitle = NSLocalizedString("Add details manually",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -153,7 +153,7 @@ final class CustomerSearchUICommand: SearchUICommand {
             subtitle: model.email,
             accessibilityLabel: "",
             detail: model.username ?? "",
-            underlinedText: searchTerm
+            underlinedText: searchTerm?.count ?? 0 > 1 ? searchTerm : "" // Only underline the search term if it's longer than 1 character
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -78,6 +78,10 @@ final class CustomerSearchUICommand: SearchUICommand {
         !featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder)
     }
 
+    var makeSearchBarFirstResponderOnStart: Bool {
+        !featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder)
+    }
+
     var syncResultsWhenSearchQueryTurnsEmpty: Bool {
         featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder) && loadResultsWhenSearchTermIsEmpty
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -109,10 +109,12 @@ private extension CustomerSelectorViewController {
     }
 
     @objc func presentNewCustomerDetailsFlow() {
-        let editOrderAddressForm = EditOrderAddressForm(dismiss: { [weak self] in
+        let editOrderAddressForm = EditOrderAddressForm(dismiss: { [weak self] action in
                                                             self?.dismiss(animated: true, completion: { [weak self] in
                                                                 // Dismiss this view too
-                                                                self?.dismiss(animated: true)
+                                                                if action == .done {
+                                                                    self?.dismiss(animated: true)
+                                                                }
                                                             })
                                                         },
                                                         showSearchButton: false,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -19,7 +19,7 @@ struct OrderCustomerSection: View {
                 NavigationView {
                     switch viewModel.customerNavigationScreen {
                     case .form:
-                        EditOrderAddressForm(dismiss: {
+                        EditOrderAddressForm(dismiss: { _ in
                                                 showAddressForm.toggle()
                                              },
                                              showSearchButton: viewModel.shouldShowSearchButtonInOrderAddressForm,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -29,7 +29,7 @@ final class EditOrderAddressHostingController: UIHostingController<EditOrderAddr
         super.init(rootView: EditOrderAddressForm(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
-        rootView.dismiss = { [weak self] in
+        rootView.dismiss = { [weak self] _ in
             self?.dismiss(animated: true, completion: nil)
         }
     }
@@ -76,13 +76,18 @@ extension EditOrderAddressHostingController: UIAdaptivePresentationControllerDel
     }
 }
 
+enum EditOrderAddressFormDismissAction {
+    case cancel
+    case done
+}
+
 /// Allows merchant to edit the customer provided address of an order.
 ///
 struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
 
     /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
     ///
-    var dismiss: (() -> Void) = {}
+    var dismiss: ((EditOrderAddressFormDismissAction) -> Void) = { _ in }
 
     /// Shows the search button on the navigation bar
     /// 
@@ -150,7 +155,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button(Localization.close, action: {
-                    dismiss()
+                    dismiss(.cancel)
                     viewModel.userDidCancelFlow()
                 })
             }
@@ -192,7 +197,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
             Button(Localization.done) {
                 viewModel.saveAddress(onFinish: { success in
                     if success {
-                        dismiss()
+                        dismiss(.done)
                     }
                 })
             }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
@@ -45,7 +45,8 @@ extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
 private extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
     func subtitleAttributedString(from viewModel: ViewModel) -> NSAttributedString {
         guard viewModel.subtitle.trimmingCharacters(in: .whitespaces).isNotEmpty else {
-            return NSMutableAttributedString(string: viewModel.placeholderSubtitle, attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.textSubtle])
+            return NSMutableAttributedString(string: viewModel.placeholderSubtitle,
+                                             attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.textTertiary])
         }
 
         let subtitle = NSMutableAttributedString(string: viewModel.subtitle, attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.text])
@@ -65,11 +66,13 @@ private extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
     }
 
     func titleAttributedString(from viewModel: ViewModel) -> NSAttributedString {
+        let titleFont = UIFont.font(forStyle: .callout, weight: .medium)
+
         guard viewModel.title.trimmingCharacters(in: .whitespaces).isNotEmpty else {
-            return NSMutableAttributedString(string: viewModel.placeholderTitle, attributes: [.font: UIFont.body, .foregroundColor: UIColor.textSubtle])
+            return NSMutableAttributedString(string: viewModel.placeholderTitle, attributes: [.font: titleFont, .foregroundColor: UIColor.textTertiary])
         }
 
-        let title = NSMutableAttributedString(string: viewModel.title, attributes: [.font: UIFont.body, .foregroundColor: UIColor.text])
+        let title = NSMutableAttributedString(string: viewModel.title, attributes: [.font: titleFont, .foregroundColor: UIColor.text])
 
         if let underlinedText = viewModel.underlinedText {
             title.underlineSubstring(underlinedText: underlinedText)
@@ -79,12 +82,14 @@ private extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
     }
 
     func detailAttributedString(from viewModel: ViewModel) -> NSAttributedString {
+        let detailFont = UIFont.font(forStyle: .callout, weight: .regular)
+
         guard viewModel.detail.isNotEmpty else {
             return NSAttributedString(string: "")
         }
 
         let composedDetail = " • \(viewModel.detail)"
-        let detail = NSMutableAttributedString(string: composedDetail, attributes: [.font: UIFont.body, .foregroundColor: UIColor.textSubtle])
+        let detail = NSMutableAttributedString(string: composedDetail, attributes: [.font: detailFont, .foregroundColor: UIColor.textSubtle])
 
         if let underlinedText = viewModel.underlinedText {
             detail.underlineSubstring(underlinedText: underlinedText)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
@@ -18,7 +18,7 @@ final class UnderlineableTitleAndSubtitleAndDetailTableViewCell: UITableViewCell
     func configureCell(searchModel: ViewModel) {
         accessibilityLabel = searchModel.accessibilityLabel
         setupTitleLabelText(with: searchModel)
-        setupSubtitleLabelText(with: searchModel)
+        subtitleLabel.attributedText = subtitleAttributedString(from: searchModel)
         subtitleLabel.applyStrongCaption1Style()
     }
 }
@@ -33,6 +33,7 @@ extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
         var id: String = UUID().uuidString
         let title: String
         let placeholderTitle: String
+        let placeholderSubtitle: String
         let subtitle: String
         let accessibilityLabel: String
         let detail: String
@@ -43,18 +44,22 @@ extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
 // MARK: - Setup
 //
 private extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
-    func setupSubtitleLabelText(with viewModel: ViewModel) {
-        let subtitle = NSMutableAttributedString(string: viewModel.subtitle, attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.text])
+    func subtitleAttributedString(from viewModel: ViewModel) -> NSAttributedString {
+        guard viewModel.subtitle.trimmingCharacters(in: .whitespaces).isNotEmpty else {
+            return NSMutableAttributedString(string: viewModel.placeholderSubtitle, attributes: [.font: UIFont.body, .foregroundColor: UIColor.textSubtle])
+        }
+
+        let subtitle = NSMutableAttributedString(string: viewModel.subtitle, attributes: [.font: UIFont.body, .foregroundColor: UIColor.text])
 
         if let underlinedText = viewModel.underlinedText {
             subtitle.underlineSubstring(underlinedText: underlinedText)
         }
 
-        subtitleLabel.attributedText = subtitle
+        return subtitle
     }
 
     func setupTitleLabelText(with viewModel: ViewModel) {
-        var titleAndDetail: NSMutableAttributedString = NSMutableAttributedString(attributedString: titleAttributedString(from: viewModel))
+        let titleAndDetail: NSMutableAttributedString = NSMutableAttributedString(attributedString: titleAttributedString(from: viewModel))
         titleAndDetail.append(detailAttributedString(from: viewModel))
 
         titleLabel.attributedText = titleAndDetail

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
@@ -19,7 +19,6 @@ final class UnderlineableTitleAndSubtitleAndDetailTableViewCell: UITableViewCell
         accessibilityLabel = searchModel.accessibilityLabel
         setupTitleLabelText(with: searchModel)
         subtitleLabel.attributedText = subtitleAttributedString(from: searchModel)
-        subtitleLabel.applyStrongCaption1Style()
     }
 }
 
@@ -46,10 +45,10 @@ extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
 private extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
     func subtitleAttributedString(from viewModel: ViewModel) -> NSAttributedString {
         guard viewModel.subtitle.trimmingCharacters(in: .whitespaces).isNotEmpty else {
-            return NSMutableAttributedString(string: viewModel.placeholderSubtitle, attributes: [.font: UIFont.body, .foregroundColor: UIColor.textSubtle])
+            return NSMutableAttributedString(string: viewModel.placeholderSubtitle, attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.textSubtle])
         }
 
-        let subtitle = NSMutableAttributedString(string: viewModel.subtitle, attributes: [.font: UIFont.body, .foregroundColor: UIColor.text])
+        let subtitle = NSMutableAttributedString(string: viewModel.subtitle, attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.text])
 
         if let underlinedText = viewModel.underlinedText {
             subtitle.underlineSubstring(underlinedText: underlinedText)

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -18,6 +18,10 @@ protocol SearchUICommand {
     ///
     var hideNavigationBar: Bool { get }
 
+    /// Makes the search bar first responder on start, focusing on there.
+    ///
+    var makeSearchBarFirstResponderOnStart: Bool { get }
+
     /// Notifies whether the SearchUICommand triggers a sync when the search query turns empty, e.g. to load the default results.
     /// This is used to show a loading state when syncing.
     ///
@@ -126,6 +130,10 @@ extension SearchUICommand {
     }
 
     var hideNavigationBar: Bool {
+        true
+    }
+
+    var makeSearchBarFirstResponderOnStart: Bool {
         true
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -230,6 +230,10 @@ where Cell.SearchModel == Command.CellViewModel {
         return true
     }
 
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
+
     // MARK: - Actions
     //
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -157,7 +157,9 @@ where Cell.SearchModel == Command.CellViewModel {
             navigationController?.setNavigationBarHidden(true, animated: true)
         }
 
-        searchBar.becomeFirstResponder()
+        if searchUICommand.makeSearchBarFirstResponderOnStart {
+            searchBar.becomeFirstResponder()
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.xib
@@ -35,7 +35,7 @@
                 </view>
                 <searchBar contentMode="redraw" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="cOC-iR-MJr">
                     <rect key="frame" x="8" y="20" width="297" height="56"/>
-                    <textInputTraits key="textInputTraits"/>
+                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="CeV-H5-n3x"/>
                     </connections>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10434 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With this PR we tweak the Better Customer Selection with the improvements suggested by @kidinov in his test. These include:

- Do not focus on the search bar (start editing) on start.
- Only underline text when the search term is longer than one character
- Do not dismiss Customer Selector when the user taps on the Cancel button of the Customer Creation Screen
- Add a placeholder when there's no email
- Add a way to dismiss the keyboard
- Adapt customer cell layout according to design

Done in https://github.com/woocommerce/woocommerce-ios/pull/10423:

- The ghost-loading animation covers the search bar when the search term is reset.
- The ghost-loading animation is shown also when loading subsequent pages (not only the first) with an empty search.

Postponed as it requires further investigation:

- We can scroll way below the last item on the list. This is due to the assignment of more space to scroll freely on top of the keyboard in the `SearchViewController`, but it doesn't play well with the page loading bottom animation.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Enable the feature flag betterCustomerSelectionInOrder in DefaultFeatureFlagService

1. Go to Orders
2. Tap on + to add a new order
3. Tap on + Add Customer Details

See videos:

- Do not focus on the search bar (start editing) on start.

https://github.com/woocommerce/woocommerce-ios/assets/1864060/5a9b972c-632d-462a-8f07-693054e2c307

- Only underline text when the search term is longer than one character


https://github.com/woocommerce/woocommerce-ios/assets/1864060/3946865c-ebb7-42ad-ae20-3aeaf6e64d15

- Do not dismiss Customer Selector when the user taps on the Cancel button of the Customer Creation Screen

https://github.com/woocommerce/woocommerce-ios/assets/1864060/1839a17c-5d23-4f47-9c5a-81424d32dc27

- Add a placeholder when there's no email


https://github.com/woocommerce/woocommerce-ios/assets/1864060/334d16a7-cd28-42a6-9439-124078b110d3

- Add a way to dismiss the keyboard (Done button in keyboard dismisses it. No need to have the Search button there as the search is triggered automatically)


https://github.com/woocommerce/woocommerce-ios/assets/1864060/a9fab348-57cf-48bc-9d59-72498265e9aa

- Adapt customer cell layout according to design
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/4c990193-6858-4755-a9ad-33a692e9f051" width="375">

Changes:
- Placeholders have a lighter color than Name and username (Name > username > email, primary, secondary, tertiary)
- Usernames and names have a different weight (medium 500, regular 400)


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

See above
---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
