### PR TITLE
Update `.contentEdgeInsets` for refund view controller to newest API

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -160,9 +160,12 @@ private extension IssueRefundViewController {
     }
 
     func configureHeaderView() {
-        selectAllButton.applyLinkButtonStyle()
-        selectAllButton.contentEdgeInsets = .zero
+        let configuration = UIButton.Configuration.plain()
+        selectAllButton.configuration = configuration
+        selectAllButton.configuration?.contentInsets = .zero
+
         selectAllButton.setTitle(Localization.selectAllTitle, for: .normal)
+        selectAllButton.applyLinkButtonStyle()
 
         itemsSelectedLabel.applySecondaryBodyStyle()
         configureHeaderStackView()


### PR DESCRIPTION

## Description
This PR addresses one of the deprecation warnings regarding the usage of contentEdgeInsets since iOS15, as we have to update the usage of this property with `UIButton.Configuration` instead:

```
Warning : 'contentEdgeInsets' was deprecated in iOS 15.0.
```

## Testing instructions
1. Go to Orders > select an Order that has been paid and is completed > Tap on the `Issue Refund` button.
2. See that the `Select All` button in the top right corner still appears correctly in light/dark mode, as well as in portrait/landscape orientations:

| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-08-09 at 13 10 47](https://github.com/woocommerce/woocommerce-ios/assets/3812076/eeae032f-8e50-4279-a1c1-673c6d3d1930) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-08-09 at 13 08 54](https://github.com/woocommerce/woocommerce-ios/assets/3812076/81f12209-e276-432a-91d5-ca9db6720230) | 
