### PR TITLE
Store creation: Update alerts wording and actions.

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSummaryView.swift
@@ -42,6 +42,7 @@ struct FreeTrialSummaryView: View {
                             Image(uiImage: .closeButton)
                                 .foregroundColor(Color(.textSubtle))
                         }
+                        .disabled(isWaitingToContinue)
 
                         Spacer()
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -150,22 +150,6 @@ private extension StoreCreationCoordinator {
         viewController.present(alertController, animated: true)
     }
 
-    func showDismissalAlert(flow: WooAnalyticsEvent.StoreCreation.Flow) {
-        let alert = UIAlertController(title: Localization.DismissalAlert.title,
-                                      message: Localization.DismissalAlert.message,
-                                      preferredStyle: .alert)
-        alert.addDestructiveActionWithTitle(Localization.DismissalAlert.confirmActionTitle) { [weak self] _ in
-            guard let self else { return }
-            self.analytics.track(event: .StoreCreation.siteCreationDismissed(source: self.source.analyticsValue, flow: flow, isFreeTrial: true))
-            self.navigationController.dismiss(animated: true)
-        }
-
-        alert.addCancelActionWithTitle(Localization.DismissalAlert.cancelActionTitle) { _ in }
-
-        // Presents the alert with the presented webview.
-        navigationController.topmostPresentedViewController.present(alert, animated: true)
-    }
-
     func showDiscardChangesAlert(flow: WooAnalyticsEvent.StoreCreation.Flow) {
         let alert = UIAlertController(title: Localization.DiscardChangesAlert.title,
                                       message: Localization.DiscardChangesAlert.message,
@@ -294,7 +278,8 @@ private extension StoreCreationCoordinator {
                                   storeName: String,
                                   profilerData: SiteProfilerData?) {
         let summaryViewController = FreeTrialSummaryHostingController(onClose: { [weak self] in
-            self?.showDismissalAlert(flow: .native)
+            guard let self else { return }
+            self.analytics.track(event: .StoreCreation.siteCreationDismissed(source: self.source.analyticsValue, flow: .native, isFreeTrial: true))
         }, onContinue: { [weak self] in
             guard let self else { return }
             self.analytics.track(event: .StoreCreation.siteCreationTryForFreeTapped())
@@ -560,25 +545,6 @@ private extension StoreCreationCoordinator {
                                                               comment: "Button to confirm the dismissal of  the store creation profiler flow")
             static let cancelActionTitle = NSLocalizedString("Cancel",
                                                              comment: "Button to dismiss the alert on the store creation profiler flow")
-        }
-
-        enum DismissalAlert {
-            static let title = NSLocalizedString(
-                "Ready for setup",
-                comment: "Title of the alert when the user dismisses the store creation flow."
-            )
-            static let message = NSLocalizedString(
-                "If you exit now, you'll be guided to 'Add a Store' as your next step. Continue setup?",
-                comment: "Message of the alert when the user dismisses the store creation flow."
-            )
-            static let confirmActionTitle = NSLocalizedString(
-                "Leave",
-                comment: "Button to dismiss the store creation flow."
-            )
-            static let cancelActionTitle = NSLocalizedString(
-                "Proceed",
-                comment: "Button to dismiss the alert on the store creation flow."
-            )
         }
 
         enum StoreCreationErrorAlert {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -123,16 +123,6 @@ private extension StoreCreationCoordinator {
             }
         }
     }
-
-    /// Shows an alert with default error message
-    func showStoreCreationDefaultErrorAlert(from navigationController: UINavigationController) {
-        let alertController = UIAlertController(title: Localization.StoreCreationErrorAlert.title,
-                                                message: Localization.StoreCreationErrorAlert.defaultErrorMessage,
-                                                preferredStyle: .alert)
-        alertController.view.tintColor = .text
-        alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
-        navigationController.present(alertController, animated: true)
-    }
 }
 
 // MARK: - Actions
@@ -352,7 +342,9 @@ private extension StoreCreationCoordinator {
             }
 
         case .failure(let error):
-            showStoreCreationErrorAlert(from: navigationController.topmostPresentedViewController, error: error)
+            showStoreCreationErrorAlert(from: navigationController.topmostPresentedViewController, error: error, onDismiss: {
+                navigationController.dismiss(animated: true)
+            })
             analytics.track(event: .StoreCreation.siteCreationFailed(source: source.analyticsValue,
                                                                      error: error,
                                                                      flow: .native,
@@ -389,20 +381,12 @@ private extension StoreCreationCoordinator {
         navigationController.pushViewController(storeCreationProgressView, animated: true)
     }
 
-    func showStoreCreationErrorAlert(from viewController: UIViewController, error: SiteCreationError) {
-        let message: String = {
-            switch error {
-            case .invalidDomain, .domainExists:
-                return Localization.StoreCreationErrorAlert.domainErrorMessage
-            default:
-                return Localization.StoreCreationErrorAlert.defaultErrorMessage
-            }
-        }()
+    func showStoreCreationErrorAlert(from viewController: UIViewController, error: SiteCreationError, onDismiss: @escaping () -> Void) {
         let alertController = UIAlertController(title: Localization.StoreCreationErrorAlert.title,
-                                                message: message,
+                                                message: Localization.StoreCreationErrorAlert.message,
                                                 preferredStyle: .alert)
-        alertController.view.tintColor = .text
-        _ = alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
+        _ = alertController.addDestructiveActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in onDismiss() }
+        _ = alertController.addDefaultActionWithTitle(Localization.StoreCreationErrorAlert.retryAction) { _ in }
         viewController.present(alertController, animated: true)
     }
 
@@ -563,14 +547,14 @@ private extension StoreCreationCoordinator {
         }
 
         enum StoreCreationErrorAlert {
-            static let title = NSLocalizedString("Cannot create store",
+            static let title = NSLocalizedString("Oops! We've hit a snag",
                                                  comment: "Title of the alert when the store cannot be created in the store creation flow.")
-            static let domainErrorMessage = NSLocalizedString("Please try a different domain.",
-                                                 comment: "Message of the alert when the store cannot be created due to the domain in the store creation flow.")
-            static let defaultErrorMessage = NSLocalizedString("Please try again.",
-                                                              comment: "Message of the alert when the store cannot be created in the store creation flow.")
+            static let message = NSLocalizedString("Let's try again in a moment. If the issue persists, please contact support.",
+                                                   comment: "Message of the alert when the store cannot be created due to the domain in the store creation flow.")
+            static let retryAction = NSLocalizedString("Retry",
+                                                       comment: "Message of the alert when the store cannot be created in the store creation flow.")
             static let cancelActionTitle = NSLocalizedString(
-                "OK",
+                "Cancel",
                 comment: "Button title to dismiss the alert when the store cannot be created in the store creation flow."
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10451
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates alerts displayed in the store creation flow:
- New wording for error alert when store creation API request fails
- New alert displayed when the dismiss button on free trial summary screen is tapped.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn on the feature flag `optimizeProfilerQuestions` and build the app.
- Log in to the app and switch to the Menu tab.
- Open the store picker and select Add a store > Create a new store.
- When the free trial summary screen is displayed, tap "x" to dismiss. A new alert should be displayed saying store creation is ready. Tapping Leave should dismiss the store creation flow.
- Open the store creation flow again. Turn off your Internet connection before tapping Start free trial
- After the request times out, the error alert should be displayed with correct wording. Tapping Cancel should dismiss the store creation flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Dismissal | Error |
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/47f5964c-9ed4-44c2-a843-0221f47cfdfe" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/2034b612-50df-4fee-acdb-427c33f11b6c" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
