### PR TITLE
Address memory leak when adding new notes to order

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -411,9 +411,7 @@ extension OrderDetailsViewModel {
         case .addOrderNote:
             ServiceLocator.analytics.track(.orderDetailAddNoteButtonTapped)
 
-            let newNoteViewController = NewNoteViewController()
-            newNoteViewController.viewModel = self
-
+            let newNoteViewController = NewNoteViewController(order: order, orderNotes: orderNotes)
             let navController = WooNavigationController(rootViewController: newNoteViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .trackingAdd:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -410,8 +410,9 @@ extension OrderDetailsViewModel {
 
         case .addOrderNote:
             ServiceLocator.analytics.track(.orderDetailAddNoteButtonTapped)
-            let newNoteViewController = NewNoteViewController(order: order, orderNotes: dataSource.orderNotes)
-            newNoteViewController.onDidFinishEditing = { [weak self] orderNote in
+            let newNoteViewModel = NewNoteViewModel(order: order, orderNotes: dataSource.orderNotes)
+            let newNoteViewController = NewNoteViewController(viewModel: newNoteViewModel)
+            newNoteViewController.viewModel.onDidFinishEditing = { [weak self] orderNote in
                 self?.insertNote(orderNote)
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -410,8 +410,11 @@ extension OrderDetailsViewModel {
 
         case .addOrderNote:
             ServiceLocator.analytics.track(.orderDetailAddNoteButtonTapped)
+            let newNoteViewController = NewNoteViewController(order: order, orderNotes: dataSource.orderNotes)
+            newNoteViewController.onDidFinishEditing = { [weak self] orderNote in
+                self?.insertNote(orderNote)
+            }
 
-            let newNoteViewController = NewNoteViewController(order: order, orderNotes: orderNotes)
             let navController = WooNavigationController(rootViewController: newNoteViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .trackingAdd:
@@ -738,6 +741,12 @@ extension OrderDetailsViewModel {
         let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storageManager, matching: predicate, sortedBy: [])
         try? resultsController.performFetch()
         return !resultsController.isEmpty
+    }
+
+    /// Inserts a new note at the top of the collection of existing notes
+    ///
+    private func insertNote(_ orderNote: OrderNote) {
+        orderNotes.insert(orderNote, at: 0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -67,9 +67,9 @@ class NewNoteViewController: UIViewController {
 
         analytics.track(.orderNoteAddButtonTapped)
         analytics.track(.orderNoteAdd,
-                                       withProperties: ["parent_id": order.orderID,
-                                                        "status": order.status.rawValue,
-                                                        "type": isCustomerNote ? "customer" : "private"])
+                        withProperties: ["parent_id": order.orderID,
+                                         "status": order.status.rawValue,
+                                         "type": isCustomerNote ? "customer" : "private"])
 
         let action = OrderNoteAction.addOrderNote(siteID: order.siteID,
                                                   orderID: order.orderID,
@@ -78,7 +78,7 @@ class NewNoteViewController: UIViewController {
             if let error = error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
                 self?.analytics.track(.orderNoteAddFailed, withError: error)
-                
+
                 self?.displayErrorNotice()
                 self?.configureForEditingNote()
                 return
@@ -87,11 +87,11 @@ class NewNoteViewController: UIViewController {
             if let orderNote = orderNote {
                 self?.onDidFinishEditing?(orderNote)
             }
-            
+
             self?.analytics.track(.orderNoteAddSuccess)
             self?.dismiss(animated: true, completion: nil)
         }
-        
+
         ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -195,14 +195,6 @@ private extension NewNoteViewController {
             ServiceLocator.analytics.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
         }
     }
-
-    private func refreshTextViewCell() {
-        guard let cell = tableView.firstSubview(ofType: TextViewTableViewCell.self) else {
-            return
-        }
-
-        setupWriteNoteCell(cell)
-    }
 }
 
 // MARK: - UITableViewDataSource Conformance

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -60,10 +60,8 @@ class NewNoteViewController: UIViewController {
     @objc func addButtonTapped() {
         configureForCommittingNote()
 
-        viewModel.track(.orderNoteAddButtonTapped)
-        viewModel.track(.orderNoteAdd, withProperties: ["parent_id": viewModel.orderID,
-                                                        "status": viewModel.orderStatus,
-                                                        "type": isCustomerNote ? "customer" : "private"])
+        viewModel.trackOrderNoteAddButtonTapped()
+        viewModel.trackOrderNoteAdd(isCustomerNote)
 
         let action = OrderNoteAction.addOrderNote(siteID: viewModel.order.siteID,
                                                   orderID: viewModel.orderID,
@@ -190,7 +188,7 @@ private extension NewNoteViewController {
             )
 
             let stateValue = newValue ? "on" : "off"
-            self.viewModel.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
+            self.viewModel.trackOrderNoteEmailCustomerToggled(stateValue)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -10,6 +10,7 @@ class NewNoteViewController: UIViewController {
 
     var order: Order
     var orderNotes: [OrderNote]
+    var onDidFinishEditing: ((OrderNote) -> Void)?
 
     init(order: Order, orderNotes: [OrderNote]) {
         self.order = order
@@ -80,8 +81,9 @@ class NewNoteViewController: UIViewController {
                 self?.configureForEditingNote()
                 return
             }
-            
-            if let orderNote = orderNote {                                                      self?.orderNotes.insert(orderNote, at: 0)
+
+            if let orderNote = orderNote {
+                self?.onDidFinishEditing?(orderNote)
             }
             
             ServiceLocator.analytics.track(.orderNoteAddSuccess)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -11,10 +11,12 @@ class NewNoteViewController: UIViewController {
     var order: Order
     var orderNotes: [OrderNote]
     var onDidFinishEditing: ((OrderNote) -> Void)?
+    var analytics: Analytics
 
-    init(order: Order, orderNotes: [OrderNote]) {
+    init(order: Order, orderNotes: [OrderNote], analytics: Analytics = ServiceLocator.analytics) {
         self.order = order
         self.orderNotes = orderNotes
+        self.analytics = analytics
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -63,8 +65,8 @@ class NewNoteViewController: UIViewController {
     @objc func addButtonTapped() {
         configureForCommittingNote()
 
-        ServiceLocator.analytics.track(.orderNoteAddButtonTapped)
-        ServiceLocator.analytics.track(.orderNoteAdd,
+        analytics.track(.orderNoteAddButtonTapped)
+        analytics.track(.orderNoteAdd,
                                        withProperties: ["parent_id": order.orderID,
                                                         "status": order.status.rawValue,
                                                         "type": isCustomerNote ? "customer" : "private"])
@@ -75,7 +77,7 @@ class NewNoteViewController: UIViewController {
                                                   note: noteText) { [weak self] (orderNote, error) in
             if let error = error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
-                ServiceLocator.analytics.track(.orderNoteAddFailed, withError: error)
+                self?.analytics.track(.orderNoteAddFailed, withError: error)
                 
                 self?.displayErrorNotice()
                 self?.configureForEditingNote()
@@ -86,7 +88,7 @@ class NewNoteViewController: UIViewController {
                 self?.onDidFinishEditing?(orderNote)
             }
             
-            ServiceLocator.analytics.track(.orderNoteAddSuccess)
+            self?.analytics.track(.orderNoteAddSuccess)
             self?.dismiss(animated: true, completion: nil)
         }
         
@@ -194,7 +196,7 @@ private extension NewNoteViewController {
             )
 
             let stateValue = newValue ? "on" : "off"
-            ServiceLocator.analytics.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
+            self.analytics.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -60,19 +60,18 @@ class NewNoteViewController: UIViewController {
     @objc func addButtonTapped() {
         configureForCommittingNote()
 
-        viewModel.analytics.track(.orderNoteAddButtonTapped)
-        viewModel.analytics.track(.orderNoteAdd,
-                                  withProperties: ["parent_id": viewModel.order.orderID,
-                                                   "status": viewModel.order.status.rawValue,
-                                                   "type": isCustomerNote ? "customer" : "private"])
+        viewModel.track(.orderNoteAddButtonTapped)
+        viewModel.track(.orderNoteAdd, withProperties: ["parent_id": viewModel.orderID,
+                                                        "status": viewModel.orderStatus,
+                                                        "type": isCustomerNote ? "customer" : "private"])
 
         let action = OrderNoteAction.addOrderNote(siteID: viewModel.order.siteID,
-                                                  orderID: viewModel.order.orderID,
+                                                  orderID: viewModel.orderID,
                                                   isCustomerNote: isCustomerNote,
                                                   note: noteText) { [weak self] (orderNote, error) in
             if let error = error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
-                self?.viewModel.analytics.track(.orderNoteAddFailed, withError: error)
+                self?.viewModel.track(.orderNoteAddFailed, withError: error)
 
                 self?.displayErrorNotice()
                 self?.configureForEditingNote()
@@ -83,7 +82,7 @@ class NewNoteViewController: UIViewController {
                 self?.viewModel.onDidFinishEditing?(orderNote)
             }
 
-            self?.viewModel.analytics.track(.orderNoteAddSuccess)
+            self?.viewModel.track(.orderNoteAddSuccess)
             self?.dismiss(animated: true, completion: nil)
         }
 
@@ -191,7 +190,7 @@ private extension NewNoteViewController {
             )
 
             let stateValue = newValue ? "on" : "off"
-            self.viewModel.analytics.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
+            self.viewModel.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
         }
     }
 }
@@ -242,7 +241,7 @@ private extension NewNoteViewController {
                 + "It reads: Unable to add note to order #{order number}. "
                 + "Parameters: %1$d - order number"
         )
-        let title = String.localizedStringWithFormat(titleFormat, viewModel.order.orderID)
+        let title = String.localizedStringWithFormat(titleFormat, viewModel.orderID)
 
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
@@ -264,7 +263,7 @@ private extension NewNoteViewController {
 
     func configureTitle() {
         let titleFormat = NSLocalizedString("Order #%1$@", comment: "Add a note screen - title. Example: Order #15. Parameters: %1$@ - order number")
-        title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
+        title = String.localizedStringWithFormat(titleFormat, viewModel.orderNumber)
     }
 
     func configureDismissButton() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewModel.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Yosemite
+
+final class NewNoteViewModel {
+    let order: Order
+    let orderNotes: [OrderNote]
+    var onDidFinishEditing: ((OrderNote) -> Void)?
+    let analytics: Analytics
+
+    init(order: Order, orderNotes: [OrderNote], analytics: Analytics = ServiceLocator.analytics) {
+        self.order = order
+        self.orderNotes = orderNotes
+        self.analytics = analytics
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewModel.swift
@@ -7,9 +7,29 @@ final class NewNoteViewModel {
     var onDidFinishEditing: ((OrderNote) -> Void)?
     let analytics: Analytics
 
+    var siteID: Int64 {
+        order.siteID
+    }
+
+    var orderID: Int64 {
+        order.orderID
+    }
+
+    var orderStatus: String {
+        order.status.rawValue
+    }
+
+    var orderNumber: String {
+        order.number
+    }
+
     init(order: Order, orderNotes: [OrderNote], analytics: Analytics = ServiceLocator.analytics) {
         self.order = order
         self.orderNotes = orderNotes
         self.analytics = analytics
+    }
+
+    func track(_ stat: WooAnalyticsStat, withProperties properties: [AnyHashable: Any]? = nil, withError: Error? = nil) {
+        analytics.track(stat, properties: properties, error: withError)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewModel.swift
@@ -28,8 +28,28 @@ final class NewNoteViewModel {
         self.orderNotes = orderNotes
         self.analytics = analytics
     }
+}
 
+// MARK: - Tracking
+//
+extension NewNoteViewModel {
     func track(_ stat: WooAnalyticsStat, withProperties properties: [AnyHashable: Any]? = nil, withError: Error? = nil) {
         analytics.track(stat, properties: properties, error: withError)
+    }
+
+    func trackOrderNoteAddButtonTapped() {
+        analytics.track(.orderNoteAddButtonTapped)
+    }
+
+    func trackOrderNoteAdd(_ isCustomerNote: Bool) {
+        analytics.track(.orderNoteAdd, withProperties: [
+            "parent_id": orderID,
+            "status": orderStatus,
+            "type": isCustomerNote ? "customer" : "private"]
+        )
+    }
+
+    func trackOrderNoteEmailCustomerToggled(_ stateValue: String) {
+        analytics.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1260,6 +1260,7 @@
 		6881CCC42A5EE6BF00AEDE36 /* WooPlanCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */; };
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
 		6888A2CA2A66C42C0026F5C0 /* FullFeatureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */; };
+		68C31B712A8617C500AE5C5A /* NewNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C31B702A8617C500AE5C5A /* NewNoteViewModel.swift */; };
 		68D1BEDB28FFEDC20074A29E /* OrderCustomerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */; };
 		68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */; };
 		68E6749F2A4DA01C0034BA1E /* WooWPComPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E6749E2A4DA01C0034BA1E /* WooWPComPlan.swift */; };
@@ -3661,6 +3662,7 @@
 		6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPlanCardView.swift; sourceTree = "<group>"; };
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
 		6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListViewModel.swift; sourceTree = "<group>"; };
+		68C31B702A8617C500AE5C5A /* NewNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteViewModel.swift; sourceTree = "<group>"; };
 		68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerListView.swift; sourceTree = "<group>"; };
 		68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommand.swift; sourceTree = "<group>"; };
 		68E6749E2A4DA01C0034BA1E /* WooWPComPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooWPComPlan.swift; sourceTree = "<group>"; };
@@ -9630,6 +9632,7 @@
 			children = (
 				CE583A0321076C0100D73C1C /* NewNoteViewController.swift */,
 				B5FD111121D3CE7700560344 /* NewNoteViewController.xib */,
+				68C31B702A8617C500AE5C5A /* NewNoteViewModel.swift */,
 			);
 			path = "Add Order Note";
 			sourceTree = "<group>";
@@ -12220,6 +12223,7 @@
 				AEC12B7A2758D55900845F97 /* OrderStatusList.swift in Sources */,
 				0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */,
 				B958640C2A66847B002C4C6E /* CouponListView.swift in Sources */,
+				68C31B712A8617C500AE5C5A /* NewNoteViewModel.swift in Sources */,
 				D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */,
 				02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */,
 				45381B4527341B8A003FEC5F /* DateRangeFilterViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7432

## Description
This PR addresses a memory leak when adding a new note to an order. This is because we keep a strong reference between the `OrderDetailsViewModel` and each instance of the `NewNoteViewController`, which causes a retain cycle as the `NewNoteViewController` instance is not deallocated when the view is dismissed, leading to a memory leak and eventual crashes like [this one](https://github.com/woocommerce/woocommerce-ios/issues/7432).

Currently, each time we add a new note the memory usage increases and is not freed after the note view has been closed, we can see this by adding multiple notes and seeing how (in this example) memory goes up by 1MB per note added.

<img width="650" alt="Screenshot 2023-08-10 at 11 23 03" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/b71cab08-3859-42d4-bc87-b2994dcfa30b">


## Changes: 
- Weakifies the `@IBOutlet` that holds the tableview
- Pass the Order and OrderNotes from the view model to the view controller via constructor injection
- Send back to the viewmodel the new note via closure callback, which will update the orderNotes accordingly.
- Remove an un-used method
- Since we're already cleaning up, we also inject the Analytics service into the constructor, rather than calling the shared instance (This doesn't add much right now since we're doing the same on the OrderDetailsViewModel, but that's the next step :D)

## Testing instructions
1. Go to Orders > select an Order > Scroll down to `+ Add a Note`
2. Open Debug Navigation > Memory Report:

<img width="1050" alt="Screenshot 2023-08-10 at 11 20 34" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/5728f465-1cef-4e4c-b17f-37a8ea07435d">


3. Write a note > Tap `Add` > Observe how the note is still appearing correctly in the Order history:

<img width=600 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/fea2caae-80e8-468b-a256-1ea6bf936e21">


4. Do this multiple times and see how the memory does not increase permanently, but remains around the same values between the Order Details and the New note.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
