### PR TITLE
[Better Customer Selector] Do not adjust table view bottom inset when showing the customer list.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -86,6 +86,10 @@ final class CustomerSearchUICommand: SearchUICommand {
         featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder) && loadResultsWhenSearchTermIsEmpty
     }
 
+    var adjustTableViewBottomInsetWhenKeyboardIsShown: Bool {
+        false
+    }
+
     func createHeaderView() -> UIView? {
         guard featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder),
         showSearchFilters else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -86,9 +86,7 @@ final class CustomerSearchUICommand: SearchUICommand {
         featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder) && loadResultsWhenSearchTermIsEmpty
     }
 
-    var adjustTableViewBottomInsetWhenKeyboardIsShown: Bool {
-        false
-    }
+    let adjustTableViewBottomInsetWhenKeyboardIsShown = false
 
     func createHeaderView() -> UIView? {
         guard featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder),

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -27,6 +27,11 @@ protocol SearchUICommand {
     ///
     var syncResultsWhenSearchQueryTurnsEmpty: Bool { get }
 
+    /// Return true if you want the table view to adjust its bottom inset when the keyboard is shown, so it's covered partially by it.
+    /// Sometimes we don't need it, as the table view adjust automatically its height thanks to the superview constraits.
+    /// 
+    var adjustTableViewBottomInsetWhenKeyboardIsShown: Bool { get }
+
     /// A closure to resynchronize models if the data source might change (e.g. when the filter changes in products search).
     /// Set externally to enable resyncing the models when needed. Otherwise, an empty closure can be set by default.
     var resynchronizeModels: (() -> Void) { get set }
@@ -139,6 +144,10 @@ extension SearchUICommand {
 
     var syncResultsWhenSearchQueryTurnsEmpty: Bool {
         false
+    }
+
+    var adjustTableViewBottomInsetWhenKeyboardIsShown: Bool {
+        true
     }
 
     func configureActionButton(_ button: UIButton, onDismiss: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -144,7 +144,9 @@ where Cell.SearchModel == Command.CellViewModel {
         configureStarterViewController()
         configureSearchResync()
 
-        startListeningToNotifications()
+        if searchUICommand.adjustTableViewBottomInsetWhenKeyboardIsShown {
+            startListeningToKeyboardNotifications()
+        }
 
         transitionToResultsUpdatedState()
         configureSearchFunctionality()
@@ -397,7 +399,7 @@ private extension SearchViewController {
 
     /// Registers for all of the related Notifications
     ///
-    func startListeningToNotifications() {
+    func startListeningToKeyboardNotifications() {
         keyboardFrameObserver.startObservingKeyboardFrame()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix the UI glitch in the Customer search list that shows a big extra space at the bottom of the table view when the keyboard is shown.

The reason behind that is the logic in place to add a bottom content inset when the keyboard is shown shouldn't apply to our case here, as the table view is already resized when the keyboard is shown. Because of that, we see extra space at the bottom of the table view (see video below).

After some investigation, I couldn't find out why the view is resized when presenting the `SearchViewController` from the edit order modally, in contrast with the other `SearchViewController` scenarios, e.g. the Order Search. Because of this, the solution here isn't quite optimal, if we move the customer search elsewhere the table view might be covered by the keyboard. However, I think we can forward with this solution because:

- As the default value of `adjustTableViewBottomInsetWhenKeyboardIsShown` is true, we can be sure that we don't break the logic elsewhere.
- As we can now dismiss the keyboard, the users can see what's behind it.
- We can be very certain that we won't move the Customer Selector somewhere else.
- It's an easy reversible solution that didn't take much effort. Spending more time fixing this is not worth it.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With the betterCustomerSelectionInOrder feature flag enabled. With a Woo Plugin version > 8.0.0 with many customers.

1. Go to Orders
2. Tap on + to create a new order
3. Tap on + Add Customer Details
4. With the keyboard shown. Scroll fast to the bottom. See that there's no extra space. (See videos).


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://github.com/woocommerce/woocommerce-ios/assets/1864060/b3fe043d-3356-4914-8102-3a76c0cd83d9




### After


https://github.com/woocommerce/woocommerce-ios/assets/1864060/1e84daff-1d21-4b27-8875-845646246b43







---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
