### PR TITLE
[In-Person Payments] Improve data tracking for all Payment Methods

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1102,6 +1102,8 @@ extension WooAnalyticsEvent {
         private enum Keys {
             static let state = "state"
             static let amount = "amount"
+            static let amountNormalized = "amount_normalized"
+            static let currency = "currency"
             static let paymentMethod = "payment_method"
             static let source = "source"
             static let flow = "flow"
@@ -1111,11 +1113,15 @@ extension WooAnalyticsEvent {
 
         static func paymentsFlowCompleted(flow: Flow,
                                           amount: String,
+                                          amountNormalized: Float64,
+                                          currency: String,
                                           method: PaymentMethod,
                                           orderID: Int64,
                                           cardReaderType: CardReaderType?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                                                                        Keys.amount: amount,
+                                                                       Keys.amountNormalized: amountNormalized,
+                                                                       Keys.currency: currency,
                                                                        Keys.paymentMethod: method.rawValue,
                                                                        Keys.orderID: orderID]
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1113,7 +1113,7 @@ extension WooAnalyticsEvent {
 
         static func paymentsFlowCompleted(flow: Flow,
                                           amount: String,
-                                          amountNormalized: Float64,
+                                          amountNormalized: Int,
                                           currency: String,
                                           method: PaymentMethod,
                                           orderID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -450,7 +450,6 @@ private extension PaymentMethodsViewModel {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let amountNormalized = currencyFormatter.convertToDecimal(formattedTotal)
 
-
         analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCompleted(flow: flow,
                                                                                     amount: formattedTotal,
                                                                                     amountNormalized: Float64(truncating: amountNormalized ?? 0),

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -448,11 +448,15 @@ private extension PaymentMethodsViewModel {
     func trackFlowCompleted(method: WooAnalyticsEvent.PaymentsFlow.PaymentMethod,
                             cardReaderType: WooAnalyticsEvent.PaymentsFlow.CardReaderType?) {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        let amountNormalized = currencyFormatter.convertToDecimal(formattedTotal)
+        let amountNormalized = currencyFormatter.convertToDecimal(formattedTotal) ?? 0
+
+        let amountInSmallestUnit = amountNormalized
+            .multiplying(by: NSDecimalNumber(value: currencySettings.currencyCode.smallestCurrencyUnitMultiplier))
+            .intValue
 
         analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCompleted(flow: flow,
                                                                                     amount: formattedTotal,
-                                                                                    amountNormalized: Float64(truncating: amountNormalized ?? 0),
+                                                                                    amountNormalized: amountInSmallestUnit,
                                                                                     currency: currencySettings.currencyCode.rawValue,
                                                                                     method: method,
                                                                                     orderID: orderID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -250,6 +250,8 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         assertEqual(analytics.receivedEvents.first, WooAnalyticsStat.paymentsFlowCompleted.rawValue)
         assertEqual(analytics.receivedProperties.first?["payment_method"] as? String, "cash")
         assertEqual(analytics.receivedProperties.first?["amount"] as? String, "$12.00")
+        assertEqual(analytics.receivedProperties.first?["amount_normalized"] as? Float64, 12.0)
+        assertEqual(analytics.receivedProperties.first?["currency"] as? String, "USD")
         assertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
         assertEqual(analytics.receivedProperties.first?["order_id"] as? Int64, orderID)
     }

--- a/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
@@ -58,3 +58,19 @@ public enum CurrencyCode: String, CaseIterable, Codable {
         self.init(rawValue: caseInsensitiveRawValue.uppercased())
     }
 }
+
+public extension CurrencyCode {
+    /// Sometimes we want to use the smallest currency unit when dealing with amounts. Use this multiplier to convert it to that unit.
+    /// Source: Currency Decimals e.g. https://stripe.com/docs/currencies
+    /// 
+    var smallestCurrencyUnitMultiplier: Int {
+        switch self {
+        case .BIF, .CLP, .DJF, .GNF, .JPY, .KMF, .KRW, .MGA, .PYG, .RWF, .UGX, .VND, .VUV, .XAF, .XOF, .XPF:
+            return 1
+        case .BHD, .JOD, .KWD, .OMR, .TND:
+            return 1000
+        default:
+            return 100
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we want to improve the data we track whenever a payment flow is completed in our app, so we can process that information better. Until now we tracked the formatter payment amount (e.g., "$12.50"), which makes it difficult to process. Now we will track the amount by the **smallest currency unit**:
- amount_normalized: Only the amount e.g., 12500
- currency: the currency code e.g., "USD"

Please note again that we track it by the smallest currency unit, which means that if a currency has zero decimals, we track the original amount:

¥12 -> `amount_normalized` 12

Or with three zero decimals:

BD12 -> `amount_normalized` 12000

We will keep tracking the formatted `amount` for backward compatibility. More info here pdND4G-fv-p2

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Menu
2. Tap on Payments
3. Tap on Collect Payment
4. Follow the Simple Payment Flow
5. When you reach the payment methods screen, use cash.
6. The event with the new properties should be tracked

` 🔵 Tracked payments_flow_completed, properties: [AnyHashable("payment_method"): "cash", AnyHashable("blog_id"): 214354650, AnyHashable("was_ecommerce_trial"): false, AnyHashable("amount_normalized"): 1250, AnyHashable("plan"): "business-bundle", AnyHashable("amount"): "$12.50", AnyHashable("flow"): "simple_payment", AnyHashable("currency"): "USD", AnyHashable("is_wpcom_store"): true, AnyHashable("order_id"): 940]`

Repeat the process with the other payment methods and ensure that they're all tracked.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.