### PR TITLE
Store onboarding: Handle store name setup

### DIFF
--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -283,7 +283,7 @@ private extension SiteRemote {
         }
 
         static func siteSettings(siteID: Int64) -> String {
-            "site/\(siteID)/settings"
+            "sites/\(siteID)/settings"
         }
     }
     enum Fields {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -64,7 +64,9 @@ struct StoreNameSetupView: View {
                         ActivityIndicator(isAnimating: .constant(true), style: .medium)
                     } else {
                         Button(Localization.save) {
-                            viewModel.saveName()
+                            viewModel.saveName {
+                                onDismiss()
+                            }
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -68,7 +68,9 @@ struct StoreNameSetupView: View {
                         ActivityIndicator(isAnimating: .constant(true), style: .medium)
                     } else {
                         Button(Localization.save) {
-                            viewModel.saveName()
+                            Task { @MainActor in
+                                await viewModel.saveName()
+                            }
                         }
                         .disabled(viewModel.shouldEnableSaving == false)
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -57,7 +57,6 @@ struct StoreNameSetupView: View {
                     Button(Localization.cancel) {
                         onDismiss()
                     }
-                    .disabled(viewModel.isSavingInProgress)
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     if viewModel.isSavingInProgress {
@@ -68,6 +67,7 @@ struct StoreNameSetupView: View {
                                 onDismiss()
                             }
                         }
+                        .disabled(viewModel.shouldEnableSaving == false)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -55,12 +55,17 @@ struct StoreNameSetupView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.cancel) {
-                        // TODO
+                        onDismiss()
                     }
+                    .disabled(viewModel.isSavingInProgress)
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.save) {
-                        // TODO
+                    if viewModel.isSavingInProgress {
+                        ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                    } else {
+                        Button(Localization.save) {
+                            viewModel.saveName()
+                        }
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -1,13 +1,88 @@
 import SwiftUI
 
+/// Hosting controller for `StoreNameSetupView`.
+///
+final class StoreNameSetupHostingController: UIHostingController<StoreNameSetupView> {
+
+    init(viewModel: StoreNameSetupViewModel) {
+        super.init(rootView: StoreNameSetupView(viewModel: viewModel))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// View to set up store name
+///
 struct StoreNameSetupView: View {
+
+    @ObservedObject private var viewModel: StoreNameSetupViewModel
+
+    init(viewModel: StoreNameSetupViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            VStack {
+                HStack {
+                    TextField(Localization.placeholder, text: $viewModel.name)
+                        .textFieldStyle(.plain)
+                    Spacer()
+                    Button(action: {
+                        viewModel.name = ""
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .secondaryBodyStyle()
+                    }
+                    .renderedIf(viewModel.name.isNotEmpty)
+                }
+                .padding(Layout.textFieldPadding)
+                .background(Color(uiColor: .systemBackground))
+                .cornerRadius(Layout.textFieldCornerRadius)
+                .padding(.horizontal, Layout.textFieldHorizontalMargin)
+                .padding(.vertical, Layout.textFieldVerticalMargin)
+
+                Spacer()
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        // TODO
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.save) {
+                        // TODO
+                    }
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle(Localization.title)
+            .background(Color(uiColor: .listBackground))
+        }
+    }
+}
+
+private extension StoreNameSetupView {
+    enum Layout {
+        static let textFieldCornerRadius: CGFloat = 8
+        static let textFieldPadding: CGFloat = 16
+        static let textFieldHorizontalMargin: CGFloat = 16
+        static let textFieldVerticalMargin: CGFloat = 24
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString("Store name", comment: "Title for the store name screen")
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the store name screen")
+        static let save = NSLocalizedString("Save", comment: "Button to save the name in the store name screen")
+        static let placeholder = NSLocalizedString("Enter your store name", comment: "Placeholder for the text field on the store name screen")
     }
 }
 
 struct StoreNameSetupView_Previews: PreviewProvider {
     static var previews: some View {
-        StoreNameSetupView()
+        StoreNameSetupView(viewModel: .init(siteID: 123, name: "Test") {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -47,8 +47,6 @@ struct StoreNameSetupView: View {
                 .padding(Layout.textFieldPadding)
                 .background(Color(uiColor: .systemBackground))
                 .cornerRadius(Layout.textFieldCornerRadius)
-                .padding(.horizontal, Layout.textFieldHorizontalMargin)
-                .padding(.vertical, Layout.textFieldVerticalMargin)
 
                 if let message = viewModel.errorMessage {
                     Text(message)
@@ -57,6 +55,8 @@ struct StoreNameSetupView: View {
 
                 Spacer()
             }
+            .padding(.horizontal, Layout.textFieldHorizontalMargin)
+            .padding(.top, Layout.textFieldVerticalMargin)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.cancel) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -68,9 +68,7 @@ struct StoreNameSetupView: View {
                         ActivityIndicator(isAnimating: .constant(true), style: .medium)
                     } else {
                         Button(Localization.save) {
-                            viewModel.saveName {
-                                onDismiss()
-                            }
+                            viewModel.saveName()
                         }
                         .disabled(viewModel.shouldEnableSaving == false)
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct StoreNameSetupView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct StoreNameSetupView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreNameSetupView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -50,6 +50,11 @@ struct StoreNameSetupView: View {
                 .padding(.horizontal, Layout.textFieldHorizontalMargin)
                 .padding(.vertical, Layout.textFieldVerticalMargin)
 
+                if let message = viewModel.errorMessage {
+                    Text(message)
+                        .errorStyle()
+                }
+
                 Spacer()
             }
             .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -6,6 +6,9 @@ final class StoreNameSetupHostingController: UIHostingController<StoreNameSetupV
 
     init(viewModel: StoreNameSetupViewModel) {
         super.init(rootView: StoreNameSetupView(viewModel: viewModel))
+        rootView.onDismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -18,6 +21,9 @@ final class StoreNameSetupHostingController: UIHostingController<StoreNameSetupV
 struct StoreNameSetupView: View {
 
     @ObservedObject private var viewModel: StoreNameSetupViewModel
+
+    /// Triggered when the cancel button is tapped
+    var onDismiss: () -> Void = {}
 
     init(viewModel: StoreNameSetupViewModel) {
         self.viewModel = viewModel

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -37,7 +37,8 @@ final class StoreNameSetupViewModel: ObservableObject {
             guard let self else { return }
             self.isSavingInProgress = false
             switch result {
-            case .success(()):
+            case .success(let site):
+                self.stores.updateDefaultStore(site)
                 onCompletion()
             case .failure(let error):
                 errorMessage = error.localizedDescription

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -39,6 +39,7 @@ final class StoreNameSetupViewModel: ObservableObject {
             switch result {
             case .success(let site):
                 self.stores.updateDefaultStore(site)
+                self.onNameSaved()
                 onCompletion()
             case .failure(let error):
                 errorMessage = error.localizedDescription

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Yosemite
+
+/// View model for `StoreNameSetupView`.
+///
+final class StoreNameSetupViewModel {
+    private let siteID: Int64
+    private let stores: StoresManager
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -30,7 +30,7 @@ final class StoreNameSetupViewModel: ObservableObject {
         self.onNameSaved = onNameSaved
     }
 
-    func saveName(onCompletion: @escaping () -> Void) {
+    func saveName() {
         errorMessage = nil
         isSavingInProgress = true
         stores.dispatch(SiteAction.updateSiteTitle(siteID: siteID, title: name, completion: { [weak self] result in
@@ -40,7 +40,6 @@ final class StoreNameSetupViewModel: ObservableObject {
             case .success(let site):
                 self.stores.updateDefaultStore(site)
                 self.onNameSaved()
-                onCompletion()
             case .failure(let error):
                 errorMessage = error.localizedDescription
                 DDLogError("⛔️ Error saving store name: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -7,6 +7,7 @@ final class StoreNameSetupViewModel: ObservableObject {
 
     @Published var name: String
     @Published private(set) var isSavingInProgress = false
+    @Published private(set) var errorMessage: String?
 
     private let siteID: Int64
     private let stores: StoresManager
@@ -22,7 +23,19 @@ final class StoreNameSetupViewModel: ObservableObject {
         self.onNameSaved = onNameSaved
     }
 
-    func saveName() {
-        
+    func saveName(onCompletion: @escaping () -> Void) {
+        errorMessage = nil
+        isSavingInProgress = true
+        stores.dispatch(SiteAction.updateSiteTitle(siteID: siteID, title: name, completion: { [weak self] result in
+            guard let self else { return }
+            self.isSavingInProgress = false
+            switch result {
+            case .success(()):
+                onCompletion()
+            case .failure(let error):
+                errorMessage = error.localizedDescription
+                DDLogError("⛔️ Error saving store name: \(error)")
+            }
+        }))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -6,6 +6,7 @@ import Yosemite
 final class StoreNameSetupViewModel: ObservableObject {
 
     @Published var name: String
+    @Published private(set) var isSavingInProgress = false
 
     private let siteID: Int64
     private let stores: StoresManager
@@ -19,5 +20,9 @@ final class StoreNameSetupViewModel: ObservableObject {
         self.name = name
         self.stores = stores
         self.onNameSaved = onNameSaved
+    }
+
+    func saveName() {
+        
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -9,9 +9,15 @@ final class StoreNameSetupViewModel: ObservableObject {
     @Published private(set) var isSavingInProgress = false
     @Published private(set) var errorMessage: String?
 
+    /// Whether the Save button should be enabled
+    var shouldEnableSaving: Bool {
+        name.isNotEmpty && name != initialStoreName
+    }
+
     private let siteID: Int64
     private let stores: StoresManager
     private let onNameSaved: () -> Void
+    private let initialStoreName: String
 
     init(siteID: Int64,
          name: String,
@@ -19,6 +25,7 @@ final class StoreNameSetupViewModel: ObservableObject {
          onNameSaved: @escaping () -> Void) {
         self.siteID = siteID
         self.name = name
+        self.initialStoreName = name
         self.stores = stores
         self.onNameSaved = onNameSaved
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -3,13 +3,21 @@ import Yosemite
 
 /// View model for `StoreNameSetupView`.
 ///
-final class StoreNameSetupViewModel {
+final class StoreNameSetupViewModel: ObservableObject {
+
+    @Published var name: String
+
     private let siteID: Int64
     private let stores: StoresManager
+    private let onNameSaved: () -> Void
 
     init(siteID: Int64,
-         stores: StoresManager = ServiceLocator.stores) {
+         name: String,
+         stores: StoresManager = ServiceLocator.stores,
+         onNameSaved: @escaping () -> Void) {
         self.siteID = siteID
+        self.name = name
         self.stores = stores
+        self.onNameSaved = onNameSaved
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupViewModel.swift
@@ -41,7 +41,7 @@ final class StoreNameSetupViewModel: ObservableObject {
                 self.stores.updateDefaultStore(site)
                 self.onNameSaved()
             case .failure(let error):
-                errorMessage = error.localizedDescription
+                self.errorMessage = error.localizedDescription
                 DDLogError("⛔️ Error saving store name: \(error)")
             }
         }))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -145,6 +145,7 @@ private extension StoreOnboardingCoordinator {
     func showStoreNameSetup() {
         let viewModel = StoreNameSetupViewModel(siteID: site.siteID, name: site.name, onNameSaved: { [weak self] in
             self?.onTaskCompleted(.storeName)
+            self?.navigationController.presentedViewController?.dismiss(animated: true)
         })
         let controller = StoreNameSetupHostingController(viewModel: viewModel)
         navigationController.present(controller, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -143,7 +143,11 @@ private extension StoreOnboardingCoordinator {
     }
 
     func showStoreNameSetup() {
-        // TODO
+        let viewModel = StoreNameSetupViewModel(siteID: site.siteID, name: site.name, onNameSaved: { [weak self] in
+            self?.onTaskCompleted(.storeName)
+        })
+        let controller = StoreNameSetupHostingController(viewModel: viewModel)
+        navigationController.present(controller, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -62,7 +62,7 @@ final class StoreOnboardingCoordinator: Coordinator {
         case .payments:
             showPaymentsSetup()
         case .storeName:
-            showStoreTitleSetup()
+            showStoreNameSetup()
         case .unsupported:
             assertionFailure("Unexpected onboarding task: \(task)")
         }
@@ -142,7 +142,7 @@ private extension StoreOnboardingCoordinator {
         coordinator.start()
     }
 
-    func showStoreTitleSetup() {
+    func showStoreNameSetup() {
         // TODO
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2081,6 +2081,7 @@
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
 		DE36E0982A8634FF00B98496 /* StoreNameSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E0972A8634FF00B98496 /* StoreNameSetupView.swift */; };
 		DE36E09A2A86351100B98496 /* StoreNameSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E0992A86351100B98496 /* StoreNameSetupViewModel.swift */; };
+		DE36E09C2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */; };
 		DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE37517B28DC5FC6000163CB /* Authenticator.swift */; };
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
@@ -4524,6 +4525,7 @@
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		DE36E0972A8634FF00B98496 /* StoreNameSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameSetupView.swift; sourceTree = "<group>"; };
 		DE36E0992A86351100B98496 /* StoreNameSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameSetupViewModel.swift; sourceTree = "<group>"; };
+		DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameSetupViewModelTests.swift; sourceTree = "<group>"; };
 		DE37517B28DC5FC6000163CB /* Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
@@ -10649,6 +10651,7 @@
 				EE3272A329A88F750015F8D0 /* StoreOnboardingViewModelTests.swift */,
 				EEB4E2D729B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift */,
 				027EB57729C18AAC003CE551 /* StoreOnboardingLaunchStoreViewModelTests.swift */,
+				DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -13466,6 +13469,7 @@
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
 				03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */,
 				DE279BAD26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift in Sources */,
+				DE36E09C2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift in Sources */,
 				57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */,
 				020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */,
 				B5C6CE612190D28E00515926 /* NSAttributedStringHelperTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2079,6 +2079,8 @@
 		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
 		DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
+		DE36E0982A8634FF00B98496 /* StoreNameSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E0972A8634FF00B98496 /* StoreNameSetupView.swift */; };
+		DE36E09A2A86351100B98496 /* StoreNameSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E0992A86351100B98496 /* StoreNameSetupViewModel.swift */; };
 		DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE37517B28DC5FC6000163CB /* Authenticator.swift */; };
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
@@ -4520,6 +4522,8 @@
 		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
 		DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
+		DE36E0972A8634FF00B98496 /* StoreNameSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameSetupView.swift; sourceTree = "<group>"; };
+		DE36E0992A86351100B98496 /* StoreNameSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameSetupViewModel.swift; sourceTree = "<group>"; };
 		DE37517B28DC5FC6000163CB /* Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
@@ -5906,6 +5910,7 @@
 		02BBD6E329A2674C00243BE2 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				DE36E0962A8634DB00B98496 /* StoreName */,
 				EE46CEE029CB31E7004E4524 /* StoreDetails */,
 				02BBD6E429A2678100243BE2 /* StoreOnboardingView.swift */,
 				02BBD6E629A268F300243BE2 /* StoreOnboardingViewModel.swift */,
@@ -10340,6 +10345,15 @@
 			path = "Native Jetpack Setup";
 			sourceTree = "<group>";
 		};
+		DE36E0962A8634DB00B98496 /* StoreName */ = {
+			isa = PBXGroup;
+			children = (
+				DE36E0972A8634FF00B98496 /* StoreNameSetupView.swift */,
+				DE36E0992A86351100B98496 /* StoreNameSetupViewModel.swift */,
+			);
+			path = StoreName;
+			sourceTree = "<group>";
+		};
 		DE4B3B2A2692DBF200EEF2D8 /* Review Order */ = {
 			isa = PBXGroup;
 			children = (
@@ -12472,6 +12486,7 @@
 				264957A329C520860095AA4C /* SubscriptionsView.swift in Sources */,
 				02DE39D92968647100BB31D4 /* DomainSettingsViewModel.swift in Sources */,
 				576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */,
+				DE36E0982A8634FF00B98496 /* StoreNameSetupView.swift in Sources */,
 				2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */,
 				B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */,
 				7E6A01972725B811001668D5 /* FilterProductCategoryListViewController.swift in Sources */,
@@ -12733,6 +12748,7 @@
 				026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */,
 				4590B64C261C673B00A6FCE0 /* WeightFormatter.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
+				DE36E09A2A86351100B98496 /* StoreNameSetupViewModel.swift in Sources */,
 				DE279BA626E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift in Sources */,
 				02B1AA6729A4709400D54FCB /* FilterTabBar.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Yosemite
+@testable import WooCommerce
+
+final class StoreNameSetupViewModelTests: XCTestCase {
+
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+    }
+
+    func test_shouldEnableSaving_returns_false_if_store_name_is_empty() {
+        // Given
+        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", onNameSaved: {})
+
+        // When
+        viewModel.name = ""
+
+        // Then
+        XCTAssertFalse(viewModel.shouldEnableSaving)
+    }
+
+    func test_shouldEnableSaving_returns_false_if_store_name_is_not_updated() {
+        // Given
+        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", onNameSaved: {})
+
+        // Then
+        XCTAssertFalse(viewModel.shouldEnableSaving)
+    }
+
+    func test_shouldEnableSaving_returns_true_if_store_name_is_updated() {
+        // Given
+        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", onNameSaved: {})
+
+        // When
+        viewModel.name = "Kitty"
+
+        // Then
+        XCTAssertTrue(viewModel.shouldEnableSaving)
+    }
+
+    func test_isSavingInProgress_returns_true_upon_saving_name() {
+        // Given
+        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
+        XCTAssertFalse(viewModel.isSavingInProgress)
+
+        // When
+        viewModel.name = "Miffy"
+        viewModel.saveName()
+
+        // Then
+        XCTAssertTrue(viewModel.isSavingInProgress)
+    }
+
+    func test_isSavingInProgress_returns_false_upon_saving_name_completes() {
+        // Given
+        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
+        XCTAssertFalse(viewModel.isSavingInProgress)
+        mockStoreNameUpdate(result: .success(Site.fake()))
+
+        // When
+        viewModel.name = "Miffy"
+        viewModel.saveName()
+
+        // Then
+        XCTAssertFalse(viewModel.isSavingInProgress)
+    }
+
+    func test_onNameSaved_is_triggered_upon_saving_store_name_success() {
+        // Given
+        var onNameSavedTriggered = false
+        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {
+            onNameSavedTriggered = true
+        })
+        mockStoreNameUpdate(result: .success(Site.fake()))
+
+        // When
+        viewModel.name = "Miffy"
+        viewModel.saveName()
+
+        // Then
+        XCTAssertTrue(onNameSavedTriggered)
+    }
+
+    func test_errorMessage_is_updated_upon_saving_store_name_failure() {
+        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
+        mockStoreNameUpdate(result: .failure(NSError(domain: "Test", code: 1)))
+        XCTAssertNil(viewModel.errorMessage)
+
+        // When
+        viewModel.name = "Miffy"
+        viewModel.saveName()
+
+        // Then
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+}
+
+private extension StoreNameSetupViewModelTests {
+    func mockStoreNameUpdate(result: Result<Site, Error>) {
+        stores.whenReceivingAction(ofType: SiteAction.self) { action in
+            switch action {
+            case let .updateSiteTitle(_, _, completion):
+                completion(result)
+            default:
+                break
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
@@ -76,6 +76,7 @@ final class StoreNameSetupViewModelTests: XCTestCase {
     }
 
     func test_errorMessage_is_updated_upon_saving_store_name_failure() async {
+        // Given
         let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
         mockStoreNameUpdate(result: .failure(NSError(domain: "Test", code: 1)))
         XCTAssertNil(viewModel.errorMessage)
@@ -86,6 +87,21 @@ final class StoreNameSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    func test_default_store_name_is_updated_upon_saving_store_name_completes() async {
+        // Given
+        let originalSite = Site.fake().copy(siteID: 123, name: "Test")
+        stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: originalSite))
+        let viewModel = StoreNameSetupViewModel(siteID: originalSite.siteID, name: originalSite.name, stores: stores, onNameSaved: {})
+        mockStoreNameUpdate(result: .success(Site.fake().copy(siteID: 123, name: "Miffy")))
+
+        // When
+        viewModel.name = "Miffy"
+        await viewModel.saveName()
+
+        // Then
+        XCTAssertEqual(stores.sessionManager.defaultSite?.name, "Miffy")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Yosemite
 @testable import WooCommerce
 
+@MainActor
 final class StoreNameSetupViewModelTests: XCTestCase {
 
     private var stores: MockStoresManager!
@@ -44,20 +45,7 @@ final class StoreNameSetupViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldEnableSaving)
     }
 
-    func test_isSavingInProgress_returns_true_upon_saving_name() {
-        // Given
-        let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
-        XCTAssertFalse(viewModel.isSavingInProgress)
-
-        // When
-        viewModel.name = "Miffy"
-        viewModel.saveName()
-
-        // Then
-        XCTAssertTrue(viewModel.isSavingInProgress)
-    }
-
-    func test_isSavingInProgress_returns_false_upon_saving_name_completes() {
+    func test_isSavingInProgress_returns_false_upon_saving_name_completes() async {
         // Given
         let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
         XCTAssertFalse(viewModel.isSavingInProgress)
@@ -65,13 +53,13 @@ final class StoreNameSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.name = "Miffy"
-        viewModel.saveName()
+        await viewModel.saveName()
 
         // Then
         XCTAssertFalse(viewModel.isSavingInProgress)
     }
 
-    func test_onNameSaved_is_triggered_upon_saving_store_name_success() {
+    func test_onNameSaved_is_triggered_upon_saving_store_name_success() async {
         // Given
         var onNameSavedTriggered = false
         let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {
@@ -81,20 +69,20 @@ final class StoreNameSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.name = "Miffy"
-        viewModel.saveName()
+        await viewModel.saveName()
 
         // Then
         XCTAssertTrue(onNameSavedTriggered)
     }
 
-    func test_errorMessage_is_updated_upon_saving_store_name_failure() {
+    func test_errorMessage_is_updated_upon_saving_store_name_failure() async {
         let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
         mockStoreNameUpdate(result: .failure(NSError(domain: "Test", code: 1)))
         XCTAssertNil(viewModel.errorMessage)
 
         // When
         viewModel.name = "Miffy"
-        viewModel.saveName()
+        await viewModel.saveName()
 
         // Then
         XCTAssertNotNil(viewModel.errorMessage)

--- a/Yosemite/Yosemite/Actions/SiteAction.swift
+++ b/Yosemite/Yosemite/Actions/SiteAction.swift
@@ -35,7 +35,7 @@ public enum SiteAction: Action {
     ///   - title: The title to update
     ///   - completion: Called when the result of the update is available.
     ///
-    case updateSiteTitle(siteID: Int64, title: String, completion: (Result<Void, Error>) -> Void)
+    case updateSiteTitle(siteID: Int64, title: String, completion: (Result<Site, Error>) -> Void)
 }
 
 /// The result of site creation including necessary site information.

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -123,14 +123,14 @@ private extension SiteStore {
         }
     }
 
-    func updateSiteTitle(siteID: Int64, title: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func updateSiteTitle(siteID: Int64, title: String, completion: @escaping (Result<Site, Error>) -> Void) {
         Task { @MainActor in
             do {
                 try await remote.updateSiteTitle(siteID: siteID, title: title)
                 // Updates site info in local storage immediately.
                 let site = try await remote.loadSite(siteID: siteID)
                 await upsertStoredSiteInBackground(readOnlySite: site)
-                completion(.success(()))
+                completion(.success(site))
             } catch {
                 completion(.failure(error))
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10463 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI and handles saving store name from the onboarding task for free trial sites with the default name.

Changes:
- Add new view and view model for setting up store name.
- Present this new view from the `StoreOnboardingCoordinator`.
- Update `SiteStore` to return the updated site upon store name update success. This is necessary to update the selected store and display the updated store name on the My Store screen immediately.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `optimizeProfilerQuestions` and build the app.
- Log in and switch to the Menu tab.
- Select the store picker and tap Add a store > Create a new store.
- Follow the steps to create a free trial store.
- When the store creation completes, you should be navigated to the My Store screen.
- Notice a new onboarding task "Name your store" on the onboarding task list.
- Tap the onboarding task to update store name. Notice a new screen is displayed.
- The Save button should be disabled when the store name is not updated or is empty.
- Disable your internet connection.
- Change the store name to a new name and tap Save. The view should display the activity indicator when saving is in progress.
- An error message should be displayed below the text field when the request times out.
- Turn on your connection and try saving the store name again.
- When saving completes, the view should be dismissed, and the updated name should be displayed on the My Store screen.
- The store name update onboarding task should be marked as complete.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/d6ea31c8-756c-4212-bf1b-2e596873b222



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
