### PR TITLE
Store profiler: Add unit tests for `StoreCreationProfilerQuestionContainerViewModel`

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -44,7 +44,11 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
 
     func saveSellingStatus(_ answer: StoreCreationSellingStatusAnswer?) {
         if answer == nil {
-            analytics.track(event: .StoreCreation.siteCreationProfilerQuestionSkipped(step: .profilerCategoryQuestion))
+            analytics.track(event: .StoreCreation.siteCreationProfilerQuestionSkipped(step: .profilerSellingStatusQuestion))
+        } else if let answer,
+                    answer.sellingStatus == .alreadySellingOnline,
+                    answer.sellingPlatforms == nil {
+            analytics.track(event: .StoreCreation.siteCreationProfilerQuestionSkipped(step: .profilerSellingPlatformsQuestion))
         }
         sellingStatus = answer
         currentQuestion = .category

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -87,12 +87,12 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
         if let previousQuestion = currentQuestion.previousQuestion {
             currentQuestion = previousQuestion
         } else {
-            // TODO: show confirm alert if needed
             completionHandler(nil)
         }
     }
 
     private func handleCompletion() {
+        // TODO-10374: add Tracks for the profiler data
         let profilerData: SiteProfilerData = {
             let sellingPlatforms = sellingStatus?.sellingPlatforms?.map { $0.rawValue }.sorted().joined(separator: ",")
             return .init(name: storeName,

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -422,7 +422,8 @@ private extension AppCoordinator {
             navigationController.topViewController is StoreCreationCategoryQuestionHostingController ||
             navigationController.topViewController is StoreCreationSellingStatusQuestionHostingController ||
             navigationController.topViewController is StoreCreationCountryQuestionHostingController ||
-            navigationController.topViewController is FreeTrialSummaryHostingController {
+            navigationController.topViewController is FreeTrialSummaryHostingController ||
+            navigationController.topViewController is StoreCreationProfilerQuestionContainerHostingController {
             return
         }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2080,6 +2080,7 @@
 		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
 		DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
+		DE36E09E2A8A2C6A00B98496 /* StoreCreationProfilerQuestionContainerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E09D2A8A2C6A00B98496 /* StoreCreationProfilerQuestionContainerViewModelTests.swift */; };
 		DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE37517B28DC5FC6000163CB /* Authenticator.swift */; };
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
@@ -4522,6 +4523,7 @@
 		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
 		DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
+		DE36E09D2A8A2C6A00B98496 /* StoreCreationProfilerQuestionContainerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerQuestionContainerViewModelTests.swift; sourceTree = "<group>"; };
 		DE37517B28DC5FC6000163CB /* Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
@@ -4927,6 +4929,7 @@
 				022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */,
 				EED028692A7B640300C5DE03 /* StoreCreationChallengesQuestionViewModelTests.swift */,
 				EE6A7BAE2A7B811700D9A028 /* StoreCreationFeaturesQuestionViewModelTests.swift */,
+				DE36E09D2A8A2C6A00B98496 /* StoreCreationProfilerQuestionContainerViewModelTests.swift */,
 			);
 			path = Profiler;
 			sourceTree = "<group>";
@@ -13563,6 +13566,7 @@
 				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,
 				573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */,
 				DEBAB70D2A7A6F1100743185 /* MockStorePlanSynchronizer.swift in Sources */,
+				DE36E09E2A8A2C6A00B98496 /* StoreCreationProfilerQuestionContainerViewModelTests.swift in Sources */,
 				77423F17251CF77E0016A083 /* ProductDownloadListViewModelTests.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,
 				DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -4,6 +4,21 @@ import XCTest
 
 final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
+
+    override func setUp() {
+        super.setUp()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analyticsProvider = nil
+        analytics = nil
+        super.tearDown()
+    }
+
     // MARK: - Saving answers
 
     func test_saveSellingStatus_updates_currentQuestion_to_category() {
@@ -137,4 +152,69 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
     }
 
     // MARK: - Analytics
+
+    func test_saveSellingStatus_tracks_skip_event_for_selling_status_question() throws {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+
+        // When
+        viewModel.saveSellingStatus(nil)
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_profiler_question_skipped" }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["step"] as? String, "store_profiler_commerce_journey")
+    }
+
+    func test_saveSellingStatus_tracks_skip_event_for_selling_platform_question() throws {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+
+        // When
+        viewModel.saveSellingStatus(.init(sellingStatus: .alreadySellingOnline, sellingPlatforms: nil))
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_profiler_question_skipped" }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["step"] as? String, "store_profiler_ecommerce_platforms")
+    }
+
+    func test_saveCategory_tracks_skip_event_for_category_question() throws {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+
+        // When
+        viewModel.saveCategory(nil)
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_profiler_question_skipped" }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["step"] as? String, "store_profiler_industries")
+    }
+
+    func test_saveChallenges_tracks_skip_event_for_challenges_questions() throws {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+
+        // When
+        viewModel.saveChallenges([])
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_profiler_question_skipped" }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["step"] as? String, "store_profiler_challenges")
+    }
+
+    func test_saveFeatures_tracks_skip_event_for_challenges_questions() throws {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+
+        // When
+        viewModel.saveFeatures([])
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_profiler_question_skipped" }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["step"] as? String, "store_profiler_features")
+    }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
+
+    // MARK: - Saving answers
+
+    func test_saveSellingStatus_updates_currentQuestion_to_category() {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in })
+        XCTAssertEqual(viewModel.currentQuestion, .sellingStatus)
+
+        // When
+        viewModel.saveSellingStatus(nil)
+
+        // Then
+        XCTAssertEqual(viewModel.currentQuestion, .category)
+    }
+
+    func test_saveCategory_updates_currentQuestion_to_country() {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in })
+
+        // When
+        viewModel.saveCategory(nil)
+
+        // Then
+        XCTAssertEqual(viewModel.currentQuestion, .country)
+    }
+
+    func test_saveCountry_updates_currentQuestion_to_challenges() {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in })
+
+        // When
+        viewModel.saveCountry(.US)
+
+        // Then
+        XCTAssertEqual(viewModel.currentQuestion, .challenges)
+    }
+
+    func test_saveFeatures_triggers_onCompletion() throws {
+        // Given
+        var profilerData: SiteProfilerData?
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { profilerData = $0 })
+
+        // When
+        viewModel.saveSellingStatus(.init(sellingStatus: .justStarting, sellingPlatforms: nil))
+        viewModel.saveCategory(nil)
+        viewModel.saveCountry(.US)
+        viewModel.saveChallenges([])
+        viewModel.saveFeatures([])
+
+        // Then
+        let data = try XCTUnwrap(profilerData)
+        XCTAssertEqual(data.name, viewModel.storeName)
+        XCTAssertEqual(data.sellingStatus, .justStarting)
+        XCTAssertNil(data.sellingPlatforms)
+        XCTAssertEqual(data.countryCode, "US")
+    }
+
+    // MARK: - `backtrackOrDismissProfiler`
+
+    func test_backtrackOrDismissProfiler_triggers_completionHandler_without_profiler_data_if_current_question_is_selling_status() {
+        // Given
+        var triggeredCompletion = false
+        var profilerData: SiteProfilerData?
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: {
+            profilerData = $0
+            triggeredCompletion = true
+        })
+        XCTAssertEqual(viewModel.currentQuestion, .sellingStatus)
+
+        // When
+        viewModel.backtrackOrDismissProfiler()
+
+        // Then
+        XCTAssertTrue(triggeredCompletion)
+        XCTAssertNil(profilerData)
+    }
+
+    func test_backtrackOrDismissProfiler_sets_current_question_to_selling_status_if_current_question_is_category() {
+        // Given
+        var triggeredCompletion = false
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        viewModel.saveSellingStatus(nil)
+
+        // When
+        viewModel.backtrackOrDismissProfiler()
+
+        // Then
+        XCTAssertFalse(triggeredCompletion)
+        XCTAssertEqual(viewModel.currentQuestion, .sellingStatus)
+    }
+
+    func test_backtrackOrDismissProfiler_sets_current_question_to_category_if_current_question_is_country() {
+        // Given
+        var triggeredCompletion = false
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        viewModel.saveCategory(nil)
+
+        // When
+        viewModel.backtrackOrDismissProfiler()
+
+        // Then
+        XCTAssertFalse(triggeredCompletion)
+        XCTAssertEqual(viewModel.currentQuestion, .category)
+    }
+
+    func test_backtrackOrDismissProfiler_sets_current_question_to_country_if_current_question_is_challenges() {
+        // Given
+        var triggeredCompletion = false
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        viewModel.saveCountry(.US)
+
+        // When
+        viewModel.backtrackOrDismissProfiler()
+
+        // Then
+        XCTAssertFalse(triggeredCompletion)
+        XCTAssertEqual(viewModel.currentQuestion, .country)
+    }
+
+    func test_backtrackOrDismissProfiler_sets_current_question_to_challenges_if_current_question_is_features() {
+        // Given
+        var triggeredCompletion = false
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        viewModel.saveChallenges([])
+
+        // When
+        viewModel.backtrackOrDismissProfiler()
+
+        // Then
+        XCTAssertFalse(triggeredCompletion)
+        XCTAssertEqual(viewModel.currentQuestion, .challenges)
+    }
+
+    // MARK: - Analytics
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10374 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tests for `StoreCreationProfilerQuestionContainerViewModel`. Also: fixed the incorrect tracking step for skipping the selling status question and updated `AppCoordinator` to not navigate to store creation if the new store profiler container controller is already present.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI passing should be enough.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
