### PR TITLE
Remove unnecessary reload call in `OrderDetails`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -75,9 +75,6 @@ final class OrderDetailsViewController: UIViewController {
         configureViewModel()
         updateTopBannerView()
         trackGiftCardsShown()
-
-        // FIXME: this is a hack. https://github.com/woocommerce/woocommerce-ios/issues/1779
-        reloadTableViewSectionsAndData()
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #1779

## Description
With https://github.com/woocommerce/woocommerce-ios/pull/1757 we found an issue where the `OrderDetailsViewController` was tightly coupled with its datasource, which caused an `indexOutOfRange` error when calling the `configureOrderItem(cell:at:)` for individual order items in the Order details view. 

This was raised in a review [here](https://github.com/woocommerce/woocommerce-ios/pull/1757/files#r370997333) and logged with #1779 

At the moment it does not seem to be an issue anymore: The view controller does no have the datasource as a direct dependency anymore but this is lazy loaded in the view model, which then is injected into the view controller, loading the data appropriately when needed. We also do not configure the order items individually anymore but configure the cells based on an aggregateOrderItems collection.

## Changes
We remove the `reloadTableViewSectionsAndData()` call in `OrderDetailsViewController` `viewDidLoad()`

I did some further testing by:
1. Following the reproduction steps of the original issue. This no longer causes an error.
2. Reproducing the case that the original PR was trying to fix (to not show refunded items with 0 quantity). This is no longer an issue either, since we updated the UI to display only a count of the aggregated refunded items, and then we can navigate to their details if needed:

| Order Detail | Aggregated order items |
|--------|--------|
| ![simulator_screenshot_D51A2B6A-B92E-43EE-AA92-13B213E61642](https://github.com/woocommerce/woocommerce-ios/assets/3812076/df7c373a-162c-4877-adb6-6947399ea036) | ![simulator_screenshot_24D983A9-1311-4516-ACCB-40899CD580D8](https://github.com/woocommerce/woocommerce-ios/assets/3812076/f4fe10eb-cbff-4970-8736-bbd535acde04) | 

## Testing instructions
- Unit tests should pass
- Running the app and opening orders (with or without refunded items) should work normally, and not return a `indexOutOfRange` error.