### PR TITLE
Store profiler: Update category values to match core profiler

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
@@ -33,7 +33,7 @@ extension StoreCreationCategoryQuestionViewModel {
 extension StoreCreationCategoryQuestionViewModel.Category {
     var name: String {
         switch self {
-        case .fashionApparelAccessories:
+        case .clothingAccessories:
             return NSLocalizedString("Clothing and accessories", comment: "Industry option in the store creation category question.")
         case .healthBeauty:
             return NSLocalizedString("Health and beauty", comment: "Industry option in the store creation category question.")

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
@@ -3,9 +3,7 @@ import Foundation
 extension StoreCreationCategoryQuestionViewModel {
     /// Industry options for a WooCommerce store. The raw value is the value that is sent to the submission API.
     /// The sources of truth are at:
-    /// - Stripe industries: https://support.stripe.com/questions/setting-an-industry-group-when-creating-a-stripe-account
-    /// - WC industry options: `https://github.com/woocommerce/woocommerce/blob/
-    ///   07a2f83f53352bc9c24f929b7dd787c95e91f4aa/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php#L28-L69`
+    /// - WC industry options: `https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx#L32`
     enum Category: String, Equatable {
         case fashionApparelAccessories = "fashion-apparel-accessories"
         case healthBeauty = "health-beauty"

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
@@ -5,19 +5,18 @@ extension StoreCreationCategoryQuestionViewModel {
     /// The sources of truth are at:
     /// - WC industry options: `https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx#L32`
     enum Category: String, Equatable {
-        case fashionApparelAccessories = "fashion-apparel-accessories"
-        case healthBeauty = "health-beauty"
-        case electronicsComputers = "electronics-computers"
-        case foodDrink = "food-drink"
-        case homeFurnitureGarden = "home-furniture-garden"
-        case cbdOtherHempDerivedProducts = "cbd-other-hemp-derived-products"
-        case educationAndLearning = "education-and-learning"
+        case clothingAccessories = "clothing_and_accessories"
+        case healthBeauty = "health_and_beauty"
+        case electronicsComputers = "electronics_and_computers"
+        case foodDrink = "food_and_drink"
+        case homeFurnitureGarden = "home_furniture_and_garden"
+        case educationAndLearning = "education_and_learning"
         case other = "other"
     }
 
     var categories: [Category] {
         [
-            .fashionApparelAccessories,
+            .clothingAccessories,
             .healthBeauty,
             .foodDrink,
             .homeFurnitureGarden,
@@ -41,8 +40,6 @@ extension StoreCreationCategoryQuestionViewModel.Category {
             return NSLocalizedString("Food and drink", comment: "Industry option in the store creation category question.")
         case .homeFurnitureGarden:
             return NSLocalizedString("Home, furniture, and garden", comment: "Industry option in the store creation category question.")
-        case .cbdOtherHempDerivedProducts:
-            return NSLocalizedString("CBD and other hemp-derived products", comment: "Industry option in the store creation category question.")
         case .educationAndLearning:
             return NSLocalizedString("Education and learning", comment: "Industry option in the store creation category question.")
         case .other:

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
@@ -31,7 +31,7 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(answer, .init(name: StoreCreationCategoryQuestionViewModel.Category.clothingAccessories.name,
-                                     value: "fashion-apparel-accessories"))
+                                     value: "clothing_and_accessories"))
     }
 
     func test_continueButtonTapped_invokes_onSkip_without_selecting_a_category() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
@@ -9,10 +9,10 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
                                                                onSkip: {})
 
         // When
-        viewModel.selectCategory(.fashionApparelAccessories)
+        viewModel.selectCategory(.clothingAccessories)
 
         // Then
-        XCTAssertEqual(viewModel.selectedCategory, .fashionApparelAccessories)
+        XCTAssertEqual(viewModel.selectedCategory, .clothingAccessories)
     }
 
     func test_continueButtonTapped_invokes_onContinue_after_selecting_a_category() throws {
@@ -23,14 +23,14 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
             },
                                                                    onSkip: {})
             // When
-            viewModel.selectCategory(.fashionApparelAccessories)
+            viewModel.selectCategory(.clothingAccessories)
             Task { @MainActor in
                 await viewModel.continueButtonTapped()
             }
         }
 
         // Then
-        XCTAssertEqual(answer, .init(name: StoreCreationCategoryQuestionViewModel.Category.fashionApparelAccessories.name,
+        XCTAssertEqual(answer, .init(name: StoreCreationCategoryQuestionViewModel.Category.clothingAccessories.name,
                                      value: "fashion-apparel-accessories"))
     }
 
@@ -72,7 +72,7 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(categories,
-                       [.fashionApparelAccessories,
+                       [.clothingAccessories,
                         .healthBeauty,
                         .foodDrink,
                         .homeFurnitureGarden,


### PR DESCRIPTION
Closes: #10478
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Updates the `Category` enum's raw values to match the answers from the core profiler flow. 

The new values are from the core profiler flow [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx#L32)


## Testing instructions

- CI passing is sufficient. 
- Follow the instructions from https://github.com/woocommerce/woocommerce-ios/pull/10473 to smoke test the profiler flow.


## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
