### PR TITLE
Merge 14.9 release notes into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 14.9
+We've enhanced the order creation process to provide a more streamlined experience. The process of selecting a customer when creating an order has been improved based on your valuable feedback. Your input drives our continuous improvements. Thank you!
+
 ## 14.8
 In this latest update, we're introducing several exciting enhancements to make your app experience even better! You can now filter products based on various new types, including subscription, variable subscription, bundle, and composite. For stores with expired WooExpress plans, upgrading within the app is more convenient than ever. Creating and managing your stores is easier with improved accessibility on the Upgrades screen. Update now to discover all the latest enhancements and improvements! 
 

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -63,7 +63,7 @@ msgstr ""
 
 msgctxt "v14.9-whats-new"
 msgid ""
-"Exciting news about order creation! We've improved the way you can request, search and select a customer when creating an order. Enjoy!\n"
+"We've enhanced the order creation process to provide a more streamlined experience. The process of selecting a customer when creating an order has been improved based on your valuable feedback. Your input drives our continuous improvements. Thank you!\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,1 +1,1 @@
-Exciting news about order creation! We've improved the way you can request, search and select a customer when creating an order. Enjoy!
+We've enhanced the order creation process to provide a more streamlined experience. The process of selecting a customer when creating an order has been improved based on your valuable feedback. Your input drives our continuous improvements. Thank you!


### PR DESCRIPTION
This PR merges the editorialized release notes for 14.9 (they were not provided until Monday) into `trunk` so that they'll get picked up by GlotPress. 