### PR TITLE
Update deprecated `accentColor(_:)` in favor of `tint(_:)`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Authentication/AuthenticationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AuthenticationFormFieldView.swift
@@ -69,7 +69,7 @@ struct AuthenticationFormFieldView: View {
                         showsSecureInput.toggle()
                     }) {
                         Image(systemName: showsSecureInput ? "eye.slash" : "eye")
-                            .accentColor(Color(.textSubtle))
+                            .tint(Color(.textSubtle))
                             .frame(width: Layout.secureFieldRevealButtonDimension * scale,
                                    height: Layout.secureFieldRevealButtonDimension * scale)
                             .padding(.leading, Layout.secureFieldRevealButtonHorizontalPadding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApllicationLogDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApllicationLogDetailView.swift
@@ -65,7 +65,7 @@ struct ApplicationLogDetailView: View {
                     Image(systemName: "chevron.down.circle.fill")
                         .resizable()
                         .frame(width: 32, height: 32)
-                        .accentColor(Color(.accent))
+                        .tint(Color(.accent))
                 })
                 .padding()
                 .transition(.move(edge: .bottom))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -71,7 +71,7 @@ struct ShippingLabelAddNewPackage: View {
                     }, label: {
                         if isSyncing {
                             ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                                .accentColor(Color(.navigationBarLoadingIndicator))
+                                .tint(Color(.navigationBarLoadingIndicator))
                         } else {
                             Text(Localization.doneButton)
                         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -56,7 +56,7 @@ struct RangedDatePicker: View {
 
                     DatePicker("", selection: $startDate, in: ...Date(), displayedComponents: [.date])
                         .datePickerStyle(.graphical)
-                        .accentColor(Color(.brand))
+                        .tint(Color(.brand))
                         .padding(.horizontal, Layout.calendarPadding)
 
                     // End Picker
@@ -68,7 +68,7 @@ struct RangedDatePicker: View {
 
                     DatePicker("", selection: $endDate, in: ...Date(), displayedComponents: [.date])
                         .datePickerStyle(.graphical)
-                        .accentColor(Color(.brand))
+                        .tint(Color(.brand))
                         .padding(.horizontal, Layout.calendarPadding)
                 }
                 .padding()

--- a/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
+++ b/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
@@ -128,10 +128,12 @@ public struct ErrorStyle: ViewModifier {
     }
 }
 
+// The color of the bar button items in the navigation bar
+//
 public struct WooNavigationBarStyle: ViewModifier {
     public func body(content: Content) -> some View {
         content
-            .accentColor(Color(.accent)) // The color of bar button items in the navigation bar
+            .tint(Color(.accent))
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5147
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the remaining instances of `accentColor(_:)` usage across some SwiftUI views and the navigation bar buttons for iOS 15+, since this instance method has been deprecated in favour of `tint(_:)`

## Testing instructions
We use the `WooNavigationBarStyle` in multiple places, just navigate through different screens and observe that the navigation buttons keep the previous "WooCommerce Purple" for those.

The change also affects to 4 SwiftUI views, which do not use the  `WooNavigationBarStyle`, but the property is used directly, shown in the screenshots below:

## Screenshots

The style remains the same before and after, some examples:

| Shipping labels | Application logs | Date pickers | Forms |
|--------|--------|--------|--------|
| <img width="555" alt="Screenshot 2023-08-15 at 13 11 33" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/3f91e064-ad09-4de5-b934-54389b5ed2a1"> | <img width="459" alt="Screenshot 2023-08-15 at 13 16 01" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/d311b10d-0aad-408b-be54-cb7b081abb93"> | <img width="441" alt="Screenshot 2023-08-15 at 13 19 30" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/004e97a5-71ed-4141-a2c5-96bade359337"> | <img width="402" alt="Screenshot 2023-08-15 at 13 21 42" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/7a7e63da-4cc1-4ad4-9344-ebf16b15a8c5"> | 