### PR TITLE
Use WordPressAuthenticator v7.0.0 to remove Google SignIn SDK

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -83,9 +83,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 6.4.0'
-#     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'trunk'
+  pod 'WordPressAuthenticator', '~> 7.0-beta'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,5 @@
 PODS:
   - Alamofire (4.8.0)
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
-    - AppAuth/Core
   - Automattic-Tracks-iOS (2.4.0):
     - Sentry (~> 8.0)
     - Sodium (>= 0.9.1)
@@ -15,15 +9,7 @@ PODS:
   - CocoaLumberjack/Core (3.7.4)
   - CocoaLumberjack/Swift (3.7.4):
     - CocoaLumberjack/Core
-  - GoogleSignIn (6.0.2):
-    - AppAuth (~> 1.4)
-    - GTMAppAuth (~> 1.0)
-    - GTMSessionFetcher/Core (~> 1.1)
   - Gridicons (1.2.0)
-  - GTMAppAuth (1.3.1):
-    - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
-  - GTMSessionFetcher/Core (1.7.2)
   - KeychainAccess (4.2.2)
   - Kingfisher (7.6.2)
   - NSObject-SafeExpectations (0.0.6)
@@ -42,8 +28,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (6.4.0):
-    - GoogleSignIn (~> 6.0.1)
+  - WordPressAuthenticator (7.0.0-beta.1):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -86,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 6.4.0)
+  - WordPressAuthenticator (~> 7.0-beta)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -99,13 +84,9 @@ SPEC REPOS:
     - WordPressKit
   trunk:
     - Alamofire
-    - AppAuth
     - Automattic-Tracks-iOS
     - CocoaLumberjack
-    - GoogleSignIn
     - Gridicons
-    - GTMAppAuth
-    - GTMSessionFetcher
     - KeychainAccess
     - Kingfisher
     - NSObject-SafeExpectations
@@ -134,13 +115,9 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
   Automattic-Tracks-iOS: eb06b138cd65453dc565ab047f55fbb759aca133
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
-  GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
-  GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
@@ -154,7 +131,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 5929076e39dd5aeebeb3ea1e985d6a53f73a984f
+  WordPressAuthenticator: 2d352b4b74a5ee5ad056a1c93298fbbe804c6b48
   WordPressKit: f4c39ae3a5949846d2d7c51843690d078711ab36
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
@@ -169,6 +146,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 06ae7b9b0bfa87de15be3b2f0e2aa65a9e29eed4
+PODFILE CHECKSUM: 9562fce8013495125aa80085dd22663ea1180a8a
 
 COCOAPODS: 1.12.1

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -111,10 +111,6 @@ class AuthenticationManager: Authentication {
         let source = options[.sourceApplication] as? String
         let annotation = options[.annotation]
 
-        if WordPressAuthenticator.shared.isGoogleAuthUrl(url) {
-            return WordPressAuthenticator.shared.handleGoogleAuthUrl(url, sourceApplication: source, annotation: annotation)
-        }
-
         if WordPressAuthenticator.shared.isWordPressAuthUrl(url) {
             return WordPressAuthenticator.shared.handleWordPressAuthUrl(url,
                                                                         rootViewController: rootViewController)
@@ -357,9 +353,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
     /// Presents the Signup Epilogue, in the specified NavigationController.
     ///
-    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
+    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, socialUser: SocialUser?) {
         // NO-OP: The current WC version does not support Signup. Let SIWA through.
-        guard case .apple = service else {
+        guard case .apple = socialUser?.service else {
             return
         }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -26,7 +26,7 @@ final class SiteCredentialLoginViewModel: NSObject, ObservableObject {
         loginFields.username = username
         loginFields.password = password
         loginFields.siteAddress = siteURL
-        loginFields.meta.userIsDotCom = false
+        loginFields.userIsDotCom = false
         return loginFields
     }
 

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -39,8 +39,7 @@ extension WordPressAuthenticator {
                                                                 enableManualSiteCredentialLogin: true,
                                                                 enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
-                                                                enableSiteAddressLoginOnlyInPrologue: true,
-                                                                googleLoginWithoutSDK: featureFlagService.isFeatureFlagEnabled(.sdkLessGoogleSignIn))
+                                                                enableSiteAddressLoginOnlyInPrologue: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -29,7 +29,7 @@ final class WPComPasswordLoginViewModel: NSObject, ObservableObject {
         loginFields.username = email
         loginFields.password = password
         loginFields.siteAddress = siteURL
-        loginFields.meta.userIsDotCom = true
+        loginFields.userIsDotCom = true
         return loginFields
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
@@ -86,7 +86,7 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         assertEqual(email, loginFields?.username)
         assertEqual(password, loginFields?.password)
         assertEqual(siteURL, loginFields?.siteAddress)
-        assertEqual(true, loginFields?.meta.userIsDotCom)
+        assertEqual(true, loginFields?.userIsDotCom)
     }
 
     func test_isLoggingIn_is_updated_correctly_and_onLoginFailure_is_triggered_when_login_fails() {


### PR DESCRIPTION
See changes from https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/777 and https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/778

I tested this by building on device and verifying the Google SignIn still works.