### PR TITLE
Store onboarding: Show notice after setting store name and add new Setting item for store name

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 15.0
 -----
+- [*] The store name can now be updated from the Settings screen. [https://github.com/woocommerce/woocommerce-ios/pull/10485]
 
 
 14.9

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -21,6 +21,12 @@ final class StoreOnboardingCoordinator: Coordinator {
     private let reloadTasks: () -> Void
     private let onUpgradePlan: (() -> Void)?
 
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = navigationController
+        return noticePresenter
+    }()
+
     init(navigationController: UINavigationController,
          site: Site,
          onTaskCompleted: @escaping (_ task: TaskType) -> Void,
@@ -145,10 +151,18 @@ private extension StoreOnboardingCoordinator {
     func showStoreNameSetup() {
         let viewModel = StoreNameSetupViewModel(siteID: site.siteID, name: site.name, onNameSaved: { [weak self] in
             self?.onTaskCompleted(.storeName)
-            self?.navigationController.presentedViewController?.dismiss(animated: true)
+            self?.navigationController.presentedViewController?.dismiss(animated: true) { [weak self] in
+                self?.showStoreNameNotice()
+            }
         })
         let controller = StoreNameSetupHostingController(viewModel: viewModel)
         navigationController.present(controller, animated: true)
+    }
+
+    func showStoreNameNotice() {
+        let notice = Notice(title: Localization.StoreNameNotice.title,
+                            subtitle: Localization.StoreNameNotice.subtitle)
+        noticePresenter.enqueue(notice: notice)
     }
 }
 
@@ -158,5 +172,20 @@ private extension StoreOnboardingCoordinator {
     func showPlanView() {
         let subscriptionController = SubscriptionsHostingController(siteID: site.siteID)
         navigationController.show(subscriptionController, sender: self)
+    }
+}
+
+private extension StoreOnboardingCoordinator {
+    enum Localization {
+        enum StoreNameNotice {
+            static let title = NSLocalizedString(
+                "Store Name Set!",
+                comment: "Title on the notice presented when the store name is updated"
+            )
+            static let subtitle = NSLocalizedString(
+                "To change again, visit Store Settings.",
+                comment: "Subtitle on the notice presented when the store name is updated"
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -154,6 +154,8 @@ private extension SettingsViewController {
             configureStoreSetupList(cell: cell)
         case let cell as BasicTableViewCell where row == .shippingZones:
             configureShippingZones(cell: cell)
+        case let cell as BasicTableViewCell where row == .storeName:
+            configureStoreName(cell: cell)
         case let cell as BasicTableViewCell where row == .support:
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .betaFeatures:
@@ -233,6 +235,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.shippingZones
+    }
+
+    func configureStoreName(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = Localization.storeName
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -434,6 +442,17 @@ private extension SettingsViewController {
         show(viewController, sender: self)
     }
 
+    func storeNameWasPressed() {
+        guard let site = stores.sessionManager.defaultSite else {
+            return
+        }
+        let viewModel = StoreNameSetupViewModel(siteID: site.siteID, name: site.name, onNameSaved: { [weak self] in
+            self?.dismiss(animated: true)
+        })
+        let controller = StoreNameSetupHostingController(viewModel: viewModel)
+        present(controller, animated: true)
+    }
+
     func privacyWasPressed() {
         ServiceLocator.analytics.track(.settingsPrivacySettingsTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
@@ -624,6 +643,8 @@ extension SettingsViewController: UITableViewDelegate {
             installJetpackWasPressed()
         case .shippingZones:
             shippingZonesWasPressed()
+        case .storeName:
+            storeNameWasPressed()
         case .privacy:
             privacyWasPressed()
         case .betaFeatures:
@@ -701,6 +722,7 @@ extension SettingsViewController {
         case installJetpack
         case storeSetupList
         case shippingZones
+        case storeName
 
         // Help & Feedback
         case support
@@ -769,6 +791,8 @@ extension SettingsViewController {
                 return BasicTableViewCell.self
             case .whatsNew:
                 return BasicTableViewCell.self
+            case .storeName:
+                return BasicTableViewCell.self
             }
         }
 
@@ -834,6 +858,11 @@ private extension SettingsViewController {
         static let shippingZones = NSLocalizedString(
             "Shipping Zones",
             comment: "Access the store shipping zones."
+        )
+
+        static let storeName = NSLocalizedString(
+            "Store Name",
+            comment: "Navigates to the Store name setup screen"
         )
 
         static let privacySettings = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -280,7 +280,7 @@ private extension SettingsViewModel {
 
         // Store settings
         let storeSettingsSection: Section? = {
-            var rows: [Row] = [.shippingZones]
+            var rows: [Row] = [.storeName, .shippingZones]
 
             let site = stores.sessionManager.defaultSite
             if site?.isJetpackCPConnected == true ||


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10463 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
According to 8sNT07kW3VEdnor4baI6ft-fi-707:58797#525947970, we want to show a notice when the store name onboarding is completed telling users that they can change their store names again anytime in Settings.

This PR adds a few changes:
- Present notice when the store onboarding task for store name setup is completed.
- Add a new item in Settings to update the store name. This setting is available for all sites.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a new free trial site if needed.
- When the store creation is completed, you should be navigated to the My Store screen.
- Tap the store name item in the onboarding list and give your site a new name.
- After the name is saved, the store name screen should be dismissed. Notice a new notice is presented saying you can still update the store name later in Settings.
- Switch to the Menu tab and select Settings. 
- Notice that a new item to setup store name is present in the Store Settings section.
- Tap the item, the store name screen should be presented with the correct name.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/d7ef4a7a-6c9b-439f-81ea-303aef77b333" width=320 />


https://github.com/woocommerce/woocommerce-ios/assets/5533851/cca4352f-3e04-4f3b-85dc-8c0f517a49c7




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.