### PR TITLE
Store profiler: Clean up dead code

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionView.swift
@@ -1,23 +1,5 @@
 import SwiftUI
 
-/// Hosting controller that wraps the `StoreCreationCategoryQuestionView`.
-final class StoreCreationCategoryQuestionHostingController: UIHostingController<StoreCreationCategoryQuestionView> {
-    init(viewModel: StoreCreationCategoryQuestionViewModel) {
-        super.init(rootView: StoreCreationCategoryQuestionView(viewModel: viewModel))
-    }
-
-    @available(*, unavailable)
-    required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        configureTransparentNavigationBar()
-    }
-}
-
 /// Shows the store category question in the store creation flow.
 struct StoreCreationCategoryQuestionView: View {
     @ObservedObject private var viewModel: StoreCreationCategoryQuestionViewModel

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionViewModel.swift
@@ -33,8 +33,7 @@ final class StoreCreationCategoryQuestionViewModel: StoreCreationProfilerQuestio
 }
 
 extension StoreCreationCategoryQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
-    @MainActor
-    func continueButtonTapped() async {
+    func continueButtonTapped() {
         guard let selectedCategory else {
             return onSkip()
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionView.swift
@@ -1,23 +1,5 @@
 import SwiftUI
 
-/// Hosting controller that wraps the `StoreCreationChallengesQuestionView`.
-final class StoreCreationChallengesQuestionHostingController: UIHostingController<StoreCreationChallengesQuestionView> {
-    init(viewModel: StoreCreationChallengesQuestionViewModel) {
-        super.init(rootView: StoreCreationChallengesQuestionView(viewModel: viewModel))
-    }
-
-    @available(*, unavailable)
-    required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        configureTransparentNavigationBar()
-    }
-}
-
 /// Shows the store challenges question in the store creation flow.
 struct StoreCreationChallengesQuestionView: View {
     @ObservedObject private var viewModel: StoreCreationChallengesQuestionViewModel

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionViewModel.swift
@@ -32,8 +32,8 @@ final class StoreCreationChallengesQuestionViewModel: StoreCreationProfilerQuest
 }
 
 extension StoreCreationChallengesQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
-    @MainActor
-    func continueButtonTapped() async {
+
+    func continueButtonTapped() {
         guard selectedChallenges.isNotEmpty else {
             return onSkip()
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -1,23 +1,5 @@
 import SwiftUI
 
-/// Hosting controller that wraps the `StoreCreationCountryQuestionView`.
-final class StoreCreationCountryQuestionHostingController: UIHostingController<StoreCreationCountryQuestionView> {
-    init(viewModel: StoreCreationCountryQuestionViewModel) {
-        super.init(rootView: StoreCreationCountryQuestionView(viewModel: viewModel))
-    }
-
-    @available(*, unavailable)
-    required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        configureTransparentNavigationBar()
-    }
-}
-
 /// Shows the store country question in the store creation flow.
 struct StoreCreationCountryQuestionView: View {
     @StateObject private var viewModel: StoreCreationCountryQuestionViewModel

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
@@ -59,8 +59,7 @@ extension StoreCreationCountryQuestionViewModel: RequiredStoreCreationProfilerQu
         $isContinueButtonEnabledValue.eraseToAnyPublisher()
     }
 
-    @MainActor
-    func continueButtonTapped() async {
+    func continueButtonTapped() {
         guard let selectedCountryCode else {
             return
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Features/StoreCreationFeaturesQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Features/StoreCreationFeaturesQuestionView.swift
@@ -1,23 +1,5 @@
 import SwiftUI
 
-/// Hosting controller that wraps the `StoreCreationFeaturesQuestionView`.
-final class StoreCreationFeaturesQuestionHostingController: UIHostingController<StoreCreationFeaturesQuestionView> {
-    init(viewModel: StoreCreationFeaturesQuestionViewModel) {
-        super.init(rootView: StoreCreationFeaturesQuestionView(viewModel: viewModel))
-    }
-
-    @available(*, unavailable)
-    required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        configureTransparentNavigationBar()
-    }
-}
-
 /// Shows the store features question in the store creation flow.
 struct StoreCreationFeaturesQuestionView: View {
     @ObservedObject private var viewModel: StoreCreationFeaturesQuestionViewModel

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Features/StoreCreationFeaturesQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Features/StoreCreationFeaturesQuestionViewModel.swift
@@ -32,8 +32,7 @@ final class StoreCreationFeaturesQuestionViewModel: StoreCreationProfilerQuestio
 }
 
 extension StoreCreationFeaturesQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
-    @MainActor
-    func continueButtonTapped() async {
+    func continueButtonTapped() {
         guard selectedFeatures.isNotEmpty else {
             return onSkip()
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/OptionalStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/OptionalStoreCreationProfilerQuestionView.swift
@@ -12,7 +12,6 @@ protocol OptionalStoreCreationProfilerQuestionViewModel {
 struct OptionalStoreCreationProfilerQuestionView<QuestionContent: View>: View {
     private let viewModel: StoreCreationProfilerQuestionViewModel & OptionalStoreCreationProfilerQuestionViewModel
     @ViewBuilder private let questionContent: () -> QuestionContent
-    @State private var isWaitingForCompletion: Bool = false
 
     init(viewModel: StoreCreationProfilerQuestionViewModel & OptionalStoreCreationProfilerQuestionViewModel,
          @ViewBuilder questionContent: @escaping () -> QuestionContent) {
@@ -30,13 +29,9 @@ struct OptionalStoreCreationProfilerQuestionView<QuestionContent: View>: View {
                     .frame(height: Layout.dividerHeight)
                     .foregroundColor(Color(.separator))
                 Button(Localization.continueButtonTitle) {
-                    Task { @MainActor in
-                        isWaitingForCompletion = true
-                        await viewModel.continueButtonTapped()
-                        isWaitingForCompletion = false
-                    }
+                    viewModel.continueButtonTapped()
                 }
-                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isWaitingForCompletion))
+                .buttonStyle(PrimaryButtonStyle())
                 .padding(Layout.defaultPadding)
             }
             .background(Color(.systemBackground))

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/OptionalStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/OptionalStoreCreationProfilerQuestionView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Handles the navigation actions in an optional profiler question view during store creation.
 /// The question is skippable.
 protocol OptionalStoreCreationProfilerQuestionViewModel {
-    func continueButtonTapped() async
+    func continueButtonTapped()
     func skipButtonTapped()
 }
 
@@ -71,7 +71,7 @@ private struct StoreCreationQuestionPreviewViewModel: StoreCreationProfilerQuest
     let title: String = "Which of these best describes you?"
     let subtitle: String = "Choose a category that defines your business the best."
 
-    func continueButtonTapped() async {}
+    func continueButtonTapped() {}
     func skipButtonTapped() {}
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
@@ -18,7 +18,6 @@ protocol RequiredStoreCreationProfilerQuestionViewModel {
 struct RequiredStoreCreationProfilerQuestionView<QuestionContent: View>: View {
     private let viewModel: StoreCreationProfilerQuestionViewModel & RequiredStoreCreationProfilerQuestionViewModel
     @ViewBuilder private let questionContent: () -> QuestionContent
-    @State private var isWaitingForCompletion: Bool = false
     @State private var isContinueButtonEnabled: Bool = false
 
     init(viewModel: StoreCreationProfilerQuestionViewModel & RequiredStoreCreationProfilerQuestionViewModel,
@@ -37,13 +36,9 @@ struct RequiredStoreCreationProfilerQuestionView<QuestionContent: View>: View {
                     .frame(height: Layout.dividerHeight)
                     .foregroundColor(Color(.separator))
                 Button(Localization.continueButtonTitle) {
-                    Task { @MainActor in
-                        isWaitingForCompletion = true
-                        await viewModel.continueButtonTapped()
-                        isWaitingForCompletion = false
-                    }
+                    viewModel.continueButtonTapped()
                 }
-                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isWaitingForCompletion))
+                .buttonStyle(PrimaryButtonStyle())
                 .disabled(!isContinueButtonEnabled)
                 .padding(Layout.defaultPadding)
             }
@@ -84,7 +79,7 @@ private final class StoreCreationQuestionPreviewViewModel: StoreCreationProfiler
     var isContinueButtonEnabled: AnyPublisher<Bool, Never> {
         $isContinueButtonEnabledValue.eraseToAnyPublisher()
     }
-    func continueButtonTapped() async {}
+    func continueButtonTapped() {}
     func supportButtonTapped() {}
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// The question is not skippable.
 protocol RequiredStoreCreationProfilerQuestionViewModel {
     /// Called when the continue button is tapped.
-    func continueButtonTapped() async
+    func continueButtonTapped()
 
     /// Called when the Help & Support button is tapped.
     func supportButtonTapped()

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionViewModel.swift
@@ -49,8 +49,7 @@ final class StoreCreationSellingPlatformsQuestionViewModel: StoreCreationProfile
 }
 
 extension StoreCreationSellingPlatformsQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
-    func continueButtonTapped() async {
-        // TODO: submission API.
+    func continueButtonTapped() {
         onContinue(.init(sellingStatus: .alreadySellingOnline, sellingPlatforms: selectedPlatforms))
     }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionContainerView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionContainerView.swift
@@ -9,24 +9,6 @@ struct StoreCreationSellingStatusAnswer: Equatable {
     let sellingPlatforms: Set<StoreCreationSellingPlatformsQuestionViewModel.Platform>?
 }
 
-/// Hosting controller that wraps the `StoreCreationSellingStatusQuestionContainerView`.
-final class StoreCreationSellingStatusQuestionHostingController: UIHostingController<StoreCreationSellingStatusQuestionContainerView> {
-    init(onContinue: @escaping (StoreCreationSellingStatusAnswer?) -> Void, onSkip: @escaping () -> Void) {
-        super.init(rootView: StoreCreationSellingStatusQuestionContainerView(onContinue: onContinue, onSkip: onSkip))
-    }
-
-    @available(*, unavailable)
-    required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        configureTransparentNavigationBar()
-    }
-}
-
 /// Displays the selling status question initially. If the user chooses the "I'm already selling online" option, the selling
 /// platforms question is shown.
 struct StoreCreationSellingStatusQuestionContainerView: View {

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
@@ -35,8 +35,7 @@ final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQu
 }
 
 extension StoreCreationSellingStatusQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
-    @MainActor
-    func continueButtonTapped() async {
+    func continueButtonTapped() {
         guard let selectedStatus else {
             return onSkip()
         }
@@ -44,7 +43,6 @@ extension StoreCreationSellingStatusQuestionViewModel: OptionalStoreCreationProf
             // Handled in `StoreCreationSellingPlatformsQuestionViewModel`.
             return
         }
-        // TODO: submission API.
         onContinue(.init(sellingStatus: selectedStatus, sellingPlatforms: nil))
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
@@ -24,9 +24,7 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
                                                                    onSkip: {})
             // When
             viewModel.selectCategory(.clothingAccessories)
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
 
         // Then
@@ -43,9 +41,7 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
                 promise(())
             })
             // When
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
@@ -46,9 +46,7 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
             viewModel.didTapChallenge(.shippingAndLogistics)
             viewModel.didTapChallenge(.managingInventory)
 
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
 
         // Then
@@ -67,9 +65,7 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
                 promise(())
             })
             // When
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
@@ -97,9 +97,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
             // When
             viewModel.selectCountry(.JP)
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
     }
 
@@ -110,9 +108,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
             XCTFail("Should not be invoked without selecting a country.")
         } onSupport: {}
         // When
-        Task { @MainActor in
-            await viewModel.continueButtonTapped()
-        }
+        viewModel.continueButtonTapped()
     }
 
     func test_supportButtonTapped_invokes_onSupport() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationFeaturesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationFeaturesQuestionViewModelTests.swift
@@ -46,9 +46,7 @@ final class StoreCreationFeaturesQuestionViewModelTests: XCTestCase {
             viewModel.didTapFeature(.productManagementAndInventoryTracking)
             viewModel.didTapFeature(.abilityToScaleAsBusinessGrows)
 
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
 
         // Then
@@ -67,9 +65,7 @@ final class StoreCreationFeaturesQuestionViewModelTests: XCTestCase {
                 promise(())
             })
             // When
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingPlatformsQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingPlatformsQuestionViewModelTests.swift
@@ -49,9 +49,7 @@ final class StoreCreationSellingPlatformsQuestionViewModelTests: XCTestCase {
             // When
             viewModel.selectPlatform(.wordPress)
             viewModel.selectPlatform(.amazon)
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
 
         // Then
@@ -65,9 +63,7 @@ final class StoreCreationSellingPlatformsQuestionViewModelTests: XCTestCase {
                 promise(answer)
             }
             // When
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
@@ -37,9 +37,7 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
             } onSkip: {}
             // When
             viewModel.selectStatus(.alreadySellingButNotOnline)
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
 
         // Then
@@ -54,9 +52,7 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
 
         // When
         viewModel.selectStatus(.alreadySellingOnline)
-        Task { @MainActor in
-            await viewModel.continueButtonTapped()
-        }
+        viewModel.continueButtonTapped()
     }
 
     func test_continueButtonTapped_invokes_onSkip_without_selecting_a_category() throws {
@@ -67,9 +63,7 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
                 promise(())
             }
             // When
-            Task { @MainActor in
-                await viewModel.continueButtonTapped()
-            }
+            viewModel.continueButtonTapped()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10374 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the unused hosting controllers for the profiler question views and removes the unnecessary async requirement for the continue button tap handlers.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI should pass. Please feel free to test the store creation flow again to see that it still works properly if needed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
