### PR TITLE
Store profiler: Track profiler info

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -80,13 +80,17 @@ extension WooAnalyticsEvent {
                               properties: [Key.step: step.rawValue])
         }
 
-        /// Tracked when completing the last profiler question during the store creation flow when free trials are enabled.
-        static func siteCreationProfilerData(_ profilerData: StoreProfilerAnswers) -> WooAnalyticsEvent {
-            let properties = [
+        /// Tracked when completing the last profiler question during the store creation flow
+        static func siteCreationProfilerData(_ profilerData: StoreProfilerAnswers,
+                                             challenges: [StoreCreationChallengesAnswer],
+                                             features: [StoreCreationFeaturesAnswer]) -> WooAnalyticsEvent {
+            let properties: [String: WooAnalyticsEventPropertyType] = [
                 Key.category: profilerData.category,
                 Key.sellingStatus: profilerData.sellingStatus?.analyticsValue,
                 Key.sellingPlatforms: profilerData.sellingPlatforms,
-                Key.countryCode: profilerData.countryCode
+                Key.countryCode: profilerData.countryCode,
+                Key.challenges: challenges.map { $0.value }.joined(separator: ","),
+                Key.features: features.map { $0.value }.joined(separator: ",")
             ].compactMapValues({ $0 })
             return WooAnalyticsEvent(statName: .siteCreationProfilerData, properties: properties)
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -18,6 +18,8 @@ extension WooAnalyticsEvent {
             static let waitingTime = "waiting_time"
             static let newSiteID = "new_site_id"
             static let initialDomain = "initial_domain"
+            static let challenges = "challenges"
+            static let features = "features"
         }
 
         /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -74,19 +74,6 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreationManageStoreTapped, properties: [:])
         }
 
-        /// Tracked when completing the last profiler question during the store creation flow.
-        static func siteCreationProfilerData(category: StoreCreationCategoryAnswer?,
-                                             sellingStatus: StoreCreationSellingStatusAnswer?,
-                                             countryCode: SiteAddress.CountryCode?) -> WooAnalyticsEvent {
-            let properties = [
-                Key.category: category?.value,
-                Key.sellingStatus: sellingStatus?.sellingStatus.analyticsValue,
-                Key.sellingPlatforms: sellingStatus?.sellingPlatforms?.map { $0.rawValue }.sorted().joined(separator: ","),
-                Key.countryCode: countryCode?.rawValue
-            ].compactMapValues({ $0 })
-            return WooAnalyticsEvent(statName: .siteCreationProfilerData, properties: properties)
-        }
-
         /// Tracked when the user skips a profiler question in the store creation flow.
         static func siteCreationProfilerQuestionSkipped(step: Step) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreationProfilerQuestionSkipped,

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionOptions.swift
@@ -3,7 +3,9 @@ import Foundation
 extension StoreCreationCategoryQuestionViewModel {
     /// Industry options for a WooCommerce store. The raw value is the value that is sent to the submission API.
     /// The sources of truth are at:
-    /// - WC industry options: `https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx#L32`
+    /// - WC industry options:
+    // swiftlint:disable:next line_length
+    /// `https://github.com/woocommerce/woocommerce/blob/462c690d613e1f5af3be9459b2aac8409a4587dc/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx#L32`
     enum Category: String, Equatable {
         case clothingAccessories = "clothing_and_accessories"
         case healthBeauty = "health_and_beauty"

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Challenges/StoreCreationChallengesQuestionOptions.swift
@@ -1,12 +1,11 @@
 import Foundation
 
 extension StoreCreationChallengesQuestionViewModel {
-    // TODO: 10386 Align with Android and send these via tracks
     enum Challenge: String, CaseIterable {
-        case settingUpTheOnlineStore = "setting-up-the-online-store"
-        case findingCustomers = "finding-customers"
-        case managingInventory = "managing-inventory"
-        case shippingAndLogistics = "shipping-and-logistics"
+        case settingUpTheOnlineStore = "setting_up_online_store"
+        case findingCustomers = "finding_customers"
+        case managingInventory = "managing_inventory"
+        case shippingAndLogistics = "shipping_and_logistics"
         case other = "other"
     }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Features/StoreCreationFeaturesQuestionOptions.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Features/StoreCreationFeaturesQuestionOptions.swift
@@ -1,16 +1,15 @@
 import Foundation
 
 extension StoreCreationFeaturesQuestionViewModel {
-    // TODO: 10386 Align with Android and send these via tracks
     enum Feature: String, CaseIterable {
-        case salesAndAnalyticsReports = "sales-and-analytics-reports"
-        case productManagementAndInventoryTracking = "product-management-and-inventory-tracking"
-        case flexibleAndSecurePaymentOptions = "flexible-and-secure-payment-options"
-        case inPersonPayment = "in-person-payment"
-        case abilityToScaleAsBusinessGrows = "ability-to-scale-as-business-grows"
-        case customizationOptionForStoreDesign = "customization-options-for-my-store-design"
-        case wideRangeOfPluginsAndExtensions = "wide-range-of-plugins-and-extensions"
-        case others = "cthers"
+        case salesAndAnalyticsReports = "sales_and_analytics"
+        case productManagementAndInventoryTracking = "product_management_and_inventory"
+        case flexibleAndSecurePaymentOptions = "payment_options"
+        case inPersonPayment = "in_person_payments"
+        case abilityToScaleAsBusinessGrows = "scale_as_business_grows"
+        case customizationOptionForStoreDesign = "customization_options_for_store_design"
+        case wideRangeOfPluginsAndExtensions = "access_plugin_and_extensions"
+        case other = "other"
     }
 
     var features: [Feature] {
@@ -35,8 +34,8 @@ extension StoreCreationFeaturesQuestionViewModel.Feature {
             return NSLocalizedString("Customization options for my store design", comment: "Feature option in the store creation features question.")
         case .wideRangeOfPluginsAndExtensions:
             return NSLocalizedString("Access to a wide range of plugins and extensions", comment: "Feature option in the store creation features question.")
-        case .others:
-            return NSLocalizedString("Others", comment: "Feature option in the store creation features question.")
+        case .other:
+            return NSLocalizedString("Other", comment: "Feature option in the store creation features question.")
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionViewModel.swift
@@ -8,17 +8,18 @@ import Foundation
 @MainActor
 final class StoreCreationSellingPlatformsQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
     /// Other online platforms that the user might be selling. Source of truth:
-    /// https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/start/config/options.json
+    // swiftlint:disable:next line_length
+    /// https://github.com/woocommerce/woocommerce/blob/462c690d613e1f5af3be9459b2aac8409a4587dc/plugins/woocommerce-admin/client/core-profiler/pages/UserProfile.tsx#L53
     enum Platform: String, CaseIterable {
-        case adobe = "adobe-commerce"
+        case adobe = "adobe_commerce"
         case amazon
-        case bigCartel = "big-cartel"
-        case bigCommerce = "big-commerce"
+        case bigCartel = "big_cartel"
+        case bigCommerce = "big_commerce"
         case eBay = "ebay"
         case ecwid
         case etsy
-        case facebookMarketplace = "facebook-marketplace"
-        case googleShopping = "google-shopping"
+        case facebookMarketplace = "facebook_marketplace"
+        case googleShopping = "google_shopping"
         case magento
         case pinterest
         case shopify

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -109,6 +109,10 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
                                         category: storeCategory?.value,
                                         countryCode: storeCountry.rawValue)
         }()
+
+        analytics.track(event: .StoreCreation.siteCreationProfilerData(answers,
+                                                                       challenges: challenges,
+                                                                       features: features))
         completionHandler(answers)
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -87,8 +87,6 @@ private extension StoreCreationCoordinator {
         let controller = StoreCreationProfilerQuestionContainerHostingController(viewModel: .init(storeName: storeName, onCompletion: { [weak self] answers in
             guard let self else { return }
             if let answers {
-                self.analytics.track(event: .StoreCreation.siteCreationProfilerData(answers))
-
                 let usecase = StoreCreationProfilerUploadAnswersUseCase(siteID: siteID)
                 usecase.storeAnswers(answers)
             }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -86,7 +86,6 @@ private extension StoreCreationCoordinator {
         navigationController.isNavigationBarHidden = false
         let controller = StoreCreationProfilerQuestionContainerHostingController(viewModel: .init(storeName: storeName, onCompletion: { [weak self] answers in
             guard let self else { return }
-            // TODO: 10385 Upload profiler answers from `DashboardViewModel`
             if let answers {
                 self.analytics.track(event: .StoreCreation.siteCreationProfilerData(answers))
 

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationChallengesQuestionViewModelTests.swift
@@ -53,9 +53,9 @@ final class StoreCreationChallengesQuestionViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(answer, [.init(name: StoreCreationChallengesQuestionViewModel.Challenge.shippingAndLogistics.name,
-                                     value: "shipping-and-logistics"),
+                                     value: "shipping_and_logistics"),
                                 .init(name: StoreCreationChallengesQuestionViewModel.Challenge.managingInventory.name,
-                                                             value: "managing-inventory")])
+                                                             value: "managing_inventory")])
     }
 
     func test_continueButtonTapped_invokes_onSkip_without_selecting_a_challenge() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationFeaturesQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationFeaturesQuestionViewModelTests.swift
@@ -53,9 +53,9 @@ final class StoreCreationFeaturesQuestionViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(answer, [.init(name: StoreCreationFeaturesQuestionViewModel.Feature.productManagementAndInventoryTracking.name,
-                                      value: "product-management-and-inventory-tracking"),
+                                      value: "product_management_and_inventory"),
                                 .init(name: StoreCreationFeaturesQuestionViewModel.Feature.abilityToScaleAsBusinessGrows.name,
-                                                              value: "ability-to-scale-as-business-grows")])
+                                                              value: "scale_as_business_grows")])
     }
 
     func test_continueButtonTapped_invokes_onSkip_without_selecting_a_feature() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -282,4 +282,34 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
         XCTAssertEqual(eventProperties["step"] as? String, "store_profiler_features")
     }
+
+    func test_profiler_data_is_tracked_onCompletion() throws {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+
+        // When
+        viewModel.saveSellingStatus(.init(sellingStatus: .alreadySellingOnline,
+                                          sellingPlatforms: [StoreCreationSellingPlatformsQuestionViewModel.Platform.bigCartel]))
+        viewModel.saveCategory(.init(name: StoreCreationCategoryQuestionViewModel.Category.clothingAccessories.name,
+                                     value: StoreCreationCategoryQuestionViewModel.Category.clothingAccessories.rawValue))
+        viewModel.saveCountry(.US)
+        viewModel.saveChallenges([.init(name: StoreCreationChallengesQuestionViewModel.Challenge.findingCustomers.name,
+                                        value: StoreCreationChallengesQuestionViewModel.Challenge.findingCustomers.rawValue),
+                                  .init(name: StoreCreationChallengesQuestionViewModel.Challenge.shippingAndLogistics.name,
+                                        value: StoreCreationChallengesQuestionViewModel.Challenge.shippingAndLogistics.rawValue)])
+        viewModel.saveFeatures([.init(name: StoreCreationFeaturesQuestionViewModel.Feature.productManagementAndInventoryTracking.name,
+                                      value: StoreCreationFeaturesQuestionViewModel.Feature.productManagementAndInventoryTracking.rawValue),
+                                .init(name: StoreCreationFeaturesQuestionViewModel.Feature.abilityToScaleAsBusinessGrows.name,
+                                      value: StoreCreationFeaturesQuestionViewModel.Feature.abilityToScaleAsBusinessGrows.rawValue)])
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_profiler_data" }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["industry_slug"] as? String, "clothing_and_accessories")
+        XCTAssertEqual(eventProperties["user_commerce_journey"] as? String, "im_already_selling")
+        XCTAssertEqual(eventProperties["ecommerce_platforms"] as? String, "big_cartel")
+        XCTAssertEqual(eventProperties["country_code"] as? String, "US")
+        XCTAssertEqual(eventProperties["challenges"] as? String, "finding_customers,shipping_and_logistics")
+        XCTAssertEqual(eventProperties["features"] as? String, "product_management_and_inventory,scale_as_business_grows")
+    }
 }


### PR DESCRIPTION
Closes: #10386 

## Description

- Tracks challenges and features in `site_creation_profiler_data` event
- Updates e-commerce platform raw values to match core profier
- Adds unit tests

Internal - pe5sF9-I3-p2#tracking

## Testing instructions
**Steps**
- Log in and switch to the Menu tab.
- Select the store picker and tap Add a store > Create a new store.
- You should see the Free trial summary screen.
- Tap the "Try for Free" button
- After the loading indicator is gone, you should see the profiler flow
- Answer the questions one by one. Validate that the `site_creation_step` is tracked as before.
- After you answer all questions, you should land on the loading screen or the dashboard screen if the site creation is complete.
- Check Xcode log and ensure that the following event is tracked. The properties should match your answers.
```
🔵 Tracked site_creation_profiler_data, properties: [AnyHashable("was_ecommerce_trial"): true, AnyHashable("industry_slug"): "education_and_learning", AnyHashable("plan"): "ecommerce-trial-bundle-monthly", AnyHashable("features"): "in_person_payments,product_management_and_inventory,other", AnyHashable("challenges"): "finding_customers,shipping_and_logistics,other", AnyHashable("blog_id"): <blog_id>, AnyHashable("user_commerce_journey"): "im_already_selling", AnyHashable("country_code"): "BE", AnyHashable("is_wpcom_store"): true, AnyHashable("ecommerce_platforms"): "adobe_commerce,big_commerce,ecwid"]
```

## Screenshots


https://github.com/woocommerce/woocommerce-ios/assets/524475/b8acfaaf-4057-4227-b0e4-0e0fed6943ce


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.