### PR TITLE
Store profiler: Update tracking

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -90,6 +90,7 @@ private extension StoreCreationCoordinator {
             if let site = self.createdStore {
                 self.continueWithSelectedSite(site: site)
             } else {
+                self.analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
                 self.showInProgressView(from: navigationController)
             }
         }), onSupport: { [weak self] in
@@ -220,7 +221,6 @@ private extension StoreCreationCoordinator {
                     siteID: siteResult.siteID,
                     domainName: siteResult.siteSlug
                 ))
-                analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
             }
 
         case .failure(let error):


### PR DESCRIPTION

Part of: #10374 
## Description

Tracks `store_installation` step when progress view is shown.

## Testing instructions
- Log in and switch to the Menu tab.
- Select the store picker and tap Add a store > Create a new store.
- You should see the Free trial summary screen.
- Tap the "Try for Free" button
- After the loading indicator is gone, you should see the profiler flow
- Skip the profiler questions and land on the progress view with the facts.
- Check Xcode log and ensure that the following `site_creation_step` event with `store_installation` as step value is tracked
```
🔵 Tracked site_creation_step, properties: [AnyHashable("plan"): "ecommerce-trial-bundle-monthly", AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): <blog_id>, AnyHashable("was_ecommerce_trial"): true, AnyHashable("step"): "store_installation"]
```
- Try creating a new store again from the store picker.
- Wait in any one of the profiler question screens for 7-10 mins to make sure that the store is ready.
- Continue, and you should land on the dashboard. (You should not see the loading screen as the store is ready already)
- Check Xcode log and ensure you don't see `site_creation_step` event with `store_installation` step value.


## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/6c9bb95d-c803-4855-ae70-9b8da01d40bc


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
