### PR TITLE
[IAP] Show monthly plans before yearly plans

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -25,8 +25,8 @@ struct OwnerUpgradesView: View {
         _isLoading = .init(initialValue: isLoading)
     }
 
-    @State private var paymentFrequency: LegacyWooPlan.PlanFrequency = .year
-    private var paymentFrequencies: [LegacyWooPlan.PlanFrequency] = [.year, .month]
+    @State private var paymentFrequency: LegacyWooPlan.PlanFrequency = .month
+    private var paymentFrequencies: [LegacyWooPlan.PlanFrequency] = [.month, .year]
 
     @State var selectedPlan: WooWPComPlan? = nil
     @State private var showingFullFeatureList = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After releasing M2 of IAP, which added the yearly plans, our sales dropped to zero for ten days.

This may be due to the sticker shock of a $300-539 In-App Purchase, compared to a $39/month monthly plan.

We’ve swapped the order and start page to show the monthly prices first to see what impact that has on sales.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US-based store with a Woo Express free trial

Launch the app
Tap `Upgrade now`
Observe that the monthly plans show first

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/509d0dfa-75dc-435b-b026-e19ca5c80cc9



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
