### PR TITLE
[IAP] Don't show free domain on monthly plans

### DIFF
--- a/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
+++ b/WooCommerce/Classes/ViewModels/InAppPurchases/UpgradeViewState.swift
@@ -8,15 +8,6 @@ enum UpgradeViewState: Equatable {
     case prePurchaseError(PrePurchaseError)
     case purchaseUpgradeError(PurchaseUpgradeError)
 
-    var shouldShowPlanDetailsView: Bool {
-        switch self {
-        case .loading, .loaded, .prePurchaseError:
-            return true
-        default:
-            return false
-        }
-    }
-
     var analyticsStep: WooAnalyticsEvent.InAppPurchases.Step? {
         switch self {
         case .loading:

--- a/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/OwnerUpgradesView.swift
@@ -42,6 +42,7 @@ struct OwnerUpgradesView: View {
             .cornerRadius(Layout.cornerRadius)
             .background(Color(.systemGroupedBackground))
             .redacted(reason: isLoading ? .placeholder : [])
+            .shimmering(active: isLoading)
 
             Picker(selection: $paymentFrequency, label: EmptyView()) {
                 ForEach(paymentFrequencies) {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -81,7 +81,6 @@ struct UpgradesView: View {
                         dismiss()
                     })
                 }
-                .renderedIf(upgradesViewModel.upgradeViewState.shouldShowPlanDetailsView)
 
                 switch upgradesViewModel.upgradeViewState {
                 case .loading:

--- a/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
+++ b/Yosemite/Yosemite/Model/WooPlans/WooPlan.swift
@@ -15,25 +15,39 @@ public struct WooPlan: Identifiable {
         }
     }
 
+    static func isYearly(_ planID: String) -> Bool {
+        guard let plan = AvailableInAppPurchasesWPComPlans(rawValue: planID) else {
+            return false
+        }
+
+        switch plan {
+        case .essentialYearly, .performanceYearly:
+            return true
+        case .essentialMonthly, .performanceMonthly:
+            return false
+        }
+    }
+
     public static func loadHardcodedPlan(_ selectedPlanID: String) -> WooPlan {
         if isEssential(selectedPlanID) {
+            var planFeatures = isYearly(selectedPlanID) ? [Localization.freeCustomDomainFeatureText] : []
+            planFeatures += [
+                Localization.supportFeatureText,
+                Localization.unlimitedAdminsFeatureText,
+                Localization.unlimitedProductsFeatureText,
+                Localization.premiumThemesFeatureText,
+                Localization.internationalSalesFeatureText,
+                Localization.autoSalesTaxFeatureText,
+                Localization.autoBackupsFeatureText,
+                Localization.integratedShipmentFeatureText,
+                Localization.analyticsDashboardFeatureText,
+                Localization.giftVouchersFeatureText,
+                Localization.emailMarketingFeatureText,
+                Localization.marketplaceSyncFeatureText,
+                Localization.advancedSEOFeatureText,
+            ]
             return WooPlan(id: selectedPlanID,
-                           planFeatures: [
-                            Localization.freeCustomDomainFeatureText,
-                            Localization.supportFeatureText,
-                            Localization.unlimitedAdminsFeatureText,
-                            Localization.unlimitedProductsFeatureText,
-                            Localization.premiumThemesFeatureText,
-                            Localization.internationalSalesFeatureText,
-                            Localization.autoSalesTaxFeatureText,
-                            Localization.autoBackupsFeatureText,
-                            Localization.integratedShipmentFeatureText,
-                            Localization.analyticsDashboardFeatureText,
-                            Localization.giftVouchersFeatureText,
-                            Localization.emailMarketingFeatureText,
-                            Localization.marketplaceSyncFeatureText,
-                            Localization.advancedSEOFeatureText,
-                           ])
+                           planFeatures: planFeatures)
         } else {
             return WooPlan(id: selectedPlanID,
                            planFeatures: [


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

@malinajirka spotted that we said that monthly plans include a free domain – this is only available with yearly plans.

This PR removes that from the feature benefits shown for essential monthly plans. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US-based store with a Woo Express free trial

Build and launch the app using the WooCommerce IAP scheme
Tap Upgrade now
Observe that when you expand the plan details:
1. monthly plans do not mention a domain
2. yearly plans mention the free domain

Additionally, the Current Plan banner had some outdated logic, which is removed, and I added the shimmer effect so that it matches the rest of the screen when loading.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/7591ff92-896c-4775-820e-66de6ad36aa2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
