### PR TITLE
Settings: Move Close Account to a new section Account Settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] The store name can now be updated from the Settings screen. [https://github.com/woocommerce/woocommerce-ios/pull/10485]
 - [**] The store creation flow has been optimized to start store creation immediately and show profiler questions afterward. [https://github.com/woocommerce/woocommerce-ios/pull/10473, https://github.com/woocommerce/woocommerce-ios/pull/10466]
+- [*] Settings: Close Account option is moved to a new section Account Settings and is now available for all WPCom users. [https://github.com/woocommerce/woocommerce-ios/pull/10502]
 
 14.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Hosting controller for `AccountSettingsView`
+final class AccountSettingsHostingController: UIHostingController<AccountSettingsView> {
+    init(viewModel: AccountSettingsViewModel) {
+        super.init(rootView: AccountSettingsView(viewModel: viewModel))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// View for Account Settings
+struct AccountSettingsView: View {
+    private let viewModel: AccountSettingsViewModel
+
+    init(viewModel: AccountSettingsViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct AccountSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AccountSettingsView(viewModel: .init())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsView.swift
@@ -27,8 +27,8 @@ struct AccountSettingsView: View {
                     .padding(.vertical, Layout.buttonHorizontalPadding)
             }
             .frame(maxWidth: .infinity)
-            .cornerRadius(Layout.buttonCornerRadius)
             .background(Color(.systemBackground))
+            .cornerRadius(Layout.buttonCornerRadius)
             .padding(.horizontal, Layout.contentHorizontalMargin)
             .padding(.top, Layout.contentTopMargin)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 /// Hosting controller for `AccountSettingsView`
 final class AccountSettingsHostingController: UIHostingController<AccountSettingsView> {
-    init(viewModel: AccountSettingsViewModel) {
-        super.init(rootView: AccountSettingsView(viewModel: viewModel))
+    init(onCloseAccount: @escaping () -> Void) {
+        super.init(rootView: AccountSettingsView(onCloseAccount: onCloseAccount))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -13,19 +13,49 @@ final class AccountSettingsHostingController: UIHostingController<AccountSetting
 
 /// View for Account Settings
 struct AccountSettingsView: View {
-    private let viewModel: AccountSettingsViewModel
+    private let closeAccountHandler: () -> Void
 
-    init(viewModel: AccountSettingsViewModel) {
-        self.viewModel = viewModel
+    init(onCloseAccount: @escaping () -> Void) {
+        self.closeAccountHandler = onCloseAccount
     }
 
     var body: some View {
-        Text("Hello, World!")
+        ScrollView {
+            Button(action: closeAccountHandler) {
+                Text(Localization.closeAccount)
+                    .errorStyle()
+                    .padding(.vertical, Layout.buttonHorizontalPadding)
+            }
+            .frame(maxWidth: .infinity)
+            .cornerRadius(Layout.buttonCornerRadius)
+            .background(Color(.systemBackground))
+            .padding(.horizontal, Layout.contentHorizontalMargin)
+            .padding(.top, Layout.contentTopMargin)
+
+            Spacer()
+        }
+        .background(Color(.listBackground))
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private extension AccountSettingsView {
+    enum Layout {
+        static let contentHorizontalMargin: CGFloat = 24
+        static let contentTopMargin: CGFloat = 32
+        static let buttonHorizontalPadding: CGFloat = 12
+        static let buttonCornerRadius: CGFloat = 8
+    }
+
+    enum Localization {
+        static let closeAccount = NSLocalizedString("Close Account", comment: "Button to close account on the Account Settings screen")
+        static let title = NSLocalizedString("Account Settings", comment: "Title of the Account Settings screen")
     }
 }
 
 struct AccountSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        AccountSettingsView(viewModel: .init())
+        AccountSettingsView {}
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsViewModel.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-/// View model for `AccountSettingsView`
-final class AccountSettingsViewModel {
-    // TODO
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/AccountSettings/AccountSettingsViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// View model for `AccountSettingsView`
+final class AccountSettingsViewModel {
+    // TODO
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -172,8 +172,8 @@ private extension SettingsViewController {
             configureAppSettings(cell: cell)
         case let cell as BasicTableViewCell where row == .wormholy:
             configureWormholy(cell: cell)
-        case let cell as BasicTableViewCell where row == .closeAccount:
-            configureCloseAccount(cell: cell)
+        case let cell as BasicTableViewCell where row == .accountSettings:
+            configureAccountSettings(cell: cell)
         case let cell as BasicTableViewCell where row == .logout:
             configureLogout(cell: cell)
         default:
@@ -286,12 +286,12 @@ private extension SettingsViewController {
         cell.textLabel?.text = Localization.whatsNew
     }
 
-    func configureCloseAccount(cell: BasicTableViewCell) {
+    func configureAccountSettings(cell: BasicTableViewCell) {
         cell.accessoryType = .none
         cell.selectionStyle = .default
         cell.textLabel?.textAlignment = .center
         cell.textLabel?.textColor = .error
-        cell.textLabel?.text = Localization.closeAccount
+        cell.textLabel?.text = Localization.accountSettings
     }
 
     func configureLogout(cell: BasicTableViewCell) {
@@ -318,9 +318,10 @@ private extension SettingsViewController {
 // MARK: - Actions
 //
 private extension SettingsViewController {
-    func closeAccountWasPressed() {
-        ServiceLocator.analytics.track(event: .closeAccountTapped(source: .settings))
-        closeAccountCoordinator.start()
+    func accountSettingsWasPressed() {
+        // TODO:
+//        ServiceLocator.analytics.track(event: .closeAccountTapped(source: .settings))
+//        closeAccountCoordinator.start()
     }
 
     func closeAccount() async throws {
@@ -659,8 +660,8 @@ extension SettingsViewController: UITableViewDelegate {
             wormholyWasPressed()
         case .whatsNew:
             whatsNewWasPressed()
-        case .closeAccount:
-            closeAccountWasPressed()
+        case .accountSettings:
+            accountSettingsWasPressed()
         case .logout:
             logoutWasPressed()
         default:
@@ -740,8 +741,8 @@ extension SettingsViewController {
         case deviceSettings
         case wormholy
 
-        // Account deletion
-        case closeAccount
+        // Account settings
+        case accountSettings
 
         // Logout
         case logout
@@ -775,7 +776,7 @@ extension SettingsViewController {
                 return SwitchTableViewCell.self
             case .shippingZones:
                 return BasicTableViewCell.self
-            case .logout, .closeAccount:
+            case .logout, .accountSettings:
                 return BasicTableViewCell.self
             case .privacy:
                 return BasicTableViewCell.self
@@ -900,9 +901,9 @@ private extension SettingsViewController {
             comment: "Navigates to screen containing the latest WooCommerce Features"
         )
 
-        static let closeAccount = NSLocalizedString(
-            "Close Account",
-            comment: "Close Account button title to close the user's WordPress.com account"
+        static let accountSettings = NSLocalizedString(
+            "Account Settings",
+            comment: "Navigates to the Account Settings screen"
         )
 
         static let logout = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -289,8 +289,6 @@ private extension SettingsViewController {
     func configureAccountSettings(cell: BasicTableViewCell) {
         cell.accessoryType = .none
         cell.selectionStyle = .default
-        cell.textLabel?.textAlignment = .center
-        cell.textLabel?.textColor = .error
         cell.textLabel?.text = Localization.accountSettings
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -287,7 +287,7 @@ private extension SettingsViewController {
     }
 
     func configureAccountSettings(cell: BasicTableViewCell) {
-        cell.accessoryType = .none
+        cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.accountSettings
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -317,9 +317,11 @@ private extension SettingsViewController {
 //
 private extension SettingsViewController {
     func accountSettingsWasPressed() {
-        // TODO:
-//        ServiceLocator.analytics.track(event: .closeAccountTapped(source: .settings))
-//        closeAccountCoordinator.start()
+        let controller = AccountSettingsHostingController(onCloseAccount: { [weak self] in
+            ServiceLocator.analytics.track(event: .closeAccountTapped(source: .settings))
+            self?.closeAccountCoordinator.start()
+        })
+        navigationController?.show(controller, sender: nil)
     }
 
     func closeAccount() async throws {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -115,7 +115,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let featureFlagService: FeatureFlagService
-    private let appleIDCredentialChecker: AppleIDCredentialCheckerProtocol
     private let defaults: UserDefaults
     private let analytics: Analytics
 
@@ -126,13 +125,11 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     init(stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         appleIDCredentialChecker: AppleIDCredentialCheckerProtocol = AppleIDCredentialChecker(),
          defaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics) {
         self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
-        self.appleIDCredentialChecker = appleIDCredentialChecker
         self.defaults = defaults
         self.analytics = analytics
 
@@ -348,17 +345,14 @@ private extension SettingsViewModel {
                            footerHeight: CGFloat.leastNonzeroMagnitude)
         }()
 
-        // Close account
-        let closeAccountSection: Section? = {
-            // Do not show the Close Account CTA when authenticated with application password
+        // Account Settings
+        let accountSettingsSection: Section? = {
+            // Do not show the Account Settings option when authenticated with application password
             guard stores.isAuthenticatedWithoutWPCom == false else {
                 return nil
             }
-            guard appleIDCredentialChecker.hasAppleUserID() else {
-                return nil
-            }
-            return Section(title: nil,
-                           rows: [.closeAccount],
+            return Section(title: Localization.accountSettings,
+                           rows: [.accountSettings],
                            footerHeight: CGFloat.leastNonzeroMagnitude)
         }()
 
@@ -375,7 +369,7 @@ private extension SettingsViewModel {
             appSettingsSection,
             aboutTheAppSection,
             otherSection,
-            closeAccountSection,
+            accountSettingsSection,
             logoutSection
         ]
         .compactMap { $0 }
@@ -471,6 +465,11 @@ private extension SettingsViewModel {
         static let otherTitle = NSLocalizedString(
             "Other",
             comment: "My Store > Settings > Other app section"
+        ).uppercased()
+
+        static let accountSettings = NSLocalizedString(
+            "Account Settings",
+            comment: "My Store > Settings > Account Settings section"
         ).uppercased()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -342,7 +342,7 @@ private extension SettingsViewModel {
             #endif
             return Section(title: Localization.otherTitle,
                            rows: rows,
-                           footerHeight: CGFloat.leastNonzeroMagnitude)
+                           footerHeight: UITableView.automaticDimension)
         }()
 
         // Account Settings

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2126,6 +2126,8 @@
 		DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
+		DE68979F2A8F7C9C00154588 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68979E2A8F7C9C00154588 /* AccountSettingsView.swift */; };
+		DE6897A12A8F7D0600154588 /* AccountSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6897A02A8F7D0600154588 /* AccountSettingsViewModel.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
 		DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */; };
 		DE6906DB27D5F69900735E3B /* OrderDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE6906DA27D5F69900735E3B /* OrderDetailsViewController.xib */; };
@@ -4576,6 +4578,8 @@
 		DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordDisabledViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
+		DE68979E2A8F7C9C00154588 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
+		DE6897A02A8F7D0600154588 /* AccountSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsViewModel.swift; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
 		DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE6906DA27D5F69900735E3B /* OrderDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderDetailsViewController.xib; sourceTree = "<group>"; };
@@ -9779,6 +9783,7 @@
 		CE85FD5820F7A59E0080B73E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				DE68979D2A8F7C8C00154588 /* AccountSettings */,
 				02ACD2592852E11700EC928E /* CloseAccountCoordinator.swift */,
 				0239305F2918F35600B2632F /* Domains */,
 				BAF1B3B32736595A00BA11DC /* Settings */,
@@ -10388,6 +10393,15 @@
 				B9B7E2E529FBF96100F9CED1 /* ProductSelectorViewModelTracker.swift */,
 			);
 			path = ProductSelector;
+			sourceTree = "<group>";
+		};
+		DE68979D2A8F7C8C00154588 /* AccountSettings */ = {
+			isa = PBXGroup;
+			children = (
+				DE68979E2A8F7C9C00154588 /* AccountSettingsView.swift */,
+				DE6897A02A8F7D0600154588 /* AccountSettingsViewModel.swift */,
+			);
+			path = AccountSettings;
 			sourceTree = "<group>";
 		};
 		DE69C54B27BB7163000BB888 /* UsageDetails */ = {
@@ -11807,6 +11821,7 @@
 				31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */,
 				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
 				02F3A6842A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift in Sources */,
+				DE6897A12A8F7D0600154588 /* AccountSettingsViewModel.swift in Sources */,
 				026D68492A0E060A00D8C22C /* LocalNotificationScheduler.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */,
@@ -12967,6 +12982,7 @@
 				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,
 				31E6F21F26B3577800227E6F /* LegacyCardReaderConnectionController.swift in Sources */,
 				CE13681729FBD94300EBF43C /* QuantityRulesViewModel.swift in Sources */,
+				DE68979F2A8F7C9C00154588 /* AccountSettingsView.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */,
 				028B68BC2A57419700FE03A8 /* AddProductFromImageViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2127,7 +2127,6 @@
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE68979F2A8F7C9C00154588 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68979E2A8F7C9C00154588 /* AccountSettingsView.swift */; };
-		DE6897A12A8F7D0600154588 /* AccountSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6897A02A8F7D0600154588 /* AccountSettingsViewModel.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
 		DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */; };
 		DE6906DB27D5F69900735E3B /* OrderDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE6906DA27D5F69900735E3B /* OrderDetailsViewController.xib */; };
@@ -4579,7 +4578,6 @@
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE68979E2A8F7C9C00154588 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
-		DE6897A02A8F7D0600154588 /* AccountSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsViewModel.swift; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
 		DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE6906DA27D5F69900735E3B /* OrderDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderDetailsViewController.xib; sourceTree = "<group>"; };
@@ -10399,7 +10397,6 @@
 			isa = PBXGroup;
 			children = (
 				DE68979E2A8F7C9C00154588 /* AccountSettingsView.swift */,
-				DE6897A02A8F7D0600154588 /* AccountSettingsViewModel.swift */,
 			);
 			path = AccountSettings;
 			sourceTree = "<group>";
@@ -11821,7 +11818,6 @@
 				31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */,
 				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
 				02F3A6842A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift in Sources */,
-				DE6897A12A8F7D0600154588 /* AccountSettingsViewModel.swift in Sources */,
 				026D68492A0E060A00D8C22C /* LocalNotificationScheduler.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10398 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the issue with the Close Account button being too close to the Log Out button on the Settings screen. A new section Account Settings is introduced where this button is moved to. This section is available for all WPCom users, so we no longer need the check for Apple ID credentials. We are still checking for the credentials on the Store picker screen, we might need another PR to remove it.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to the app with a WPCom.
- Switch to the Menu tab and tap Settings.
- Scroll down to the bottom, notice that a new section Account Settings has replaced the Close Account button.
- Tap the Account Settings row, you should see the Close Account button there.

Please feel free to test again by logging in with application password, the Account Settings section should not be available on the Settings screen

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/87251cf6-1568-419d-894c-4705e20786bc" width=320 /><img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/ffa1b2a1-8874-4eb7-933d-591edd1747c9" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
