### PR TITLE
Bump WooCommerceShared to 0.6.0

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/woocommerce/woocommerce-shared.git",
         "state": {
           "branch": null,
-          "revision": "03d9c94279361e0b002055b9fff3f75ca51ed33e",
-          "version": "0.5.0"
+          "revision": "b68d4c71a2a2b7ba1af2e683f04dffe563fc6194",
+          "version": "0.6.0"
         }
       },
       {


### PR DESCRIPTION

# Why

This PR bumps the `WooCommerceShared` to its 0.6.0 version. This is a minimal change that adds minor enhancements to the shipping zones lists screens

# Demo

<img width="431" alt="Screenshot 2023-08-18 at 9 13 44 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/8b34253f-d7b1-42de-984c-dfdc6659de77">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
