### PR TITLE
Point Tracks to a stable version instead of `trunk` 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,8 +27,8 @@ def aztec
 end
 
 def tracks
-#  pod 'Automattic-Tracks-iOS', '~> 2.2'
-   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
+   pod 'Automattic-Tracks-iOS', '~> 2.3'
+#  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
 #   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,12 +28,12 @@ PODS:
   - Kingfisher (7.6.2)
   - NSObject-SafeExpectations (0.0.6)
   - "NSURL+IDN (0.4)"
-  - Sentry (8.9.2):
-    - Sentry/Core (= 8.9.2)
-    - SentryPrivate (= 8.9.2)
-  - Sentry/Core (8.9.2):
-    - SentryPrivate (= 8.9.2)
-  - SentryPrivate (8.9.2)
+  - Sentry (8.10.0):
+    - Sentry/Core (= 8.10.0)
+    - SentryPrivate (= 8.10.0)
+  - Sentry/Core (8.10.0):
+    - SentryPrivate (= 8.10.0)
+  - SentryPrivate (8.10.0)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
   - StripeTerminal (2.19.1)
@@ -77,7 +77,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, branch `trunk`)
+  - Automattic-Tracks-iOS (~> 2.3)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -100,6 +100,7 @@ SPEC REPOS:
   trunk:
     - Alamofire
     - AppAuth
+    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - GoogleSignIn
     - Gridicons
@@ -131,16 +132,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  Automattic-Tracks-iOS:
-    :branch: trunk
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-
-CHECKOUT OPTIONS:
-  Automattic-Tracks-iOS:
-    :commit: aad902bf945e7528a00ba5b9c5640974d58ff2fd
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
@@ -154,8 +145,8 @@ SPEC CHECKSUMS:
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
-  Sentry: 4fe92c018ba6ed61ce1fc652dd1ccac34505a4c6
-  SentryPrivate: b58fc25b3a0ac7e3d4ec229be63d583e3314a47a
+  Sentry: 71cd4427146ac56eab6e70401ac7a24384c3d3b5
+  SentryPrivate: 9334613897c85a9e30f2c9d7a331af8aaa4fe71f
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 93e18a93c6f92e51ceedc5b78ab3075327075a80
@@ -178,6 +169,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: d4c144c76aeaa030c4c92ad810890347a8159d19
+PODFILE CHECKSUM: c3a8390d80b2cc4f8d5e746e2e0b537efc6955d8
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
This PR points Tracks to a stable version instead of using `trunk`. It reverts https://github.com/woocommerce/woocommerce-ios/pull/10373/commits/72ffadf904b51e92258247736a3e29d144d7d222 from a few weeks ago and addresses @mokagio's feedback on this merge PR:  https://github.com/woocommerce/woocommerce-ios/pull/10505#pullrequestreview-1586093697

It also updated Sentry from `8.9.2` to `8.10.0` when I ran `pod install`. I [reviewed the latest releases](https://github.com/getsentry/sentry-cocoa/releases) from Sentry and didn't see anything that would cause issues for us.