### PR TITLE
Remove stale feature flags for login 

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -23,8 +23,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .loginPrologueOnboarding:
             return true
-        case .loginMagicLinkEmphasisM2:
-            return true
         case .promptToEnableCodInIppOnboarding:
             return true
         case .searchProductsBySKU:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -21,8 +21,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .loginPrologueOnboarding:
-            return true
         case .promptToEnableCodInIppOnboarding:
             return true
         case .searchProductsBySKU:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -38,10 +38,6 @@ public enum FeatureFlag: Int {
     ///
     case loginPrologueOnboarding
 
-    /// Whether to show the magic link as a secondary button instead of a table view cell on the password screen
-    ///
-    case loginMagicLinkEmphasisM2
-
     /// Whether to include the Cash on Delivery enable step in In-Person Payment onboarding
     ///
     case promptToEnableCodInIppOnboarding

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -34,10 +34,6 @@ public enum FeatureFlag: Int {
     ///
     case consolidatedCardReaderManuals
 
-    /// Onboarding experiment on the login prologue screen
-    ///
-    case loginPrologueOnboarding
-
     /// Whether to include the Cash on Delivery enable step in In-Person Payment onboarding
     ///
     case promptToEnableCodInIppOnboarding

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -6,7 +6,7 @@ import struct Networking.Settings
 extension WordPressAuthenticator {
     static func initializeWithCustomConfigs(dotcomAuthScheme: String = ApiCredentials.dotcomAuthScheme,
                                             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
-        let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
+        let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = true
         let isManualErrorHandlingEnabled = featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -201,8 +201,7 @@ private extension AppCoordinator {
             return false
         }
 
-        guard featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding),
-              loggedOutAppSettings.hasFinishedOnboarding == false else {
+        guard loggedOutAppSettings.hasFinishedOnboarding == false else {
             return false
         }
         return true

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -42,7 +42,10 @@ final class AppCoordinatorTests: XCTestCase {
 
     func test_starting_app_logged_out_presents_authentication() throws {
         // Given
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()
@@ -93,7 +96,10 @@ final class AppCoordinatorTests: XCTestCase {
         stores.authenticate(credentials: SessionSettings.wporgCredentials)
         sessionManager.defaultStoreID = nil
 
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()
@@ -108,7 +114,10 @@ final class AppCoordinatorTests: XCTestCase {
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         sessionManager.defaultStoreID = nil
 
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()
@@ -264,7 +273,10 @@ final class AppCoordinatorTests: XCTestCase {
         // Given
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
         sessionManager.defaultStoreID = 134
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -42,7 +42,7 @@ final class AppCoordinatorTests: XCTestCase {
 
     func test_starting_app_logged_out_presents_authentication() throws {
         // Given
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()
@@ -93,7 +93,7 @@ final class AppCoordinatorTests: XCTestCase {
         stores.authenticate(credentials: SessionSettings.wporgCredentials)
         sessionManager.defaultStoreID = nil
 
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()
@@ -108,7 +108,7 @@ final class AppCoordinatorTests: XCTestCase {
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         sessionManager.defaultStoreID = nil
 
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()
@@ -264,7 +264,7 @@ final class AppCoordinatorTests: XCTestCase {
         // Given
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
         sessionManager.defaultStoreID = 134
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager, loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()
@@ -281,12 +281,10 @@ final class AppCoordinatorTests: XCTestCase {
         stores.deauthenticate()
         sessionManager.defaultStoreID = 134
         let loggedOutAppSettings = MockLoggedOutAppSettings(hasFinishedOnboarding: false)
-        let featureFlagService = MockFeatureFlagService(isLoginPrologueOnboardingEnabled: true)
         let appCoordinator = makeCoordinator(window: window,
                                              stores: stores,
                                              authenticationManager: authenticationManager,
-                                             loggedOutAppSettings: loggedOutAppSettings,
-                                             featureFlagService: featureFlagService)
+                                             loggedOutAppSettings: loggedOutAppSettings)
 
         // When
         appCoordinator.start()
@@ -301,32 +299,10 @@ final class AppCoordinatorTests: XCTestCase {
         stores.deauthenticate()
         sessionManager.defaultStoreID = 134
         let loggedOutAppSettings = MockLoggedOutAppSettings(hasFinishedOnboarding: true)
-        let featureFlagService = MockFeatureFlagService(isLoginPrologueOnboardingEnabled: true)
         let appCoordinator = makeCoordinator(window: window,
                                              stores: stores,
                                              authenticationManager: authenticationManager,
-                                             loggedOutAppSettings: loggedOutAppSettings,
-                                             featureFlagService: featureFlagService)
-
-        // When
-        appCoordinator.start()
-
-        // Then
-        assertThat(window.rootViewController, isAnInstanceOf: LoginNavigationController.self)
-        XCTAssertNil(window.rootViewController?.presentedViewController)
-    }
-
-    func test_starting_app_logged_out_does_not_present_onboarding_when_feature_flag_is_disabled() throws {
-        // Given
-        stores.deauthenticate()
-        sessionManager.defaultStoreID = 134
-        let loggedOutAppSettings = MockLoggedOutAppSettings(hasFinishedOnboarding: false)
-        let featureFlagService = MockFeatureFlagService(isLoginPrologueOnboardingEnabled: false)
-        let appCoordinator = makeCoordinator(window: window,
-                                             stores: stores,
-                                             authenticationManager: authenticationManager,
-                                             loggedOutAppSettings: loggedOutAppSettings,
-                                             featureFlagService: featureFlagService)
+                                             loggedOutAppSettings: loggedOutAppSettings)
 
         // When
         appCoordinator.start()
@@ -346,8 +322,7 @@ final class AppCoordinatorTests: XCTestCase {
                                              stores: stores,
                                              authenticationManager: authenticationManager,
                                              analytics: WooAnalytics(analyticsProvider: analytics),
-                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: false),
-                                             featureFlagService: MockFeatureFlagService(isLoginPrologueOnboardingEnabled: true))
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: false))
 
         // When
         appCoordinator.start()
@@ -412,6 +387,7 @@ final class AppCoordinatorTests: XCTestCase {
         let mockInAppPurchasesManager = MockInAppPurchasesForWPComPlansManager(isIAPSupported: true)
         let upgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(inAppPurchaseManager: mockInAppPurchasesManager)
         let coordinator = makeCoordinator(window: window,
+                                          loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true),
                                           pushNotesManager: pushNotesManager,
                                           upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator)
         coordinator.start()

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -6,7 +6,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSplitViewInOrdersTabOn: Bool
     private let isUpdateOrderOptimisticallyOn: Bool
     private let shippingLabelsOnboardingM1: Bool
-    private let isLoginPrologueOnboardingEnabled: Bool
     private let isDomainSettingsEnabled: Bool
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
@@ -28,7 +27,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSplitViewInOrdersTabOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
-         isLoginPrologueOnboardingEnabled: Bool = false,
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
@@ -49,7 +47,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
-        self.isLoginPrologueOnboardingEnabled = isLoginPrologueOnboardingEnabled
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
@@ -78,8 +75,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isUpdateOrderOptimisticallyOn
         case .shippingLabelsOnboardingM1:
             return shippingLabelsOnboardingM1
-        case .loginPrologueOnboarding:
-            return isLoginPrologueOnboardingEnabled
         case .domainSettings:
             return isDomainSettingsEnabled
         case .supportRequests:

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -128,7 +128,10 @@ final class StoresManagerTests: XCTestCase {
         cancellable = manager.isLoggedInPublisher.sink { isLoggedIn in
             isLoggedInValues.append(isLoggedIn)
         }
-        let appCoordinator = AppCoordinator(window: UIWindow(frame: .zero), stores: manager, authenticationManager: mockAuthenticationManager)
+        let appCoordinator = AppCoordinator(window: UIWindow(frame: .zero),
+                                            stores: manager,
+                                            authenticationManager: mockAuthenticationManager,
+                                            loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
         appCoordinator.start()
 
         // Action


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9618 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR cleans up the stale feature flags from the login experiments in Q3 2022. According to the discussion [p1682647903364049-slack-C03L1NF1EA3], we can remove the feature flag `loginMagicLinkEmphasisM2` - and while we don't have exact numbers for the login onboarding, we should also remove the flag `loginPrologueOnboarding` as the feature has been enabled for almost a year now.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Reinstall the app to test the login onboarding.
- When the app is first opened, the login onboarding screen should be displayed. 
- Skip the onboarding then reopen the app. The login onboarding screen should not be displayed.
- Log in to a non-A8C WPCom account. After the email step, the password screen should be displayed with the magic link option as the secondary CTA.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/a27437c3-b969-441e-a0e1-3fd21245e66f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.