### PR TITLE
Add a source parameter to the shipping label purchase API request for revenue attribution

### DIFF
--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -309,7 +309,8 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
                 ParameterKey.originAddress: try originAddress.toDictionary(),
                 ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
                 ParameterKey.packages: try packages.map { try $0.toDictionary() },
-                ParameterKey.emailReceipt: emailCustomerReceipt
+                ParameterKey.emailReceipt: emailCustomerReceipt,
+                ParameterKey.source: "wc-ios"
             ]
             let path = "\(Path.shippingLabels)/\(orderID)"
             let request = JetpackRequest(wooApiVersion: .wcConnectV1,
@@ -374,6 +375,7 @@ private extension ShippingLabelRemote {
         static let emailReceipts = "email_receipts"
         static let emailReceipt = "email_receipt"
         static let async = "async"
+        static let source = "source"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -486,6 +486,22 @@ final class ShippingLabelRemoteTests: XCTestCase {
         XCTAssertNotNil(result.failure)
     }
 
+    func test_purchaseShippingLabel_request_contains_source_parameter() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+
+        // When
+        remote.purchaseShippingLabel(siteID: self.sampleSiteID,
+                                     orderID: self.sampleOrderID,
+                                     originAddress: ShippingLabelAddress.fake(),
+                                     destinationAddress: ShippingLabelAddress.fake(),
+                                     packages: [ShippingLabelPackagePurchase.fake()],
+                                     emailCustomerReceipt: true) { _ in }
+
+        // Then
+        XCTAssertEqual(network.queryParametersDictionary?["source"] as? String, "wc-ios")
+    }
+
     func test_checkLabelStatus_parses_success_response() throws {
         // Given
         let sampleLabelID: Int64 = 4321


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10499 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Currently, we don't have a formal way to track the source of each shipping label purchase (mobile apps or web). As in paJDVv-2BY-p2, we plan to support a `source` parameter (`wc-ios|wc-android`) in the purchase API request body to be recorded in a Tracks event `woocommerceconnect_server_label_purchase` and the billing table entry as a tag.

In the mobile client, we just need to pass a `source: wc-ios` parameter in the shipping label purchase API request body **after** the server-side changes are deployed.

## How

A new `source` parameter was added to the shipping label purchase request parameters.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the site and user are eligible for shipping label creation. You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Log in to a site with a user as in the prerequisites
- Go to the Orders tab
- Create an order with at least one physical simple product if needed
- Tap on the order with at least one physical simple product --> there should be a CTA to create a shipping label either as a primary button, or in the ellipsis menu at the `Product` header row
- Tap `Create Shipping Label`
- Complete the flow to create a shipping label --> it should get to the success state after a bit


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.