### PR TITLE
[Manual Taxes] Fetch "tax based on" setting

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -573,6 +573,8 @@
 		B5C6FCD620A3768900A4F8E4 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = B5C6FCD520A3768900A4F8E4 /* order.json */; };
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
 		B918DDF12A3C960000E74DE5 /* products-sku-search-variation.json in Resources */ = {isa = PBXBuildFile; fileRef = B918DDF02A3C960000E74DE5 /* products-sku-search-variation.json */; };
+		B93E032C2A96112A009CA9C1 /* setting-tax-based-on-shipping-success.json in Resources */ = {isa = PBXBuildFile; fileRef = B93E032B2A96112A009CA9C1 /* setting-tax-based-on-shipping-success.json */; };
+		B93E032E2A9613CB009CA9C1 /* setting-tax-based-on-parse-error.json in Resources */ = {isa = PBXBuildFile; fileRef = B93E032D2A9613CA009CA9C1 /* setting-tax-based-on-parse-error.json */; };
 		B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */; };
 		B9CB14DE2A42DE60005912C2 /* products-sku-search-non-purchasable.json in Resources */ = {isa = PBXBuildFile; fileRef = B9CB14DD2A42DE60005912C2 /* products-sku-search-non-purchasable.json */; };
 		BAB373722795A1FB00837B4A /* OrderTaxLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB373712795A1FB00837B4A /* OrderTaxLine.swift */; };
@@ -1536,6 +1538,8 @@
 		B5C6FCD520A3768900A4F8E4 /* order.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = order.json; sourceTree = "<group>"; };
 		B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsRemote.swift; sourceTree = "<group>"; };
 		B918DDF02A3C960000E74DE5 /* products-sku-search-variation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-sku-search-variation.json"; sourceTree = "<group>"; };
+		B93E032B2A96112A009CA9C1 /* setting-tax-based-on-shipping-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-tax-based-on-shipping-success.json"; sourceTree = "<group>"; };
+		B93E032D2A9613CA009CA9C1 /* setting-tax-based-on-parse-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-tax-based-on-parse-error.json"; sourceTree = "<group>"; };
 		B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemRefundMetaData.swift; sourceTree = "<group>"; };
 		B9CB14DD2A42DE60005912C2 /* products-sku-search-non-purchasable.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-sku-search-non-purchasable.json"; sourceTree = "<group>"; };
 		BAB373712795A1FB00837B4A /* OrderTaxLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTaxLine.swift; sourceTree = "<group>"; };
@@ -2704,6 +2708,8 @@
 				D88D5A40230BC5DA007B6E01 /* reviews-all.json */,
 				57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */,
 				D88D5A42230BC668007B6E01 /* reviews-single.json */,
+				B93E032B2A96112A009CA9C1 /* setting-tax-based-on-shipping-success.json */,
+				B93E032D2A9613CA009CA9C1 /* setting-tax-based-on-parse-error.json */,
 				DE74F29B27E0A1D00002FE59 /* setting-coupon.json */,
 				DE74F29F27E3137F0002FE59 /* setting-analytics.json */,
 				74046E20217A73D0007DD7BF /* settings-general.json */,
@@ -3464,6 +3470,7 @@
 				DE66C5632977CBC700DAA978 /* shipping-label-eligibility-failure-without-data.json in Resources */,
 				DE42F96F296BC9A700D514C2 /* countries-without-data.json in Resources */,
 				EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */,
+				B93E032E2A9613CB009CA9C1 /* setting-tax-based-on-parse-error.json in Resources */,
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				DE5CA111288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
@@ -3542,6 +3549,7 @@
 				D865CE6B278CA266002C8520 /* stripe-payment-intent-error.json in Resources */,
 				CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */,
 				0286981A29ED324900853B88 /* generative-text-failure.json in Resources */,
+				B93E032C2A96112A009CA9C1 /* setting-tax-based-on-shipping-success.json in Resources */,
 				021D741C2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json in Resources */,
 				B57B1E6C21C94C9F0046E764 /* timeout_error.json in Resources */,
 				0313651B28AE60E000EEE571 /* payment-gateway-cod.json in Resources */,

--- a/Networking/NetworkingTests/Responses/setting-tax-based-on-parse-error.json
+++ b/Networking/NetworkingTests/Responses/setting-tax-based-on-parse-error.json
@@ -1,0 +1,29 @@
+{
+    "data": {
+        "id": "woocommerce_tax_based_on",
+          "label": "Calculate tax based on",
+          "description": "",
+          "type": "select",
+          "default": "shipping",
+          "options": {
+            "shipping": "Customer shipping address",
+            "billing": "Customer billing address",
+            "base": "Shop base address"
+          },
+          "tip": "This option determines which address is used to calculate tax.",
+          "value": "this is a value that cannot be parsed",
+          "group_id": "tax",
+          "_links": {
+            "self": [
+              {
+                "href": "https://cool-shop.mystagingwebsite.com/wp-json/wc/v3/settings/tax/woocommerce_tax_based_on"
+              }
+            ],
+            "collection": [
+              {
+                "href": "https://cool-shop.mystagingwebsite.com/wp-json/wc/v3/settings/tax"
+              }
+            ]
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/setting-tax-based-on-shipping-success.json
+++ b/Networking/NetworkingTests/Responses/setting-tax-based-on-shipping-success.json
@@ -1,0 +1,29 @@
+{
+    "data": {
+        "id": "woocommerce_tax_based_on",
+          "label": "Calculate tax based on",
+          "description": "",
+          "type": "select",
+          "default": "shipping",
+          "options": {
+            "shipping": "Customer shipping address",
+            "billing": "Customer billing address",
+            "base": "Shop base address"
+          },
+          "tip": "This option determines which address is used to calculate tax.",
+          "value": "shipping",
+          "group_id": "tax",
+          "_links": {
+            "self": [
+              {
+                "href": "https://cool-shop.mystagingwebsite.com/wp-json/wc/v3/settings/tax/woocommerce_tax_based_on"
+              }
+            ],
+            "collection": [
+              {
+                "href": "https://cool-shop.mystagingwebsite.com/wp-json/wc/v3/settings/tax"
+              }
+            ]
+        }
+    }
+}

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		B5EED1A820F4F3CF00652449 /* Account+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EED1A720F4F3CF00652449 /* Account+ReadOnlyConvertible.swift */; };
 		B5F2AE9520EBAD6000FEDC59 /* ResultsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F2AE9420EBAD6000FEDC59 /* ResultsControllerTests.swift */; };
 		B5F2AE9720EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F2AE9620EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift */; };
+		B93E03282A960CAD009CA9C1 /* TaxBasedOnSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93E03272A960CAD009CA9C1 /* TaxBasedOnSetting.swift */; };
 		B9AECD3C2850F3C600E78584 /* OrderCardPresentPaymentEligibilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD3B2850F3C600E78584 /* OrderCardPresentPaymentEligibilityStore.swift */; };
 		B9AECD3E2850F41100E78584 /* OrderCardPresentPaymentEligibilityAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD3D2850F41100E78584 /* OrderCardPresentPaymentEligibilityAction.swift */; };
 		B9AECD402850FE4600E78584 /* Order+CardPresentPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD3F2850FE4600E78584 /* Order+CardPresentPayment.swift */; };
@@ -788,6 +789,7 @@
 		B5EED1A720F4F3CF00652449 /* Account+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Account+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		B5F2AE9420EBAD6000FEDC59 /* ResultsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsControllerTests.swift; sourceTree = "<group>"; };
 		B5F2AE9620EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedResultsControllerDelegateWrapper.swift; sourceTree = "<group>"; };
+		B93E03272A960CAD009CA9C1 /* TaxBasedOnSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxBasedOnSetting.swift; sourceTree = "<group>"; };
 		B9AECD3B2850F3C600E78584 /* OrderCardPresentPaymentEligibilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCardPresentPaymentEligibilityStore.swift; sourceTree = "<group>"; };
 		B9AECD3D2850F41100E78584 /* OrderCardPresentPaymentEligibilityAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCardPresentPaymentEligibilityAction.swift; sourceTree = "<group>"; };
 		B9AECD3F2850FE4600E78584 /* Order+CardPresentPayment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Order+CardPresentPayment.swift"; sourceTree = "<group>"; };
@@ -1012,6 +1014,7 @@
 				E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */,
 				03F3AFE628097D6400E328BE /* CardPresentPaymentsPlugin.swift */,
 				E109876B284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift */,
+				B93E03272A960CAD009CA9C1 /* TaxBasedOnSetting.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2222,6 +2225,7 @@
 				B52E0034211A449600700FDE /* Site+ReadOnlyType.swift in Sources */,
 				247CE86C25832D5800F9D9D1 /* MockShipmentActionHandler.swift in Sources */,
 				D8C11A5822DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift in Sources */,
+				B93E03282A960CAD009CA9C1 /* TaxBasedOnSetting.swift in Sources */,
 				CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */,
 				74D42DBC221C983F00B4977D /* ShipmentTracking+ReadOnlyConvertible.swift in Sources */,
 				247CE87A258332B400F9D9D1 /* MockNotificationActionHandler.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Networking
 
+public enum SettingError: Error {
+    case parseError
+}
 
 /// SettingAction: Defines all of the Actions supported by the SettingStore.
 ///
@@ -33,4 +36,8 @@ public enum SettingAction: Action {
     /// Enables WC Analytics for the specified store
     ///
     case enableAnalyticsSetting(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Retrieves the information on what are the taxes based on (shop, billing, or shipping address)
+    ///
+    case retrieveTaxBasedOnSetting(siteID: Int64, onCompletion: (Result<TaxBasedOnSetting, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Enums/TaxBasedOnSetting.swift
+++ b/Yosemite/Yosemite/Model/Enums/TaxBasedOnSetting.swift
@@ -1,0 +1,7 @@
+/// Represents the address used to calculate the taxes
+///
+public enum TaxBasedOnSetting {
+    case customerShippingAddress
+    case customerBillingAddress
+    case shopBaseAddress
+}

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -165,7 +165,7 @@ private extension SettingStore {
         }
     }
 
-    /// Retrieves the setting for whether WC Analytics are enabled for the specified store
+    /// Retrieves the used address to calculate the tax
     ///
     func retrieveTaxBasedOnSetting(siteID: Int64, onCompletion: @escaping (Result<TaxBasedOnSetting, Error>) -> Void) {
         siteSettingsRemote.loadSetting(for: siteID, settingGroup: .custom("tax"), settingID: SettingKeys.taxBasedOn) { [weak self] result in
@@ -177,7 +177,6 @@ private extension SettingStore {
                         onCompletion(.failure(SettingError.parseError))
                         return
                     }
-
 
                     onCompletion(.success(taxBasedOnSetting))
                 }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -48,6 +48,8 @@ public class SettingStore: Store {
             retrieveAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
         case let .enableAnalyticsSetting(siteID, onCompletion):
             enableAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
+        case let .retrieveTaxBasedOnSetting(siteID: siteID, onCompletion: onCompletion):
+            retrieveTaxBasedOnSetting(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -162,6 +164,28 @@ private extension SettingStore {
             }
         }
     }
+
+    /// Retrieves the setting for whether WC Analytics are enabled for the specified store
+    ///
+    func retrieveTaxBasedOnSetting(siteID: Int64, onCompletion: @escaping (Result<TaxBasedOnSetting, Error>) -> Void) {
+        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .custom("tax"), settingID: SettingKeys.taxBasedOn) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    guard let taxBasedOnSetting = TaxBasedOnSetting(backendValue: setting.value) else {
+                        onCompletion(.failure(SettingError.parseError))
+                        return
+                    }
+
+
+                    onCompletion(.success(taxBasedOnSetting))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
 }
 
 
@@ -258,9 +282,25 @@ extension SettingStore {
     private enum SettingKeys {
         static let coupons = "woocommerce_enable_coupons"
         static let analytics = "woocommerce_analytics_enabled"
+        static let taxBasedOn = "woocommerce_tax_based_on"
     }
 
     private enum SettingValue {
         static let yes = "yes"
+    }
+}
+
+extension TaxBasedOnSetting {
+    init?(backendValue: String) {
+        switch backendValue {
+        case "shipping":
+            self = .customerShippingAddress
+        case "billing":
+            self = .customerBillingAddress
+        case "base":
+            self = .shopBaseAddress
+        default:
+            return nil
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10513 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we retrieve the "tax based on" setting, so it can be displayed in the Editable Order Details screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
As we don't display the value yet, we will have a debug code to check it. 

- Enable taxes in `wp-admin/admin.php?page=wc-settings&tab=general`
- Change the value of "Calculate tax based on"  in `wp-admin/admin.php?page=wc-settings&tab=tax`

Add this code wherever you feel appropriate, e.g. at the end of the `EditableOrderViewModel` [init](https://github.com/woocommerce/woocommerce-ios/blob/37245ea41123036daf1fe269aed4bc8e410d04c6/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/EditableOrderViewModel.swift#L366):

        stores.dispatch(SettingAction.retrieveTaxBasedOnSetting(siteID: siteID, onCompletion: { result in
            debugPrint("result", result)
        }))

Run the app and check that the retrieved value matches the value in `wp-admin`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
