### PR TITLE
Add support for `enabled` payment gateway status

### DIFF
--- a/Networking/Networking/Model/WCPayAccountStatusEnum.swift
+++ b/Networking/Networking/Model/WCPayAccountStatusEnum.swift
@@ -8,6 +8,10 @@ public enum WCPayAccountStatusEnum: Decodable, Hashable, GeneratedFakeable {
     /// card present payments.
     case complete
 
+    /// Enabled means the account is in good standing to process payments and receive payouts,
+    /// though additional information might be required if another payment volume threshold is reached.
+    case enabled
+
     /// This state occurs when there is required business information missing from the account.
     /// If `hasOverdueRequirements` is also true, then the deadline for providing that information HAS PASSED and
     /// the merchant will probably NOT be able to collect card present payments.
@@ -59,6 +63,8 @@ extension WCPayAccountStatusEnum: RawRepresentable {
         switch rawValue {
         case Keys.complete:
             self = .complete
+        case Keys.enabled:
+            self = .enabled
         case Keys.restricted:
             self = .restricted
         case Keys.restrictedSoon:
@@ -83,6 +89,7 @@ extension WCPayAccountStatusEnum: RawRepresentable {
     public var rawValue: String {
         switch self {
         case .complete:               return Keys.complete
+        case .enabled:                return Keys.enabled
         case .restricted:             return Keys.restricted
         case .restrictedSoon:         return Keys.restrictedSoon
         case .rejectedFraud:          return Keys.rejectedFraud
@@ -100,6 +107,9 @@ extension WCPayAccountStatusEnum: RawRepresentable {
 private enum Keys {
     /// The WCPay account is fully set up without restriction and ready for card present payments.
     static let complete               = "complete"
+    /// The WCPay account has provided enough information to process payments and receive payouts temporarily
+    /// but more information will be eventually required to continue processing payments
+    static let enabled                = "enabled"
     /// The WCPay account is restricted - it is under review or has pending or overdue requirements.
     static let restricted             = "restricted"
     /// The WCPay account has required information missing but it's not restricted yet.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -485,6 +485,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
     func accountStatusAllowedForCardPresentPayments(account: PaymentGatewayAccount) -> Bool {
         account.wcpayStatus == .complete ||
+        account.wcpayStatus == .enabled ||
         account.wcpayStatus == .restrictedSoon
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -859,6 +859,42 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
     }
 
+    func test_onboarding_returns_complete_when_account_status_is_enabled_using_wcpay_plugin() {
+        // Given
+        let accountStatus: WCPayAccountStatusEnum = .enabled
+
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: accountStatus)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
+    }
+
+    func test_onboarding_returns_complete_when_account_status_is_enabled_using_stripe_plugin() {
+        // Given
+        let accountStatus: WCPayAccountStatusEnum = .enabled
+
+        setupCountry(country: .us)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: StripeAccount.self, status: accountStatus)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .stripe, available: [.stripe])))
+    }
+
     func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -4,6 +4,11 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     ///
     case loading
 
+    /// All the requirements are temporarily met and the feature is ready to use.
+    /// While the account is in good standing, additional information might be required if a payment volume threshold is reached
+    ///
+    case enabled
+
     /// All the requirements are met and the feature is ready to use
     ///
     case completed(plugin: CardPresentPaymentsPluginState)
@@ -80,6 +85,8 @@ extension CardPresentPaymentOnboardingState {
         switch self {
         case .loading:
             return "loading"
+        case .enabled:
+            return "enabled"
         case .completed:
             return "completed"
         case .selectPlugin:


### PR DESCRIPTION
Context: p1692780778792139-slack-C025A8VV728

## Description
This PR adds support for the `enabled` payment account status, so when a merchant account has this state, its valid to allow processing card-present payments. This resolves a problem where users could fall into a `generic error` state if their accounts were set to `enabled`, as we were not contemplating this option.

This status reflects an account that is currently in good standing to process payments and receive payouts, however, is not yet `completed` and additional information might be required if a payment volume threshold is reached.

## Testing instructions
1. Using an IPP-eligible store (edit the target's scheme to enable `simulate-stripe-card-reader` if using the simulated card reader)
2. In proxyman or any other networking tool, intercept requests to `/wc/v3/payments/accounts&_method=get`, in my case, I set a breakpoint at `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/SITE_ID/rest-api/?json=true&path=/wc/v3/payments/accounts*`
3. Run the app, and once the request is intercepted, change the body response for the `status` property to  `enabled`:

<img width="1314" alt="Screenshot 2023-08-23 at 13 04 33" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/eddc7c58-a8ae-47d8-84fe-ef686c869eae">

3. Go to Menu > Payments and observe that there's no "needs setup" banner notification if your account was previously set as "status: completed", or that you can setup the plugins normally if there's anything left to configure in order to process a payment.
 
4. Process an IPP payment using the card reader, for example in Menu > Payments > Collect Payment > Take Payment > Card Reader

5. Observe that the payment is processed normally:

<img width=600 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/9c9cc956-abb6-4c50-9fc6-42ac0a32486b">
