### PR TITLE
[Coupons] Configure navigation bar items when data is loaded.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
@@ -68,6 +68,7 @@ private extension EnhancedCouponListViewController {
         let couponListViewController = CouponListViewController(siteID: siteID,
                                                             showFeedbackBannerIfAppropriate: true,
                                                             emptyStateActionTitle: Localization.createCouponAction,
+                                                            onDataLoaded: configureNavigationBarItems,
                                                             emptyStateAction: displayCouponTypeBottomSheet,
                                                             onCouponSelected: showDetails)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we configure the navigation bar items when the data is loaded, so coupons can be searched and added. It was removed accidentally here 29a9bda09d9af3f167b740314b89bd5809799365

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open the app
2. Go to Menu
3. Tap on Cupons
4. See that the Search and Add buttons are added in the navigation bar.

### Before
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/3faf20af-da92-46b2-9177-3843051c221f" width="375">

### After
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/6e00b2eb-8e68-4254-864f-de8b8a790a43" width="375">

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
