### PR TITLE
Store profiler: Store each answer

### DIFF
--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -95,23 +95,29 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
     }
 
     public func uploadStoreProfilerAnswers(siteID: Int64, answers: StoreProfilerAnswers) async throws {
-        let industry: [String]? = {
-            guard let category = answers.category else {
-                return nil
-            }
-            return [category]
-        }()
-        let onboarding: [String: Any] = [
-            "industry": industry,
-            "is_store_country_set": true,
-            "business_choice": answers.sellingStatus?.remoteValue,
-            "selling_platforms": answers.sellingPlatforms
-        ].compactMapValues { $0 }
+        let parameters: [String: Any] = {
+            let industry: [String]? = {
+                guard let category = answers.category else {
+                    return nil
+                }
+                return [category]
+            }()
+            let onboarding: [String: Any?] = [
+                "industry": industry,
+                "is_store_country_set": answers.countryCode != nil,
+                "business_choice": answers.sellingStatus?.remoteValue,
+                "selling_platforms": answers.sellingPlatforms
+            ]
 
-        let parameters: [String: Any] = [
-            "woocommerce_default_country": answers.countryCode,
-            "woocommerce_onboarding_profile": onboarding
-        ]
+            var params: [String: Any?] = [
+                "woocommerce_onboarding_profile": onboarding.compactMapValues { $0 }
+            ]
+            if let countryCode = answers.countryCode {
+                params["woocommerce_default_country"] = countryCode
+            }
+            return params.compactMapValues { $0 }
+        }()
+
         let request = JetpackRequest(wooApiVersion: .wcAdmin,
                                      method: .post,
                                      siteID: siteID,
@@ -225,7 +231,7 @@ public struct StoreProfilerAnswers: Codable, Equatable {
     public let sellingStatus: SellingStatus?
     public let sellingPlatforms: String?
     public let category: String?
-    public let countryCode: String
+    public let countryCode: String?
 
     /// Selling status options.
     /// Its raw value is the value to be sent to the backend.
@@ -252,7 +258,7 @@ public struct StoreProfilerAnswers: Codable, Equatable {
     public init(sellingStatus: StoreProfilerAnswers.SellingStatus?,
                 sellingPlatforms: String?,
                 category: String?,
-                countryCode: String) {
+                countryCode: String?) {
         self.sellingStatus = sellingStatus
         self.sellingPlatforms = sellingPlatforms
         self.category = category

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -109,12 +109,10 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
                 "selling_platforms": answers.sellingPlatforms
             ]
 
-            var params: [String: Any?] = [
-                "woocommerce_onboarding_profile": onboarding.compactMapValues { $0 }
+            let params: [String: Any?] = [
+                "woocommerce_onboarding_profile": onboarding.compactMapValues { $0 },
+                "woocommerce_default_country": answers.countryCode
             ]
-            if let countryCode = answers.countryCode {
-                params["woocommerce_default_country"] = countryCode
-            }
             return params.compactMapValues { $0 }
         }()
 

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -223,6 +223,59 @@ final class SiteRemoteTests: XCTestCase {
         XCTAssertFalse(profilerDictionary.keys.contains("selling_platforms"))
     }
 
+    func test_uploadStoreProfilerAnswers_with_valid_country_sets_is_store_country_set_parameter_as_true() async throws {
+        // When
+        try? await remote.uploadStoreProfilerAnswers(siteID: 134,
+                                                     answers: .init(sellingStatus: nil,
+                                                                    sellingPlatforms: "wordpress",
+                                                                    category: "clothing_and_accessories",
+                                                                    countryCode: "US"))
+
+        // Then
+        let parameterDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        let profilerDictionary = try XCTUnwrap(parameterDictionary["woocommerce_onboarding_profile"] as? [String: Any])
+        XCTAssertTrue(try XCTUnwrap(profilerDictionary["is_store_country_set"] as? Bool))
+    }
+
+    func test_uploadStoreProfilerAnswers_with_nil_country_sets_is_store_country_set_parameter_as_false() async throws {
+        // When
+        try? await remote.uploadStoreProfilerAnswers(siteID: 134,
+                                                     answers: .init(sellingStatus: nil,
+                                                                    sellingPlatforms: "wordpress",
+                                                                    category: "clothing_and_accessories",
+                                                                    countryCode: nil))
+
+        // Then
+        let parameterDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        let profilerDictionary = try XCTUnwrap(parameterDictionary["woocommerce_onboarding_profile"] as? [String: Any])
+        XCTAssertFalse(try XCTUnwrap(profilerDictionary["is_store_country_set"] as? Bool))
+    }
+
+    func test_uploadStoreProfilerAnswers_with_valid_country_has_woocommerce_default_country_value() async throws {
+        // When
+        try? await remote.uploadStoreProfilerAnswers(siteID: 134,
+                                                     answers: .init(sellingStatus: nil,
+                                                                    sellingPlatforms: "wordpress",
+                                                                    category: "clothing_and_accessories",
+                                                                    countryCode: "US"))
+
+        // Then
+        let parameterDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertEqual(try XCTUnwrap(parameterDictionary["woocommerce_default_country"] as? String), "US")
+    }
+
+    func test_uploadStoreProfilerAnswers_with_nil_country_sets_has_woocommerce_default_country_as_nil() async throws {
+        // When
+        try? await remote.uploadStoreProfilerAnswers(siteID: 134,
+                                                     answers: .init(sellingStatus: nil,
+                                                                    sellingPlatforms: "wordpress",
+                                                                    category: "clothing_and_accessories",
+                                                                    countryCode: nil))
+
+        // Then
+        let parameterDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertNil(parameterDictionary["woocommerce_default_country"])
+    }
 
     func test_uploadStoreProfilerAnswers_returns_DotcomError_on_failure() async throws {
         // Given

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
@@ -113,6 +113,9 @@ private extension StoreCreationProfilerQuestionContainerView {
 
 struct StoreCreationProfilerQuestionContainerView_Previews: PreviewProvider {
     static var previews: some View {
-        StoreCreationProfilerQuestionContainerView(viewModel: .init(storeName: "Test", onCompletion: { _ in }), onSupport: {})
+        StoreCreationProfilerQuestionContainerView(viewModel: .init(storeName: "Test",
+                                                                    onCompletion: { },
+                                                                    uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123)),
+                                                   onSupport: {})
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -36,7 +36,7 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
             storeAnswers()
         }
     }
-    private var storeCountry: SiteAddress.CountryCode = .US {
+    private var storeCountry: SiteAddress.CountryCode? {
         didSet {
             storeAnswers()
         }
@@ -51,7 +51,7 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
         return StoreProfilerAnswers(sellingStatus: sellingStatus,
                                     sellingPlatforms: sellingPlatforms,
                                     category: storeCategory?.value,
-                                    countryCode: storeCountry.rawValue)
+                                    countryCode: storeCountry?.rawValue)
     }
 
     @Published private(set) var currentQuestion: StoreCreationProfilerQuestion = .sellingStatus

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -81,19 +81,19 @@ private extension StoreCreationCoordinator {
 
     func showProfilerFlow(storeName: String, siteID: Int64, from navigationController: UINavigationController) {
         navigationController.isNavigationBarHidden = false
-        let controller = StoreCreationProfilerQuestionContainerHostingController(viewModel: .init(storeName: storeName, onCompletion: { [weak self] answers in
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: storeName,
+                                                                        onCompletion: { [weak self] in
             guard let self else { return }
-            if let answers {
-                let usecase = StoreCreationProfilerUploadAnswersUseCase(siteID: siteID)
-                usecase.storeAnswers(answers)
-            }
             if let site = self.createdStore {
                 self.continueWithSelectedSite(site: site)
             } else {
                 self.analytics.track(event: .StoreCreation.siteCreationStep(step: .storeInstallation))
                 self.showInProgressView(from: navigationController)
             }
-        }), onSupport: { [weak self] in
+        },
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: siteID))
+        let controller = StoreCreationProfilerQuestionContainerHostingController(viewModel: viewModel,
+                                                                                 onSupport: { [weak self] in
             self?.showSupport(from: navigationController)
         })
         navigationController.setViewControllers([controller], animated: true)

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -23,7 +23,9 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveSellingStatus_updates_currentQuestion_to_category() {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         XCTAssertEqual(viewModel.currentQuestion, .sellingStatus)
 
         // When
@@ -35,8 +37,9 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveCategory_updates_currentQuestion_to_country() {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in })
-
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         // When
         viewModel.saveCategory(nil)
 
@@ -46,7 +49,9 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveCountry_updates_currentQuestion_to_challenges() {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveCountry(.US)
@@ -57,33 +62,28 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveFeatures_triggers_onCompletion() throws {
         // Given
-        var profilerData: StoreProfilerAnswers?
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { profilerData = $0 })
+        var triggeredCompletion = false
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: { triggeredCompletion = true },
+                                                                        uploadAnswersUseCase: MockStoreCreationProfilerUploadAnswersUseCase())
 
         // When
-        viewModel.saveSellingStatus(.init(sellingStatus: .justStarting, sellingPlatforms: nil))
-        viewModel.saveCategory(nil)
-        viewModel.saveCountry(.US)
-        viewModel.saveChallenges([])
         viewModel.saveFeatures([])
 
         // Then
-        let data = try XCTUnwrap(profilerData)
-        XCTAssertEqual(data.sellingStatus, .justStarting)
-        XCTAssertNil(data.sellingPlatforms)
-        XCTAssertEqual(data.countryCode, "US")
+        XCTAssertTrue(triggeredCompletion)
     }
 
     // MARK: - `backtrackOrDismissProfiler`
 
-    func test_backtrackOrDismissProfiler_triggers_completionHandler_without_profiler_data_if_current_question_is_selling_status() {
+    func test_backtrackOrDismissProfiler_triggers_completionHandler_if_current_question_is_selling_status() {
         // Given
         var triggeredCompletion = false
-        var profilerData: StoreProfilerAnswers?
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: {
-            profilerData = $0
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {
             triggeredCompletion = true
-        })
+        },
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         XCTAssertEqual(viewModel.currentQuestion, .sellingStatus)
 
         // When
@@ -91,13 +91,14 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(triggeredCompletion)
-        XCTAssertNil(profilerData)
     }
 
     func test_backtrackOrDismissProfiler_sets_current_question_to_selling_status_if_current_question_is_category() {
         // Given
         var triggeredCompletion = false
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: { triggeredCompletion = true },
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         viewModel.saveSellingStatus(nil)
 
         // When
@@ -111,7 +112,9 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
     func test_backtrackOrDismissProfiler_sets_current_question_to_category_if_current_question_is_country() {
         // Given
         var triggeredCompletion = false
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: { triggeredCompletion = true },
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         viewModel.saveCategory(nil)
 
         // When
@@ -125,7 +128,9 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
     func test_backtrackOrDismissProfiler_sets_current_question_to_country_if_current_question_is_challenges() {
         // Given
         var triggeredCompletion = false
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: { triggeredCompletion = true },
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         viewModel.saveCountry(.US)
 
         // When
@@ -139,7 +144,9 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
     func test_backtrackOrDismissProfiler_sets_current_question_to_challenges_if_current_question_is_features() {
         // Given
         var triggeredCompletion = false
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", onCompletion: { _ in triggeredCompletion = true })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: { triggeredCompletion = true },
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         viewModel.saveChallenges([])
 
         // When
@@ -154,7 +161,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_onAppear_tracks_site_creation_event_for_selling_status_question() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.onAppear()
@@ -167,7 +177,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveSellingStatus_tracks_skip_event_for_selling_status_question() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveSellingStatus(nil)
@@ -180,7 +193,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveSellingStatus_tracks_skip_event_for_selling_platform_question() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveSellingStatus(.init(sellingStatus: .alreadySellingOnline, sellingPlatforms: nil))
@@ -193,7 +209,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveSellingStatus_tracks_site_creation_event_for_category_question() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveSellingStatus(.init(sellingStatus: .alreadySellingOnline, sellingPlatforms: nil))
@@ -206,7 +225,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveCategory_tracks_skip_event_for_category_question() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveCategory(nil)
@@ -219,7 +241,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveCategory_tracks_site_creation_event_for_country_question() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveCategory(nil)
@@ -233,7 +258,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveCountry_tracks_site_creation_event_for_country_features() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveCountry(.AD)
@@ -246,7 +274,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveChallenges_tracks_skip_event_for_challenges_questions() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveChallenges([])
@@ -259,7 +290,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveChallenges_tracks_site_creation_event_for_features_question() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveChallenges([])
@@ -272,7 +306,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveFeatures_tracks_skip_event_for_challenges_questions() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveFeatures([])
@@ -285,7 +322,10 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_profiler_data_is_tracked_onCompletion() throws {
         // Given
-        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test", analytics: analytics, onCompletion: { _ in })
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        analytics: analytics,
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
         viewModel.saveSellingStatus(.init(sellingStatus: .alreadySellingOnline,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -35,6 +35,22 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentQuestion, .category)
     }
 
+    func test_saveSellingStatus_saves_answer() throws {
+        // Given
+        let usecase = MockStoreCreationProfilerUploadAnswersUseCase()
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: usecase)
+        // When
+        viewModel.saveSellingStatus(.init(sellingStatus: .alreadySellingOnline,
+                                          sellingPlatforms: [.bigCartel, .bigCommerce]))
+
+        // Then
+        let data = try XCTUnwrap(usecase.storedAnswers)
+        XCTAssertEqual(data.sellingStatus, .alreadySellingOnline)
+        XCTAssertEqual(data.sellingPlatforms, "big_cartel,big_commerce")
+    }
+
     func test_saveCategory_updates_currentQuestion_to_country() {
         // Given
         let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
@@ -45,6 +61,23 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.currentQuestion, .country)
+    }
+
+    func test_saveCategory_saves_answer() throws {
+        // Given
+        let usecase = MockStoreCreationProfilerUploadAnswersUseCase()
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: usecase)
+
+        // When
+        viewModel.saveCategory(.init(name: StoreCreationCategoryQuestionViewModel.Category.foodDrink.name,
+                                     value: StoreCreationCategoryQuestionViewModel.Category.foodDrink.rawValue))
+
+
+        // Then
+        let data = try XCTUnwrap(usecase.storedAnswers)
+        XCTAssertEqual(data.category, StoreCreationCategoryQuestionViewModel.Category.foodDrink.rawValue)
     }
 
     func test_saveCountry_updates_currentQuestion_to_challenges() {
@@ -58,6 +91,21 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.currentQuestion, .challenges)
+    }
+
+    func test_saveCountry_saves_answer() throws {
+        // Given
+        let usecase = MockStoreCreationProfilerUploadAnswersUseCase()
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: usecase)
+        // When
+        viewModel.saveCountry(.AG)
+
+
+        // Then
+        let data = try XCTUnwrap(usecase.storedAnswers)
+        XCTAssertEqual(data.countryCode, "AG")
     }
 
     func test_saveFeatures_triggers_onCompletion() throws {

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoreCreationProfilerUploadAnswersUseCase.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoreCreationProfilerUploadAnswersUseCase.swift
@@ -4,9 +4,9 @@ import struct Yosemite.StoreProfilerAnswers
 import Foundation
 
 class MockStoreCreationProfilerUploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCaseProtocol {
-    var storeAnswersCalled = false
+    var storedAnswers: StoreProfilerAnswers?
     func storeAnswers(_ data: StoreProfilerAnswers) {
-        storeAnswersCalled = true
+        storedAnswers = data
     }
 
     var uploadAnswersCalled = false


### PR DESCRIPTION
Closes: #10525

## Description

Previously, if the user left the app after answering part of the questions from the store creation profiler flow, we will not save the previous answers. 

This PR changes that and saves the answer after each step. This ensures that the answers are not lost. 

## Testing instructions

**Prerequisites**
Proxyman setup to intercept the network request.

**Steps**
- Log in and switch to the Menu tab.
- Select the store picker and tap Add a store > Create a new store.
- You should see the Free trial summary screen.
- Tap the "Try for Free" button
- After the loading indicator is gone, you should see the profiler flow
- Answer the questions one by one. 
- After you answer all questions, you should land on the loading screen or the dashboard screen if the site creation is complete.
- After you land in the dashboard, check proxyman and you should see a network request to `wc-admin/options` to update the profiler answers.

**Quitting the app case**
- Log in and switch to the Menu tab.
- Select the store picker and tap Add a store > Create a new store.
- You should see the Free trial summary screen.
- Tap the "Try for Free" button
- Intercept the `sites/new` network request and note down the site URL.
- After the loading indicator is gone, you should see the profiler flow
- Answer only a few questions and quit the app. 
- Wait for a 7 to 10 mins for the site to be configured.
- Launch the app.
- Open store picker.
- Switch to the new store using the previously noted URL. 
- After you land in the dashboard of the newly created store, check proxyman and you should see a network request to `wc-admin/options` to update the profiler answers.
- This request should contain the partial answers. 

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/6c9bb95d-c803-4855-ae70-9b8da01d40bc

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
