### PR TITLE
Order list tracks event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -149,13 +149,18 @@ extension WooAnalyticsEvent {
         }
     }
 
-    static func ordersListLoaded(totalDuration: TimeInterval, pageNumber: Int, filters: FilterOrderListViewModel.Filters?) -> WooAnalyticsEvent {
-        WooAnalyticsEvent(statName: .ordersListLoaded, properties: [
+    static func ordersListLoaded(totalDuration: TimeInterval,
+                                 pageNumber: Int,
+                                 filters: FilterOrderListViewModel.Filters?,
+                                 totalCompletedOrders: Int?) -> WooAnalyticsEvent {
+        let properties: [String: WooAnalyticsEventPropertyType?] = [
             "status": (filters?.orderStatus ?? []).map { $0.rawValue }.joined(separator: ","),
             "page_number": Int64(pageNumber),
             "total_duration": Double(totalDuration),
-            "date_range": filters?.dateRange?.analyticsDescription ?? String()
-        ])
+            "date_range": filters?.dateRange?.analyticsDescription ?? String(),
+            "total_completed_orders": totalCompletedOrders
+        ]
+        return WooAnalyticsEvent(statName: .ordersListLoaded, properties: properties.compactMapValues { $0 })
     }
 
     static func ordersListLoadError(_ error: Error) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -909,6 +909,26 @@ private extension OrderListViewController {
     }
 }
 
+// MARK: - Total completed order count
+//
+private extension OrderListViewController {
+    @MainActor
+    func retrieveTotalCompletedOrderCount(siteID: Int64) async -> Int? {
+        await withCheckedContinuation { continuation in
+            let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { result in
+                switch result {
+                case let .success(statuses):
+                    continuation.resume(returning: statuses.first { $0.status == .completed }?.total)
+                case let .failure(error):
+                    DDLogError("⛔️ Could not successfully fetch number of completed orders for siteID \(siteID): \(error)")
+                    continuation.resume(returning: nil)
+                }
+            }
+            ServiceLocator.stores.dispatch(action)
+        }
+    }
+}
+
 // MARK: - Constants
 //
 private extension OrderListViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -403,9 +403,14 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
                         // save timestamp of last successful update
                         self.lastFullSyncTimestamp = Date()
                     }
-                    ServiceLocator.analytics.track(event: .ordersListLoaded(totalDuration: totalDuration,
-                                                                            pageNumber: pageNumber,
-                                                                            filters: self.viewModel.filters))
+
+                    Task {
+                        let totalCompletedOrderCount = await self.retrieveTotalCompletedOrderCount(siteID: self.siteID)
+                        ServiceLocator.analytics.track(event: .ordersListLoaded(totalDuration: totalDuration,
+                                                                                pageNumber: pageNumber,
+                                                                                filters: self.viewModel.filters,
+                                                                                totalCompletedOrders: totalCompletedOrderCount))
+                    }
                 }
 
                 self.transitionToResultsUpdatedState()


### PR DESCRIPTION
Closes: #10532 

## Description

Adds a property to the `orders_list_loaded` tracks event to track the completed order count. 

## Testing instructions

1. Launch and login into the app
2. Navigate to the Orders tab
3. Pull to refresh and ensure that the following event is tracked.
```
Tracked orders_list_loaded, properties: [AnyHashable("date_range"): "", AnyHashable("is_wpcom_store"): false, AnyHashable("total_duration"): 1.8034749031066895, AnyHashable("status"): "", AnyHashable("blog_id"): <blog_id>, AnyHashable("total_completed_orders"): 1, AnyHashable("page_number"): 1, AnyHashable("plan"): "jetpack_free", AnyHashable("was_ecommerce_trial"): false]
```
4. Ensure that `total_completed_orders` reflects the completed order count of your store. 

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/f74097b9-4326-4a6c-9314-5effa821a999" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
