### PR TITLE
Switch store upon tapping store ready notification

### DIFF
--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -18,15 +18,15 @@ struct LocalNotification {
     /// The scenario for the local notification.
     /// Its raw value is used for the identifier of a local notification and also the event property for analytics.
     enum Scenario {
-        case storeCreationComplete
+        case storeCreationComplete(siteID: Int64)
         case sixHoursAfterFreeTrialSubscribed(siteID: Int64)
         case freeTrialSurvey24hAfterFreeTrialSubscribed(siteID: Int64)
         case threeDaysAfterStillExploring(siteID: Int64)
 
         var identifier: String {
             switch self {
-            case .storeCreationComplete:
-                return "store_creation_complete"
+            case let .storeCreationComplete(siteID):
+                return Identifier.Prefix.storeCreationComplete + "\(siteID)"
             case let .sixHoursAfterFreeTrialSubscribed(siteID):
                 return Identifier.Prefix.sixHoursAfterFreeTrialSubscribed + "\(siteID)"
             case let .freeTrialSurvey24hAfterFreeTrialSubscribed(siteID):
@@ -38,6 +38,7 @@ struct LocalNotification {
 
         enum Identifier {
             enum Prefix {
+                static let storeCreationComplete = "store_creation_complete"
                 static let sixHoursAfterFreeTrialSubscribed = "six_hours_after_free_trial_subscribed"
                 static let freeTrialSurvey24hAfterFreeTrialSubscribed = "free_trial_survey_24h_after_free_trial_subscribed"
                 static let threeDaysAfterStillExploring = "three_days_after_still_exploring"
@@ -46,7 +47,9 @@ struct LocalNotification {
 
         /// Helper method to remove postfix from notification identifiers if needed.
         static func identifierForAnalytics(_ identifier: String) -> String {
-            if identifier.hasPrefix(Identifier.Prefix.sixHoursAfterFreeTrialSubscribed) {
+            if identifier.hasPrefix(Identifier.Prefix.storeCreationComplete) {
+                return Identifier.Prefix.storeCreationComplete
+            } else if identifier.hasPrefix(Identifier.Prefix.sixHoursAfterFreeTrialSubscribed) {
                 return Identifier.Prefix.sixHoursAfterFreeTrialSubscribed
             } else if identifier.hasPrefix(Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed) {
                 return Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -46,7 +46,8 @@ final class AppCoordinator {
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator()) {
+         upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(),
+         switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil) {
         self.window = window
         self.tabBarController = {
             let storyboard = UIStoryboard(name: "Main", bundle: nil) // Main is the name of storyboard
@@ -63,7 +64,7 @@ final class AppCoordinator {
         self.loggedOutAppSettings = loggedOutAppSettings
         self.pushNotesManager = pushNotesManager
         self.featureFlagService = featureFlagService
-        self.switchStoreUseCase = SwitchStoreUseCase(stores: stores, storageManager: storageManager)
+        self.switchStoreUseCase = switchStoreUseCase ?? SwitchStoreUseCase(stores: stores, storageManager: storageManager)
         self.upgradesViewPresentationCoordinator = upgradesViewPresentationCoordinator
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -345,6 +345,7 @@ private extension AppCoordinator {
 
     func handleLocalNotificationResponse(_ response: UNNotificationResponse) {
         let identifier = response.notification.request.identifier
+        let storeCreationComplete = LocalNotification.Scenario.Identifier.Prefix.storeCreationComplete
         let sixHoursAfterFreeTrialSubscribed = LocalNotification.Scenario.Identifier.Prefix.sixHoursAfterFreeTrialSubscribed
         let freeTrialSurvey24hAfterFreeTrialSubscribed = LocalNotification.Scenario.Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed
 
@@ -359,6 +360,12 @@ private extension AppCoordinator {
                                                                           userInfo: userInfo))
 
         switch identifier {
+        case let identifier where identifier.hasPrefix(storeCreationComplete):
+            guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+                  let siteID = Int64(identifier.replacingOccurrences(of: storeCreationComplete, with: "")) else {
+                return
+            }
+            switchStoreUseCase.switchStore(with: siteID) { _ in }
         case let identifier where identifier.hasPrefix(sixHoursAfterFreeTrialSubscribed):
             guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
                   let siteID = Int64(identifier.replacingOccurrences(of: sixHoursAfterFreeTrialSubscribed, with: "")) else {

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -29,7 +29,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         }
 
         // When
-        let notification = LocalNotification(scenario: .storeCreationComplete)
+        let notification = LocalNotification(scenario: .storeCreationComplete(siteID: 123))
         await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: .storeCreationCompleteNotification)
 
         // Then
@@ -49,7 +49,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         }
 
         // When
-        let notification = LocalNotification(scenario: .storeCreationComplete)
+        let notification = LocalNotification(scenario: .storeCreationComplete(siteID: 123))
         await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: .storeCreationCompleteNotification)
 
         // Then
@@ -62,7 +62,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
 
         // When
-        let notification = LocalNotification(scenario: .storeCreationComplete)
+        let notification = LocalNotification(scenario: .storeCreationComplete(siteID: 123))
         await scheduler.schedule(notification: notification, trigger: nil, remoteFeatureFlag: nil)
 
         // Then
@@ -82,7 +82,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         }
 
         // When
-        let notification = LocalNotification(scenario: .storeCreationComplete)
+        let notification = LocalNotification(scenario: .storeCreationComplete(siteID: 123))
         await scheduler.schedule(notification: notification,
                                  trigger: nil,
                                  remoteFeatureFlag: .storeCreationCompleteNotification,

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationTests.swift
@@ -5,7 +5,7 @@ final class LocalNotificationTests: XCTestCase {
 
     func test_storeCreationComplete_scenario_returns_correct_notification_contents() throws {
         // Given
-        let scenario = LocalNotification.Scenario.storeCreationComplete
+        let scenario = LocalNotification.Scenario.storeCreationComplete(siteID: 123)
         let testName = "Miffy"
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, displayName: testName))
 


### PR DESCRIPTION
Closes: #10534 

## Description

Switches to the newly created store when the user taps on the "Store ready" local notification to open the app.

## Testing instructions
**Steps**
- Log in and switch to the Menu tab.
- Select the store picker and tap Add a store > Create a new store.
- You should see the Free trial summary screen.
- Tap the "Try for Free" button
- After the loading indicator is gone, you should see the profiler flow
- Quit the app and wait for 5 mins 
- You should see the "Store ready" local notification. 
- Tap the notification to open the app.
- Validate that the app switches to the newly created store. 

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/9a014108-3eca-4c39-b9cb-665757acee86" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
