### PR TITLE
Prologue: Update buttons' styles and positions 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -83,8 +83,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-#  pod 'WordPressAuthenticator', '~> 6.3.0'
-     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '62dfe6d22beba1b7365bdd62a194305a290562f3'
+  pod 'WordPressAuthenticator', '~> 6.4.0'
+#     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -83,8 +83,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 6.3.0'
-  #   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+#  pod 'WordPressAuthenticator', '~> 6.3.0'
+     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '62dfe6d22beba1b7365bdd62a194305a290562f3'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -86,7 +86,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `62dfe6d22beba1b7365bdd62a194305a290562f3`)
+  - WordPressAuthenticator (~> 6.4.0)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -95,6 +95,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
     - WordPressKit
   trunk:
     - Alamofire
@@ -131,16 +132,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: 62dfe6d22beba1b7365bdd62a194305a290562f3
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 62dfe6d22beba1b7365bdd62a194305a290562f3
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
@@ -163,7 +154,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 0406143755a661b818b80d1e926a206b234f99f6
+  WordPressAuthenticator: 5929076e39dd5aeebeb3ea1e985d6a53f73a984f
   WordPressKit: f4c39ae3a5949846d2d7c51843690d078711ab36
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
@@ -178,6 +169,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 404192559db38ce921680978cc36c13a95e120a0
+PODFILE CHECKSUM: afa59f82653c9554d145cc7bdaf98f5143eed3dc
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (6.3.0):
+  - WordPressAuthenticator (6.4.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -50,7 +50,7 @@ PODS:
     - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.5.0):
+  - WordPressKit (8.5.1):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -86,7 +86,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 6.3.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `62dfe6d22beba1b7365bdd62a194305a290562f3`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -95,7 +95,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
     - WordPressKit
   trunk:
     - Alamofire
@@ -132,6 +131,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: 62dfe6d22beba1b7365bdd62a194305a290562f3
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 62dfe6d22beba1b7365bdd62a194305a290562f3
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
@@ -154,8 +163,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 9bfb316cb165e1997b73aa94d92fadc991cc9725
-  WordPressKit: 2424ae2203179d7658c88630e9bdf1dc42e9f7ff
+  WordPressAuthenticator: 0406143755a661b818b80d1e926a206b234f99f6
+  WordPressKit: f4c39ae3a5949846d2d7c51843690d078711ab36
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
@@ -169,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: c3a8390d80b2cc4f8d5e746e2e0b537efc6955d8
+PODFILE CHECKSUM: 404192559db38ce921680978cc36c13a95e120a0
 
 COCOAPODS: 1.12.1

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -26,7 +26,7 @@ enum LoginProloguePageType: CaseIterable {
             return NSLocalizedString("Monitor and approve your product reviews",
                                      comment: "Caption displayed in promotional screens shown during the login flow.")
         case .getStarted:
-            return NSLocalizedString("The e-commerce platform that grows with you",
+            return NSLocalizedString("The ecommerce platform that grows with you",
                                      comment: "Caption displayed in the simplified prologue screen")
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10374 
Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/781.
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the work in #10539 to update the prologue screen. In this PR, the styles of the prologue buttons are updated following a change in `WordPressAuthenticator` library. Also, the title is also updated following the confirmation that "ecommerce" is consistently used for WooExpress on the web. [8sNT07kW3VEdnor4baI6ft-fi?type=design&mode=design&t=YF2LNxXDPbhxfjdH-0#537405433]

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app if needed.
- Confirm that the title and buttons are correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/4101c540-a416-430b-a29f-aa9b631ae73e" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.