### PR TITLE
[Manual Taxes] Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -641,6 +641,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderGoToCouponsButtonTapped, properties: [:])
         }
 
+        static func orderTaxHelpButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderTaxHelpButtonTapped, properties: [:])
+        }
+
         static func productDiscountAdd(type: FeeOrDiscountLineDetailsViewModel.FeeOrDiscountType) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductDiscountAdd, properties: [Keys.type: type.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -645,6 +645,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderTaxHelpButtonTapped, properties: [:])
         }
 
+        static func taxEducationalDialogEditInAdminButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .taxEducationalDialogEditInAdminButtonTapped, properties: [:])
+        }
+
         static func productDiscountAdd(type: FeeOrDiscountLineDetailsViewModel.FeeOrDiscountType) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductDiscountAdd, properties: [Keys.type: type.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -417,6 +417,7 @@ public enum WooAnalyticsStat: String {
     case orderCouponAdd = "order_coupon_add"
     case orderCouponRemove = "order_coupon_remove"
     case orderGoToCouponsButtonTapped = "order_go_to_coupons_button_tapped"
+    case orderTaxHelpButtonTapped = "order_taxes_help_button_tapped"
     case orderProductDiscountAdd = "order_product_discount_add"
     case orderProductDiscountRemove = "order_product_discount_remove"
     case orderProductDiscountAddButtonTapped = "order_product_discount_add_button_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -431,6 +431,10 @@ public enum WooAnalyticsStat: String {
     case orderDetailsSubscriptionsShown = "order_details_subscriptions_shown"
     case orderDetailsGiftCardShown = "order_details_gift_card_shown"
 
+    // MARK: Order Tax Educational Dialog
+    //
+    case taxEducationalDialogEditInAdminButtonTapped = "tax_educational_dialog_edit_in_admin_button_tapped"
+
     // MARK: Order List Sorting/Filtering
     //
     case orderListViewFilterOptionsTapped = "order_list_view_filter_options_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -738,6 +738,7 @@ extension EditableOrderViewModel {
         let feeLineViewModel: FeeOrDiscountLineDetailsViewModel
         let addNewCouponLineClosure: (Coupon) -> Void
         let onGoToCouponsClosure: () -> Void
+        let onTaxHelpButtonTappedClosure: () -> Void
         let onDismissWpAdminWebViewClosure: () -> Void
 
         init(siteID: Int64 = 0,
@@ -768,6 +769,7 @@ extension EditableOrderViewModel {
              saveFeeLineClosure: @escaping (String?) -> Void = { _ in },
              addNewCouponLineClosure: @escaping (Coupon) -> Void = { _ in },
              onGoToCouponsClosure: @escaping () -> Void = {},
+             onTaxHelpButtonTappedClosure: @escaping () -> Void = {},
              onDismissWpAdminWebViewClosure: @escaping () -> Void = {},
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
             self.siteID = siteID
@@ -805,6 +807,7 @@ extension EditableOrderViewModel {
                                                             didSelectSave: saveFeeLineClosure)
             self.addNewCouponLineClosure = addNewCouponLineClosure
             self.onGoToCouponsClosure = onGoToCouponsClosure
+            self.onTaxHelpButtonTappedClosure = onTaxHelpButtonTappedClosure
             self.onDismissWpAdminWebViewClosure = onDismissWpAdminWebViewClosure
         }
     }
@@ -1129,6 +1132,9 @@ private extension EditableOrderViewModel {
                                             },
                                             onGoToCouponsClosure: { [weak self] in
                                                 self?.analytics.track(event: WooAnalyticsEvent.Orders.orderGoToCouponsButtonTapped())
+                                            },
+                                            onTaxHelpButtonTappedClosure: { [weak self] in
+                                                self?.analytics.track(event: WooAnalyticsEvent.Orders.orderTaxHelpButtonTapped())
                                             },
                                             onDismissWpAdminWebViewClosure: { [weak self] in
                                                 self?.retrieveTaxBasedOnSetting()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -190,6 +190,7 @@ struct OrderPaymentSection: View {
 
             Button {
                 shouldShowTaxEducationalDialog = true
+                viewModel.onTaxHelpButtonTappedClosure()
             } label: {
                 Image(systemName: "questionmark.circle")
                     .foregroundColor(Color(.wooCommercePurple(.shade60)))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
@@ -58,6 +58,7 @@ struct TaxEducationalDialogView: View {
                     }.renderedIf(viewModel.taxLines.isNotEmpty)
 
                     Button {
+                        viewModel.onGoToWpAdminButtonTapped()
                         showingWPAdminWebview = true
                     } label: {
                         Label {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModel.swift
@@ -12,7 +12,10 @@ struct TaxEducationalDialogViewModel {
     private let stores: StoresManager
     private let analytics: Analytics
 
-    init(orderTaxLines: [OrderTaxLine], taxBasedOnSetting: TaxBasedOnSetting?, stores: StoresManager = ServiceLocator.stores, analytics: Analytics = ServiceLocator.analytics) {
+    init(orderTaxLines: [OrderTaxLine],
+         taxBasedOnSetting: TaxBasedOnSetting?,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.taxLines = orderTaxLines.map { TaxLine(title: $0.label, value: $0.ratePercent.percentFormatted() ?? "") }
         self.taxBasedOnSettingExplanatoryText = taxBasedOnSetting?.explanatoryText
         self.stores = stores

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModel.swift
@@ -10,11 +10,13 @@ struct TaxEducationalDialogViewModel {
     let taxLines: [TaxLine]
     let taxBasedOnSettingExplanatoryText: String?
     private let stores: StoresManager
+    private let analytics: Analytics
 
-    init(orderTaxLines: [OrderTaxLine], taxBasedOnSetting: TaxBasedOnSetting?, stores: StoresManager = ServiceLocator.stores) {
+    init(orderTaxLines: [OrderTaxLine], taxBasedOnSetting: TaxBasedOnSetting?, stores: StoresManager = ServiceLocator.stores, analytics: Analytics = ServiceLocator.analytics) {
         self.taxLines = orderTaxLines.map { TaxLine(title: $0.label, value: $0.ratePercent.percentFormatted() ?? "") }
         self.taxBasedOnSettingExplanatoryText = taxBasedOnSetting?.explanatoryText
         self.stores = stores
+        self.analytics = analytics
     }
 
     /// WPAdmin URL to navigate user to edit the tax settings
@@ -35,6 +37,10 @@ struct TaxEducationalDialogViewModel {
         }
 
         return URL(string: "\(path)\(Constants.wpAdminTaxSettingsPath)")
+    }
+
+    func onGoToWpAdminButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.Orders.taxEducationalDialogEditInAdminButtonTapped())
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -511,6 +511,18 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderGoToCouponsButtonTapped.rawValue)
     }
 
+    func test_payment_data_view_model_when_calling_onTaxHelpButtonTappedClosure_then_calls_to_track_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        viewModel.paymentDataViewModel.onTaxHelpButtonTappedClosure()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderTaxHelpButtonTapped.rawValue)
+    }
+
     // MARK: - Add Products to Order via SKU Scanner Tests
 
     func test_trackBarcodeScanningButtonTapped_tracks_right_event() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModelTests.swift
@@ -66,4 +66,18 @@ final class TaxEducationalDialogViewModelTests: XCTestCase {
         let expectedURLString = sampleAdminURL + "admin.php?page=wc-settings&tab=tax"
         XCTAssertEqual(viewModel.wpAdminTaxSettingsURL?.absoluteString, expectedURLString)
     }
+
+    func test_onGoToWpAdminButtonTapped_tracks_right_event() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+
+        viewModel = TaxEducationalDialogViewModel(orderTaxLines: [], taxBasedOnSetting: nil, analytics: analytics)
+
+        // When
+        viewModel.onGoToWpAdminButtonTapped()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.taxEducationalDialogEditInAdminButtonTapped.rawValue)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10548
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add tracking to the events related to the Manual Taxes 1 milestone.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Tax Help Button

1. Go to Orders
2. Tap on + to create a new order
3. Tap on the ? button on the Taxes Total row.
4. The event should be tracked:

`🔵 Tracked order_taxes_help_button_tapped, properties: [AnyHashable("plan"): "business-bundle", AnyHashable("blog_id"): 214354650, AnyHashable("was_ecommerce_trial"): false, AnyHashable("is_wpcom_store"): true]`

### Go to wp-admin button in the Tax Educational Dialog

1. Go to Orders
2. Tap on + to create a new order
3. Tap on the ? button on the Taxes Total row.
4. Tap on Edit Tax Rates in Admin.
5. The event should be tracked:

`🔵 Tracked tax_educational_dialog_edit_in_admin_button_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("was_ecommerce_trial"): false, AnyHashable("blog_id"): 214354650, AnyHashable("plan"): "business-bundle"]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
