### PR TITLE
Store creation profiler: Fix UI bugs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 15.2
 -----
+- [*] Fixed minor UI issues in the store creation profiler flow. [https://github.com/woocommerce/woocommerce-ios/pull/10555]
 
 
 15.1

--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSummaryView.swift
@@ -45,15 +45,13 @@ struct FreeTrialSummaryView: View {
                         .disabled(isWaitingToContinue)
 
                         Spacer()
-
-                        Image(uiImage: .freeTrialIllustration)
                     }
-                    .padding([.trailing, .bottom], Layout.illustrationInset)
 
                     // Title
                     Text(Localization.launchInDays)
                         .bold()
                         .titleStyle()
+                        .padding(.top, Layout.titleTopSpacing)
                         .padding(.bottom, Layout.titleSpacing)
                         .padding(.trailing, Layout.estimatedIllustrationWidth)
 
@@ -98,8 +96,17 @@ struct FreeTrialSummaryView: View {
                     }
                 }
                 .padding()
+                .background(
+                    VStack {
+                        HStack(alignment: .top) {
+                            Spacer()
+                            Image(uiImage: .freeTrialIllustration)
+                        }
+                        Spacer()
+                    }
+                    .background(Color(.listBackground))
+                )
             }
-            .background(Color(.listBackground))
 
             // Continue Footer
             VStack() {
@@ -142,7 +149,7 @@ private extension FreeTrialSummaryView {
         static let titleSpacing = 16.0
         static let sectionsSpacing = 32.0
         static let infoTrailingMargin = 8.0
-        static let illustrationInset = -32.0
+        static let titleTopSpacing = 64.0
         static let estimatedIllustrationWidth = 150.0
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/OptionalStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/OptionalStoreCreationProfilerQuestionView.swift
@@ -41,7 +41,6 @@ struct OptionalStoreCreationProfilerQuestionView<QuestionContent: View>: View {
                 Button(Localization.skipButtonTitle) {
                     viewModel.skipButtonTapped()
                 }
-                .buttonStyle(LinkButtonStyle())
             }
         }
         // Disables large title to avoid a large gap below the navigation bar.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10553 
Also closes: #10554 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes minor issues in the UI for the store profiler flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to the app.
- Switch to the menu tab and open the store picker.
- Select Add a store > Create a new store.
- Notice there is no gap on top of the asset on the trial summary screen.
- Tap the CTA to create a new store.
- When the profiler step is presented, notice that the Skip button doesn't have some extra spacing on the right.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Free trial summary | Store profiler step |
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/9c25e953-ed1b-47e8-8721-53c55f607e9c" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/7fc6b78a-dcba-49e9-8bb4-a2134fd7cbdc" width=320 /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
