### PR TITLE
[Manual Taxes M2] Add "Set New Tax Rate" section to Editable Order Details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -74,6 +74,10 @@ final class EditableOrderViewModel: ObservableObject {
         featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) && flow == .creation
     }
 
+    var shouldShowNewTaxRateSection: Bool {
+        featureFlagService.isFeatureFlagEnabled(.manualTaxesInOrderM2)
+    }
+
     /// Indicates the customer details screen to be shown. If there's no address added show the customer selector, otherwise the form so it can be edited
     ///
     var customerNavigationScreen: CustomerNavigationScreen {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -106,40 +106,48 @@ struct OrderForm: View {
         GeometryReader { geometry in
             ScrollViewReader { scroll in
                 ScrollView {
-                    VStack(spacing: Layout.noSpacing) {
+                    Group {
+                        VStack(spacing: Layout.noSpacing) {
 
-                        Group {
-                            Divider() // Needed because `NonEditableOrderBanner` does not have a top divider
-                            NonEditableOrderBanner(width: geometry.size.width)
-                        }
-                        .renderedIf(viewModel.shouldShowNonEditableIndicators)
+                            Group {
+                                Divider() // Needed because `NonEditableOrderBanner` does not have a top divider
+                                NonEditableOrderBanner(width: geometry.size.width)
+                            }
+                            .renderedIf(viewModel.shouldShowNonEditableIndicators)
 
-                        OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
+                            OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
 
-                        Spacer(minLength: Layout.sectionSpacing)
+                            Spacer(minLength: Layout.sectionSpacing)
 
-                        ProductsSection(scroll: scroll, viewModel: viewModel, navigationButtonID: $navigationButtonID)
-                            .disabled(viewModel.shouldShowNonEditableIndicators)
+                            ProductsSection(scroll: scroll, viewModel: viewModel, navigationButtonID: $navigationButtonID)
+                                .disabled(viewModel.shouldShowNonEditableIndicators)
 
-                        Spacer(minLength: Layout.sectionSpacing)
+                            Spacer(minLength: Layout.sectionSpacing)
 
-                        Group {
-                            if let title = viewModel.multipleLinesMessage {
-                                MultipleLinesMessage(title: title)
-                                Spacer(minLength: Layout.sectionSpacing)
+                            Group {
+                                if let title = viewModel.multipleLinesMessage {
+                                    MultipleLinesMessage(title: title)
+                                    Spacer(minLength: Layout.sectionSpacing)
+                                }
+
+                                OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
+                                    .disabled(viewModel.shouldShowNonEditableIndicators)
                             }
 
-                            OrderPaymentSection(viewModel: viewModel.paymentDataViewModel)
-                                .disabled(viewModel.shouldShowNonEditableIndicators)
+                            Spacer(minLength: Layout.sectionSpacing)
                         }
 
-                        Spacer(minLength: Layout.sectionSpacing)
+                        VStack(spacing: Layout.noSpacing) {
+                            NewTaxRateSection()
 
-                        OrderCustomerSection(viewModel: viewModel, addressFormViewModel: viewModel.addressFormViewModel)
+                            Spacer(minLength: Layout.sectionSpacing)
 
-                        Spacer(minLength: Layout.sectionSpacing)
+                            OrderCustomerSection(viewModel: viewModel, addressFormViewModel: viewModel.addressFormViewModel)
 
-                        CustomerNoteSection(viewModel: viewModel)
+                            Spacer(minLength: Layout.sectionSpacing)
+
+                            CustomerNoteSection(viewModel: viewModel)
+                        }
                     }
                     .disabled(viewModel.disabled)
                 }
@@ -213,6 +221,20 @@ private struct MultipleLinesMessage: View {
             Divider()
         }
         .background(Color(.listForeground(modal: true)))
+    }
+}
+
+private struct NewTaxRateSection: View {
+    var body: some View {
+        Button(action: {},
+               label: {
+            Text(OrderForm.Localization.setNewTaxRate)
+                .multilineTextAlignment(.center)
+                .padding(OrderForm.Layout.sectionSpacing)
+                .frame(maxWidth: .infinity)
+        })
+        .background(Color(.listForeground(modal: true)))
+        .addingTopAndBottomDividers()
     }
 }
 
@@ -395,6 +417,7 @@ private extension OrderForm {
                                                           "Please enable camera permissions in your device settings",
                                                           comment: "Message of the action sheet button that links to settings for camera access")
         static let permissionsOpenSettings = NSLocalizedString("Open Settings", comment: "Button title to open device settings in an action sheet")
+        static let setNewTaxRate = NSLocalizedString("Set New Tax Rate", comment: "Button title to set a new tax rate to an order")
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -230,10 +230,10 @@ private struct NewTaxRateSection: View {
     var body: some View {
         Button(action: {},
                label: {
-            Text(OrderForm.Localization.setNewTaxRate)
-                .multilineTextAlignment(.center)
-                .padding(OrderForm.Layout.sectionSpacing)
-                .frame(maxWidth: .infinity)
+                    Text(OrderForm.Localization.setNewTaxRate)
+                        .multilineTextAlignment(.center)
+                        .padding(OrderForm.Layout.sectionSpacing)
+                        .frame(maxWidth: .infinity)
         })
         .background(Color(.listForeground(modal: true)))
         .addingTopAndBottomDividers()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -138,9 +138,11 @@ struct OrderForm: View {
                         }
 
                         VStack(spacing: Layout.noSpacing) {
-                            NewTaxRateSection()
-
-                            Spacer(minLength: Layout.sectionSpacing)
+                            Group {
+                                NewTaxRateSection()
+                                Spacer(minLength: Layout.sectionSpacing)
+                            }
+                            .renderedIf(viewModel.shouldShowNewTaxRateSection)
 
                             OrderCustomerSection(viewModel: viewModel, addressFormViewModel: viewModel.addressFormViewModel)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Please review https://github.com/woocommerce/woocommerce-ios/pull/10569 first

Closes: #10557 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add a new row to the Editable Order Details so it can show the tax rate selector in further tasks. 

Apart from that, we had to split the previous VStack into a Group with two stacks, given that the previous VStack reached the [maximum number of static views in one container](https://stackoverflow.com/questions/58470268/cant-add-more-than-10-items-to-view-swiftui) (10). Having a group ensures we can still apply the same modifier `.disabled(viewModel.disabled)` to all members.

Furthermore, we use the `manualTaxesInOrderM2` feature flag to hide this functionality in Release.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to create a new order
3. Scroll down. See that there is a section "Set New Tax Rate". See that it's clickable.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/9ef64403-cca8-4e38-9e9a-8aaa5b2fed11" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
