### PR TITLE
[Manual Taxes] Remove feature flag for Milestone 1

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -85,8 +85,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .betterCustomerSelectionInOrder:
             return true
-        case .manualTaxesInOrder:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .manualTaxesInOrderM2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -182,10 +182,6 @@ public enum FeatureFlag: Int {
     /// 
     case betterCustomerSelectionInOrder
 
-    /// Enables the improvements related to taxes in the order flows (Milestone 1)
-    /// 
-    case manualTaxesInOrder
-
     /// Enables the improvements related to taxes in the order flows (Milestone 2)
     ///
     case manualTaxesInOrderM2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 15.2
 -----
 - [*] Fixed minor UI issues in the store creation profiler flow. [https://github.com/woocommerce/woocommerce-ios/pull/10555]
+- [**] Taxes in orders: Users can now see the order tax rates, get more information about them, and navigate to wp-admin to change them. [https://github.com/woocommerce/woocommerce-ios/pull/10569]
 
 
 15.1

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -726,7 +726,6 @@ extension EditableOrderViewModel {
         let shouldShowDiscountTotal: Bool
         let shouldShowCoupon: Bool
         let shouldDisableAddingCoupons: Bool
-        let shouldShowTaxExtraInformation: Bool
 
         /// Whether payment data is being reloaded (during remote sync)
         ///
@@ -755,7 +754,6 @@ extension EditableOrderViewModel {
              orderTotal: String = "0",
              shouldShowCoupon: Bool = false,
              shouldDisableAddingCoupons: Bool = false,
-             shouldShowTaxExtraInformation: Bool = false,
              couponLineViewModels: [CouponLineViewModel] = [],
              taxBasedOnSetting: TaxBasedOnSetting? = nil,
              taxLineViewModels: [TaxLineViewModel] = [],
@@ -788,7 +786,6 @@ extension EditableOrderViewModel {
             self.showNonEditableIndicators = showNonEditableIndicators
             self.shouldShowCoupon = shouldShowCoupon
             self.shouldDisableAddingCoupons = shouldDisableAddingCoupons
-            self.shouldShowTaxExtraInformation = shouldShowTaxExtraInformation
             self.couponLineViewModels = couponLineViewModels
             self.taxBasedOnSetting = taxBasedOnSetting
             self.taxLineViewModels = taxLineViewModels
@@ -1114,7 +1111,6 @@ private extension EditableOrderViewModel {
                                             orderTotal: order.total.isNotEmpty ? order.total : "0",
                                             shouldShowCoupon: order.coupons.isNotEmpty,
                                             shouldDisableAddingCoupons: order.items.isEmpty,
-                                            shouldShowTaxExtraInformation: self.featureFlagService.isFeatureFlagEnabled(.manualTaxesInOrder),
                                             couponLineViewModels: self.couponLineViewModels(from: order.coupons),
                                             taxBasedOnSetting: taxBasedOnSetting,
                                             taxLineViewModels: self.taxLineViewModels(from: order.taxes),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -110,16 +110,12 @@ struct OrderPaymentSection: View {
                     }
                 }
 
-            if viewModel.shouldShowTaxExtraInformation {
-                taxesSection
-                    .fullScreenCover(isPresented: $shouldShowTaxEducationalDialog) {
-                        TaxEducationalDialogView(viewModel: viewModel.taxEducationalDialogViewModel,
-                                                 onDismissWpAdminWebView: viewModel.onDismissWpAdminWebViewClosure)
-                            .background(FullScreenCoverClearBackgroundView())
+            taxesSection
+                .fullScreenCover(isPresented: $shouldShowTaxEducationalDialog) {
+                    TaxEducationalDialogView(viewModel: viewModel.taxEducationalDialogViewModel,
+                                             onDismissWpAdminWebView: viewModel.onDismissWpAdminWebViewClosure)
+                        .background(FullScreenCoverClearBackgroundView())
                     }
-            } else {
-                TitleAndValueRow(title: Localization.taxes, value: .content(viewModel.taxesTotal))
-            }
 
             TitleAndValueRow(title: Localization.discountTotal, value: .content(viewModel.discountTotal))
                 .renderedIf(viewModel.shouldShowDiscountTotal)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10511 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we remove the Manual Taxes M1 feature flag so it can run in Release. As the feature is easily hideable in case we need it, we remove the feature flag altogether instead of just setting it to `true`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run the app with the Release build configuration and ensure the feature is visible. You can set the Release build configuration by editing the WooCommerce schema (see screenshot).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="928" alt="Screenshot 2023-07-17 at 10 44 14" src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/676ff06d-352c-431d-b8e5-9545eaee0753">


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
