### PR TITLE
Fix `application_store_snapshot` event not showing up in Tracks

### DIFF
--- a/WooCommerce/Classes/Yosemite/SiteSnapshotTracker.swift
+++ b/WooCommerce/Classes/Yosemite/SiteSnapshotTracker.swift
@@ -40,7 +40,7 @@ final class SiteSnapshotTracker {
         let paymentGatewaySnapshot = PaymentGatewaySnapshot(plugins: systemPlugins)
         let properties: [String: Any] = PaymentGatewaySnapshot.Plugin.allCases.reduce(otherProperties) { partialResult, plugin in
             var newResult = partialResult
-            newResult[plugin.rawValue] = paymentGatewaySnapshot.status(of: plugin).rawValue
+            newResult[plugin.eventPropertyName] = paymentGatewaySnapshot.status(of: plugin).rawValue
             return newResult
         }
         analytics.track(.applicationSiteSnapshot, withProperties: properties)
@@ -69,6 +69,10 @@ private struct PaymentGatewaySnapshot {
         case stripe = "woocommerce-gateway-stripe"
         case square = "woocommerce-square"
         case payPal = "woocommerce-paypal-payments"
+
+        var eventPropertyName: String {
+            rawValue.replacingOccurrences(of: "-", with: "_")
+        }
     }
 
     private let plugins: [SystemPlugin]

--- a/WooCommerce/WooCommerceTests/Yosemite/SiteSnapshotTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/SiteSnapshotTrackerTests.swift
@@ -68,10 +68,10 @@ final class SiteSnapshotTrackerTests: XCTestCase {
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
         XCTAssertEqual(eventProperties["orders_count"] as? Int64, 115)
         XCTAssertEqual(eventProperties["products_count"] as? Int64, 98)
-        XCTAssertEqual(eventProperties["woocommerce-payments"] as? String, "installed_and_activated")
-        XCTAssertEqual(eventProperties["woocommerce-gateway-stripe"] as? String, "not_installed")
-        XCTAssertEqual(eventProperties["woocommerce-square"] as? String, "not_installed")
-        XCTAssertEqual(eventProperties["woocommerce-paypal-payments"] as? String, "installed_and_not_activated")
+        XCTAssertEqual(eventProperties["woocommerce_payments"] as? String, "installed_and_activated")
+        XCTAssertEqual(eventProperties["woocommerce_gateway_stripe"] as? String, "not_installed")
+        XCTAssertEqual(eventProperties["woocommerce_square"] as? String, "not_installed")
+        XCTAssertEqual(eventProperties["woocommerce_paypal_payments"] as? String, "installed_and_not_activated")
     }
 
     func test_event_is_not_tracked_when_the_site_snapshot_has_been_tracked() throws {


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Part of #10574 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Even though we implemented the Tracks event `application_store_snapshot` in https://github.com/woocommerce/woocommerce-ios/pull/10484, we didn't see any events in Tracks after a day of release.

After a deeper look, I found a silent validation error on the event properties because the property name can only contain alpha characters and underscores while the payment gateway properties have `-`: `Custom properties dictionary keys must contain alpha characters and underscores only.`

Validation errors like this aren’t logged to the console at all, and were missed during development/review. I'm also looking into the validation error logging issue in https://github.com/Automattic/Automattic-Tracks-iOS/issues/262.

## How

The event properties are fixed by replacing `-` with `_` in payment gateway event properties in the snapshot event.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Reinstall the app, or log in to a store whose snapshot hasn't been tracked
- Log in and connect to a store --> shortly after entering the site, an event is logged in the console `🔵 Tracked application_store_snapshot` AND it should also get sent in the Tracks POST request after a bit. You can check the Tracks POST request body in the Menu tab > Settings > Launch Wormholy Debug, and search for `tracks/record` POST requests and find `application_store_snapshot` in the request body

---

- [x] @jaclync make sure the event shows up in Tracks

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
