### PR TITLE
Fastlane: Automatically distribute builds to TestFlight

### DIFF
--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -17,7 +17,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec build_and_upload_to_app_store_connect \
+bundle exec fastlane build_and_upload_to_app_store_connect \
   skip_confirm:true \
   skip_prechecks:true \
   beta_release:${1:-true} # use first call param, default to true for safety

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -17,8 +17,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_itc \
+bundle exec build_and_upload_to_app_store_connect \
   skip_confirm:true \
   skip_prechecks:true \
-  create_release:true \
   beta_release:${1:-true} # use first call param, default to true for safety

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -646,7 +646,7 @@ platform :ios do
     COMMENT_BODY
 
     comment_on_pr(
-      project: 'woocommerce/woocommerce-ios',
+      project: GITHUB_REPO,
       pr_number: Integer(ENV.fetch('BUILDKITE_PULL_REQUEST')),
       reuse_identifier: 'installable-build-link',
       body: comment_body

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -567,7 +567,7 @@ platform :ios do
       # If there is a build waiting for beta review, we want to reject that so the new build can be submitted instead
       reject_build_waiting_for_review: true,
       # These three groups are the same for iOS and Mac
-      groups: ['Internal a8c beta testers', 'Public Beta Testers'],
+      groups: ['Internal a8c beta testers', 'Public Beta Testers']
     )
     sh('cd .. && rm WooCommerce.ipa')
   end
@@ -1142,7 +1142,7 @@ lane :test_without_building do |options|
     e.include?(options[:name])
   end.first
 
-  unless !xctestrun_path.nil? && File.exist?((xctestrun_path))
+  unless !xctestrun_path.nil? && File.exist?(xctestrun_path)
     UI.user_error!("Unable to find .xctestrun file at #{xctestrun_path}")
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -537,12 +537,6 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
-    testflight(
-      skip_waiting_for_build_processing: true,
-      api_key_path: ASC_KEY_PATH
-    )
-    sh('cd .. && rm WooCommerce.ipa')
-
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: 'a8c',
@@ -551,21 +545,31 @@ platform :ios do
     )
     sh('cd .. && rm WooCommerce.app.dSYM.zip')
 
-    if options[:create_release]
-      archive_zip_path = File.join(File.dirname(Dir.pwd), 'WooCommerce.xarchive.zip')
-      zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
+    archive_zip_path = File.join(File.dirname(Dir.pwd), 'WooCommerce.xarchive.zip')
+    zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
+    sh("rm #{archive_zip_path}")
 
-      version = options[:beta_release] ? ios_get_build_version : app_version
-      create_release(
-        repository: GITHUB_REPO,
-        version: version,
-        release_notes_file_path: RELEASE_NOTES_PATH,
-        release_assets: archive_zip_path.to_s,
-        prerelease: options[:beta_release]
-      )
+    version = options[:beta_release] ? ios_get_build_version : app_version
+    create_release(
+      repository: GITHUB_REPO,
+      version: version,
+      release_notes_file_path: RELEASE_NOTES_PATH,
+      release_assets: archive_zip_path.to_s,
+      prerelease: options[:beta_release]
+    )
 
-      sh("rm #{archive_zip_path}")
-    end
+    upload_to_testflight(
+      api_key_path: ASC_KEY_PATH,
+      # Wait 2 hours for the build to process then time out
+      wait_processing_timeout_duration: 7200,
+      changelog: File.read(RELEASE_NOTES_PATH),
+      distribute_external: true,
+      # If there is a build waiting for beta review, we want to reject that so the new build can be submitted instead
+      reject_build_waiting_for_review: true,
+      # These three groups are the same for iOS and Mac
+      groups: ['Internal a8c beta testers', 'Public Beta Testers'],
+    )
+    sh('cd .. && rm WooCommerce.ipa')
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -422,12 +422,10 @@ platform :ios do
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_and_upload_beta [skip_confirm:<skip confirm>]
-  #  [create_gh_release:<create release on GH>]
   #
   # Example:
   # bundle exec fastlane build_and_upload_beta
   # bundle exec fastlane build_and_upload_beta skip_confirm:true
-  # bundle exec fastlane build_and_upload_beta create_gh_release:true
   #####################################################################################
   desc 'Builds and uploads for distribution'
   lane :build_and_upload_beta do |options|
@@ -437,11 +435,10 @@ platform :ios do
       external: true
     )
     ios_build_preflight
-    build_and_upload_itc(
+    build_and_upload_to_app_store_connect(
       skip_prechecks: true,
       skip_confirm: options[:skip_confirm],
-      beta_release: true,
-      create_release: options[:create_gh_release]
+      beta_release: true
     )
   end
 
@@ -452,12 +449,10 @@ platform :ios do
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>]
-  #  [create_gh_release:<create release on GH>]
   #
   # Example:
   # bundle exec fastlane build_and_upload_release
   # bundle exec fastlane build_and_upload_release skip_confirm:true
-  # bundle exec fastlane build_and_upload_release create_gh_release:true
   #####################################################################################
   desc 'Builds and uploads for distribution'
   lane :build_and_upload_release do |options|
@@ -467,11 +462,10 @@ platform :ios do
       external: true
     )
     ios_build_preflight
-    build_and_upload_itc(
+    build_and_upload_to_app_store_connect(
       skip_prechecks: true,
       skip_confirm: options[:skip_confirm],
-      beta_release: false,
-      create_release: options[:create_gh_release]
+      beta_release: false
     )
   end
 
@@ -508,21 +502,20 @@ platform :ios do
   end
 
   #####################################################################################
-  # build_and_upload_itc
+  # build_and_upload_to_app_store_connect
   # -----------------------------------------------------------------------------------
   # This lane builds the app and upload it for external distribution
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>] [create_release:<Create release on GH>] [beta_release:<intermediate beta?>]
+  # bundle exec fastlane build_and_upload_to_app_store_connect [skip_confirm:<skip confirm>] [beta_release:<intermediate beta?>]
   #
   # Example:
-  # bundle exec fastlane build_and_upload_itc
-  # bundle exec fastlane build_and_upload_itc skip_confirm:true
-  # bundle exec fastlane build_and_upload_itc create_release:true
-  # bundle exec fastlane build_and_upload_itc create_release:true beta_release:true
+  # bundle exec fastlane build_and_upload_to_app_store_connect
+  # bundle exec fastlane build_and_upload_to_app_store_connect skip_confirm:true
+  # bundle exec fastlane build_and_upload_to_app_store_connect beta_release:true
   #####################################################################################
   desc 'Builds and uploads for distribution'
-  lane :build_and_upload_itc do |options|
+  lane :build_and_upload_to_app_store_connect do |options|
     ensure_sentry_installed
 
     unless options[:skip_prechecks]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -707,7 +707,7 @@ platform :ios do
   desc 'Build Screenshots'
   lane :build_screenshots do
     # Ensure we're using the latest Pods
-    sh('bundle exec pod install --verbose')
+    cocoapods(verbose: true)
 
     # Ensure we're using the right version of Xcode, defined in `.xcode-version` file
     xcversion


### PR DESCRIPTION
### Summary
This PR includes the following changes:
- Adds automatic TestFlight distribution after building and uploading a new build to App Store Connect. This has been working great for Day One iOS and Mac for several months, so I'd like to bring that over to WCiOS now. It removes a few manual steps from the Release Scenario.
- Removes the `create_release` option to make creating a GitHub release non-optional. I have never needed to not have a GitHub release created when creating a build and I'm not aware of a circumstance where you would want that. Please let me know if I'm overlooking a use-case for it!
- Uses the `GITHUB_REPO` constant to replace a hardcoded value
- Uses the `cocoapods` Fastlane action instead of a `sh` command
- Minor Rubocop fixes

There are other updates I want to bring to the WCiOS Fastfile (removing all `sh` commands, consistent `build` folder constant, etc), but I'll leave those for another PR. 

### Testing
There's not really a great way to fix this outside of a release branch. If this is merged before Friday, Sept 1, I will be able to fully test it when creating the initial 15.2 build.