### PR TITLE
[Mobile Payments] Handle plugin install on IPP onboarding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -35,6 +35,10 @@ protocol CardPresentPaymentsOnboardingUseCaseProtocol {
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin)
 
     func clearPluginSelection()
+
+    /// Sends the `installSitePlugin` action to the dispatcher
+    ///
+    func installCardPresentPlugin()
 }
 
 final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol, ObservableObject {
@@ -102,6 +106,26 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         } else {
             refresh()
         }
+    }
+
+    func installCardPresentPlugin() {
+        guard let siteID = siteID else {
+            return
+        }
+
+        // Only WCPay is currently supported, so we don't expose a different plugin option
+        let pluginSlug = CardPresentPaymentsPlugin.wcPay.gatewayID
+
+        let installPluginAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: pluginSlug, onCompletion: { result in
+            switch result {
+            case .success:
+                DDLogInfo("Success installing \(pluginSlug)")
+                self.refresh()
+            case .failure(let error):
+                DDLogError("Error installing plugin: \(error)")
+            }
+        })
+        stores.dispatch(installPluginAction)
     }
 
     private func refreshOnboardingState() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -51,8 +51,7 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsCountryNotSupportedStripe(countryCode: countryCode, analyticReason: viewModel.state.reasonForAnalytics)
             case .pluginNotInstalled:
                 InPersonPaymentsPluginNotInstalled(analyticReason: viewModel.state.reasonForAnalytics,
-                                                   onInstall: viewModel.installPlugin,
-                                                   onRefresh: viewModel.refresh)
+                                                   onInstall: viewModel.installPlugin)
             case .pluginUnsupportedVersion(let plugin):
                 InPersonPaymentsPluginNotSupportedVersion(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .pluginNotActivated(let plugin):

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -50,7 +50,9 @@ struct InPersonPaymentsView: View {
             case .countryNotSupportedStripe(_, let countryCode):
                 InPersonPaymentsCountryNotSupportedStripe(countryCode: countryCode, analyticReason: viewModel.state.reasonForAnalytics)
             case .pluginNotInstalled:
-                InPersonPaymentsPluginNotInstalled(analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
+                InPersonPaymentsPluginNotInstalled(analyticReason: viewModel.state.reasonForAnalytics,
+                                                   onInstall: viewModel.installPlugin,
+                                                   onRefresh: viewModel.refresh)
             case .pluginUnsupportedVersion(let plugin):
                 InPersonPaymentsPluginNotSupportedVersion(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .pluginNotActivated(let plugin):

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -57,24 +57,10 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
         useCase.refresh()
     }
 
-    /// Sends the action to the dispatcher to install the CPP plugin
-    /// At the moment we only do so for WCPay
+    /// Sends the action to install the Card Present plugin
     ///
     func installPlugin() {
-        guard let siteID = stores.sessionManager.defaultSite?.siteID else {
-            return
-        }
-        let pluginSlug = "woocommerce-payments"
-        let installPluginAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: pluginSlug, onCompletion: { result in
-            switch result {
-            case .success:
-                DDLogInfo("Success installing \(pluginSlug)")
-                self.refresh()
-            case .failure(let error):
-                DDLogError("Error installing plugin: \(error)")
-            }
-        })
-        stores.dispatch(installPluginAction)
+        useCase.installCardPresentPlugin()
     }
 
     /// Skips the Pending Requirements step when the user taps `Skip`

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -57,6 +57,26 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
         useCase.refresh()
     }
 
+    /// Sends the action to the dispatcher to install the CPP plugin
+    /// At the moment we only do so for WCPay
+    ///
+    func installPlugin() {
+        guard let siteID = stores.sessionManager.defaultSite?.siteID else {
+            return
+        }
+        let pluginSlug = "woocommerce-payments"
+        let installPluginAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: pluginSlug, onCompletion: { result in
+            switch result {
+            case .success:
+                print("Success installing \(pluginSlug)")
+                self.useCase.updateState()
+            case .failure(let error):
+                DDLogError("Error installing plugin: \(error)")
+            }
+        })
+        stores.dispatch(installPluginAction)
+    }
+
     /// Skips the Pending Requirements step when the user taps `Skip`
     ///
     func skipPendingRequirements() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -68,8 +68,8 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
         let installPluginAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: pluginSlug, onCompletion: { result in
             switch result {
             case .success:
-                print("Success installing \(pluginSlug)")
-                self.useCase.updateState()
+                DDLogInfo("Success installing \(pluginSlug)")
+                self.refresh()
             case .failure(let error):
                 DDLogError("Error installing plugin: \(error)")
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct InPersonPaymentsPluginNotInstalled: View {
     let analyticReason: String
     let onInstall: () -> Void
-    let onRefresh: () -> Void
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -39,6 +38,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotInstalled_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotInstalled(analyticReason: "", onInstall: {}, onRefresh: {})
+        InPersonPaymentsPluginNotInstalled(analyticReason: "", onInstall: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsPluginNotInstalled: View {
     let analyticReason: String
+    let onInstall: () -> Void
     let onRefresh: () -> Void
 
     var body: some View {
@@ -16,9 +17,9 @@ struct InPersonPaymentsPluginNotInstalled: View {
             learnMore: true,
             analyticReason: analyticReason,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
-                text: Localization.primaryButton,
+                text: Localization.title,
                 analyticReason: analyticReason,
-                action: onRefresh
+                action: onInstall
             )
         )
     }
@@ -34,15 +35,10 @@ private enum Localization {
         "You’ll need to install the free WooCommerce Payments extension on your store to accept In-Person Payments.",
         comment: "Error message when WooCommerce Payments is not installed"
     )
-
-    static let primaryButton = NSLocalizedString(
-        "Refresh After Installing",
-        comment: "Button to reload plugin data after installing the WooCommerce Payments plugin"
-    )
 }
 
 struct InPersonPaymentsPluginNotInstalled_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotInstalled(analyticReason: "", onRefresh: {})
+        InPersonPaymentsPluginNotInstalled(analyticReason: "", onInstall: {}, onRefresh: {})
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -287,6 +287,27 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
     }
 
+    func test_onboarding_sends_install_plugin_action_for_wcpay_plugin_when_installPlugin_is_invoked() throws {
+        // Given
+        setupCountry(country: .us)
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+
+        // When
+        useCase.installCardPresentPlugin()
+
+        // Then
+        let action = try XCTUnwrap(stores.receivedActions.last as? SitePluginAction)
+
+        switch action {
+        case let .installSitePlugin(_, slug, _):
+            XCTAssertEqual(slug, "woocommerce-payments")
+        default:
+            XCTFail("Did not send installSitePlugin SitePluginAction")
+        }
+    }
+
     func test_onboarding_returns_wcpay_plugin_not_activated_when_wcpay_installed_but_not_active() {
         // Given
         setupCountry(country: .us)

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -287,7 +287,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
     }
 
-    func test_onboarding_sends_install_plugin_action_for_wcpay_plugin_when_installPlugin_is_invoked() throws {
+    func test_onboarding_sends_install_plugin_action_for_wcpay_plugin_when_installPlugin_is_invoked_then_installs_wcpay_plugin() throws {
         // Given
         setupCountry(country: .us)
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
@@ -39,6 +39,10 @@ final class MockCardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboard
         clearPluginSelectionWasCalled = true
     }
 
+    func installCardPresentPlugin() {
+        // no-op
+    }
+
     // MARK: Convenience Initializer
     init(initial: CardPresentPaymentOnboardingState, publisher: AnyPublisher<CardPresentPaymentOnboardingState, Never>? = nil) {
         self.state = initial


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-ios/issues/10565
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the IPP onboarding `.pluginNotInstalled` state by changing the current `Refresh After Installing` button for an `Install WooCommerce Payments` button.

When the merchant taps this button, it will perform an API request to install _WooCommerce Payments_, then it will refresh the onboarding state once completed and show the next steps (generally, "Refresh after activating", since the plugin will be installed but inactive).

![Simulator Screen Recording - iPhone 11 Pro - 2023-08-31 at 10 56 42](https://github.com/woocommerce/woocommerce-ios/assets/3812076/f80771db-b054-487e-b3b7-9fd57b26d138)

## Caveats

As we've seen in our call, there's a current issue with the `system_status` endpoint, which we use for refreshing plugin state, which caches the response for 60 minutes and may lead to the wrong state if the plugin is installed, deleted, and installed again within 60 minutes. This was reproduced in Android as well: p1693465086253119-slack-C025A8VV728. We've reported this issue separately, but makes testing a bit more convoluted:

If you need to test the full flow more than once within 60 minutes, you can refresh the state by removing WCPay, then installing and activating any other plugin on the site. With this the API cache should be cleared.

## Testing instructions
On a US store, with no WCPay or Stripe plugins installed (you can use [https://atomicippwcpaytests.wpcomstaging.com/](https://atomicippwcpaytests.wpcomstaging.com/):

1. Go to Menu > Payments > See the notice at the bottom that says that `In-Person Payments setup is incomplete. Continue setup`. Tap the link.
2. See the `Install WooCommerce Payments` button
3. Tap on Install
4. See the `.loading` state screen
5. See that we've moved to the `.pluginNotActivated` case, and observe the button shows now `Refresh After Activating`.
6. Confirm in the site's `wp-admin` that the WCPay plugin is installed (not active, just installed).

| Before tapping install | After installing |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-08-31 at 10 58 06](https://github.com/woocommerce/woocommerce-ios/assets/3812076/d9fd737c-73c9-4ad9-910a-63e1995773c2) |  ![Simulator Screen Shot - iPhone 11 Pro - 2023-08-31 at 10 56 57](https://github.com/woocommerce/woocommerce-ios/assets/3812076/bc9f4659-5839-47ee-ac85-9b7ab0497806) |
