### PR TITLE
Store onboarding: Update analytics for WCPay setup

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
@@ -55,8 +55,10 @@ private extension StoreOnboardingTask.TaskType {
             return "products"
         case .customizeDomains:
             return "add_domain"
-        case .payments, .woocommercePayments:
+        case .payments:
             return "payments"
+        case .woocommercePayments:
+            return "woocommerce-payments"
         case .storeName:
             return "store_name"
         case .unsupported(let task):

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -192,6 +192,8 @@ public enum WooAnalyticsStat: String {
     case storeOnboardingTaskCompleted = "store_onboarding_task_completed"
     case storeOnboardingCompleted = "store_onboarding_completed"
     case storeOnboardingHideList = "store_onboarding_hide_list"
+    case storeOnboardingWCPayBeginSetupTapped = "store_onboarding_wcpay_begin_setup_tapped"
+    case storeOnboardingWCPayTermsContinueTapped = "store_onboarding_wcpay_terms_continue_tapped"
 
     // MARK: Site picker. Can be triggered by login epilogue or settings.
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
@@ -14,17 +14,20 @@ final class StoreOnboardingPaymentsSetupCoordinator: Coordinator {
     private let task: Task
     private let site: Site
     private let analytics: Analytics
+    private let onCompleted: (() -> Void)?
     private let onDismiss: (() -> Void)?
 
     init(task: Task,
          site: Site,
          navigationController: UINavigationController,
          analytics: Analytics = ServiceLocator.analytics,
+         onCompleted: (() -> Void)? = nil,
          onDismiss: (() -> Void)? = nil) {
         self.task = task
         self.site = site
         self.navigationController = navigationController
         self.analytics = analytics
+        self.onCompleted = onCompleted
         self.onDismiss = onDismiss
     }
 
@@ -74,7 +77,10 @@ private extension StoreOnboardingPaymentsSetupCoordinator {
             return assertionFailure("Invalid URL for onboarding payments setup: \(urlString)")
         }
 
-        let webViewModel = WooPaymentSetupWebViewModel(title: title, initialURL: url) { [weak self] _ in
+        let webViewModel = WooPaymentSetupWebViewModel(title: title, initialURL: url) { [weak self] success in
+            if success {
+                self?.onCompleted?()
+            }
             self?.dismissWebview()
             // TODO: show celebratory screen if success
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
@@ -13,15 +13,18 @@ final class StoreOnboardingPaymentsSetupCoordinator: Coordinator {
 
     private let task: Task
     private let site: Site
+    private let analytics: Analytics
     private let onDismiss: (() -> Void)?
 
     init(task: Task,
          site: Site,
          navigationController: UINavigationController,
+         analytics: Analytics = ServiceLocator.analytics,
          onDismiss: (() -> Void)? = nil) {
         self.task = task
         self.site = site
         self.navigationController = navigationController
+        self.analytics = analytics
         self.onDismiss = onDismiss
     }
 
@@ -36,13 +39,15 @@ final class StoreOnboardingPaymentsSetupCoordinator: Coordinator {
 private extension StoreOnboardingPaymentsSetupCoordinator {
     func showSetupView(in navigationController: UINavigationController) {
         let setupController = StoreOnboardingPaymentsSetupHostingController(task: task) { [weak self] in
+            self?.analytics.track(.storeOnboardingWCPayTermsContinueTapped)
             self?.showWebview(in: navigationController)
         } onDismiss: {
             navigationController.dismiss(animated: true)
         }
 
         if task == .wcPay {
-            let instructionsController = WooPaymentsSetupInstructionsHostingController {
+            let instructionsController = WooPaymentsSetupInstructionsHostingController { [weak self] in
+                self?.analytics.track(.storeOnboardingWCPayBeginSetupTapped)
                 navigationController.pushViewController(setupController, animated: true)
             } onDismiss: {
                 navigationController.dismiss(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -130,6 +130,9 @@ private extension StoreOnboardingCoordinator {
         let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .wcPay,
                                                                   site: site,
                                                                   navigationController: navigationController,
+                                                                  onCompleted: { [weak self] in
+            self?.onTaskCompleted(.woocommercePayments)
+        },
                                                                   onDismiss: { [weak self] in
              self?.reloadTasks()
          })


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10588
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates tracking events for the WCPay onboarding task.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a new JN site with Jetpack and Woo. Set up your site with a WCPay-supported country (e.g. US).
- Follow the setup steps in P91TBi-4BH-p2 up to the step of installing the dev plugin only.
- Log in to the app and switch to the JN site.
- On the My Store screen, select Get Paid on the onboarding task list. Notice in Xcode console: `🔵 Tracked store_onboarding_task_tapped, properties: [ AnyHashable("task"): "woocommerce-payments"]`
- Select Begin Setup, notice in Xcode console: `🔵 Tracked store_onboarding_wcpay_begin_setup_tapped`.
- Select Continue Setup, notice in Xcode console: `🔵 Tracked store_onboarding_wcpay_terms_continue_tapped`.
- Finish the setup in test mode. When the setup completes (the page says "Redirecting to WooPayments..."), notice in Xcode console: `🔵 Tracked store_onboarding_task_completed, properties: [AnyHashable("task"): "woocommerce-payments"]`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
