### PR TITLE
Order details: add-ons from `_pao_ids` metadata - networking layer changes

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -568,6 +568,7 @@ extension Networking.OrderItem {
             total: .fake(),
             totalTax: .fake(),
             attributes: .fake(),
+            addOns: .fake(),
             parent: .fake()
         )
     }
@@ -579,6 +580,17 @@ extension Networking.OrderItemAttribute {
         .init(
             metaID: .fake(),
             name: .fake(),
+            value: .fake()
+        )
+    }
+}
+extension Networking.OrderItemProductAddOn {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.OrderItemProductAddOn {
+        .init(
+            addOnID: .fake(),
+            key: .fake(),
             value: .fake()
         )
     }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		02AAFCD42A13517800F05E60 /* dotcom-plugins.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AAFCD32A13517800F05E60 /* dotcom-plugins.json */; };
 		02AD47702A6EB71100E652D6 /* URLRequestConvertible+Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AD476F2A6EB71100E652D6 /* URLRequestConvertible+Path.swift */; };
 		02AD47722A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AD47712A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift */; };
+		02AED9D82AA03F3F006DC460 /* order-with-all-addon-types.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AED9D72AA03F3F006DC460 /* order-with-all-addon-types.json */; };
+		02AED9DC2AA04716006DC460 /* KeyedDecodingContainer+WooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AED9DB2AA04716006DC460 /* KeyedDecodingContainer+WooTests.swift */; };
 		02AF07EA27492DBC00B2D81E /* WordPressMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AF07E927492DBC00B2D81E /* WordPressMedia.swift */; };
 		02AF07EC27492FDD00B2D81E /* media-library-from-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */; };
 		02AF07EE27493AE700B2D81E /* media-upload-to-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AF07ED27493AE700B2D81E /* media-upload-to-wordpress-site.json */; };
@@ -118,6 +120,7 @@
 		02DD6492248A3EC00082523E /* product-external.json in Resources */ = {isa = PBXBuildFile; fileRef = 02DD6491248A3EC00082523E /* product-external.json */; };
 		02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */; };
 		02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */ = {isa = PBXBuildFile; fileRef = 02E7FFCE25621C7900C53030 /* shipping-label-print.json */; };
+		02EBCB3E2AA03D520019085B /* OrderItemProductAddOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBCB3D2AA03D520019085B /* OrderItemProductAddOn.swift */; };
 		02EF1664292DADDE00D90AD6 /* PaymentRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF1663292DADDE00D90AD6 /* PaymentRemote.swift */; };
 		02EF166E292F0C5800D90AD6 /* PaymentRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF166D292F0C5800D90AD6 /* PaymentRemoteTests.swift */; };
 		02EF1670292F0CF400D90AD6 /* create-cart-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02EF166F292F0CF400D90AD6 /* create-cart-success.json */; };
@@ -1050,6 +1053,8 @@
 		02AAFCD32A13517800F05E60 /* dotcom-plugins.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "dotcom-plugins.json"; sourceTree = "<group>"; };
 		02AD476F2A6EB71100E652D6 /* URLRequestConvertible+Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequestConvertible+Path.swift"; sourceTree = "<group>"; };
 		02AD47712A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequestConvertible+PathTests.swift"; sourceTree = "<group>"; };
+		02AED9D72AA03F3F006DC460 /* order-with-all-addon-types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-all-addon-types.json"; sourceTree = "<group>"; };
+		02AED9DB2AA04716006DC460 /* KeyedDecodingContainer+WooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+WooTests.swift"; sourceTree = "<group>"; };
 		02AF07E927492DBC00B2D81E /* WordPressMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMedia.swift; sourceTree = "<group>"; };
 		02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library-from-wordpress-site.json"; sourceTree = "<group>"; };
 		02AF07ED27493AE700B2D81E /* media-upload-to-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-upload-to-wordpress-site.json"; sourceTree = "<group>"; };
@@ -1081,6 +1086,7 @@
 		02DD6491248A3EC00082523E /* product-external.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-external.json"; sourceTree = "<group>"; };
 		02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemoteTests.swift; sourceTree = "<group>"; };
 		02E7FFCE25621C7900C53030 /* shipping-label-print.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-print.json"; sourceTree = "<group>"; };
+		02EBCB3D2AA03D520019085B /* OrderItemProductAddOn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderItemProductAddOn.swift; sourceTree = "<group>"; };
 		02EF1663292DADDE00D90AD6 /* PaymentRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRemote.swift; sourceTree = "<group>"; };
 		02EF166D292F0C5800D90AD6 /* PaymentRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRemoteTests.swift; sourceTree = "<group>"; };
 		02EF166F292F0CF400D90AD6 /* create-cart-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-cart-success.json"; sourceTree = "<group>"; };
@@ -2397,6 +2403,7 @@
 				CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */,
 				B5C6FCCE20A3592900A4F8E4 /* OrderItem.swift */,
 				021EAA5525493B3600AA8CCD /* OrderItemAttribute.swift */,
+				02EBCB3D2AA03D520019085B /* OrderItemProductAddOn.swift */,
 				CE430671234B9EB20073CBFF /* OrderItemTax.swift */,
 				CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */,
 				74C8F06320EEB44800B6EDC9 /* OrderNote.swift */,
@@ -2625,6 +2632,7 @@
 				02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */,
 				02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */,
 				CE19CB10222486A500E8AF7A /* order-statuses.json */,
+				02AED9D72AA03F3F006DC460 /* order-with-all-addon-types.json */,
 				268EC45B26C169F600716F5C /* order-with-faulty-attributes.json */,
 				0272E3F4254AA48F00436277 /* order-with-line-item-attributes.json */,
 				0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */,
@@ -3006,6 +3014,7 @@
 				CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */,
 				EE62EE64295AD46D009C965B /* String+URLTests.swift */,
 				02AD47712A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift */,
+				02AED9DB2AA04716006DC460 /* KeyedDecodingContainer+WooTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3615,6 +3624,7 @@
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
 				029B86902A6FBBE000E944D1 /* wcpay-account-null-isLive.json in Resources */,
+				02AED9D82AA03F3F006DC460 /* order-with-all-addon-types.json in Resources */,
 				DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */,
 				74A1D263211898F000931DFA /* site-visits-day.json in Resources */,
 				31054710262E2EE400C5C02B /* wcpay-payment-intent-succeeded.json in Resources */,
@@ -3877,6 +3887,7 @@
 				02C2548425635BD000A04423 /* ShippingLabelPaperSize.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
 				DE66C5532976508300DAA978 /* CookieNonceAuthenticator.swift in Sources */,
+				02EBCB3E2AA03D520019085B /* OrderItemProductAddOn.swift in Sources */,
 				26650332261FFA1A0079A159 /* ProductAddOnEnvelope.swift in Sources */,
 				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,
 				DEFBA74E29485A7600C35BA9 /* RESTRequest.swift in Sources */,
@@ -4368,6 +4379,7 @@
 				31A451BD2786344B00FE81AA /* StripeRemoteTests.swift in Sources */,
 				743E84F822172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift in Sources */,
 				EE57C11729794BD500BC31E7 /* ApplicationPasswordNameAndUUIDMapperTests.swift in Sources */,
+				02AED9DC2AA04716006DC460 /* KeyedDecodingContainer+WooTests.swift in Sources */,
 				45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */,
 				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,
 				6812FC012A6B27E100D7C625 /* InAppPurchasesTransactionMapperTests.swift in Sources */,

--- a/Networking/Networking/Extensions/KeyedDecodingContainer+Woo.swift
+++ b/Networking/Networking/Extensions/KeyedDecodingContainer+Woo.swift
@@ -65,7 +65,7 @@ extension KeyedDecodingContainer {
         return nil
     }
 
-    /// Decodes a String for the specified key. Supported Encodings = [String, Integer]
+    /// Decodes a String for the specified key. Supported Encodings = [String, Integer, Double]
     ///
     /// This method *does NOT throw*. We want this behavior so that if a malformed entity is received, we just skip it, rather
     /// than breaking the entire parsing chain.
@@ -77,6 +77,10 @@ extension KeyedDecodingContainer {
 
         if let stringAsInteger = failsafeDecodeIfPresent(Int.self, forKey: key) {
             return String(stringAsInteger)
+        }
+
+        if let stringAsDouble = failsafeDecodeIfPresent(Double.self, forKey: key) {
+            return String(stringAsDouble)
         }
 
         return nil

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -716,6 +716,7 @@ extension Networking.OrderItem {
         total: CopiableProp<String> = .copy,
         totalTax: CopiableProp<String> = .copy,
         attributes: CopiableProp<[OrderItemAttribute]> = .copy,
+        addOns: CopiableProp<[OrderItemProductAddOn]> = .copy,
         parent: NullableCopiableProp<Int64> = .copy
     ) -> Networking.OrderItem {
         let itemID = itemID ?? self.itemID
@@ -732,6 +733,7 @@ extension Networking.OrderItem {
         let total = total ?? self.total
         let totalTax = totalTax ?? self.totalTax
         let attributes = attributes ?? self.attributes
+        let addOns = addOns ?? self.addOns
         let parent = parent ?? self.parent
 
         return Networking.OrderItem(
@@ -749,6 +751,7 @@ extension Networking.OrderItem {
             total: total,
             totalTax: totalTax,
             attributes: attributes,
+            addOns: addOns,
             parent: parent
         )
     }
@@ -767,6 +770,24 @@ extension Networking.OrderItemAttribute {
         return Networking.OrderItemAttribute(
             metaID: metaID,
             name: name,
+            value: value
+        )
+    }
+}
+
+extension Networking.OrderItemProductAddOn {
+    public func copy(
+        addOnID: NullableCopiableProp<Int64> = .copy,
+        key: CopiableProp<String> = .copy,
+        value: CopiableProp<String> = .copy
+    ) -> Networking.OrderItemProductAddOn {
+        let addOnID = addOnID ?? self.addOnID
+        let key = key ?? self.key
+        let value = value ?? self.value
+
+        return Networking.OrderItemProductAddOn(
+            addOnID: addOnID,
+            key: key,
             value: value
         )
     }

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -26,6 +26,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
 
     public let attributes: [OrderItemAttribute]
 
+    public let addOns: [OrderItemProductAddOn]
+
     /// Item ID of parent `OrderItem`, if any.
     ///
     /// An `OrderItem` can have a parent if, for example, it is a bundled item within a product bundle.
@@ -48,6 +50,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
                 total: String,
                 totalTax: String,
                 attributes: [OrderItemAttribute],
+                addOns: [OrderItemProductAddOn],
                 parent: Int64?) {
         self.itemID = itemID
         self.name = name
@@ -63,6 +66,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         self.total = total
         self.totalTax = totalTax
         self.attributes = attributes
+        self.addOns = addOns
         self.parent = parent
     }
 
@@ -104,6 +108,9 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         let allAttributes = container.failsafeDecodeIfPresent(lossyList: [OrderItemAttribute].self, forKey: .attributes)
         attributes = allAttributes.filter { !$0.name.hasPrefix("_") } // Exclude private items (marked with an underscore)
 
+        let productAddOns = container.failsafeDecodeIfPresent(lossyList: [OrderItemProductAddOnContainer].self,
+                                                              forKey: .attributes).first?.value ?? []
+
         // Product Bundle extension properties:
         // If the order item is part of a product bundle, `bundledBy` is the parent order item (product bundle).
         // If it's not a bundled item, the API returns an empty string for `bundledBy` and the value will be `nil`.
@@ -129,6 +136,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
                   total: total,
                   totalTax: totalTax,
                   attributes: attributes,
+                  addOns: productAddOns,
                   parent: bundledBy ?? compositeParent)
     }
 
@@ -190,4 +198,8 @@ extension OrderItem: Comparable {
             (lhs.itemID == rhs.itemID && lhs.productID < rhs.productID) ||
             (lhs.itemID == rhs.itemID && lhs.productID == rhs.productID && lhs.name < rhs.name)
     }
+}
+
+private struct OrderItemProductAddOnContainer: Decodable {
+    let value: [OrderItemProductAddOn]
 }

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -108,8 +108,10 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         let allAttributes = container.failsafeDecodeIfPresent(lossyList: [OrderItemAttribute].self, forKey: .attributes)
         attributes = allAttributes.filter { !$0.name.hasPrefix("_") } // Exclude private items (marked with an underscore)
 
+        // Product add-ons became available in `_pao_ids` with Product Add-Ons plugin v5.0.2+.
         let productAddOns = container.failsafeDecodeIfPresent(lossyList: [OrderItemProductAddOnContainer].self,
-                                                              forKey: .attributes).first?.value ?? []
+                                                              forKey: .attributes)
+            .first(where: { $0.key == "_pao_ids" })?.value ?? []
 
         // Product Bundle extension properties:
         // If the order item is part of a product bundle, `bundledBy` is the parent order item (product bundle).
@@ -201,5 +203,6 @@ extension OrderItem: Comparable {
 }
 
 private struct OrderItemProductAddOnContainer: Decodable {
+    let key: String
     let value: [OrderItemProductAddOn]
 }

--- a/Networking/Networking/Model/OrderItemProductAddOn.swift
+++ b/Networking/Networking/Model/OrderItemProductAddOn.swift
@@ -1,0 +1,43 @@
+import Codegen
+
+/// Represents a product add-on (from the Product Add-ons extension) of an `OrderItem` in its `attributes` (meta) property.
+/// The value type is string but could be from different types like numbers in the API.
+///
+public struct OrderItemProductAddOn: Decodable, Hashable, Equatable, GeneratedFakeable, GeneratedCopiable {
+    /// The ID can be `nil` (e.g. when WCPay plugin is active).
+    public let addOnID: Int64?
+    public let key: String
+    public let value: String
+
+    public init(addOnID: Int64?, key: String, value: String) {
+        self.addOnID = addOnID
+        self.key = key
+        self.value = value
+    }
+
+    /// The public initializer for OrderItemProductAddOn.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let addOnID = container.failsafeDecodeIfPresent(integerForKey: .addOnID).map { Int64($0) }
+        let key = try container.decode(String.self, forKey: .key)
+        guard let value = container.failsafeDecodeIfPresent(stringForKey: .value) else {
+            throw OrderItemProductAddOnDecodingError.invalidValue
+        }
+        self.init(addOnID: addOnID, key: key, value: value)
+    }
+}
+
+/// Defines all of the OrderItemProductAddOn's CodingKeys.
+///
+private extension OrderItemProductAddOn {
+    enum CodingKeys: String, CodingKey {
+        case addOnID = "id"
+        case key
+        case value
+    }
+}
+
+enum OrderItemProductAddOnDecodingError: Error {
+    case invalidValue
+}

--- a/Networking/NetworkingTests/Extensions/KeyedDecodingContainer+WooTests.swift
+++ b/Networking/NetworkingTests/Extensions/KeyedDecodingContainer+WooTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Networking
+
+final class KeyedDecodingContainer_WooTests: XCTestCase {
+    func test_failsafeDecodeIfPresent_string_supports_alternative_types() throws {
+        let data = """
+                {
+                    "string": "woo",
+                    "integer": 8,
+                    "double": 6.8
+                }
+                """
+            .data(using: .utf8)!
+
+        // When
+        let stringConvertible = try JSONDecoder().decode(StringConvertible.self, from: data)
+
+        // Then
+        XCTAssertEqual(stringConvertible.fromString, "woo")
+        XCTAssertEqual(stringConvertible.fromInteger, "8")
+        XCTAssertEqual(stringConvertible.fromDouble, "6.8")
+    }
+}
+
+private extension KeyedDecodingContainer_WooTests {
+    struct StringConvertible: Decodable {
+        let fromString: String?
+        let fromInteger: String?
+        let fromDouble: String?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.fromString = container.failsafeDecodeIfPresent(stringForKey: .string)
+            self.fromInteger = container.failsafeDecodeIfPresent(stringForKey: .integer)
+            self.fromDouble = container.failsafeDecodeIfPresent(stringForKey: .double)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case string
+            case integer
+            case double
+        }
+    }
+}

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -438,6 +438,38 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(order.shippingLines.first?.taxes.first?.taxID, 1)
         XCTAssertEqual(order.items.first?.sku, "123")
     }
+
+    func test_order_line_item_addons_without_ID_are_parsed_correctly() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadOrderWithAddOnButNoAddIDResponse())
+
+        // When
+        let addOns = try XCTUnwrap(order.items.first?.addOns)
+
+        // Then
+        XCTAssertEqual(addOns, [.init(addOnID: nil, key: "As a Gift", value: "No")])
+    }
+
+    func test_order_line_item_addons_with_all_types_are_decoded_correctly() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadOrderWithAllAddOnTypesResponse())
+
+        // When
+        let addOns = try XCTUnwrap(order.items.first?.addOns)
+
+        // Then
+        assertEqual(addOns, [
+            .init(addOnID: 1690787061, key: "Extra cheese (multiple choice)", value: "20-year parmesan"),
+            .init(addOnID: 1691020417, key: "Test checkbox", value: "10% bigger"),
+            .init(addOnID: 1691020418, key: "Pizza pattern (file)", value: "https://example.com/wp-content/uploads/product_addons_uploads/file-2.jpg"),
+            .init(addOnID: 1691020419, key: "Tip (customer defined price)", value: " ($2.50)"),
+            .init(addOnID: 1691020420, key: "Birthday candle (quantity)", value: "10"),
+            .init(addOnID: 1691020421, key: "Recipient email (short text)", value: "test@example.com"),
+            .init(addOnID: 1692927665, key: "Customizations (long text)", value: "Very long text."),
+            .init(addOnID: 1690419140, key: "As a Gift", value: "Yes"),
+            .init(addOnID: 1690786915, key: "Wrapping paper", value: "Yes"),
+        ])
+    }
 }
 
 
@@ -496,6 +528,16 @@ private extension OrderMapperTests {
     ///
     func mapLoadOrderWithFaultyAttributesResponse() -> Order? {
         return mapOrder(from: "order-with-faulty-attributes")
+    }
+
+    /// Returns the Order output with a line item with a product add-on but no ID.
+    func mapLoadOrderWithAddOnButNoAddIDResponse() -> Order? {
+        mapOrder(from: "order-with-subscription-renewal")
+    }
+
+    /// Returns the Order output with a line item with all types of product add-ons.
+    func mapLoadOrderWithAllAddOnTypesResponse() -> Order? {
+        return mapOrder(from: "order-with-all-addon-types")
     }
 
     /// Returns the Order output upon receiving `order-with-line-item-attributes-before-API-support`

--- a/Networking/NetworkingTests/Responses/order-with-all-addon-types.json
+++ b/Networking/NetworkingTests/Responses/order-with-all-addon-types.json
@@ -1,0 +1,304 @@
+{
+    "data": {
+        "id": 159,
+        "parent_id": 0,
+        "status": "processing",
+        "currency": "USD",
+        "discount_total": "0.00",
+        "discount_tax": "0.00",
+        "shipping_total": "0.00",
+        "shipping_tax": "0.00",
+        "total": "44.54",
+        "total_tax": "0.00",
+        "customer_id": 0,
+        "order_key": "wc_order_16",
+        "billing": {
+            "first_name": "",
+            "last_name": "",
+            "company": "",
+            "address_1": "",
+            "address_2": "",
+            "city": "",
+            "state": "",
+            "postcode": "",
+            "country": "",
+            "email": "",
+            "phone": ""
+        },
+        "shipping" : {
+          "city" : "",
+          "country" : "",
+          "address_1" : "",
+          "last_name" : "",
+          "company" : "",
+          "postcode" : "",
+          "address_2" : "",
+          "state" : "",
+          "first_name" : ""
+        },
+        "payment_method": "cod",
+        "payment_method_title": "Cash on delivery",
+        "customer_note": "",
+        "number": "159",
+        "meta_data": [
+            {
+                "id": 997,
+                "key": "_shipping_hash",
+                "value": "9d4568c009d203ab10e33ea9953a0264"
+            },
+            {
+                "id": 998,
+                "key": "_coupons_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 999,
+                "key": "_fees_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 1000,
+                "key": "_taxes_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 1001,
+                "key": "is_vat_exempt",
+                "value": "no"
+            }
+        ],
+        "line_items": [
+            {
+                "id": 31,
+                "name": "Brick Oven Supreme Pizza",
+                "product_id": 103,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "",
+                "subtotal": "44.54",
+                "subtotal_tax": "0.00",
+                "total": "44.54",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 293,
+                        "key": "Extra cheese (multiple choice)",
+                        "value": "20-year parmesan",
+                        "display_key": "Extra cheese (multiple choice)",
+                        "display_value": "20-year parmesan"
+                    },
+                    {
+                        "id": 294,
+                        "key": "Test checkbox",
+                        "value": "10% bigger",
+                        "display_key": "Test checkbox",
+                        "display_value": "10% bigger"
+                    },
+                    {
+                        "id": 295,
+                        "key": "Pizza pattern (file)",
+                        "value": "https://example.com/wp-content/uploads/product_addons_uploads/file-2.jpg",
+                        "display_key": "Pizza pattern (file)",
+                        "display_value": "156A3A50-36B5-4723-B546-CA7E37326A6C-16064-00000C857B9CC1D5_file-2.jpg"
+                    },
+                    {
+                        "id": 296,
+                        "key": "Tip (customer defined price)",
+                        "value": " ($2.50)",
+                        "display_key": "Tip (customer defined price)",
+                        "display_value": "($2.50)"
+                    },
+                    {
+                        "id": 297,
+                        "key": "Birthday candle (quantity)",
+                        "value": "10",
+                        "display_key": "Birthday candle (quantity)",
+                        "display_value": "10"
+                    },
+                    {
+                        "id": 298,
+                        "key": "Recipient email (short text)",
+                        "value": "test@example.com",
+                        "display_key": "Recipient email (short text)",
+                        "display_value": "test@example.com"
+                    },
+                    {
+                        "id": 299,
+                        "key": "Customizations (long text)",
+                        "value": "Very long text.",
+                        "display_key": "Customizations (long text)",
+                        "display_value": "Very long text."
+                    },
+                    {
+                        "id": 300,
+                        "key": "As a Gift",
+                        "value": "Yes",
+                        "display_key": "As a Gift",
+                        "display_value": "Yes"
+                    },
+                    {
+                        "id": 301,
+                        "key": "Wrapping paper",
+                        "value": "Yes",
+                        "display_key": "Wrapping paper",
+                        "display_value": "Yes"
+                    },
+                    {
+                        "id": 302,
+                        "key": "_pao_ids",
+                        "value": [
+                            {
+                                "key": "Extra cheese (multiple choice)",
+                                "value": "20-year parmesan",
+                                "id": "1690787061"
+                            },
+                            {
+                                "key": "Test checkbox",
+                                "value": "10% bigger",
+                                "id": "1691020417"
+                            },
+                            {
+                                "key": "Pizza pattern (file)",
+                                "value": "https://example.com/wp-content/uploads/product_addons_uploads/file-2.jpg",
+                                "id": "1691020418"
+                            },
+                            {
+                                "key": "Tip (customer defined price)",
+                                "value": " ($2.50)",
+                                "id": "1691020419"
+                            },
+                            {
+                                "key": "Birthday candle (quantity)",
+                                "value": 10,
+                                "id": "1691020420"
+                            },
+                            {
+                                "key": "Recipient email (short text)",
+                                "value": "test@example.com",
+                                "id": "1691020421"
+                            },
+                            {
+                                "key": "Customizations (long text)",
+                                "value": "Very long text.",
+                                "id": "1692927665"
+                            },
+                            {
+                                "key": "As a Gift",
+                                "value": "Yes",
+                                "id": 1690419140
+                            },
+                            {
+                                "key": "Wrapping paper",
+                                "value": "Yes",
+                                "id": 1690786915
+                            }
+                        ],
+                        "display_key": "_pao_ids",
+                        "display_value": [
+                            {
+                                "key": "Extra cheese (multiple choice)",
+                                "value": "20-year parmesan",
+                                "id": "1690787061"
+                            },
+                            {
+                                "key": "Test checkbox",
+                                "value": "10% bigger",
+                                "id": "1691020417"
+                            },
+                            {
+                                "key": "Pizza pattern (file)",
+                                "value": "https://example.com/wp-content/uploads/product_addons_uploads/file-2.jpg",
+                                "id": "1691020418"
+                            },
+                            {
+                                "key": "Tip (customer defined price)",
+                                "value": " ($2.50)",
+                                "id": "1691020419"
+                            },
+                            {
+                                "key": "Birthday candle (quantity)",
+                                "value": 10,
+                                "id": "1691020420"
+                            },
+                            {
+                                "key": "Recipient email (short text)",
+                                "value": "test@example.com",
+                                "id": "1691020421"
+                            },
+                            {
+                                "key": "Customizations (long text)",
+                                "value": "Very long text.",
+                                "id": "1692927665"
+                            },
+                            {
+                                "key": "As a Gift",
+                                "value": "Yes",
+                                "id": 1690419140
+                            },
+                            {
+                                "key": "Wrapping paper",
+                                "value": "Yes",
+                                "id": 1690786915
+                            }
+                        ]
+                    }
+                ],
+                "sku": "",
+                "price": 44.54,
+                "image": {
+                    "id": "102",
+                    "src": "https://example.com/wp-content/uploads/2023/07/img_1721.jpeg"
+                },
+                "parent_name": null,
+                "bundled_by": "",
+                "bundled_item_title": "",
+                "bundled_items": []
+            }
+        ],
+        "tax_lines": [],
+        "shipping_lines": [
+            {
+                "id": 32,
+                "method_title": "Free shipping",
+                "method_id": "free_shipping",
+                "instance_id": "2",
+                "total": "0.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 308,
+                        "key": "Items",
+                        "value": "Brick Oven Supreme Pizza &times; 1",
+                        "display_key": "Items",
+                        "display_value": "Brick Oven Supreme Pizza &times; 1"
+                    }
+                ]
+            }
+        ],
+        "fee_lines": [],
+        "coupon_lines": [],
+        "refunds": [],
+        "payment_url": "https://example.com/checkout/order-pay/159/?pay_for_order=true&key=wc_order_xr71TI25TsOnI",
+        "is_editable": false,
+        "needs_payment": false,
+        "needs_processing": true,
+        "date_created_gmt": "2023-08-25T08:45:29",
+        "date_modified_gmt": "2023-08-25T08:46:57",
+        "date_paid_gmt": null,
+        "gift_cards": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders/159"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -156,6 +156,7 @@ private extension ProductInputTransformer {
                          total: parameters.total,
                          totalTax: "",
                          attributes: [],
+                         addOns: [],
                          parent: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -527,6 +527,7 @@ extension ShippingLabelPackagesFormViewModel {
                               total: "30.00",
                               totalTax: "1.20",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         let item2 = OrderItem(itemID: 891,
@@ -543,6 +544,7 @@ extension ShippingLabelPackagesFormViewModel {
                               total: "0.00",
                               totalTax: "0.00",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         return [item1, item2]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -102,6 +102,7 @@ private extension ShippingLabelSampleData {
                               total: "30.00",
                               totalTax: "1.20",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         let item2 = OrderItem(itemID: 891,
@@ -118,6 +119,7 @@ private extension ShippingLabelSampleData {
                               total: "0.00",
                               totalTax: "0.00",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         return [item1, item2]

--- a/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
@@ -33,6 +33,7 @@ public struct MockOrderItem {
                          total: total,
                          totalTax: totalTax,
                          attributes: attributes,
+                         addOns: [],
                          parent: parent)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -646,6 +646,7 @@ private extension OrderDetailsDataSourceTests {
                   total: "1",
                   totalTax: "1",
                   attributes: [],
+                  addOns: [],
                   parent: nil)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -225,6 +225,7 @@ private extension ProductDetailsCellViewModelTests {
                   total: total,
                   totalTax: "",
                   attributes: attributes,
+                  addOns: [],
                   parent: nil)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
@@ -105,6 +105,7 @@ private extension ProductLoaderViewControllerModelTests {
                   total: "",
                   totalTax: "",
                   attributes: [],
+                  addOns: [],
                   parent: nil)
     }
 

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		029F44CB28D310BA00FCF439 /* ProductSearchFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029F44CA28D310BA00FCF439 /* ProductSearchFilter.swift */; };
 		02A26F1E2744FE97008E4EDB /* MockAccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */; };
 		02AB40802784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AB407F2784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift */; };
+		02AED9DA2AA0446F006DC460 /* OrderItemProductAddOn+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AED9D92AA0446F006DC460 /* OrderItemProductAddOn+ReadOnlyConvertible.swift */; };
 		02C254F62563B47C00A04423 /* ShippingLabelAddress+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254F52563B47C00A04423 /* ShippingLabelAddress+ReadonlyConvertible.swift */; };
 		02C254FA2563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254F92563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift */; };
 		02C254FE2563C6E500A04423 /* ShippingLabelSettings+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254FD2563C6E500A04423 /* ShippingLabelSettings+ReadOnlyConvertible.swift */; };
@@ -525,6 +526,7 @@
 		029F44CA28D310BA00FCF439 /* ProductSearchFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchFilter.swift; sourceTree = "<group>"; };
 		02A26F1D2744FE97008E4EDB /* MockAccountRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAccountRemote.swift; sourceTree = "<group>"; };
 		02AB407F2784176600929CF3 /* TopEarnerStatsItem+ComparableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopEarnerStatsItem+ComparableTests.swift"; sourceTree = "<group>"; };
+		02AED9D92AA0446F006DC460 /* OrderItemProductAddOn+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderItemProductAddOn+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		02C254F52563B47C00A04423 /* ShippingLabelAddress+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAddress+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		02C254F92563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelRefund+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		02C254FD2563C6E500A04423 /* ShippingLabelSettings+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelSettings+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1310,6 +1312,7 @@
 				CEE9188B29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift */,
 				74685D4D20F7EFA7008958C1 /* OrderItem+ReadOnlyConvertible.swift */,
 				021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */,
+				02AED9D92AA0446F006DC460 /* OrderItemProductAddOn+ReadOnlyConvertible.swift */,
 				CE4FD44F2350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift */,
 				CE4FD4532350FC0100A16B31 /* OrderItemRefund+ReadOnlyConvertible.swift */,
 				CE4FD4512350FB5400A16B31 /* OrderItemTaxRefund+ReadOnlyConvertible.swift */,
@@ -2265,6 +2268,7 @@
 				02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */,
 				749737672141CC8C0008C490 /* TopEarnerStats+ReadOnlyType.swift in Sources */,
 				CCE5F39D29F0165900087332 /* SubscriptionStore.swift in Sources */,
+				02AED9DA2AA0446F006DC460 /* OrderItemProductAddOn+ReadOnlyConvertible.swift in Sources */,
 				7493751222498B2C007D85D1 /* ProductTag+ReadOnlyConvertible.swift in Sources */,
 				E109876C284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift in Sources */,
 				03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -216,6 +216,7 @@ extension MockObjectGraph {
             total: "\(total)",
             totalTax: "0",
             attributes: [],
+            addOns: [],
             parent: nil
         )
     }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -45,6 +45,7 @@ public typealias Order = Networking.Order
 public typealias OrderItem = Networking.OrderItem
 public typealias OrderItemAttribute = Networking.OrderItemAttribute
 public typealias OrderItemTax = Networking.OrderItemTax
+public typealias OrderItemProductAddOn = Networking.OrderItemProductAddOn
 public typealias OrderItemRefund = Networking.OrderItemRefund
 public typealias OrderItemTaxRefund = Networking.OrderItemTaxRefund
 public typealias OrderStatusEnum = Networking.OrderStatusEnum

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -5,6 +5,10 @@ extension Storage.OrderItem {
     var attributesArray: [Storage.OrderItemAttribute] {
         return attributes?.toArray() ?? []
     }
+
+    var addOnsArray: [Storage.OrderItemProductAddOn] {
+        addOns?.toArray() ?? []
+    }
 }
 
 // MARK: - Storage.OrderItem: ReadOnlyConvertible
@@ -34,6 +38,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.OrderItem {
         let orderItemTaxes = taxes?.map { $0.toReadOnly() }.sorted(by: { $0.taxID < $1.taxID }) ?? [Yosemite.OrderItemTax]()
         let attributes = attributesArray.map { $0.toReadOnly() }
+        let addOns = addOnsArray.map { $0.toReadOnly() }
 
         return OrderItem(itemID: itemID,
                          name: name ?? "",
@@ -49,6 +54,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
                          total: total ?? "",
                          totalTax: totalTax ?? "",
                          attributes: attributes,
+                         addOns: addOns,
                          parent: parent?.int64Value)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderItemProductAddOn+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItemProductAddOn+ReadOnlyConvertible.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Storage
+
+// MARK: - Storage.OrderItemProductAddOn: ReadOnlyConvertible
+//
+extension Storage.OrderItemProductAddOn: ReadOnlyConvertible {
+    /// Updates the Storage.OrderItemProductAddOn with the a ReadOnly.
+    ///
+    public func update(with addOn: Yosemite.OrderItemProductAddOn) {
+        addOnID = addOn.addOnID.map { NSNumber(value: $0) }
+        key = addOn.key
+        value = addOn.value
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.OrderItemProductAddOn {
+        .init(addOnID: addOnID?.int64Value, key: key, value: value)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -268,6 +268,7 @@ private extension OrdersUpsertUseCaseTests {
                   total: "",
                   totalTax: "",
                   attributes: [],
+                  addOns: [],
                   parent: nil)
     }
 
@@ -290,6 +291,7 @@ private extension OrdersUpsertUseCaseTests {
               total: "-18.00",
               totalTax: "0.00",
               attributes: attributes,
+              addOns: [],
               parent: nil)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1503,6 +1503,7 @@ private extension OrderStoreTests {
                               total: "30.00",
                               totalTax: "1.20",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         let item2 = OrderItem(itemID: 891,
@@ -1519,6 +1520,7 @@ private extension OrderStoreTests {
                               total: "0.00",
                               totalTax: "0.00",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         return [item1, item2]
@@ -1539,6 +1541,7 @@ private extension OrderStoreTests {
                               total: "64.00",
                               totalTax: "4.00",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         let item2 = OrderItem(itemID: 891,
@@ -1555,6 +1558,7 @@ private extension OrderStoreTests {
                               total: "30.40",
                               totalTax: "0.40",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         let item3 = OrderItem(itemID: 23,
@@ -1571,6 +1575,7 @@ private extension OrderStoreTests {
                               total: "140.40",
                               totalTax: "10.40",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         return [item1, item2, item3]
@@ -1591,6 +1596,7 @@ private extension OrderStoreTests {
                               total: "64.00",
                               totalTax: "4.00",
                               attributes: [],
+                              addOns: [],
                               parent: nil)
 
         return [item1]

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -1094,6 +1094,7 @@ private extension ProductVariationStoreTests {
               total: "30.00",
               totalTax: "1.20",
               attributes: [],
+              addOns: [],
               parent: nil)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -528,6 +528,7 @@ private extension ReceiptStoreTests {
                            total: total,
                            totalTax: "",
                            attributes: [],
+                           addOns: [],
                            parent: nil)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10419 
⚠️ Please make sure https://github.com/woocommerce/woocommerce-ios/pull/10589 is approved before reviewing this PR

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Currently, we're getting the product add-ons of an order line item by manually mapping the metadata entries with the product and global add-ons that need to be synced separately. Starting Product Add-Ons v5.0.2 pe5pgL-3wp-p2#comment-2967, a new metadata field `_pao_ids` became available to get a list of add-ons of an order line item. After the storage layer changes in https://github.com/woocommerce/woocommerce-ios/pull/10589, this PR includes the networking layer changes with a readonly `OrderItemProductAddOn`.

## How

🗒️ Please excuse the 500+ diffs, the json file with all add-on types has ~300 diffs.

- Updated `KeyedDecodingContainer.failsafeDecodeIfPresent(stringForKey:)` to support `Double`-to-`String` transformation with a test case. This is needed due to various value types in the API in, ref pe5pgL-3wp-p2#caveat-2-wcpay-plugin-removes-the-add-on-id
- Added a readonly `OrderItemProductAddOn`
- `ReadOnlyConvertible` was implemented, but not used yet since the add-ons persistence will be in a future PR

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.