### PR TITLE
Store onboarding: Update different priorities for wcpay and payment tasks

### DIFF
--- a/Networking/Networking/Model/StoreOnboardingTask.swift
+++ b/Networking/Networking/Model/StoreOnboardingTask.swift
@@ -60,14 +60,16 @@ private extension StoreOnboardingTask.TaskType {
             return 1
         case .addFirstProduct:
             return 2
-        case .payments, .woocommercePayments:
+        case .woocommercePayments:
             return 3
         case .launchStore:
             return 4
         case .customizeDomains:
             return 5
-        case .unsupported:
+        case .payments:
             return 6
+        case .unsupported:
+            return 7
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -55,7 +55,30 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
     // MARK: - `tasksForDisplay``
 
-    func test_tasksForDisplay_returns_first_3_incomplete_tasks_when_isExpanded_is_false() async {
+    func test_tasksForDisplay_returns_first_3_incomplete_tasks_including_wcpay_when_isExpanded_is_false() async {
+        // Given
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: false, type: .customizeDomains),
+            .init(isComplete: false, type: .woocommercePayments)
+        ]))
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: false,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertEqual(sut.tasksForDisplay.count, 3)
+
+        XCTAssertEqual(sut.tasksForDisplay[0].task.type, .addFirstProduct)
+        XCTAssertEqual(sut.tasksForDisplay[1].task.type, .woocommercePayments)
+        XCTAssertEqual(sut.tasksForDisplay[2].task.type, .launchStore)
+    }
+
+    func test_tasksForDisplay_returns_first_3_incomplete_tasks_not_including_payments_when_isExpanded_is_false() async {
         // Given
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),
@@ -74,8 +97,8 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tasksForDisplay.count, 3)
 
         XCTAssertEqual(sut.tasksForDisplay[0].task.type, .addFirstProduct)
-        XCTAssertEqual(sut.tasksForDisplay[1].task.type, .payments)
-        XCTAssertEqual(sut.tasksForDisplay[2].task.type, .launchStore)
+        XCTAssertEqual(sut.tasksForDisplay[1].task.type, .launchStore)
+        XCTAssertEqual(sut.tasksForDisplay[2].task.type, .customizeDomains)
     }
 
     func test_tasksForDisplay_returns_all_tasks_when_isExpanded_is_true() async {
@@ -103,7 +126,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
             .init(isComplete: false, type: .addFirstProduct),
             .init(isComplete: false, type: .launchStore),
             .init(isComplete: false, type: .customizeDomains),
-            .init(isComplete: false, type: .payments)
+            .init(isComplete: false, type: .woocommercePayments)
         ]))
         let sut = StoreOnboardingViewModel(siteID: 0,
                                            isExpanded: false,
@@ -118,7 +141,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tasksForDisplay.count, 3)
 
         XCTAssertEqual(sut.tasksForDisplay[0].task.type, .addFirstProduct)
-        XCTAssertEqual(sut.tasksForDisplay[1].task.type, .payments)
+        XCTAssertEqual(sut.tasksForDisplay[1].task.type, .woocommercePayments)
         XCTAssertEqual(sut.tasksForDisplay[2].task.type, .launchStore)
     }
 
@@ -506,7 +529,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Given
         let initialTasks: [StoreOnboardingTask] = [
             .init(isComplete: false, type: .addFirstProduct),
-            .init(isComplete: false, type: .payments),
+            .init(isComplete: false, type: .woocommercePayments),
             .init(isComplete: false, type: .launchStore),
             .init(isComplete: true, type: .customizeDomains)
         ]
@@ -533,9 +556,9 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Given
         let initialTasks: [StoreOnboardingTask] = [
             .init(isComplete: false, type: .addFirstProduct),
-            .init(isComplete: false, type: .payments),
             .init(isComplete: false, type: .launchStore),
-            .init(isComplete: true, type: .customizeDomains)
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
         ]
 
         let tasks = initialTasks + [(.init(isComplete: true, type: .unsupported("")))]

--- a/Yosemite/YosemiteTests/Stores/StoreOnboardingTasksStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/StoreOnboardingTasksStoreTests.swift
@@ -57,7 +57,36 @@ final class StoreOnboardingTasksStoreTests: XCTestCase {
         XCTAssertEqual(tasks, [.init(isComplete: true, type: .launchStore)])
     }
 
-    func test_loadOnboardingTasks_returns_sorted_tasks_on_success() throws {
+    func test_loadOnboardingTasks_returns_sorted_tasks_with_wcpay_before_launchStore_on_success() throws {
+        // Given
+        let unsortedTasks: [StoreOnboardingTask] = [.init(isComplete: true, type: .unsupported("")),
+                                                    .init(isComplete: true, type: .customizeDomains),
+                                                    .init(isComplete: true, type: .launchStore),
+                                                    .init(isComplete: true, type: .addFirstProduct),
+                                                    .init(isComplete: true, type: .storeDetails),
+                                                    .init(isComplete: true, type: .woocommercePayments)]
+        remote.whenLoadingOnboardingTasks(thenReturn: .success(unsortedTasks))
+
+        // When
+        let result: Result<[StoreOnboardingTask], Error> = waitFor { promise in
+            let action = StoreOnboardingTasksAction.loadOnboardingTasks(siteID: 0) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let tasks = try XCTUnwrap(result.get())
+        XCTAssertEqual(tasks, [.init(isComplete: true, type: .storeDetails),
+                               .init(isComplete: true, type: .addFirstProduct),
+                               .init(isComplete: true, type: .woocommercePayments),
+                               .init(isComplete: true, type: .launchStore),
+                               .init(isComplete: true, type: .customizeDomains),
+                               .init(isComplete: true, type: .unsupported(""))])
+    }
+
+    func test_loadOnboardingTasks_returns_sorted_tasks_with_payments_after_launchStore_on_success() throws {
         // Given
         let unsortedTasks: [StoreOnboardingTask] = [.init(isComplete: true, type: .unsupported("")),
                                                     .init(isComplete: true, type: .customizeDomains),
@@ -80,9 +109,9 @@ final class StoreOnboardingTasksStoreTests: XCTestCase {
         let tasks = try XCTUnwrap(result.get())
         XCTAssertEqual(tasks, [.init(isComplete: true, type: .storeDetails),
                                .init(isComplete: true, type: .addFirstProduct),
-                               .init(isComplete: true, type: .payments),
                                .init(isComplete: true, type: .launchStore),
                                .init(isComplete: true, type: .customizeDomains),
+                               .init(isComplete: true, type: .payments),
                                .init(isComplete: true, type: .unsupported(""))])
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10556 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR separates the priorities for `woocommercePayments` and `payments` onboarding task following the decision in p1693390418081459-slack-C03L1NF1EA3. The WCPay item is prioritized over `launchStore` and `domain`, but the regular payments item should be placed at the end like before.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to the app and create a new free trial store if needed.
- If you have never configured WCPay for the store, you should see an item on the onboarding list for WCPay.
- Tap the item to open the setup web view, then dismiss it.
- The onboarding list should be reloaded, this time the WCPay item is no longer present.
- Tap View All to see all onboarding tasks, you should see the item for configuring payment gateways at the end of the list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/bdd9969b-e973-43a9-94bf-872b6569b9f4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
