### PR TITLE
[Mobile Payments] Track IPP onboarding CTA plugin install failed

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1820,6 +1820,22 @@ extension WooAnalyticsEvent {
                               ])
         }
 
+        /// Tracked when a In-Person Payments onboarding step's CTA is tapped by the user and the expected action fails
+        ///
+        /// - Parameters:
+        ///   - reason: the reason why the onboarding step was shown (effectively the name of the step)
+        ///   - countryCode: the country code of the store
+        ///   - error: the logged error
+        ///
+        static func cardPresentOnboardingCtaFailed(reason: String, countryCode: String, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardPresentOnboardingCtaFailed,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.reason: reason,
+                                Keys.errorDescription: error.localizedDescription
+                              ])
+        }
+
         enum CashOnDeliverySource: String {
             case onboarding
             case paymentsHub = "payments_hub"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1832,8 +1832,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.countryCode: countryCode,
                                 Keys.reason: reason,
-                                Keys.errorDescription: error.localizedDescription
-                              ])
+                              ], error: error)
         }
 
         enum CashOnDeliverySource: String {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -308,6 +308,7 @@ public enum WooAnalyticsStat: String {
     case cardPresentOnboardingNotCompleted = "card_present_onboarding_not_completed"
     case cardPresentOnboardingStepSkipped = "card_present_onboarding_step_skipped"
     case cardPresentOnboardingCtaTapped = "card_present_onboarding_cta_tapped"
+    case cardPresentOnboardingCtaFailed = "card_present_onboarding_cta_failed"
 
     // MARK: Tap to Pay
     case tapToPaySummaryTryPaymentTapped = "tap_to_pay_summary_try_payment_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -122,16 +122,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
                 DDLogInfo("Success installing \(pluginSlug)")
                 self.refresh()
             case .failure(let error):
-                guard let countryCode = self.storeCountryCode else {
-                    DDLogError("Error installing plugin: \(error)")
-                    return
-                }
-                ServiceLocator.analytics.track(event: WooAnalyticsEvent(statName: .cardPresentOnboardingCtaFailed,
-                                                                        properties: [
-                                                                            "country": "\(countryCode)",
-                                                                            "reason": "plugin_install_tapped",
-                                                                            "error_description": "\(error)"
-                                                                        ]))
+                self.trackPluginInstallFailed(error)
             }
         })
         stores.dispatch(installPluginAction)
@@ -524,6 +515,19 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
     func isNetworkError(_ error: Error) -> Bool {
         (error as NSError).domain == NSURLErrorDomain
+    }
+}
+
+// MARK: - Analytics
+private extension CardPresentPaymentsOnboardingUseCase {
+    func trackPluginInstallFailed(_ error: Error) {
+        guard let countryCode = self.storeCountryCode else {
+            DDLogError("Error installing plugin: \(error)")
+            return
+        }
+        ServiceLocator.analytics.track(event: .InPersonPayments.cardPresentOnboardingCtaFailed(reason: "plugin_install_tapped",
+                                                                                               countryCode: countryCode,
+                                                                                               error: error))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -122,7 +122,16 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
                 DDLogInfo("Success installing \(pluginSlug)")
                 self.refresh()
             case .failure(let error):
-                DDLogError("Error installing plugin: \(error)")
+                guard let countryCode = self.storeCountryCode else {
+                    DDLogError("Error installing plugin: \(error)")
+                    return
+                }
+                ServiceLocator.analytics.track(event: WooAnalyticsEvent(statName: .cardPresentOnboardingCtaFailed,
+                                                                        properties: [
+                                                                            "country": "\(countryCode)",
+                                                                            "reason": "plugin_install_tapped",
+                                                                            "error_description": "\(error)"
+                                                                        ]))
             }
         })
         stores.dispatch(installPluginAction)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -116,13 +116,16 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         // Only WCPay is currently supported, so we don't expose a different plugin option
         let pluginSlug = CardPresentPaymentsPlugin.wcPay.gatewayID
 
-        let installPluginAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: pluginSlug, onCompletion: { result in
+        let installPluginAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: pluginSlug, onCompletion: { [weak self] result in
+            guard let self = self else { return }
+            self.state = .loading
             switch result {
             case .success:
                 DDLogInfo("Success installing \(pluginSlug)")
                 self.refresh()
             case .failure(let error):
                 self.trackPluginInstallFailed(error)
+                self.state = .genericError
             }
         })
         stores.dispatch(installPluginAction)


### PR DESCRIPTION
Closes: #10567 . Based on #10565 

## Description
This PR adds the `card_present_onboarding_cta_failed` track event which will help us track when there's a failed outcome from tapping on a CTAs during the IPP onboarding flow, as well as improves the UX for state handling when install is called and fails.

At the moment, we're only tracking the case for `plugin_install_tapped` when the plugin installation fails. More cases will be added in future PRs.

![Simulator Screen Recording - iPhone 11 Pro - 2023-09-04 at 11 51 16](https://github.com/woocommerce/woocommerce-ios/assets/3812076/114974d3-4792-4f6b-92dd-d10e8c1e8664)


## Testing instructions
1. On a WCPay eligible store, with WCPay not installed ( you can use https://atomicippwcpaytests.wpcomstaging.com/ ):

2. Change the plugin slug in `CardPresentPaymentsOnboardingUseCase` [here](https://github.com/woocommerce/woocommerce-ios/blob/64d42ea8e16c5c03047f604daa0061a4913b43a4/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/CardPresentPaymentsOnboardingUseCase.swift#L117) to a non-existent plugin slug:
```diff
- let pluginSlug = CardPresentPaymentsPlugin.wcPay.gatewayID
+ let pluginSlug = "so much fail"
```

3. Now go to `Menu` > `Payments` > See the notice at the bottom that says that `In-Person Payments setup is incomplete. Continue setup`. Tap the link.
4. Observe the following: 
* See the `Install WooCommerce Payments` button. Tap on Install
* The loading screen might appear (depends on how fast the failure happens)
* The following events are tracked:
* `card_present_onboarding_cta_tapped`, with reason `wcpay_not_installed`
```
2023-09-01 10:47:40.895200+0200 WooCommerce[25224:24233219] 🔵 Tracked card_present_onboarding_cta_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("was_ecommerce_trial"): false, AnyHashable("country"): "US", AnyHashable("reason"): "wcpay_not_installed", AnyHashable("blog_id"): 222904906, AnyHashable("plan"): "business-bundle"]
```
* `card_present_onboarding_cta_failed` with reason `plugin_install_tapped`, and `error_description` 
```
2023-09-01 11:07:21.617058+0200 WooCommerce[26632:24252223] 🔵 Tracked card_present_onboarding_cta_failed, properties: [AnyHashable("blog_id"): 222904906, AnyHashable("reason"): "plugin_install_tapped", AnyHashable("error_description"): "Dotcom Error: [plugins_api_failed] Plugin not found.", AnyHashable("country"): "US", AnyHashable("was_ecommerce_trial"): false, AnyHashable("is_wpcom_store"): true, AnyHashable("plan"): "business-bundle"]
```
* The generic error view is displayed (a more specific error view might be implemented in the future)
* Go back 2 steps to the `Menu` > tap on `Payments` > Tap on `Continue setup` again.
* See that `Install WooCommerce Payments` is available again. 

Note that at the moment we do not seem to refresh the onboarding state until we leave the Payments view, so the failure state will remain if we just go back and  tap on "Continue Setup" immediately. This is done for all flows, and might require further discussion outside of this project.

