### PR TITLE
[Data Sprint] Add site_url to Tracks events

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 15.3
 -----
-
+- [internal] Add `site_url` to Tracks events [https://github.com/woocommerce/woocommerce-ios/pull/10610]
 
 15.2
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -13,7 +13,7 @@ public class WooAnalytics: Analytics {
     /// AnalyticsProvider: Interface to the actual analytics implementation
     ///
     private(set) var analyticsProvider: AnalyticsProvider
-    
+
     private var stores: StoresManager
 
     /// Time when app was opened — used for calculating the time-in-app property

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -23,6 +23,8 @@ class WooAnalyticsTests: XCTestCase {
 
     private let sampleSiteURL: String = "https://example.com"
 
+    private let originalStores: StoresManager = ServiceLocator.stores
+
     // MARK: - Overridden Methods
 
     override func setUp() {
@@ -31,7 +33,13 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultSite: Site.fake().copy(
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
-        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider(), stores: stores)
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        ServiceLocator.setStores(originalStores)
     }
 
     /// Verifies basic events are received by the AnalyticsProvider
@@ -160,7 +168,8 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultSite: Site.fake().copy(
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
-        analytics = WooAnalytics(analyticsProvider: testingProvider, stores: stores)
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: testingProvider)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)
@@ -194,7 +203,8 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultSite: Site.fake().copy(
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
-        analytics = WooAnalytics(analyticsProvider: testingProvider, stores: stores)
+        ServiceLocator.setStores(stores)
+        analytics = WooAnalytics(analyticsProvider: testingProvider)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10609 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When analysing user interactions which span the web/app divide, we regularly face difficulties integrating the data. To make it easier to link user actions in the app to flows which continue on the web, this PR adds the site_url in our app tracks events.

For more context see peaMlT-aA-p2#comment-404

Relates to https://github.com/woocommerce/woocommerce-android/pull/9703

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check analytics logged while using the app – all analytics (except for a few excluded by `WooAnalyticsStat.shouldSendSiteProperties` should have the base URL of the current site as `site_url`.

The site should be updated when the site is changed.

Note that these base properties are not included in the console logs; you need to check with Tracks live view, or using a tool such as Proxyman or Charles to see the events as they go over the network.

### Scenarios
- Logged in and using the app: check various events
- Switching stores: check that after changing, the new URL is used
- Logging out: check that while logged out, no URL is logged
- Logging in: check that after logging in, the correct URL is logged.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Site Picker Continue tapped in tracks live view with name and url highlighted](https://github.com/woocommerce/woocommerce-ios/assets/2472348/a27fea2f-4fba-4b34-b499-18558121bc37)

![Logout confirmation event with site_url, followed by a login event with no url tracked](https://github.com/woocommerce/woocommerce-ios/assets/2472348/ff438908-2bb2-4ada-85a4-d972165d2de1)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.