### PR TITLE
[Tooling] Modernize Prototype Build comment

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -13,4 +13,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_installable_build
+bundle exec fastlane build_and_upload_prototype_build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,16 +29,16 @@ steps:
           context: "Build"
 
   #################
-  # Create Installable Build
+  # Create Prototype Build
   #################
-  - label: "🛠 Installable Build"
-    command: ".buildkite/commands/installable-build.sh"
+  - label: "🛠 Prototype Build"
+    command: ".buildkite/commands/prototype-build.sh"
     env: *common_env
     plugins: *common_plugins
     if: build.pull_request.id != null
     notify:
       - github_commit_status:
-          context: "Installable Build"
+          context: "Prototype Build"
 
   #################
   # Run Unit Tests

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -19,7 +19,7 @@ The project has three build configurations to match the WooCommerce app: `Debug`
 
 - `Debug` build configuration: `DEBUG` value is set. Used for debug builds from Xcode
 - `Release` build configuration: no values are set. Used for release builds for the App Store
-- `Release-Alpha` build configuration: `ALPHA` value is set. Used for one-off installable builds for internal testing, which we can trigger from a commit in a pull request
+- `Release-Alpha` build configuration: `ALPHA` value is set. Used for one-off prototype builds for internal testing, which we can trigger from a commit in a pull request
 
 In the default implementation of `FeatureFlagService`, some of the feature flags are based on build configurations - enabled in `Debug` and `Release-Alpha` configurations, and disabled in `Release` builds.
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ MAIN_BUNDLE_IDENTIFIERS = [
 ].freeze
 
 ALPHA_VERSION_BUNDLE_IDENTIFIER = 'com.automattic.alpha.woocommerce'
-# Registered in our Enterprise account, for App Center / Installable Builds
+# Registered in our Enterprise account, for App Center / Prototype Builds
 ALPHA_BUNDLE_IDENTIFIERS = [
   ALPHA_VERSION_BUNDLE_IDENTIFIER,
   "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgets"
@@ -573,19 +573,19 @@ platform :ios do
   end
 
   #####################################################################################
-  # build_and_upload_installable_build
+  # build_and_upload_prototype_build
   # -----------------------------------------------------------------------------------
   # This lane builds the app and upload it for adhoc testing
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_installable_build [version_long:<version_long>]
+  # bundle exec fastlane build_and_upload_prototype_build [version_long:<version_long>]
   #
   # Example:
-  # bundle exec fastlane build_and_upload_installable_build
-  # bundle exec fastlane build_and_upload_installable_build build_number:123
+  # bundle exec fastlane build_and_upload_prototype_build
+  # bundle exec fastlane build_and_upload_prototype_build build_number:123
   #####################################################################################
-  desc 'Builds and uploads an installable build'
-  lane :build_and_upload_installable_build do
+  desc 'Builds and uploads an prototype build'
+  lane :build_and_upload_prototype_build do
     ensure_sentry_installed
     xcversion # Ensure we're using the right version of Xcode, defined in `.xcode-version` file
 
@@ -593,7 +593,7 @@ platform :ios do
 
     # Get the current build version, and update it if needed
     versions = Xcodeproj::Config.new(File.new(PUBLIC_CONFIG_FILE)).to_hash
-    build_number = generate_installable_build_number
+    build_number = generate_prototype_build_number
     UI.message("Updating build version to #{build_number}")
     versions['VERSION_LONG'] = build_number
     new_config = Xcodeproj::Config.new(versions)
@@ -629,26 +629,19 @@ platform :ios do
       dsym_path: './build/WooCommerce.app.dSYM.zip'
     )
 
-    UI.message("Successfully built and uploaded installable build `#{build_number}` to App Center.")
+    UI.message("Successfully built and uploaded prototype build `#{build_number}` to App Center.")
 
     return if ENV['BUILDKITE_PULL_REQUEST'].nil?
 
-    install_url = 'https://install.appcenter.ms/orgs/automattic/apps/WooCommerce-Installable-Builds'
-    qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
-
-    comment_body = <<~COMMENT_BODY
-      You can test the changes from this Pull Request by:<ul>
-        <li><a href='#{install_url}'>Clicking here</a> or scanning the QR code below to access App Center</li>
-        <li>Then installing the build number <code>#{build_number}</code> on your iPhone</li>
-      </ul>
-      <img src='#{qr_code_url}' width='150' height='150' />
-      If you need access to App Center, please ask a maintainer to add you.
-    COMMENT_BODY
-
+    # PR Comment
+    comment_body = prototype_build_details_comment(
+      app_display_name: 'WooCommerce iOS',
+      app_center_org_name: 'automattic'
+    )
     comment_on_pr(
       project: GITHUB_REPO,
       pr_number: Integer(ENV.fetch('BUILDKITE_PULL_REQUEST')),
-      reuse_identifier: 'installable-build-link',
+      reuse_identifier: 'prototype-build-link',
       body: comment_body
     )
   end
@@ -1175,9 +1168,9 @@ lane :test_without_building do |options|
 end
 
 # -----------------------------------------------------------------------------------
-# Generates Installable Build Version Numbers in a Buildkite-specific way
+# Generates Prototype Build Version Numbers in a Buildkite-specific way
 # -----------------------------------------------------------------------------------
-def generate_installable_build_number
+def generate_prototype_build_number
   if ENV.key?('BUILDKITE')
     commit = ENV.fetch('BUILDKITE_COMMIT')[0, 7]
     branch = ENV.fetch('BUILDKITE_BRANCH')


### PR DESCRIPTION
## Description

Recently while I was browsing PRs in this repo, I noticed that the "Installable Builds" PR comment were quite old-looking and not using our more modern and rich comment (which was announced internally in paaHJt-4ET-p2 and paaHJt-4ue-p2).

This PR thus:
 - Uses our `prototype_build_details_comment` action from `release-toolkit` to generate a richer PR comment body
   - Which will make that PR comment look more standardized, and with **more information** about the build
   - And with a **direct link to install the right build** from App Center (instead of developers having to manually scroll and find to the right build to install from the releases list)
 - Rename that feature from "Installable Build" to "Prototype Build", since this is the vocabulary that we've started to adopt for a while in other apps (also because all builds are "installable" in some way, so the term "Installable Builds" wasn't super specific)

## Testing instructions

 - Check that the comment left about the Prototype Build looks nicer and have all the new information
 - Follow the link to the Prototype Build in App Center (either by clicking the link or using the QR code) and validate that it points to a direct URL to the explicit release associated with that PR — as opposed to pointing to a list of all releases, defaulting to having the latest one selected, as it was before)

## Screenshots

<table><tr>
  <th>Before</th>
  <td><img width="929" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/216089/53f56c2f-5310-487a-931b-acc744a7d075"></td>
</tr><tr>
  <th>After</th>
  <td><img width="925" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/216089/12113bb2-696e-4929-a270-337cf2c8fe6d"></td>
</tr></table>

---
- [ ] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~