### PR TITLE
[What's New] Show announcements when current version in range

### DIFF
--- a/WooCommerce/Classes/Tools/VersionHelpers.swift
+++ b/WooCommerce/Classes/Tools/VersionHelpers.swift
@@ -10,6 +10,11 @@ final class VersionHelpers {
         VersionHelpers.compare(version, minimumRequired) != .orderedAscending
     }
 
+    static func isVersionSupported(version: String, minimumRequired: String, maximumPermitted: String) -> Bool {
+        VersionHelpers.compare(version, minimumRequired) != .orderedAscending &&
+        VersionHelpers.compare(version, maximumPermitted) != .orderedDescending
+    }
+
     /// Compares two strings as versions using the same approach as PHP `version_compare`.
     /// https://www.php.net/manual/en/function.version-compare.php
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -230,7 +230,8 @@ private extension SettingsViewModel {
     func loadWhatsNewOnWooCommerce() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
             guard let self = self else { return }
-            guard let (announcement, _) = try? result.get(), announcement.appVersionName == UserAgent.bundleShortVersion else {
+            guard let (announcement, _) = try? result.get(),
+                    announcement.shownInThisAppVersion else {
                 return DDLogInfo("📣 There are no announcements to show!")
             }
 
@@ -471,5 +472,17 @@ private extension SettingsViewModel {
             "Account Settings",
             comment: "My Store > Settings > Account Settings section"
         ).uppercased()
+    }
+}
+
+private extension Yosemite.Announcement {
+    var isForThisAppVersion: Bool {
+        appVersionName == UserAgent.bundleShortVersion
+    }
+
+    var shownInThisAppVersion: Bool {
+        return isForThisAppVersion || VersionHelpers.isVersionSupported(version: UserAgent.bundleShortVersion,
+                                                                        minimumRequired: minimumAppVersion,
+                                                                        maximumPermitted: maximumAppVersion)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -1,7 +1,6 @@
 import Codegen
 import XCTest
 import Yosemite
-import class Networking.UserAgent
 
 import protocol Storage.StorageType
 import protocol Storage.StorageManagerType


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

"What's New" announcements are for a particular version, but also get a max/minimum version range where they should show.

If the current version is in the range, the announcement will have shown on launch. These users may also want to look at the announcement again, after dismissing it.

Previously, we only showed the What's New row in settings if the announcement's `appVersionName` exactly matched the current app version. This PR changes this behaviour to show the What’s New row if there’s an announcement for which the current version falls within the min/max range (inclusive at both ends).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There is an announcement configured for 15.2-15.4 at the moment. It will only show for A11n accounts, as it's not yet active.

### Announcement for future version

1. Delete the app
2. Change the marketing version to 15.1.9
3. Launch the app
4. Observe that no Announcement is shown on launch
5. Check in `Menu > Settings`
6. Observe that the `What's New` row is not shown

### Announcement for exactly this version

1. Change the marketing version to 15.2
2. Launch the app
3. Observe that the Announcement is shown on launch
4. Check in `Menu > Settings`
5. Observe that the `What's New` row is shown
6. Tap it, and observe that the announcement is shown again

### Announcement for the previous version which should still show

1. Change the marketing version to 15.2.1
2. Launch the app
3. Observe that the announcment is not shown (because it was previously shown and you did not delete the app)
4. Check in `Menu > Settings` – observe that the `What's New` row is shown and works

### Announcement for previous version that was not seen

1. Delete the app
2. Change the marketing version to 15.3
3. Launch the app
4. Observe that the Announcement is shown on launch
5. Check in `Menu > Settings`
6. Observe that the `What's New` row is shown
7. Tap it, and observe that the announcement is shown again

### Announcement for a past version

1. Delete the app
2. Change the marketing version to 15.5
3. Launch the app
4. Observe that no Announcement is shown on launch
5. Check in `Menu > Settings`
6. Observe that the `What's New` row is not shown


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
