### PR TITLE
[Hazmat Shipping] Map and validate hazmat data to shipping models

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -18,6 +18,9 @@ struct ShippingLabelPackageAttributes: Equatable {
 
     /// List of items in the package.
     let items: [ShippingLabelPackageItem]
+
+    /// Selected hazmat category, `nil` if there's no declaration of hazardous materials
+    let selectedHazmatCategory: ShippingLabelHazmatCategory?
 }
 
 extension ShippingLabelPackageAttributes {

--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -19,8 +19,8 @@ struct ShippingLabelPackageAttributes: Equatable {
     /// List of items in the package.
     let items: [ShippingLabelPackageItem]
 
-    /// Selected hazmat category, `nil` if there's no declaration of hazardous materials
-    let selectedHazmatCategory: ShippingLabelHazmatCategory?
+    /// Selected hazmat category, `.none` if there's no declaration of hazardous materials
+    let selectedHazmatCategory: ShippingLabelHazmatCategory
 }
 
 extension ShippingLabelPackageAttributes {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -111,7 +111,8 @@ private extension ShippingLabelPackagesFormViewModel {
                                                                       productVariations: productVariations) }
         selectedPackages = [ShippingLabelPackageAttributes(packageID: selectedPackageID,
                                                            totalWeight: "",
-                                                           items: items)]
+                                                           items: items,
+                                                           selectedHazmatCategory: nil)]
     }
 
     /// Set up item view models on change selected packages.
@@ -223,14 +224,16 @@ private extension ShippingLabelPackagesFormViewModel {
                 if updatedItems.isNotEmpty {
                     let updatedPackage = ShippingLabelPackageAttributes(packageID: package.packageID,
                                                                         totalWeight: package.totalWeight,
-                                                                        items: updatedItems)
+                                                                        items: updatedItems,
+                                                                        selectedHazmatCategory: package.selectedHazmatCategory)
                     updatedPackages.append(updatedPackage)
                 }
 
                 // Create a package with original packaging box ID and the matching item.
                 let originalPackage = ShippingLabelPackageAttributes(packageID: ShippingLabelPackageAttributes.originalPackagingBoxID,
                                                                      totalWeight: "",
-                                                                     items: [matchingItem])
+                                                                     items: [matchingItem],
+                                                                     selectedHazmatCategory: nil)
                 updatedPackages.append(originalPackage)
             } else {
                 updatedPackages.append(package)
@@ -265,21 +268,24 @@ private extension ShippingLabelPackagesFormViewModel {
             if updatedItems.isNotEmpty {
                 let updatedPackage = ShippingLabelPackageAttributes(packageID: currentPackage.packageID,
                                                                     totalWeight: "",
-                                                                    items: updatedItems)
+                                                                    items: updatedItems,
+                                                                    selectedHazmatCategory: currentPackage.selectedHazmatCategory)
                 temporaryPackages.append(updatedPackage)
             }
 
             // Create new package with the matching item, using same package ID as current package's
             let newPackage = ShippingLabelPackageAttributes(packageID: currentPackage.packageID,
                                                             totalWeight: "",
-                                                            items: [matchingItem])
+                                                            items: [matchingItem],
+                                                            selectedHazmatCategory: currentPackage.selectedHazmatCategory)
             temporaryPackages.append(newPackage)
         } else {
             // Get last selected package ID to use as ID of the new package if possible.
             let selectedPackageID = resultsControllers?.accountSettings?.lastSelectedPackageID ?? ""
             let newPackage = ShippingLabelPackageAttributes(packageID: selectedPackageID,
                                                             totalWeight: "",
-                                                            items: currentPackage.items)
+                                                            items: currentPackage.items,
+                                                            selectedHazmatCategory: currentPackage.selectedHazmatCategory)
             temporaryPackages.insert(newPackage, at: packageIndex)
         }
         // This will trigger updating item view models, and therefore updates the package list UI.
@@ -310,7 +316,8 @@ private extension ShippingLabelPackagesFormViewModel {
             if updatedItems.isNotEmpty {
                 updatedCurrentPackage = ShippingLabelPackageAttributes(packageID: currentPackage.packageID,
                                                                        totalWeight: "",
-                                                                       items: updatedItems)
+                                                                       items: updatedItems,
+                                                                       selectedHazmatCategory: currentPackage.selectedHazmatCategory)
             }
         }
 
@@ -332,7 +339,8 @@ private extension ShippingLabelPackagesFormViewModel {
         // Create a copy of the new package with updated items
         let updatedNewPackage = ShippingLabelPackageAttributes(packageID: newPackage.packageID,
                                                                totalWeight: "",
-                                                               items: newItems)
+                                                               items: newItems,
+                                                               selectedHazmatCategory: newPackage.selectedHazmatCategory)
         temporaryPackages[newPackageIndex] = updatedNewPackage
 
         if let updatedCurrentPackage = updatedCurrentPackage {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -112,7 +112,7 @@ private extension ShippingLabelPackagesFormViewModel {
         selectedPackages = [ShippingLabelPackageAttributes(packageID: selectedPackageID,
                                                            totalWeight: "",
                                                            items: items,
-                                                           selectedHazmatCategory: nil)]
+                                                           selectedHazmatCategory: .none)]
     }
 
     /// Set up item view models on change selected packages.
@@ -127,7 +127,7 @@ private extension ShippingLabelPackagesFormViewModel {
                          selectedPackageID: details.packageID,
                          totalWeight: details.totalWeight,
                          isOriginalPackaging: details.isOriginalPackaging,
-                         hazmatCategory: details.selectedHazmatCategory ?? .none,
+                         hazmatCategory: details.selectedHazmatCategory,
                          onItemMoveRequest: { [weak self] in
                 self?.itemViewModels.forEach {
                     $0.dismissPopover()
@@ -234,7 +234,7 @@ private extension ShippingLabelPackagesFormViewModel {
                 let originalPackage = ShippingLabelPackageAttributes(packageID: ShippingLabelPackageAttributes.originalPackagingBoxID,
                                                                      totalWeight: "",
                                                                      items: [matchingItem],
-                                                                     selectedHazmatCategory: nil)
+                                                                     selectedHazmatCategory: package.selectedHazmatCategory)
                 updatedPackages.append(originalPackage)
             } else {
                 updatedPackages.append(package)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -127,6 +127,7 @@ private extension ShippingLabelPackagesFormViewModel {
                          selectedPackageID: details.packageID,
                          totalWeight: details.totalWeight,
                          isOriginalPackaging: details.isOriginalPackaging,
+                         hazmatCategory: details.selectedHazmatCategory ?? .none,
                          onItemMoveRequest: { [weak self] in
                 self?.itemViewModels.forEach {
                     $0.dismissPopover()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -168,6 +168,7 @@ struct ShippingLabelSinglePackage_Previews: PreviewProvider {
                                                             selectedPackageID: "Box 1",
                                                             totalWeight: "",
                                                             isOriginalPackaging: false,
+                                                            hazmatCategory: .none,
                                                             onItemMoveRequest: {},
                                                             onPackageSwitch: { _ in },
                                                             onPackagesSync: { _ in })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -251,7 +251,11 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
 
         $containsHazmatMaterials.combineLatest($selectedHazmatCategory)
             .map { containsHazmat, selectedCategory -> Bool in
-                selectedCategory != .none && containsHazmat
+                if containsHazmat {
+                    return selectedCategory != .none
+                } else {
+                    return true
+                }
             }
             .assign(to: &$hasValidHazmatDeclaration)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -80,6 +80,11 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
     /// Attributes of the package if validated.
     ///
     var validatedPackageAttributes: ShippingLabelPackageAttributes? {
+        if containsHazmatMaterials {
+            guard selectedHazmatCategory != .none else {
+                return nil
+            }
+        }
         guard validateTotalWeight(totalWeight) else {
             return nil
         }
@@ -88,7 +93,8 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
         }
         return ShippingLabelPackageAttributes(packageID: selectedPackageID,
                                               totalWeight: totalWeight,
-                                              items: orderItems)
+                                              items: orderItems,
+                                              selectedHazmatCategory: selectedHazmatCategory)
     }
 
     /// Whether the Package contains hazmat materials or not
@@ -234,10 +240,12 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
 // MARK: ShippingLabelPackageSelectionDelegate conformance
 extension ShippingLabelSinglePackageViewModel: ShippingLabelPackageSelectionDelegate {
     func didSelectPackage(id: String) {
+        let hazmatCategory = selectedHazmatCategory != .none ? selectedHazmatCategory : nil
         let newTotalWeight = isPackageWeightEdited ? totalWeight : ""
         let newPackage = ShippingLabelPackageAttributes(packageID: id,
                                                         totalWeight: newTotalWeight,
-                                                        items: orderItems)
+                                                        items: orderItems,
+                                                        selectedHazmatCategory: hazmatCategory)
 
         onPackageSwitch(newPackage)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -146,6 +146,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
          selectedPackageID: String,
          totalWeight: String,
          isOriginalPackaging: Bool = false,
+         hazmatCategory: ShippingLabelHazmatCategory,
          onItemMoveRequest: @escaping () -> Void,
          onPackageSwitch: @escaping PackageSwitchHandler,
          onPackagesSync: @escaping PackagesSyncHandler,
@@ -173,6 +174,10 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
         configureTotalWeight(initialTotalWeight: totalWeight)
         if isOriginalPackaging, let item = orderItems.first {
             configureOriginalPackageDimensions(for: item)
+        }
+        if hazmatCategory != .none {
+            containsHazmatMaterials = true
+            selectedHazmatCategory = hazmatCategory
         }
         configureValidation(originalPackaging: isOriginalPackaging)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -175,19 +175,6 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
         if isOriginalPackaging, let item = orderItems.first {
             configureOriginalPackageDimensions(for: item)
         }
-        if hazmatCategory != .none {
-            containsHazmatMaterials = true
-            selectedHazmatCategory = hazmatCategory
-        }
-        $containsHazmatMaterials
-            .map { [weak self] contains in
-                if contains {
-                    return self?.selectedHazmatCategory ?? .none
-                } else {
-                    return ShippingLabelHazmatCategory.none
-                }
-            }
-            .assign(to: &$selectedHazmatCategory)
         configureValidation(originalPackaging: isOriginalPackaging)
     }
 
@@ -237,6 +224,22 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
         let height = item.dimensions.height.isEmpty ? "0" : item.dimensions.height
         originalPackageDimensions = String(format: "%@ x %@ x %@ %@", length, width, height, unit)
         hasValidPackageDimensions = item.dimensions.length.isNotEmpty && item.dimensions.width.isNotEmpty && item.dimensions.height.isNotEmpty
+    }
+    
+    private func configureHazmatCategory(hazmatCategory: ShippingLabelHazmatCategory) {
+        if hazmatCategory != .none {
+            containsHazmatMaterials = true
+            selectedHazmatCategory = hazmatCategory
+        }
+
+        $containsHazmatMaterials
+            .map { [weak self] contains in
+                if contains {
+                    return self?.selectedHazmatCategory ?? .none
+                }
+                return ShippingLabelHazmatCategory.none
+            }
+            .assign(to: &$selectedHazmatCategory)
     }
 
     private func configureValidation(originalPackaging: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -179,6 +179,15 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
             containsHazmatMaterials = true
             selectedHazmatCategory = hazmatCategory
         }
+        $containsHazmatMaterials
+            .map { [weak self] contains in
+                if contains {
+                    return self?.selectedHazmatCategory ?? .none
+                } else {
+                    return ShippingLabelHazmatCategory.none
+                }
+            }
+            .assign(to: &$selectedHazmatCategory)
         configureValidation(originalPackaging: isOriginalPackaging)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -152,7 +152,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
          selectedPackageID: String,
          totalWeight: String,
          isOriginalPackaging: Bool = false,
-         hazmatCategory: ShippingLabelHazmatCategory,
+         hazmatCategory: ShippingLabelHazmatCategory = .none,
          onItemMoveRequest: @escaping () -> Void,
          onPackageSwitch: @escaping PackageSwitchHandler,
          onPackagesSync: @escaping PackagesSyncHandler,
@@ -275,12 +275,11 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject, Identifiable 
 // MARK: ShippingLabelPackageSelectionDelegate conformance
 extension ShippingLabelSinglePackageViewModel: ShippingLabelPackageSelectionDelegate {
     func didSelectPackage(id: String) {
-        let hazmatCategory = selectedHazmatCategory != .none ? selectedHazmatCategory : nil
         let newTotalWeight = isPackageWeightEdited ? totalWeight : ""
         let newPackage = ShippingLabelPackageAttributes(packageID: id,
                                                         totalWeight: newTotalWeight,
                                                         items: orderItems,
-                                                        selectedHazmatCategory: hazmatCategory)
+                                                        selectedHazmatCategory: selectedHazmatCategory)
 
         onPackageSwitch(newPackage)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/SinglePackageHazmatDeclaration.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/SinglePackageHazmatDeclaration.swift
@@ -161,6 +161,7 @@ struct HazmatDeclaration_Previews: PreviewProvider {
                                                             selectedPackageID: "Box 1",
                                                             totalWeight: "",
                                                             isOriginalPackaging: false,
+                                                            hazmatCategory: .none,
                                                             onItemMoveRequest: {},
                                                             onPackageSwitch: { _ in },
                                                             onPackagesSync: { _ in })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
@@ -30,8 +30,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_foundMultiplePackages_returns_correctly() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake(), .fake()])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake(), .fake()])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake(), .fake()], selectedHazmatCategory: .none)
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake(), .fake()], selectedHazmatCategory: .none)
 
         // When & Then
         let viewModel1 = ShippingLabelPackagesFormViewModel(order: order,
@@ -81,8 +81,9 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
                                                       totalWeight: "12",
                                                       items: [.fake(id: 1),
                                                               .fake(id: 33),
-                                                              .fake(id: 23)])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake(id: 49)])
+                                                              .fake(id: 23)],
+                                                      selectedHazmatCategory: .none)
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake(id: 49)], selectedHazmatCategory: .none)
 
         // When
         let viewModel = ShippingLabelPackagesFormViewModel(order: order,
@@ -100,8 +101,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_doneButtonEnabled_returns_true_when_all_packages_are_valid() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()], selectedHazmatCategory: .none)
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()], selectedHazmatCategory: .none)
 
         // When
         let viewModel = ShippingLabelPackagesFormViewModel(order: order,
@@ -117,8 +118,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_doneButtonEnabled_returns_false_when_not_all_packages_are_valid() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()], selectedHazmatCategory: .none)
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()], selectedHazmatCategory: .none)
 
         // When
         let viewModel = ShippingLabelPackagesFormViewModel(order: order,
@@ -135,8 +136,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_onCompletion_returns_correctly() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()], selectedHazmatCategory: .none)
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()], selectedHazmatCategory: .none)
 
         var result: [ShippingLabelPackageAttributes] = []
         let completionHandler = { packages in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -519,6 +519,34 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.isValidPackage)
     }
+
+    func test_when_containsHazmatMaterials_is_unchecked_then_category_is_reverted_to_none() {
+        // Given
+        let dimensions = ProductDimensions(length: "2", width: "3", height: "5")
+        let item = ShippingLabelPackageItem.fake(dimensions: dimensions)
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
+                                                            orderItems: [item],
+                                                            packagesResponse: mockPackageResponse(),
+                                                            selectedPackageID: "invividual",
+                                                            totalWeight: "10",
+                                                            isOriginalPackaging: true,
+                                                            onItemMoveRequest: {},
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in },
+                                                            formatter: currencyFormatter,
+                                                            weightUnit: "kg")
+
+        // Then
+        viewModel.containsHazmatMaterials = true
+        viewModel.selectedHazmatCategory = .class1
+        XCTAssertEqual(viewModel.selectedHazmatCategory, .class1)
+        viewModel.containsHazmatMaterials = false
+        XCTAssertEqual(viewModel.selectedHazmatCategory, .none)
+    }
 }
 
 // MARK: - Mocks

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -467,6 +467,58 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.selectedHazmatCategory, .none)
     }
+
+    func test_package_is_not_valid_when_contains_hazmat_without_category_selected() {
+        // Given
+        let dimensions = ProductDimensions(length: "2", width: "3", height: "5")
+        let item = ShippingLabelPackageItem.fake(dimensions: dimensions)
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
+                                                            orderItems: [item],
+                                                            packagesResponse: mockPackageResponse(),
+                                                            selectedPackageID: "invividual",
+                                                            totalWeight: "10",
+                                                            isOriginalPackaging: true,
+                                                            onItemMoveRequest: {},
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in },
+                                                            formatter: currencyFormatter,
+                                                            weightUnit: "kg")
+        viewModel.containsHazmatMaterials = true
+        viewModel.selectedHazmatCategory = .none
+
+        // Then
+        XCTAssertFalse(viewModel.isValidPackage)
+    }
+
+    func test_package_is_valid_when_contains_hazmat_with_category_selected() {
+        // Given
+        let dimensions = ProductDimensions(length: "2", width: "3", height: "5")
+        let item = ShippingLabelPackageItem.fake(dimensions: dimensions)
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
+                                                            orderItems: [item],
+                                                            packagesResponse: mockPackageResponse(),
+                                                            selectedPackageID: "invividual",
+                                                            totalWeight: "10",
+                                                            isOriginalPackaging: true,
+                                                            onItemMoveRequest: {},
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in },
+                                                            formatter: currencyFormatter,
+                                                            weightUnit: "kg")
+        viewModel.containsHazmatMaterials = true
+        viewModel.selectedHazmatCategory = .class1
+
+        // Then
+        XCTAssertTrue(viewModel.isValidPackage)
+    }
 }
 
 // MARK: - Mocks

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -239,7 +239,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     userDefaults: userDefaults)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [], selectedHazmatCategory: .none)
 
         // When
         shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
@@ -256,7 +256,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     userDefaults: userDefaults)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [], selectedHazmatCategory: .none)
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
@@ -287,7 +287,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil,
                                                                     userDefaults: userDefaults)
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: "my-package-id", totalWeight: expectedPackageWeight, items: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: "my-package-id", totalWeight: expectedPackageWeight, items: [], selectedHazmatCategory: .none)
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)
@@ -993,7 +993,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
         let item = ShippingLabelPackageItem.fake(id: expectedProductID)
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: "Food Package", totalWeight: "55", items: [item])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: "Food Package", totalWeight: "55", items: [item], selectedHazmatCategory: .none)
         viewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -239,7 +239,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     userDefaults: userDefaults)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [], selectedHazmatCategory: .none)
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID,
+                                                             totalWeight: expectedPackageWeight,
+                                                             items: [],
+                                                             selectedHazmatCategory: .none)
 
         // When
         shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
@@ -256,7 +259,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     userDefaults: userDefaults)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [], selectedHazmatCategory: .none)
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID,
+                                                             totalWeight: expectedPackageWeight,
+                                                             items: [],
+                                                             selectedHazmatCategory: .none)
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
@@ -287,7 +293,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil,
                                                                     userDefaults: userDefaults)
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: "my-package-id", totalWeight: expectedPackageWeight, items: [], selectedHazmatCategory: .none)
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: "my-package-id",
+                                                             totalWeight: expectedPackageWeight,
+                                                             items: [],
+                                                             selectedHazmatCategory: .none)
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)


### PR DESCRIPTION
Partially fix #10605 

Why
==========
When a package is flagged with containing hazmat materials, we must enforce that the user selects a category before submitting the changes. Also, the Hazmat configuration should be stored and preserved between the Shipping Label Form and the Package details.

How
==========
This PR updates the internal package validation to account for the Hazmat state correctness, and also make sure that the main models containing the Package data gets updated with the Hazmat category selected.

Screen Capture
==========
https://github.com/woocommerce/woocommerce-ios/assets/5920403/68546121-a800-49ff-ad04-9ef0f6adf3bf

How to Test
==========
1. Open the order details of an order eligible for Shipping label creation
2. Start the shipping label creation flow until you reach the Package details section
3. Inside the package details view, make sure the Contains hazardous materials toggle is visible and interactable
4. Make sure the toggle expands and collapses a view that will serve as the main control options for the HAZMAT declaration
5. Verify that checking the `contains hazardous materials` without selecting a category blocks the Package changes from be submitted.
6. Select a hazmat category and hit `done`
7. Once back to the `Create Shipping Label` form, go back to the Package Details and verify that all hazmat package selection state are the same from the submission.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.