### PR TITLE
Product variations: Update Networking and Yosemite to support sorting list

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -10,6 +10,8 @@ public protocol ProductVariationsRemoteProtocol {
                                   context: String?,
                                   pageNumber: Int,
                                   pageSize: Int,
+                                  orderBy: ProductVariationsRemote.OrderKey,
+                                  order: ProductVariationsRemote.Order,
                                   completion: @escaping ([ProductVariation]?, Error?) -> Void)
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func createProductVariation(for siteID: Int64,
@@ -53,11 +55,15 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                          context: String? = nil,
                                          pageNumber: Int = Default.pageNumber,
                                          pageSize: Int = Default.pageSize,
+                                         orderBy: ProductVariationsRemote.OrderKey = .date,
+                                         order: ProductVariationsRemote.Order = .descending,
                                          completion: @escaping ([ProductVariation]?, Error?) -> Void) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
-            ParameterKey.contextKey: context ?? Default.context
+            ParameterKey.contextKey: context ?? Default.context,
+            ParameterKey.order: order.rawValue,
+            ParameterKey.orderBy: orderBy.rawValue
         ]
 
         let path = "\(Path.products)/\(productID)/variations"
@@ -263,6 +269,16 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
 // MARK: - Constants
 //
 public extension ProductVariationsRemote {
+    enum OrderKey: String {
+        case date
+        case title
+    }
+
+    enum Order: String {
+        case ascending = "asc"
+        case descending = "desc"
+    }
+
     enum Default {
         public static let pageSize: Int   = 25
         public static let pageNumber: Int = 1
@@ -278,5 +294,7 @@ public extension ProductVariationsRemote {
         static let perPage: String    = "per_page"
         static let contextKey: String = "context"
         static let image: String = "image"
+        static let order: String = "order"
+        static let orderBy: String = "orderby"
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -102,6 +102,28 @@ final class ProductVariationsRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    func test_loadAllProductVariations_sends_correct_order_and_orderby_values() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        let expectation = self.expectation(description: "Load All Product Variations returns error")
+        let orderBy = ProductVariationsRemote.OrderKey.title
+        let order = ProductVariationsRemote.Order.ascending
+
+        // When
+        remote.loadAllProductVariations(for: sampleSiteID, productID: sampleProductID, orderBy: orderBy, order: order) { (productVariations, error) in
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let orderValue = try XCTUnwrap(request.parameters["order"] as? String)
+        XCTAssertEqual(orderValue, order.rawValue)
+        let orderByValue = try XCTUnwrap(request.parameters["orderby"] as? String)
+        XCTAssertEqual(orderByValue, orderBy.rawValue)
+    }
+
     /// Verifies that loadAllProductVariations properly relays Networking Layer errors.
     ///
     func testLoadAllProductVariationsProperlyRelaysNetwokingErrors() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -68,7 +68,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowScrollIndicator, "Scroll indicator is not disabled at start")
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 XCTAssertTrue(viewModel.shouldShowScrollIndicator, "Scroll indicator is not enabled during sync")
                 onCompletion(.success(false))
             default:
@@ -89,7 +89,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
                 onCompletion(.success(false))
             default:
@@ -110,7 +110,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
                 self.insert(self.sampleProductVariation)
                 onCompletion(.success(false))
@@ -134,7 +134,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .results)
                 onCompletion(.success(false))
             default:
@@ -191,7 +191,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: Product.fake(), stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -68,7 +68,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowScrollIndicator, "Scroll indicator is not disabled at start")
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 XCTAssertTrue(viewModel.shouldShowScrollIndicator, "Scroll indicator is not enabled during sync")
                 onCompletion(.success(false))
             default:
@@ -89,7 +89,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
                 onCompletion(.success(false))
             default:
@@ -110,7 +110,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
                 self.insert(self.sampleProductVariation)
                 onCompletion(.success(false))
@@ -134,7 +134,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .results)
                 onCompletion(.success(false))
             default:
@@ -191,7 +191,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: Product.fake(), stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
@@ -22,7 +22,7 @@ final class BulkUpdateViewControllerTests: XCTestCase {
                                             storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
@@ -22,7 +22,7 @@ final class BulkUpdateViewControllerTests: XCTestCase {
                                             storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -31,6 +31,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let expectedProductID: Int64 = 19
         let expectedPageSize = 100
         let expectedPageNumber = 1
+        let expectedOrder: ProductVariationsSortOrder = .dateDescending
         let viewModel = BulkUpdateViewModel(siteID: expectedSiteID,
                                             productID: expectedProductID,
                                             variationCount: 10,
@@ -44,7 +45,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         // Then
         let action = try XCTUnwrap(storesManager.receivedActions.first as? ProductVariationAction)
 
-        guard case let .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, _, _, _) = action else {
+        guard case let .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, order, _) = action else {
             XCTFail("Expected \(action) to be \(ProductVariationAction.self).synchronizeProductVariations.")
             return
         }
@@ -53,6 +54,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         XCTAssertEqual(productID, expectedProductID)
         XCTAssertEqual(pageNumber, expectedPageNumber)
         XCTAssertEqual(pageSize, expectedPageSize)
+        XCTAssertEqual(order, expectedOrder)
     }
 
     func test_initial_sync_state() throws {
@@ -97,7 +99,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                                             storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")
@@ -121,7 +123,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                                             storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -143,7 +145,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[0], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -179,7 +181,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -217,7 +219,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -254,7 +256,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -291,7 +293,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -44,7 +44,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         // Then
         let action = try XCTUnwrap(storesManager.receivedActions.first as? ProductVariationAction)
 
-        guard case let .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, _) = action else {
+        guard case let .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, _, _, _) = action else {
             XCTFail("Expected \(action) to be \(ProductVariationAction.self).synchronizeProductVariations.")
             return
         }
@@ -97,7 +97,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                                             storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")
@@ -121,7 +121,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
                                             storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -143,7 +143,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[0], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -179,7 +179,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -217,7 +217,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -254,7 +254,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
@@ -291,7 +291,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storageManager.insertSampleProductVariation(readOnlyProductVariation: variations[1], on: product)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariations(_, _, _, _, _, _, onCompletion):
                 onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateAllVariationsUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateAllVariationsUseCaseTests.swift
@@ -14,7 +14,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
             default:
                 break
@@ -46,7 +46,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
             case .createProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
@@ -79,7 +79,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, let onCompletion):
                 let variation = ProductVariation.fake().copy(attributes: [.init(id: 1, name: "Size", option: "XS")])
                 onCompletion(.success([variation]))
             case .createProductVariations(_, _, _, let onCompletion):
@@ -114,7 +114,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
             case .createProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
@@ -151,7 +151,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, let onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0)))
             default:
                 break
@@ -183,7 +183,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
             case .createProductVariations(_, _, _, let onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0)))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateAllVariationsUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateAllVariationsUseCaseTests.swift
@@ -14,7 +14,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
                 onCompletion(.success([]))
             default:
                 break
@@ -46,7 +46,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
                 onCompletion(.success([]))
             case .createProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
@@ -79,7 +79,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
                 let variation = ProductVariation.fake().copy(attributes: [.init(id: 1, name: "Size", option: "XS")])
                 onCompletion(.success([variation]))
             case .createProductVariations(_, _, _, let onCompletion):
@@ -114,7 +114,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
                 onCompletion(.success([]))
             case .createProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
@@ -151,7 +151,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0)))
             default:
                 break
@@ -183,7 +183,7 @@ final class GenerateAllVariationsUseCaseTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeAllProductVariations(_, _, let onCompletion):
+            case .synchronizeAllProductVariations(_, _, _, _, let onCompletion):
                 onCompletion(.success([]))
             case .createProductVariations(_, _, _, let onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0)))

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		DE3C5B21286BF2270049E6AA /* MockSystemStatusActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */; };
 		DE3C5B23286C03F90049E6AA /* MockCardPresentPaymentActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3C5B22286C03F80049E6AA /* MockCardPresentPaymentActionHandler.swift */; };
 		DE50296728C7114800551736 /* JetpackConnectionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */; };
+		DE5A816C2AA715AD00FAFBD8 /* ProductVariationSortOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5A816B2AA715AD00FAFBD8 /* ProductVariationSortOrder.swift */; };
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
@@ -874,6 +875,7 @@
 		DE3C5B20286BF2270049E6AA /* MockSystemStatusActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusActionHandler.swift; sourceTree = "<group>"; };
 		DE3C5B22286C03F80049E6AA /* MockCardPresentPaymentActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentActionHandler.swift; sourceTree = "<group>"; };
 		DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionStoreTests.swift; sourceTree = "<group>"; };
+		DE5A816B2AA715AD00FAFBD8 /* ProductVariationSortOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationSortOrder.swift; sourceTree = "<group>"; };
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
@@ -939,6 +941,7 @@
 			isa = PBXGroup;
 			children = (
 				0212AC5D242C67FA00C51F6C /* ProductsSortOrder.swift */,
+				DE5A816B2AA715AD00FAFBD8 /* ProductVariationSortOrder.swift */,
 				073AF84327DB10270074EDF0 /* CardPresentPaymentGatewayExtension.swift */,
 			);
 			path = Enums;
@@ -2195,6 +2198,7 @@
 				02FF055323D983F30058E6E7 /* URL+Media.swift in Sources */,
 				022F00BE24725BAF008CD97F /* NotificationCountStore.swift in Sources */,
 				31799AFA27050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift in Sources */,
+				DE5A816C2AA715AD00FAFBD8 /* ProductVariationSortOrder.swift in Sources */,
 				7499936620EFBC7200CF01CD /* OrderNoteStore.swift in Sources */,
 				DE2E8EA72953F85C002E4B14 /* WordPressSiteStore.swift in Sources */,
 				74858DB421C02B5A00754F3E /* OrderNote+ReadOnlyType.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -10,8 +10,7 @@ public enum ProductVariationAction: Action {
     ///
     case synchronizeAllProductVariations(siteID: Int64,
                                          productID: Int64,
-                                         orderBy: ProductVariationsRemote.OrderKey = .date,
-                                         order: ProductVariationsRemote.Order = .descending,
+                                         order: ProductVariationsSortOrder = .dateDescending,
                                          onCompletion: (Result<[ProductVariation], Error>) -> Void)
 
     /// Synchronizes the ProductVariation's matching the specified criteria.
@@ -21,8 +20,7 @@ public enum ProductVariationAction: Action {
                                       productID: Int64,
                                       pageNumber: Int,
                                       pageSize: Int,
-                                      orderBy: ProductVariationsRemote.OrderKey = .date,
-                                      order: ProductVariationsRemote.Order = .descending,
+                                      order: ProductVariationsSortOrder = .dateDescending,
                                       onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Retrieves the specified ProductVariation.

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -8,12 +8,22 @@ public enum ProductVariationAction: Action {
 
     /// Synchronizes all the ProductVariation's available in the store.
     ///
-    case synchronizeAllProductVariations(siteID: Int64, productID: Int64, onCompletion: (Result<[ProductVariation], Error>) -> Void)
+    case synchronizeAllProductVariations(siteID: Int64,
+                                         productID: Int64,
+                                         orderBy: ProductVariationsRemote.OrderKey = .date,
+                                         order: ProductVariationsRemote.Order = .descending,
+                                         onCompletion: (Result<[ProductVariation], Error>) -> Void)
 
     /// Synchronizes the ProductVariation's matching the specified criteria.
     /// If successful, the result boolean value, will indicate weather there are more variations to fetch or not.
     ///
-    case synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Result<Bool, Error>) -> Void)
+    case synchronizeProductVariations(siteID: Int64,
+                                      productID: Int64,
+                                      pageNumber: Int,
+                                      pageSize: Int,
+                                      orderBy: ProductVariationsRemote.OrderKey = .date,
+                                      order: ProductVariationsRemote.Order = .descending,
+                                      onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Retrieves the specified ProductVariation.
     ///

--- a/Yosemite/Yosemite/Stores/Enums/ProductVariationSortOrder.swift
+++ b/Yosemite/Yosemite/Stores/Enums/ProductVariationSortOrder.swift
@@ -1,0 +1,38 @@
+import Networking
+
+/// How product variations are sorted in a product list.
+///
+public enum ProductVariationsSortOrder: String {
+    // From the newest to the oldest
+    case dateDescending
+    // From the oldest to the newest
+    case dateAscending
+    // Product name from Z to A
+    case nameDescending
+    // Product name from A to Z
+    case nameAscending
+
+    public static let `default`: ProductVariationsSortOrder = .nameAscending
+}
+
+// MARK: ProductsRemote
+//
+extension ProductVariationsSortOrder {
+    var remoteOrderKey: ProductVariationsRemote.OrderKey {
+        switch self {
+        case .dateAscending, .dateDescending:
+            return .date
+        case .nameAscending, .nameDescending:
+            return .title
+        }
+    }
+
+    var remoteOrder: ProductVariationsRemote.Order {
+        switch self {
+        case .dateAscending, .nameAscending:
+            return .ascending
+        case .dateDescending, .nameDescending:
+            return .descending
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -86,6 +86,8 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
                                   context: String?,
                                   pageNumber: Int,
                                   pageSize: Int,
+                                  orderBy: ProductVariationsRemote.OrderKey = .date,
+                                  order: ProductVariationsRemote.Order = .descending,
                                   completion: @escaping ([ProductVariation]?, Error?) -> Void) {
         // no-op
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10619 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Networking and Yosemite layers with new params for sorting product variations. The change is done following the [API doc](https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-product-variations) and the current behavior of the product list. We are supporting only sorting by date and title.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to the app and navigate to the Products tab.
- Select an existing variable product or create a new one with variations if needed.
- The variation list should still be listed as before as we are using the default values for `order` and `orderby`. Generating new variations should still work properly too.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/df622acd-611c-4a1c-8fa5-db109610e56d" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
