### PR TITLE
Update "WooCommerce payments" wording on onboarding view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
@@ -104,7 +104,7 @@ private extension StoreOnboardingPaymentsSetupCoordinator {
 private extension StoreOnboardingPaymentsSetupCoordinator {
     enum Localization {
         static let wcPayWebviewTitle = NSLocalizedString(
-            "WooCommerce Payments",
+            "WooPayments",
             comment: "Title of the webview for WCPay setup from onboarding."
         )
         static let paymentsWebviewTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupView.swift
@@ -149,7 +149,7 @@ private extension StoreOnboardingPaymentsSetupView.Task {
         switch self {
         case .wcPay:
             return NSLocalizedString(
-                "WooCommerce Payments",
+                "WooPayments",
                 comment: "Highlighted header text on the store onboarding WCPay setup screen."
             )
         case .payments:
@@ -178,7 +178,7 @@ private extension StoreOnboardingPaymentsSetupView.Task {
         switch self {
         case .wcPay:
             return NSLocalizedString(
-                "By using WooCommerce Payments you agree to be bound by our " +
+                "By using WooPayments you agree to be bound by our " +
                 "[Terms of Service](https://wordpress.com/tos) and acknowledge that " +
                 "you have read our [Privacy Policy](https://automattic.com/privacy/).",
                 comment: "Details on the store onboarding WCPay setup screen."


### PR DESCRIPTION
Closes: #10621 

## Description
Update the wording from "WooCommerce Payments" to "WooPayments".

## Testing instructions
1. Start with a fresh site (both a self-hosted or an upgraded WooExpress one would work).
2. If the site is self-hosted, then install WooPayments.
3. Make sure the country is set to US.
4. Install the WCPay Dev plugin (Jurassic Ninja has a toggle to include it automatically)
5. Open the app, then sign in to the site.
6. Click on the "Get Paid" task and tap "Begin setup"
7. Validate that the title and subtitle texts have "WooPayments" instead of "WooCommerce payments".
8. Tap "Continue Setup" and the title should read "WooPayments" instead of "WooCommerce payments".

## Screenshots

![Simulator Screen Recording - iPhone 14 Pro - 2023-09-05 at 16 09 58](https://github.com/woocommerce/woocommerce-ios/assets/524475/ec95e768-c414-401b-a1e4-6e56a240caff)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.