### PR TITLE
[Mobile Payments] Track IPP onboarding CTA plugin activate failed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -130,7 +130,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
                 DDLogInfo("Success installing \(pluginSlug)")
                 self.refresh()
             case .failure(let error):
-                self.trackPluginInstallFailed(error)
+                self.trackCardPresentPluginActionFailed(error, trigger: .notInstalled)
                 self.state = .genericError
             }
         })
@@ -152,7 +152,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
                 DDLogInfo("Success activating \(pluginName)")
                 self.refresh()
             case .failure(let error):
-                self.trackPluginActivateFailed(error)
+                self.trackCardPresentPluginActionFailed(error, trigger: .notActivated)
                 self.state = .genericError
             }
         })
@@ -551,20 +551,17 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
 // MARK: - Analytics
 private extension CardPresentPaymentsOnboardingUseCase {
-    func trackPluginInstallFailed(_ error: Error) {
-        guard let countryCode = self.storeCountryCode else {
-            return
-        }
-        analytics.track(event: .InPersonPayments.cardPresentOnboardingCtaFailed(reason: "plugin_install_tapped",
-                                                                                countryCode: countryCode,
-                                                                                error: error))
+    enum PluginFailureTrigger: String {
+        case notInstalled = "plugin_install_tapped"
+        case notActivated = "plugin_activate_tapped"
     }
 
-    func trackPluginActivateFailed(_ error: Error) {
+    func trackCardPresentPluginActionFailed(_ error: Error, trigger: PluginFailureTrigger) {
         guard let countryCode = self.storeCountryCode else {
             return
         }
-        analytics.track(event: .InPersonPayments.cardPresentOnboardingCtaFailed(reason: "plugin_activate_tapped",
+
+        analytics.track(event: .InPersonPayments.cardPresentOnboardingCtaFailed(reason: trigger.rawValue,
                                                                                 countryCode: countryCode,
                                                                                 error: error))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10567 . Please review https://github.com/woocommerce/woocommerce-ios/pull/10616/ first

## Description

This PR adds an additional case to the existing event `card_present_onboarding_cta_failed`. When a merchant taps on the "Activate Plugin" CTA and the plugin activation fails, we'll track the failure with `reason: plugin_activate_tapped` and the appropriate error description that comes from the API.

## Changes:
- Collapses track methods for "plugin_install_tapped" and "plugin_activate_tapped" into a single function. 
- Injects analytics into `CardPresentPaymentsOnboardingUseCase`

## Testing instructions
1. On a WCPay eligible store ( you can use https://atomicippwcpaytests.wpcomstaging.com/ ):
2. Change the plugin name within `activateCardPresentPlugin()` in `CardPresentPaymentsOnboardingUseCase` [here](https://github.com/woocommerce/woocommerce-ios/blob/26c83134d83f868483ec988569be770b21e727bc/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/CardPresentPaymentsOnboardingUseCase.swift#L145) to a non-existent plugin name:

```diff
- let pluginName = CardPresentPaymentsPlugin.wcPay.fileNameWithPathExtension
+ let pluginName = "so much fail"
```
3. Now go to `Menu` > `Payments` > See the notice at the bottom that says that `In-Person Payments setup is incomplete. Continue setup`. Tap the link.
4. Tap on install if WCPay is not installed. Wait for it to complete
5. Observe `Activate Plugin` button. Tap on it.
6. See it fail, and the following tracks are logged:

* `card_present_onboarding_cta_tapped`, with reason: `wcpay_not_activated`
```
🔵 Tracked card_present_onboarding_cta_tapped, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "business-bundle", AnyHashable("reason"): "wcpay_not_activated", AnyHashable("country"): "US", AnyHashable("blog_id"): 222904906, AnyHashable("is_wpcom_store"): true]
```
* `card_present_onboarding_cta_failed`, with reason: `plugin_activate_tapped`, and error `Dotcom Error: [rest_plugin_not_found] Plugin not found`.
```
🔵 Tracked card_present_onboarding_cta_failed, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "business-bundle", AnyHashable("country"): "US", AnyHashable("error_domain"): "Networking.DotcomError", AnyHashable("blog_id"): 222904906, AnyHashable("error_description"): "Dotcom Error: [rest_plugin_not_found] Plugin not found.", AnyHashable("reason"): "plugin_activate_tapped", AnyHashable("error_code"): "0", AnyHashable("is_wpcom_store"): true]
```