### PR TITLE
[Manual Taxes M2] Populate UI with fetched tax rates

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2371,7 +2371,7 @@ extension Networking.TaxRate {
         siteID: CopiableProp<Int64> = .copy,
         name: CopiableProp<String> = .copy,
         country: CopiableProp<String> = .copy,
-        countries: CopiableProp<[String]> = .copy,
+        state: CopiableProp<String> = .copy,
         postcode: CopiableProp<String> = .copy,
         postcodes: CopiableProp<[String]> = .copy,
         priority: CopiableProp<Int64> = .copy,
@@ -2387,6 +2387,7 @@ extension Networking.TaxRate {
         let siteID = siteID ?? self.siteID
         let name = name ?? self.name
         let country = country ?? self.country
+        let state = state ?? self.state
         let postcode = postcode ?? self.postcode
         let postcodes = postcodes ?? self.postcodes
         let priority = priority ?? self.priority

--- a/Networking/Networking/Remote/TaxRemote.swift
+++ b/Networking/Networking/Remote/TaxRemote.swift
@@ -43,7 +43,9 @@ public class TaxRemote: Remote {
                                      method: .get,
                                      siteID: siteID,
                                      path: path,
-                                     parameters: nil,
+                                     parameters: [
+                                        ParameterKeys.page: String(pageNumber),
+                                        ParameterKeys.perPage: String(pageSize)],
                                      availableAsRESTRequest: true)
         let mapper = TaxRateListMapper(siteID: siteID)
 
@@ -57,5 +59,10 @@ public extension TaxRemote {
 
     private enum Path {
         static let taxes   = "taxes"
+    }
+
+    private enum ParameterKeys {
+        static let page: String             = "page"
+        static let perPage: String          = "per_page"
     }
 }

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -185,4 +185,10 @@ public extension StorageType {
             deleteObject($0)
         }
     }
+
+    func deleteTaxRates(siteID: Int64) {
+        loadTaxRates(siteID: siteID).forEach {
+            deleteObject($0)
+        }
+    }
 }

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -453,8 +453,8 @@ public extension StorageType {
 
     /// Retrieves all of the stored TaxRates
     ///
-    func loadTaxRates() -> [TaxRate]? {
-        let predicate = NSPredicate()
+    func loadTaxRates(siteID: Int64) -> [TaxRate] {
+        let predicate = \TaxRate.siteID == siteID
         return allObjects(ofType: TaxRate.self, matching: predicate, sortedBy: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -145,7 +145,7 @@ struct OrderForm: View {
                                     shouldShowNewTaxRateSelector = true
                                 }
                                 .sheet(isPresented: $shouldShowNewTaxRateSelector) {
-                                    NewTaxRateSelectorView(viewModel: NewTaxRateSelectorViewModel(),
+                                    NewTaxRateSelectorView(viewModel: NewTaxRateSelectorViewModel(siteID: viewModel.siteID),
                                                            taxEducationalDialogViewModel: viewModel.paymentDataViewModel.taxEducationalDialogViewModel,
                                                            onDismissWpAdminWebView: viewModel.paymentDataViewModel.onDismissWpAdminWebViewClosure)
                                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -80,6 +80,7 @@ struct NewTaxRateSelectorView: View {
                 }
             }
             .onAppear {
+                // Even if we are calling this on appear (it might be called multiple times) the view model will only load the first it's called
                 viewModel.onLoadTriggerOnce.send()
             }
             .navigationTitle(Localization.navigationTitle)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -80,7 +80,7 @@ struct NewTaxRateSelectorView: View {
                 }
             }
             .onAppear {
-                viewModel.onLoadTrigger.send()
+                viewModel.onLoadTriggerOnce.send()
             }
             .navigationTitle(Localization.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -48,7 +48,7 @@ struct NewTaxRateSelectorView: View {
                                                       refreshAction: { completion in
                             viewModel.onRefreshAction(completion: completion)
                         }) {
-                            ForEach(viewModel.taxRateViewModels, id: \.name) { viewModel in
+                            ForEach(viewModel.taxRateViewModels, id: \.id) { viewModel in
                                 TaxRateRow(viewModel: viewModel)
                             }
                             .background(Color(.listForeground(modal: false)))
@@ -61,7 +61,7 @@ struct NewTaxRateSelectorView: View {
                     case .syncingFirstPage:
                         ScrollView {
                             LazyVStack(spacing: 0) {
-                                ForEach(viewModel.placeholderRowViewModels, id: \.name) { rowViewModel in
+                                ForEach(viewModel.placeholderRowViewModels, id: \.id) { rowViewModel in
                                     TaxRateRow(viewModel: rowViewModel)
                                         .redacted(reason: .placeholder)
                                         .shimmering()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -37,7 +37,7 @@ struct NewTaxRateSelectorView: View {
                     .footnoteStyle()
                     .multilineTextAlignment(.leading)
                     .padding([.leading, .trailing], Layout.generalPadding)
-                    .padding(.bottom, Layout.taxRatesSectionTitleBottomPadding)
+                    .padding([.top, .bottom], Layout.taxRatesSectionTitleVerticalPadding)
 
                 Divider()
 
@@ -50,6 +50,7 @@ struct NewTaxRateSelectorView: View {
                         }) {
                             ForEach(viewModel.taxRateViewModels, id: \.id) { viewModel in
                                 TaxRateRow(viewModel: viewModel)
+                                Divider()
                             }
                             .background(Color(.listForeground(modal: false)))
 
@@ -133,7 +134,7 @@ extension NewTaxRateSelectorView {
         static let generalPadding: CGFloat = 16
         static let explanatoryBoxHorizontalSpacing: CGFloat = 11
         static let explanatoryBoxCornerRadius: CGFloat = 8
-        static let taxRatesSectionTitleBottomPadding: CGFloat = 8
+        static let taxRatesSectionTitleVerticalPadding: CGFloat = 8
         static let editTaxRatesInWpAdminSectionTopPadding: CGFloat = 24
         static let editTaxRatesInWpAdminSectionVerticalSpacing: CGFloat = 8
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -43,11 +43,8 @@ struct NewTaxRateSelectorView: View {
 
                 switch viewModel.syncState {
                     case .results:
-                        RefreshableInfiniteScrollList(isLoading: viewModel.shouldShowBottomActivityIndicator,
-                                                      loadAction: viewModel.onLoadNextPageAction,
-                                                      refreshAction: { completion in
-                            viewModel.onRefreshAction(completion: completion)
-                        }) {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
                             ForEach(viewModel.taxRateViewModels, id: \.id) { viewModel in
                                 TaxRateRow(viewModel: viewModel)
                                 Divider()
@@ -55,8 +52,15 @@ struct NewTaxRateSelectorView: View {
                             .background(Color(.listForeground(modal: false)))
 
                             bottomNotice
-                            .renderedIf(!viewModel.shouldShowBottomActivityIndicator)
+                                .renderedIf(!viewModel.shouldShowBottomActivityIndicator)
+
+                            InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
+                                .padding(.top, Layout.generalPadding)
+                                .onAppear {
+                                    viewModel.onLoadNextPageAction()
+                                }
                         }
+                    }
                     case .empty:
                         EmptyState(title: "",
                                    description: "",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -52,6 +52,9 @@ struct NewTaxRateSelectorView: View {
                                 TaxRateRow(viewModel: viewModel)
                             }
                             .background(Color(.listForeground(modal: false)))
+
+                            bottomNotice
+                            .renderedIf(!viewModel.shouldShowBottomActivityIndicator)
                         }
                     case .empty:
                         EmptyState(title: "",
@@ -70,35 +73,6 @@ struct NewTaxRateSelectorView: View {
                         }
                         .background(Color(.listForeground(modal: false)))
                 }
-
-                Text(Localization.editTaxRatesInWpAdminSectionTitle)
-                    .foregroundColor(Color(.textSubtle))
-                    .footnoteStyle()
-                    .padding(.top, Layout.editTaxRatesInWpAdminSectionTopPadding)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding([.leading, .trailing], Layout.generalPadding)
-
-                Button(action: {
-                    showingWPAdminWebview = true
-                }) {
-                    HStack {
-                        Text(Localization.editTaxRatesInWpAdminButtonTitle)
-                            .fontWeight(.semibold)
-                            .font(.footnote)
-                            .foregroundColor(Color(.wooCommercePurple(.shade60)))
-
-                        Image(systemName: "arrow.up.forward.square")
-                    }
-                    .frame(maxWidth: .infinity, alignment: .center)
-                }
-                .padding(.top, Layout.editTaxRatesInWpAdminSectionVerticalSpacing)
-                .safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminTaxSettingsURL, onDismiss: {
-                    onDismissWpAdminWebView()
-                    showingWPAdminWebview = false
-                })
-
-                Spacer()
-
             }
             .onAppear {
                 viewModel.onLoadTrigger.send()
@@ -121,6 +95,36 @@ struct NewTaxRateSelectorView: View {
                 }
         }
         .wooNavigationBarStyle()
+    }
+
+    var bottomNotice: some View {
+        Group {
+            Text(Localization.editTaxRatesInWpAdminSectionTitle)
+                .foregroundColor(Color(.textSubtle))
+                .footnoteStyle()
+                .padding(.top, Layout.editTaxRatesInWpAdminSectionTopPadding)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding([.leading, .trailing], Layout.generalPadding)
+
+            Button(action: {
+                showingWPAdminWebview = true
+            }) {
+                HStack {
+                    Text(Localization.editTaxRatesInWpAdminButtonTitle)
+                        .fontWeight(.semibold)
+                        .font(.footnote)
+                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
+
+                    Image(systemName: "arrow.up.forward.square")
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .padding(.top, Layout.editTaxRatesInWpAdminSectionVerticalSpacing)
+            .safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminTaxSettingsURL, onDismiss: {
+                onDismissWpAdminWebView()
+                showingWPAdminWebview = false
+            })
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -51,7 +51,6 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
         wpAdminTaxSettingsURLProvider.provideWpAdminTaxSettingsURL()
     }
 
-    /// Inbox notes ResultsController.
     private lazy var resultsController: ResultsController<StorageTaxRate> = {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageTaxRate.id, ascending: true)
@@ -61,13 +60,10 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
         return resultsController
     }()
 
-    /// Called when the next page should be loaded.
     func onLoadNextPageAction() {
         paginationTracker.ensureNextPageIsSynced()
     }
 
-    /// Called when the user pulls down the list to refresh.
-    /// - Parameter completion: called when the refresh completes.
     func onRefreshAction(completion: @escaping () -> Void) {
         paginationTracker.resync(reason: nil) {
             completion()
@@ -148,14 +144,12 @@ private extension NewTaxRateSelectorViewModel {
 // MARK: - State Machine
 
 extension NewTaxRateSelectorViewModel {
-    /// Represents possible states for syncing inbox notes.
     enum SyncState: Equatable {
         case syncingFirstPage
         case results
         case empty
     }
 
-    /// Update states for sync from remote.
     func transitionToSyncingState() {
         shouldShowBottomActivityIndicator = true
         if taxRateViewModels.isEmpty {
@@ -163,7 +157,6 @@ extension NewTaxRateSelectorViewModel {
         }
     }
 
-    /// Update states after sync is complete.
     func transitionToResultsUpdatedState() {
         shouldShowBottomActivityIndicator = false
         syncState = taxRateViewModels.isNotEmpty ? .results: .empty

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -82,11 +82,11 @@ extension NewTaxRateSelectorViewModel: PaginationTrackerDelegate {
                 let hasNextPage = results.count == pageSize
                 onCompletion?(.success(hasNextPage))
 
-                if taxRateViewModels.isEmpty {
+                if self.taxRateViewModels.isEmpty {
                     self.syncState = .empty
                 } else if results.isEmpty {
                     // We had results previously, but we didn't have any on this page request. Transition to results to stop the syncing visuals.
-                    transitionToResultsUpdatedState()
+                    self.transitionToResultsUpdatedState()
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error synchronizing tax rates: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -82,12 +82,15 @@ extension NewTaxRateSelectorViewModel: PaginationTrackerDelegate {
         let action = TaxAction.retrieveTaxRates(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case .success:
-                let hasNextPage = taxRateViewModels.count == pageSize
+            case .success(let results):
+                let hasNextPage = results.count == pageSize
                 onCompletion?(.success(hasNextPage))
 
                 if taxRateViewModels.isEmpty {
                     self.syncState = .empty
+                } else if results.isEmpty {
+                    // We had results previously, but we didn't have any on this page request. Transition to results to stop the syncing visuals.
+                    transitionToResultsUpdatedState()
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error synchronizing tax rates: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -53,7 +53,7 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
 
     private lazy var resultsController: ResultsController<StorageTaxRate> = {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageTaxRate.id, ascending: true)
+        let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageTaxRate.order, ascending: true)
         let resultsController = ResultsController<StorageTaxRate>(storageManager: storageManager,
                                                                     matching: predicate,
                                                                     sortedBy: [ sortDescriptorByID])

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -1,24 +1,166 @@
 import Foundation
+import Yosemite
+import Combine
+import Storage
 
-struct NewTaxRateSelectorViewModel {
-    // Demo values. To be removed once we fetch the tax rates remotely
-    struct DemoTaxRate {
-        let title: String
-        let value: String
+final class NewTaxRateSelectorViewModel: ObservableObject {
+    private let wpAdminTaxSettingsURLProvider: WPAdminTaxSettingsURLProviderProtocol
+    private let stores: StoresManager
+    private let siteID: Int64
+    private var subscriptions = Set<AnyCancellable>()
+
+    /// Supports infinite scroll.
+    private let paginationTracker: PaginationTracker
+
+    /// Storage to fetch tax rates
+    private let storageManager: StorageManagerType
+
+    @Published private(set) var taxRateViewModels: [TaxRateViewModel] = []
+
+    /// Current sync status; used to determine the view state.
+    @Published private(set) var syncState: SyncState = .empty
+
+    /// Tracks if the infinite scroll indicator should be displayed.
+    @Published private(set) var shouldShowBottomActivityIndicator = false
+
+    /// Trigger to perform any one time setups.
+    let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
+
+    /// View models for placeholder rows.
+    let placeholderRowViewModels: [TaxRateViewModel] = [Int64](0..<3).map { index in
+        TaxRateViewModel(name: "placeholder-" + String(index), rate: "   ")
     }
 
-    let demoTaxRates: [DemoTaxRate] = [DemoTaxRate(title: "Government Sales Tax · US CA 94016 San Francisco", value: "10%"),
-                                       DemoTaxRate(title: "GST · US CA", value: "10%"),
-                                       DemoTaxRate(title: "GST · AU", value: "10%")]
-
-    private let wpAdminTaxSettingsURLProvider: WPAdminTaxSettingsURLProviderProtocol
-
-    init(wpAdminTaxSettingsURLProvider: WPAdminTaxSettingsURLProviderProtocol = WPAdminTaxSettingsURLProvider()) {
+    init(siteID: Int64,
+         wpAdminTaxSettingsURLProvider: WPAdminTaxSettingsURLProviderProtocol = WPAdminTaxSettingsURLProvider(),
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.siteID = siteID
         self.wpAdminTaxSettingsURLProvider = wpAdminTaxSettingsURLProvider
+        self.stores = stores
+        self.storageManager = storageManager
+        self.paginationTracker = PaginationTracker(pageFirstIndex: 1, pageSize: 25)
+
+        configureResultsController()
+        configurePaginationTracker()
+        configureFirstPageLoad()
     }
 
     /// WPAdmin URL to navigate user to edit the tax settings
     var wpAdminTaxSettingsURL: URL? {
         wpAdminTaxSettingsURLProvider.provideWpAdminTaxSettingsURL()
+    }
+
+    /// Inbox notes ResultsController.
+    private lazy var resultsController: ResultsController<StorageTaxRate> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageTaxRate.id, ascending: true)
+        let resultsController = ResultsController<StorageTaxRate>(storageManager: storageManager,
+                                                                    matching: predicate,
+                                                                    sortedBy: [ sortDescriptorByID])
+        return resultsController
+    }()
+
+    /// Called when the next page should be loaded.
+    func onLoadNextPageAction() {
+        paginationTracker.ensureNextPageIsSynced()
+    }
+
+    /// Called when the user pulls down the list to refresh.
+    /// - Parameter completion: called when the refresh completes.
+    func onRefreshAction(completion: @escaping () -> Void) {
+        paginationTracker.resync(reason: nil) {
+            completion()
+        }
+    }
+}
+
+extension NewTaxRateSelectorViewModel: PaginationTrackerDelegate {
+    func sync(pageNumber: Int, pageSize: Int, reason: String?, onCompletion: SyncCompletion?) {
+        transitionToSyncingState()
+
+        let action = TaxAction.retrieveTaxRates(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success:
+                let hasNextPage = taxRateViewModels.count == pageSize
+                onCompletion?(.success(hasNextPage))
+
+                if taxRateViewModels.isEmpty {
+                    self.syncState = .empty
+                }
+            case .failure(let error):
+                DDLogError("⛔️ Error synchronizing tax rates: \(error)")
+                onCompletion?(.failure(error))
+            }
+        }
+        stores.dispatch(action)
+    }
+}
+
+private extension NewTaxRateSelectorViewModel {
+    func configurePaginationTracker() {
+        paginationTracker.delegate = self
+    }
+
+    func configureFirstPageLoad() {
+        // Listens only to the first emitted event.
+        onLoadTrigger.first()
+            .sink { [weak self] in
+                guard let self = self else { return }
+                self.syncFirstPage()
+            }
+            .store(in: &subscriptions)
+    }
+
+    /// Performs initial fetch from storage and updates results.
+    func configureResultsController() {
+        resultsController.onDidChangeContent = { [weak self] in
+            self?.updateResults()
+        }
+        resultsController.onDidResetContent = { [weak self] in
+            self?.updateResults()
+        }
+
+        do {
+            try resultsController.performFetch()
+        } catch {
+            ServiceLocator.crashLogging.logError(error)
+        }
+    }
+
+    /// Updates row view models and sync state.
+    func updateResults() {
+        taxRateViewModels = resultsController.fetchedObjects.map { TaxRateViewModel(name: $0.name, rate: $0.rate) }
+        transitionToResultsUpdatedState()
+    }
+
+    func syncFirstPage() {
+        paginationTracker.syncFirstPage()
+    }
+}
+
+// MARK: - State Machine
+
+extension NewTaxRateSelectorViewModel {
+    /// Represents possible states for syncing inbox notes.
+    enum SyncState: Equatable {
+        case syncingFirstPage
+        case results
+        case empty
+    }
+
+    /// Update states for sync from remote.
+    func transitionToSyncingState() {
+        shouldShowBottomActivityIndicator = true
+        if taxRateViewModels.isEmpty {
+            syncState = .syncingFirstPage
+        }
+    }
+
+    /// Update states after sync is complete.
+    func transitionToResultsUpdatedState() {
+        shouldShowBottomActivityIndicator = false
+        syncState = taxRateViewModels.isNotEmpty ? .results: .empty
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -28,7 +28,7 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
 
     /// View models for placeholder rows.
     let placeholderRowViewModels: [TaxRateViewModel] = [Int64](0..<3).map { index in
-        TaxRateViewModel(name: "placeholder-" + String(index), rate: "   ")
+        TaxRateViewModel(id: index, name: "placeholder", rate: "10%")
     }
 
     init(siteID: Int64,
@@ -131,7 +131,7 @@ private extension NewTaxRateSelectorViewModel {
 
     /// Updates row view models and sync state.
     func updateResults() {
-        taxRateViewModels = resultsController.fetchedObjects.map { TaxRateViewModel(name: $0.name, rate: $0.rate) }
+        taxRateViewModels = resultsController.fetchedObjects.map { TaxRateViewModel(id: $0.id, name: $0.name, rate: $0.rate) }
         transitionToResultsUpdatedState()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -63,12 +63,6 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     func onLoadNextPageAction() {
         paginationTracker.ensureNextPageIsSynced()
     }
-
-    func onRefreshAction(completion: @escaping () -> Void) {
-        paginationTracker.resync(reason: nil) {
-            completion()
-        }
-    }
 }
 
 extension NewTaxRateSelectorViewModel: PaginationTrackerDelegate {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -26,7 +26,7 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     /// Trigger to perform any one time setups.
     let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
 
-    /// View models for placeholder rows.
+    /// View models for placeholder rows. Strings are visible to the user as it is shimmering (loading)
     let placeholderRowViewModels: [TaxRateViewModel] = [Int64](0..<3).map { index in
         TaxRateViewModel(id: index, name: "placeholder", rate: "10%")
     }
@@ -134,7 +134,9 @@ private extension NewTaxRateSelectorViewModel {
 
     /// Updates row view models and sync state.
     func updateResults() {
-        taxRateViewModels = resultsController.fetchedObjects.map { TaxRateViewModel(id: $0.id, name: $0.name, rate: $0.rate) }
+        taxRateViewModels = resultsController.fetchedObjects.map {
+            TaxRateViewModel(id: $0.id, name: $0.name, rate: Double($0.rate)?.percentFormatted() ?? "")
+        }
         transitionToResultsUpdatedState()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -24,7 +24,7 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     @Published private(set) var shouldShowBottomActivityIndicator = false
 
     /// Trigger to perform any one time setups.
-    let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
+    let onLoadTriggerOnce: PassthroughSubject<Void, Never> = PassthroughSubject()
 
     /// View models for placeholder rows. Strings are visible to the user as it is shimmering (loading)
     let placeholderRowViewModels: [TaxRateViewModel] = [Int64](0..<3).map { index in
@@ -98,7 +98,7 @@ private extension NewTaxRateSelectorViewModel {
 
     func configureFirstPageLoad() {
         // Listens only to the first emitted event.
-        onLoadTrigger.first()
+        onLoadTriggerOnce.first()
             .sink { [weak self] in
                 guard let self = self else { return }
                 self.syncFirstPage()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -28,7 +28,7 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
 
     /// View models for placeholder rows. Strings are visible to the user as it is shimmering (loading)
     let placeholderRowViewModels: [TaxRateViewModel] = [Int64](0..<3).map { index in
-        TaxRateViewModel(id: index, name: "placeholder", rate: "10%")
+        TaxRateViewModel(id: index, title: "placeholder", rate: "10%")
     }
 
     init(siteID: Int64,
@@ -125,7 +125,14 @@ private extension NewTaxRateSelectorViewModel {
     /// Updates row view models and sync state.
     func updateResults() {
         taxRateViewModels = resultsController.fetchedObjects.map {
-            TaxRateViewModel(id: $0.id, name: $0.name, rate: Double($0.rate)?.percentFormatted() ?? "")
+            var title = $0.name
+            let titleSuffix = "\($0.country) \($0.state) \($0.postcodes.joined(separator: ",")) \($0.cities.joined(separator: ","))"
+
+            if titleSuffix.trimmingCharacters(in: .whitespaces).isNotEmpty {
+                title.append(" • \(titleSuffix)")
+            }
+
+            return TaxRateViewModel(id: $0.id, title: title, rate: Double($0.rate)?.percentFormatted() ?? "")
         }
         transitionToResultsUpdatedState()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct TaxRateRow: View {
+    let viewModel: TaxRateViewModel
+
+    var body: some View {
+        HStack {
+            Button(action: { }) {
+                AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.generalPadding) {
+                    Text(viewModel.name)
+                        .foregroundColor(Color(.text))
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Text(viewModel.rate)
+                        .foregroundColor(Color(.text))
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: nil, alignment: .trailing)
+
+                    Image(systemName: "chevron.right")
+                        .font(.body)
+                        .font(Font.title.weight(.semibold))
+                        .foregroundColor(Color(.textTertiary))
+                        .padding(.leading, Layout.generalPadding)
+                }
+                .padding(Layout.generalPadding)
+            }
+        }
+    }
+}
+
+extension TaxRateRow {
+    enum Layout {
+        static let generalPadding: CGFloat = 16
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
@@ -7,7 +7,7 @@ struct TaxRateRow: View {
         HStack {
             Button(action: { }) {
                 AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.generalPadding) {
-                    Text(viewModel.name)
+                    Text(viewModel.title)
                         .foregroundColor(Color(.text))
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateViewModel.swift
@@ -1,5 +1,5 @@
 struct TaxRateViewModel {
     let id: Int64
-    let name: String
+    let title: String
     let rate: String
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateViewModel.swift
@@ -1,4 +1,5 @@
 struct TaxRateViewModel {
+    let id: Int64
     let name: String
     let rate: String
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateViewModel.swift
@@ -1,0 +1,4 @@
+struct TaxRateViewModel {
+    let name: String
+    let rate: String
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1630,6 +1630,8 @@
 		B92FF9AE27FC7217005C34E3 /* OrderListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B92FF9AD27FC7217005C34E3 /* OrderListViewController.xib */; };
 		B92FF9B027FC7821005C34E3 /* ProductsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B92FF9AF27FC7821005C34E3 /* ProductsViewController.xib */; };
 		B932847429A8D6E600B01251 /* CardPresentPaymentsOnboardingIPPUsersRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B932847329A8D6E600B01251 /* CardPresentPaymentsOnboardingIPPUsersRefresher.swift */; };
+		B933CCB02AA6220E00938F3F /* TaxRateRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B933CCAF2AA6220E00938F3F /* TaxRateRow.swift */; };
+		B933CCB22AA622AE00938F3F /* TaxRateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B933CCB12AA622AE00938F3F /* TaxRateViewModel.swift */; };
 		B935D3592A9F44000067B927 /* NewTaxRateSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B935D3582A9F44000067B927 /* NewTaxRateSelectorViewModel.swift */; };
 		B935D35C2A9F44C60067B927 /* WPAdminTaxSettingsURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B935D35B2A9F44C60067B927 /* WPAdminTaxSettingsURLProvider.swift */; };
 		B935D35F2A9F4EDA0067B927 /* WPAdminTaxSettingsURLProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B935D35E2A9F4EDA0067B927 /* WPAdminTaxSettingsURLProviderTests.swift */; };
@@ -4077,6 +4079,8 @@
 		B92FF9AD27FC7217005C34E3 /* OrderListViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderListViewController.xib; sourceTree = "<group>"; };
 		B92FF9AF27FC7821005C34E3 /* ProductsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductsViewController.xib; sourceTree = "<group>"; };
 		B932847329A8D6E600B01251 /* CardPresentPaymentsOnboardingIPPUsersRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresher.swift; sourceTree = "<group>"; };
+		B933CCAF2AA6220E00938F3F /* TaxRateRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRateRow.swift; sourceTree = "<group>"; };
+		B933CCB12AA622AE00938F3F /* TaxRateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRateViewModel.swift; sourceTree = "<group>"; };
 		B935D3582A9F44000067B927 /* NewTaxRateSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTaxRateSelectorViewModel.swift; sourceTree = "<group>"; };
 		B935D35B2A9F44C60067B927 /* WPAdminTaxSettingsURLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAdminTaxSettingsURLProvider.swift; sourceTree = "<group>"; };
 		B935D35E2A9F4EDA0067B927 /* WPAdminTaxSettingsURLProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAdminTaxSettingsURLProviderTests.swift; sourceTree = "<group>"; };
@@ -8866,6 +8870,8 @@
 				B935D3582A9F44000067B927 /* NewTaxRateSelectorViewModel.swift */,
 				B90DDF7B2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift */,
 				B935D35B2A9F44C60067B927 /* WPAdminTaxSettingsURLProvider.swift */,
+				B933CCAF2AA6220E00938F3F /* TaxRateRow.swift */,
+				B933CCB12AA622AE00938F3F /* TaxRateViewModel.swift */,
 			);
 			path = Taxes;
 			sourceTree = "<group>";
@@ -12891,6 +12897,7 @@
 				740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */,
 				B93E03262A94EE63009CA9C1 /* TaxLineViewModel.swift in Sources */,
 				DEC0293A29C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift in Sources */,
+				B933CCB22AA622AE00938F3F /* TaxRateViewModel.swift in Sources */,
 				03191AE628E1DF0600670723 /* WooCommercePluginViewModel.swift in Sources */,
 				CE22709F2293052700C0626C /* WebviewHelper.swift in Sources */,
 				02BA12852461674B008D8325 /* Optional+String.swift in Sources */,
@@ -13031,6 +13038,7 @@
 				4520A15C2721B2A9001FA573 /* FilterOrderListViewModel.swift in Sources */,
 				D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */,
 				B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */,
+				B933CCB02AA6220E00938F3F /* TaxRateRow.swift in Sources */,
 				57532CAC24BFF4DA0032B84E /* MessageComposerPresenter.swift in Sources */,
 				DE4D23AE29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift in Sources */,
 				0270F47824D006F60005210A /* ProductFormPresentationStyle.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
@@ -7,7 +7,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         let wpAdminTaxSettingsURL = URL(string: "https://www.site.com/wp-admin/mock-taxes-settings")
         let wpAdminTaxSettingsURLProvider = MockWPAdminTaxSettingsURLProvider(wpAdminTaxSettingsURL: wpAdminTaxSettingsURL)
 
-        let viewModel = NewTaxRateSelectorViewModel(wpAdminTaxSettingsURLProvider: wpAdminTaxSettingsURLProvider)
+        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, wpAdminTaxSettingsURLProvider: wpAdminTaxSettingsURLProvider)
 
         XCTAssertEqual(viewModel.wpAdminTaxSettingsURL, wpAdminTaxSettingsURL)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
@@ -34,35 +34,11 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         XCTAssertTrue(retrieveTaxRatesIsCalled)
     }
 
-    func test_onRefreshAction_then_resyncs_the_first_page() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        var pageNumberCalled = -1
-        stores.whenReceivingAction(ofType: TaxAction.self) { action in
-            guard case let .retrieveTaxRates(_, pageNumber, _, completion) = action else {
-                return
-            }
-            pageNumberCalled = pageNumber
-            completion(.success([]))
-        }
-        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, stores: stores)
-
-        // When
-        waitFor { promise in
-            viewModel.onRefreshAction {
-                promise(())
-            }
-        }
-
-        // Then
-        XCTAssertEqual(pageNumberCalled, 1)
-    }
-
     func test_taxRateViewModels_match_loaded_tax_rates() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storageManager = MockStorageManager()
-        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate")
+        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
         stores.whenReceivingAction(ofType: TaxAction.self) { action in
             guard case let .retrieveTaxRates(_, _, _, completion) = action else {
                 return
@@ -80,8 +56,10 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         viewModel.onLoadTriggerOnce.send()
 
         // Then
+        let expectedTitle = "\(taxRate.name) • \(taxRate.country) \(taxRate.state) " +
+        "\(taxRate.postcodes.joined(separator: ",")) \(taxRate.cities.joined(separator: ","))"
         XCTAssertEqual(viewModel.taxRateViewModels.first?.id, taxRate.id)
-        XCTAssertEqual(viewModel.taxRateViewModels.first?.name, taxRate.name)
+        XCTAssertEqual(viewModel.taxRateViewModels.first?.title, expectedTitle)
         XCTAssertEqual(viewModel.taxRateViewModels.first?.rate, Double(taxRate.rate)?.percentFormatted() ?? "")
         XCTAssertEqual(viewModel.taxRateViewModels.first?.id, taxRate.id)
         XCTAssertEqual(viewModel.taxRateViewModels.count, 1)
@@ -91,25 +69,22 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         var retrieveTaxRatesCallCount = 0
+        let pageSize = 25
+        let firstPageTaxRates = [TaxRate](repeating: .fake().copy(siteID: sampleSiteID), count: pageSize)
+
         stores.whenReceivingAction(ofType: TaxAction.self) { action in
             guard case let .retrieveTaxRates(_, _, _, completion) = action else {
                 return
             }
             retrieveTaxRatesCallCount += 1
-            completion(.success([]))
+
+            completion(.success(firstPageTaxRates))
         }
         let viewModel = NewTaxRateSelectorViewModel(siteID: 1, stores: stores)
 
         // When
-        waitFor { promise in
-            viewModel.onRefreshAction {
-                promise(())
-            }
-        }
-
         viewModel.onLoadTriggerOnce.send()
         viewModel.onLoadNextPageAction()
-
         // Then
         XCTAssertEqual(retrieveTaxRatesCallCount, 2)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
@@ -28,7 +28,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, stores: stores)
 
         // When
-        viewModel.onLoadTrigger.send()
+        viewModel.onLoadTriggerOnce.send()
 
         // Then
         XCTAssertTrue(retrieveTaxRatesIsCalled)
@@ -77,7 +77,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
 
         // When
-        viewModel.onLoadTrigger.send()
+        viewModel.onLoadTriggerOnce.send()
 
         // Then
         XCTAssertEqual(viewModel.taxRateViewModels.first?.id, taxRate.id)
@@ -107,7 +107,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
             }
         }
 
-        viewModel.onLoadTrigger.send()
+        viewModel.onLoadTriggerOnce.send()
         viewModel.onLoadNextPageAction()
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
@@ -1,7 +1,10 @@
 import XCTest
+import Yosemite
 @testable import WooCommerce
 
 final class NewTaxRateSelectorViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 322
+
     func test_wpAdminTaxSettingsURL_passes_right_url() {
         // Given
         let wpAdminTaxSettingsURL = URL(string: "https://www.site.com/wp-admin/mock-taxes-settings")
@@ -10,5 +13,104 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         let viewModel = NewTaxRateSelectorViewModel(siteID: 1, wpAdminTaxSettingsURLProvider: wpAdminTaxSettingsURLProvider)
 
         XCTAssertEqual(viewModel.wpAdminTaxSettingsURL, wpAdminTaxSettingsURL)
+    }
+
+    func test_onLoadTrigger_then_calls_to_retrieveTaxRates() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var retrieveTaxRatesIsCalled = false
+        stores.whenReceivingAction(ofType: TaxAction.self) { action in
+            guard case .retrieveTaxRates = action else {
+                return
+            }
+            retrieveTaxRatesIsCalled = true
+        }
+        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertTrue(retrieveTaxRatesIsCalled)
+    }
+
+    func test_onRefreshAction_then_resyncs_the_first_page() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var pageNumberCalled = -1
+        stores.whenReceivingAction(ofType: TaxAction.self) { action in
+            guard case let .retrieveTaxRates(_, pageNumber, _, completion) = action else {
+                return
+            }
+            pageNumberCalled = pageNumber
+            completion(.success([]))
+        }
+        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, stores: stores)
+
+        // When
+        waitFor { promise in
+            viewModel.onRefreshAction {
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertEqual(pageNumberCalled, 1)
+    }
+
+    func test_taxRateViewModels_match_loaded_tax_rates() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storageManager = MockStorageManager()
+        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate")
+        stores.whenReceivingAction(ofType: TaxAction.self) { action in
+            guard case let .retrieveTaxRates(_, _, _, completion) = action else {
+                return
+            }
+
+            let newTaxRate = storageManager.viewStorage.insertNewObject(ofType: StorageTaxRate.self)
+            newTaxRate.update(with: taxRate)
+            storageManager.viewStorage.saveIfNeeded()
+            completion(.success([taxRate]))
+        }
+
+        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+
+        // When
+        viewModel.onLoadTrigger.send()
+
+        // Then
+        XCTAssertEqual(viewModel.taxRateViewModels.first?.id, taxRate.id)
+        XCTAssertEqual(viewModel.taxRateViewModels.first?.name, taxRate.name)
+        XCTAssertEqual(viewModel.taxRateViewModels.first?.rate, Double(taxRate.rate)?.percentFormatted() ?? "")
+        XCTAssertEqual(viewModel.taxRateViewModels.first?.id, taxRate.id)
+        XCTAssertEqual(viewModel.taxRateViewModels.count, 1)
+    }
+
+    func test_onLoadNextPageAction_loads_next_page() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var retrieveTaxRatesCallCount = 0
+        stores.whenReceivingAction(ofType: TaxAction.self) { action in
+            guard case let .retrieveTaxRates(_, _, _, completion) = action else {
+                return
+            }
+            retrieveTaxRatesCallCount += 1
+            completion(.success([]))
+        }
+        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, stores: stores)
+
+        // When
+        waitFor { promise in
+            viewModel.onRefreshAction {
+                promise(())
+            }
+        }
+
+        viewModel.onLoadTrigger.send()
+        viewModel.onLoadNextPageAction()
+
+        // Then
+        XCTAssertEqual(retrieveTaxRatesCallCount, 2)
     }
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -257,6 +257,7 @@ public typealias StorageSystemPlugin = Storage.SystemPlugin
 public typealias StorageTopEarnerStats = Storage.TopEarnerStats
 public typealias StorageTopEarnerStatsItem = Storage.TopEarnerStatsItem
 public typealias StorageTaxClass = Storage.TaxClass
+public typealias StorageTaxRate = Storage.TaxRate
 public typealias StorageWCPayCharge = Storage.WCPayCharge
 public typealias FeatureAnnouncementCampaign = Storage.FeatureAnnouncementCampaign
 public typealias FeatureAnnouncementCampaignSettings = Storage.FeatureAnnouncementCampaignSettings

--- a/Yosemite/Yosemite/Model/Storage/TaxRate+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TaxRate+ReadOnlyConvertible.swift
@@ -27,20 +27,20 @@ extension Storage.TaxRate: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.TaxRate {
-        return TaxRate(id: id,
-                       siteID: siteID,
-                       name: name ?? "",
-                       country: country ?? "",
-                       state: state ?? "",
-                       postcode: postcode ?? "",
-                       postcodes: postcodes as? [String] ?? [],
-                       priority: priority,
-                       rate: rate ?? "",
-                       order: order,
-                       taxRateClass: taxRateClass ?? "",
-                       shipping: shipping,
-                       compound: compound,
-                       city: city ?? "",
-                       cities: cities as? [String] ?? [])
+        .init(id: id,
+              siteID: siteID,
+              name: name ?? "",
+              country: country ?? "",
+              state: state ?? "",
+              postcode: postcode ?? "",
+              postcodes: postcodes as? [String] ?? [],
+              priority: priority,
+              rate: rate ?? "",
+              order: order,
+              taxRateClass: taxRateClass ?? "",
+              shipping: shipping,
+              compound: compound,
+              city: city ?? "",
+              cities: cities as? [String] ?? [])
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/TaxRate+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TaxRate+ReadOnlyConvertible.swift
@@ -9,6 +9,7 @@ extension Storage.TaxRate: ReadOnlyConvertible {
     ///
     public func update(with taxRate: Yosemite.TaxRate) {
         id = taxRate.id
+        siteID = taxRate.siteID
         country = taxRate.country
         state = taxRate.state
         postcode = taxRate.postcode

--- a/Yosemite/Yosemite/Stores/TaxStore.swift
+++ b/Yosemite/Yosemite/Stores/TaxStore.swift
@@ -158,7 +158,10 @@ private extension TaxStore {
     /// Updates (OR Inserts) the specified ReadOnly TaxRate Entities *in a background thread*. onCompletion will be called
     /// on the main thread!
     ///
-    func upsertStoredTaxRatesInBackground(readOnlyTaxRates: [Networking.TaxRate], siteID: Int64, shouldDeleteExistingTaxRates: Bool, onCompletion: @escaping () -> Void) {
+    func upsertStoredTaxRatesInBackground(readOnlyTaxRates: [Networking.TaxRate],
+                                          siteID: Int64,
+                                          shouldDeleteExistingTaxRates: Bool,
+                                          onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform { [weak self] in
             guard let self = self else { return }

--- a/Yosemite/Yosemite/Stores/TaxStore.swift
+++ b/Yosemite/Yosemite/Stores/TaxStore.swift
@@ -155,12 +155,13 @@ private extension TaxStore {
 //
 private extension TaxStore {
 
-    /// Updates (OR Inserts) the specified ReadOnly TaxClass Entities *in a background thread*. onCompletion will be called
+    /// Updates (OR Inserts) the specified ReadOnly TaxRate Entities *in a background thread*. onCompletion will be called
     /// on the main thread!
     ///
     func upsertStoredTaxRatesInBackground(readOnlyTaxRates: [Networking.TaxRate], siteID: Int64, onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
+            derivedStorage.deleteTaxRates(siteID: siteID)
             self.upsertStoredTaxRates(readOnlyTaxRates: readOnlyTaxRates, siteID: siteID, in: derivedStorage)
         }
 
@@ -183,10 +184,12 @@ private extension TaxStore {
                                                          id: readOnlyTaxRate.id) {
                     return storedTaxRate
                 }
+
                 return storage.insertNewObject(ofType: Storage.TaxRate.self)
             }()
 
             storageTaxRate.update(with: readOnlyTaxRate)
+            storageTaxRate.siteID = siteID
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10612 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the UI population with the fetch tax rates. We also added pagination to the view and the logic to show the bottom notice when all pages are loaded. Furthermore, we tweaked the UI to add some missing parts and extract some views to their own structs.  Apart from that, we fixed some elements in Yosemite and Networking to ensure the right functioning of this feature.
Please note that the empty state is not implemented in this PR to avoid making it even bigger. It will be part of one of the next PRs once the design is finalized.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With a store with tax rates (please let me know if you want to use one with many tax rates added)

1. Go to Orders
2. Tap on + to create a new order
3. Tap on Set New Tax Rate
4. Make sure that pagination and pull to refresh work fine. Please also check that the _Edit Tax Rates in Admin_ notice is shown at the bottom

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Many Pages

https://github.com/woocommerce/woocommerce-ios/assets/1864060/6fb83be4-8744-4a7e-a8cc-8fd09605d8d4

### One page

https://github.com/woocommerce/woocommerce-ios/assets/1864060/8a160c7b-6305-492c-94db-80cfc043918c

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
