### PR TITLE
[Hazmat Shipping] Map Shipping Hazmat value to network layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1487,6 +1487,7 @@ extension Networking.ShippingLabelPackageSelected {
             height: .fake(),
             weight: .fake(),
             isLetter: .fake(),
+            hazmatCategory: .fake(),
             customsForm: .fake()
         )
     }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -12,6 +12,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
     public let height: Double
     public let weight: Double
     public let isLetter: Bool
+    public let hazmat: String
     public let customsForm: ShippingLabelCustomsForm?
 
     public init(id: String,
@@ -21,6 +22,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
                 height: Double,
                 weight: Double,
                 isLetter: Bool,
+                hazmat: String,
                 customsForm: ShippingLabelCustomsForm?) {
         self.id = id
         self.boxID = boxID
@@ -29,6 +31,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
         self.height = height
         self.weight = weight
         self.isLetter = isLetter
+        self.hazmat = hazmat
         self.customsForm = customsForm
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -12,7 +12,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
     public let height: Double
     public let weight: Double
     public let isLetter: Bool
-    public let hazmat: String
+    public let hazmatCategory: String?
     public let customsForm: ShippingLabelCustomsForm?
 
     public init(id: String,
@@ -22,7 +22,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
                 height: Double,
                 weight: Double,
                 isLetter: Bool,
-                hazmat: String,
+                hazmatCategory: String,
                 customsForm: ShippingLabelCustomsForm?) {
         self.id = id
         self.boxID = boxID
@@ -31,7 +31,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
         self.height = height
         self.weight = weight
         self.isLetter = isLetter
-        self.hazmat = hazmat
+        self.hazmatCategory = hazmatCategory.isEmpty ? nil : hazmatCategory
         self.customsForm = customsForm
     }
 }
@@ -49,6 +49,7 @@ extension ShippingLabelPackageSelected: Encodable {
         try container.encode(height, forKey: .height)
         try container.encode(weight, forKey: .weight)
         try container.encode(isLetter, forKey: .isLetter)
+        try container.encode(hazmatCategory, forKey: .hazmatCategory)
         if let form = customsForm {
             try container.encode(form.contentsType.rawValue, forKey: .contentsType)
             try container.encode(form.contentExplanation, forKey: .contentsExplanation)
@@ -73,6 +74,7 @@ extension ShippingLabelPackageSelected: Encodable {
         case restrictionType = "restriction_type"
         case restrictionComments = "restriction_comments"
         case nonDeliveryOption = "non_delivery_option"
+        case hazmatCategory = "hazmat"
         case itn
         case items
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
@@ -26,7 +26,7 @@ enum ShippingLabelHazmatCategory: String, CaseIterable {
     case groundOnly = "GROUND_ONLY"
     case id8000 = "ID8000"
     case lighters = "LIGHTERS"
-    case limitedQuantity = ""
+    case limitedQuantity = "LIMITED_QUANTITY"
     case smallQuantityProvision = "SMALL_QUANTITY_PROVISION"
 
     var localizedName: String {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
@@ -2,32 +2,32 @@ import Foundation
 
 enum ShippingLabelHazmatCategory: String, CaseIterable {
     case none
-    case airEligibleEthanol
-    case class1
-    case class3
-    case class4
-    case class5
-    case class6
-    case class7
-    case class8Corrosive
-    case class8WetBattery
-    case class9NewLithiumIndividual
-    case class9UsedLithium
-    case class9newLithiumDevice
-    case class9DryIce
-    case class9UnmarkedLithium
-    case class9Magnitized
-    case division41
-    case division51
-    case division52
-    case division61
-    case division62
-    case exceptedQuantityProvision
-    case groundOnly
-    case id8000
-    case lighters
-    case limitedQuantity
-    case smallQuantityProvision
+    case airEligibleEthanol = "AIR_ELIGIBLE_ETHANOL"
+    case class1 = "CLASS_1"
+    case class3 = "CLASS_3"
+    case class4 = "CLASS_4"
+    case class5 = "CLASS_5"
+    case class6 = "CLASS_6"
+    case class7 = "CLASS_7"
+    case class8Corrosive = "CLASS_8_CORROSIVE"
+    case class8WetBattery = "CLASS_8_WET_BATTERY"
+    case class9NewLithiumIndividual = "CLASS_9_NEW_LITHIUM_INDIVIDUAL"
+    case class9UsedLithium = "CLASS_9_USED_LITHIUM"
+    case class9newLithiumDevice = "CLASS_9_NEW_LITHIUM_DEVICE"
+    case class9DryIce = "CLASS_9_DRY_ICE"
+    case class9UnmarkedLithium = "CLASS_9_UNMARKED_LITHIUM"
+    case class9Magnitized = "CLASS_9_MAGNETIZED"
+    case division41 = "DIVISION_4_1"
+    case division51 = "DIVISION_5_1"
+    case division52 = "DIVISION_5_2"
+    case division61 = "DIVISION_6_1"
+    case division62 = "DIVISION_6_2"
+    case exceptedQuantityProvision = "EXCEPTED_QUANTITY_PROVISION"
+    case groundOnly = "GROUND_ONLY"
+    case id8000 = "ID8000"
+    case lighters = "LIGHTERS"
+    case limitedQuantity = ""
+    case smallQuantityProvision = "SMALL_QUANTITY_PROVISION"
 
     var localizedName: String {
         switch self {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -73,6 +73,7 @@ final class ShippingLabelFormViewModel {
                                                     height: customPackage.getHeight(),
                                                     weight: weight,
                                                     isLetter: customPackage.isLetter,
+                                                    hazmat: package.selectedHazmatCategory.rawValue,
                                                     customsForm: customsForm)
             }
 
@@ -86,6 +87,7 @@ final class ShippingLabelFormViewModel {
                                                         height: predefinedPackage.getHeight(),
                                                         weight: weight,
                                                         isLetter: predefinedPackage.isLetter,
+                                                        hazmat: package.selectedHazmatCategory.rawValue,
                                                         customsForm: customsForm)
                 }
             }
@@ -98,6 +100,7 @@ final class ShippingLabelFormViewModel {
                                                     height: Double(item.dimensions.height) ?? 0,
                                                     weight: item.weight,
                                                     isLetter: false,
+                                                    hazmat: package.selectedHazmatCategory.rawValue,
                                                     customsForm: customsForm)
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -73,7 +73,7 @@ final class ShippingLabelFormViewModel {
                                                     height: customPackage.getHeight(),
                                                     weight: weight,
                                                     isLetter: customPackage.isLetter,
-                                                    hazmat: package.selectedHazmatCategory.rawValue,
+                                                    hazmatCategory: package.selectedHazmatCategory.rawValue,
                                                     customsForm: customsForm)
             }
 
@@ -87,7 +87,7 @@ final class ShippingLabelFormViewModel {
                                                         height: predefinedPackage.getHeight(),
                                                         weight: weight,
                                                         isLetter: predefinedPackage.isLetter,
-                                                        hazmat: package.selectedHazmatCategory.rawValue,
+                                                        hazmatCategory: package.selectedHazmatCategory.rawValue,
                                                         customsForm: customsForm)
                 }
             }
@@ -100,7 +100,7 @@ final class ShippingLabelFormViewModel {
                                                     height: Double(item.dimensions.height) ?? 0,
                                                     weight: item.weight,
                                                     isLetter: false,
-                                                    hazmat: package.selectedHazmatCategory.rawValue,
+                                                    hazmatCategory: package.selectedHazmatCategory.rawValue,
                                                     customsForm: customsForm)
             }
 


### PR DESCRIPTION
Closes #10605 

Why
==========
Effectively connects the Hazmat UI work with the network layer, making possible to submit a shipping label with hazmat instructions.

### ⚠️ Testing the shipping label creation can be tricky, in case you don't have a store configuration with the staging scenario for the shipping label creation flow, proceed with the instructions in `PbTz5e-11v` or contact me in slack.

How
==========
From https://github.com/woocommerce/woocommerce-ios/pull/10617, the ShippingLabel Form is now aware when a package contains hazmat content or not. This PR simply maps the hazmat value to the network layer so it's included in the Shipping Label rates and purchase requests.

Captures
==========
https://github.com/woocommerce/woocommerce-ios/assets/5920403/9f1915e5-3804-4f1a-89f2-756b591dca86

How to Test
==========
1. Open the order details of an order eligible for Shipping label creation
2. Start the shipping label creation flow with valid US address options until you reach the Package details section
3. Inside the package details view, make sure the Contains hazardous materials toggle is visible and interactable
4. Make sure the toggle expands and collapses a basic view that will serve as the main control options for the HAZMAT declaration
5. Select a hazmat option, make sure the Package Details are complete
6. Continue to the shipping rates calculation displays a USPS option, select that one and create the Shipping Label
7. Verify that the shipping label contains the `HAZMAT` info in the bottom section

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.