### PR TITLE
Refactor media export interface from completion block to async/await

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 15.3
 -----
-
+- [Internal] Some internal changes were made to the image upload feature to support image processing in the app, no app changes are expected. [https://github.com/woocommerce/woocommerce-ios/pull/10631]
 
 15.2
 -----

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -92,17 +92,17 @@ private extension MediaStore {
                      productID: Int64,
                      mediaAsset: ExportableAsset,
                      onCompletion: @escaping (Result<Media, Error>) -> Void) {
-        mediaExportService.export(mediaAsset,
-                                  onCompletion: { [weak self] (uploadableMedia, error) in
-            guard let uploadableMedia = uploadableMedia, error == nil else {
-                onCompletion(.failure(error ?? MediaActionError.unknown))
-                return
+        Task(priority: .background) {
+            do {
+                let uploadableMedia = try await mediaExportService.export(mediaAsset)
+                uploadMedia(siteID: siteID,
+                            productID: productID,
+                            uploadableMedia: uploadableMedia,
+                            onCompletion: onCompletion)
+            } catch {
+                onCompletion(.failure(error))
             }
-            self?.uploadMedia(siteID: siteID,
-                              productID: productID,
-                              uploadableMedia: uploadableMedia,
-                              onCompletion: onCompletion)
-        })
+        }
     }
 
     func uploadMedia(siteID: Int64,

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -92,7 +92,7 @@ private extension MediaStore {
                      productID: Int64,
                      mediaAsset: ExportableAsset,
                      onCompletion: @escaping (Result<Media, Error>) -> Void) {
-        Task(priority: .background) {
+        Task {
             do {
                 let uploadableMedia = try await mediaExportService.export(mediaAsset)
                 uploadMedia(siteID: siteID,

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -79,8 +79,8 @@ final class MediaAssetExporter: MediaExporter {
         let exporter = MediaImageExporter(data: imageData,
                                           filename: filename,
                                           typeHint: typeHint,
-                                          options: self.imageOptions,
-                                          mediaDirectoryType: self.mediaDirectoryType)
+                                          options: imageOptions,
+                                          mediaDirectoryType: mediaDirectoryType)
         return try exporter.export()
     }
 }

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -29,19 +29,18 @@ final class MediaAssetExporter: MediaExporter {
         self.mediaDirectoryType = mediaDirectoryType
     }
 
-    func export(onCompletion: @escaping MediaExportCompletion) {
+    func export() async throws -> UploadableMedia {
         switch asset.mediaType {
-        case .image:
-            return exportImage(forAsset: asset, onCompletion: onCompletion)
-        default:
-            onCompletion(nil, AssetExportError.unsupportedPHAssetMediaType)
+            case .image:
+                return try await exportImage(forAsset: asset)
+            default:
+                throw AssetExportError.unsupportedPHAssetMediaType
         }
     }
 
-    private func exportImage(forAsset asset: PHAsset, onCompletion: @escaping MediaExportCompletion) {
+    private func exportImage(forAsset asset: PHAsset) async throws -> UploadableMedia {
         guard asset.mediaType == .image else {
-            onCompletion(nil, AssetExportError.expectedPHAssetImageType)
-            return
+            throw AssetExportError.expectedPHAssetImageType
         }
         var filename = UUID().uuidString + ".jpg"
         var resourceAvailableLocally = false
@@ -52,8 +51,7 @@ final class MediaAssetExporter: MediaExporter {
             filename = resource.originalFilename
             if resource.uniformTypeIdentifier == UTType.gif.identifier {
                 // Handles GIF export differently from images.
-                exportGIF(forAsset: asset, resource: resource, onCompletion: onCompletion)
-                return
+                return try await exportGIF(forAsset: asset, resource: resource)
             }
         }
 
@@ -66,42 +64,37 @@ final class MediaAssetExporter: MediaExporter {
         // If we have a resource object that means we have a local copy of the asset so we can request the image in sync mode.
         options.isSynchronous = resourceAvailableLocally
 
-        // Configure an error handler for the image request.
-        let onImageRequestError: (Error?) -> Void = { (error) in
-            guard let error = error else {
-                onCompletion(nil, AssetExportError.failedLoadingPHImageManagerRequest)
-                return
+        // Request the image.
+        let (data, uti, _, info) = await requestImage(asset: asset, options: options)
+        guard let imageData = data else {
+            guard let error = info?[PHImageErrorKey] as? Error else {
+                throw AssetExportError.failedLoadingPHImageManagerRequest
             }
-            onCompletion(nil, error)
+            throw error
         }
 
-        // Request the image.
-        imageManager.requestImageDataAndOrientation(for: asset,
-                                      options: options,
-                                      resultHandler: { [weak self] (data, uti, orientation, info) in
-                                        guard let self = self else {
-                                            return
-                                        }
+        let typeHint = preferredExportTypeFor(uti: uti)
 
-                                        guard let imageData = data else {
-                                            onImageRequestError(info?[PHImageErrorKey] as? Error)
-                                            return
-                                        }
-
-                                        let typeHint = self.preferredExportTypeFor(uti: uti)
-
-                                        // Hands off the image export to a shared image writer.
-                                        let exporter = MediaImageExporter(data: imageData,
-                                                                          filename: filename,
-                                                                          typeHint: typeHint,
-                                                                          options: self.imageOptions,
-                                                                          mediaDirectoryType: self.mediaDirectoryType)
-                                        exporter.export(onCompletion: onCompletion)
-        })
+        // Hands off the image export to a shared image writer.
+        let exporter = MediaImageExporter(data: imageData,
+                                          filename: filename,
+                                          typeHint: typeHint,
+                                          options: self.imageOptions,
+                                          mediaDirectoryType: self.mediaDirectoryType)
+        return try exporter.export()
     }
 }
 
 private extension MediaAssetExporter {
+    func requestImage(asset: PHAsset, options: PHImageRequestOptions?) async -> (Data?, String?, CGImagePropertyOrientation, [AnyHashable: Any]?) {
+        await withCheckedContinuation { continuation in
+            imageManager.requestImageDataAndOrientation(for: asset,
+                                                        options: options) { (data, uti, orientation, info) in
+                continuation.resume(returning: (data, uti, orientation, info))
+            }
+        }
+    }
+
     func preferredExportTypeFor(uti: String?) -> String? {
         guard let uti = uti else {
             return nil
@@ -122,35 +115,38 @@ private extension MediaAssetExporter {
     /// - parameter onCompletion: Called on successful export, with the local file URL of the exported asset.
     /// - parameter onError: Called if an error was encountered during export.
     ///
-    private func exportGIF(forAsset asset: PHAsset, resource: PHAssetResource, onCompletion: @escaping MediaExportCompletion) {
+    func exportGIF(forAsset asset: PHAsset, resource: PHAssetResource) async throws -> UploadableMedia {
         guard resource.uniformTypeIdentifier == UTType.gif.identifier else {
-            onCompletion(nil, AssetExportError.expectedPHAssetGIFType)
-            return
+            throw AssetExportError.expectedPHAssetGIFType
         }
         let url: URL
         do {
             url = try mediaFileManager.createLocalMediaURL(filename: resource.originalFilename,
                                                            fileExtension: "gif")
         } catch {
-            onCompletion(nil, error)
-            return
+            throw error
         }
         let options = PHAssetResourceRequestOptions()
         options.isNetworkAccessAllowed = true
-        let manager = PHAssetResourceManager.default()
-        manager.writeData(for: resource,
-                          toFile: url,
-                          options: options,
-                          completionHandler: { (error) in
-                            guard error == nil else {
-                                onCompletion(nil, error)
-                                return
-                            }
-                            let exported = UploadableMedia(localURL: url,
-                                                           filename: url.lastPathComponent,
-                                                           mimeType: url.mimeTypeForPathExtension)
-                            onCompletion(exported, nil)
-        })
+        return try await writeData(resource: resource, toFile: url, options: options)
+    }
+
+    func writeData(resource: PHAssetResource, toFile url: URL, options: PHAssetResourceRequestOptions) async throws -> UploadableMedia {
+        try await withCheckedThrowingContinuation { continuation in
+            let manager = PHAssetResourceManager.default()
+            manager.writeData(for: resource,
+                              toFile: url,
+                              options: options,
+                              completionHandler: { error in
+                if let error {
+                    return continuation.resume(throwing: error)
+                }
+                let exported = UploadableMedia(localURL: url,
+                                               filename: url.lastPathComponent,
+                                               mimeType: url.mimeTypeForPathExtension)
+                continuation.resume(returning: exported)
+            })
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Tools/Media/MediaExport.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExport.swift
@@ -11,12 +11,9 @@ protocol MediaExporter {
     ///
     var mediaDirectoryType: MediaDirectory { get }
 
-    /// Export a media to another format
+    /// Export a media to another format.
     ///
-    /// - Parameters:
-    ///   - onCompletion: a callback to invoke when the export finishes.
-    ///
-    func export(onCompletion: @escaping MediaExportCompletion)
+    func export() async throws -> UploadableMedia
 }
 
 /// Extension providing generic helper implementation particular to a MediaExporter.

--- a/Yosemite/YosemiteTests/Mocks/MockMediaExportService.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockMediaExportService.swift
@@ -7,8 +7,10 @@ struct MockMediaExportService: MediaExportService {
         self.uploadableMedia = uploadableMedia
     }
 
-    func export(_ exportable: ExportableAsset, onCompletion: @escaping MediaExportCompletion) {
-        let error = uploadableMedia == nil ? NSError(domain: "\(type(of: self))", code: 0, userInfo: nil): nil
-        onCompletion(uploadableMedia, error)
+    func export(_ exportable: ExportableAsset) async throws -> UploadableMedia {
+        guard let uploadableMedia else {
+            throw NSError(domain: "\(type(of: self))", code: 0, userInfo: nil)
+        }
+        return uploadableMedia
     }
 }

--- a/Yosemite/YosemiteTests/Tools/Media/MediaImageExporterTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/MediaImageExporterTests.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 @testable import Yosemite
 
 final class MediaImageExporterTests: XCTestCase {
-    func testExportingAnImageWithTypeHint() {
+    func testExportingAnImageWithTypeHint() throws {
         // Loads the test image into png data.
         let mockData = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!.pngData()
         let filename = "test"
@@ -23,18 +23,14 @@ final class MediaImageExporterTests: XCTestCase {
             let expectedImageURL = try exporter.mediaFileManager
                 .createLocalMediaURL(filename: filename,
                                      fileExtension: URL.fileExtensionForUTType(typeHint))
-            let expectation = self.expectation(description: "Export image data")
-            exporter.export { (uploadableMedia, error) in
-                XCTAssertEqual(mockImageSourceWriter.targetURL, expectedImageURL)
-                expectation.fulfill()
-            }
-            waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+            let _ = try exporter.export()
+            XCTAssertEqual(mockImageSourceWriter.targetURL, expectedImageURL)
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
 
-    func testExportingAnImageWithAnUnknownTypeHintUsesTheImageDataType() {
+    func testExportingAnImageWithAnUnknownTypeHintUsesTheImageDataType() throws {
         // Loads the test image into png data.
         let mockData = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!.pngData()
         let filename = "test"
@@ -52,18 +48,14 @@ final class MediaImageExporterTests: XCTestCase {
             let expectedImageURL = try exporter.mediaFileManager
                 .createLocalMediaURL(filename: filename,
                                      fileExtension: "png")
-            let expectation = self.expectation(description: "Export image data")
-            exporter.export { (uploadableMedia, error) in
-                XCTAssertEqual(mockImageSourceWriter.targetURL, expectedImageURL)
-                expectation.fulfill()
-            }
-            waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+            let _ = try exporter.export()
+            XCTAssertEqual(mockImageSourceWriter.targetURL, expectedImageURL)
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
 
-    func testExportingNonImageData() {
+    func testExportingNonImageData() throws {
         let mockData = Data()
         let filename = "test"
         let typeHint = UTType.jpeg.identifier
@@ -77,11 +69,10 @@ final class MediaImageExporterTests: XCTestCase {
                                           mediaDirectoryType: .temporary,
                                           imageSourceWriter: mockImageSourceWriter)
 
-        let expectation = self.expectation(description: "Export image data")
-        exporter.export { (uploadableMedia, error) in
+        do {
+            let _ = try exporter.export()
+        } catch {
             XCTAssertEqual(error as? MediaImageExporter.ImageExportError, .imageSourceIsAnUnknownType)
-            expectation.fulfill()
         }
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Prerequisite for HACK Week pe5pgL-3Bl-p2#comment-2957
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In order to implement image processing like background removal for product images, the app needs to support image types like `UIImage` other than `PHAsset` from the camera or device photo library. This requires some changes in how we export media, and I took the chance to refactor the media export interface to use async/await instead of a completion block that returns `(UploadableMedia?, Error?)` (not ideal for handling the edge case when both are `nil`) as in `MediaExportCompletion`. The changes in this PR are not expected to affect the app's behavior. Hopefully, it's easier to read with the concurrency syntax.

## How

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- `MediaExportService` protocol's `export` now returns a throwable media async
  - The implementation `DefaultMediaExportService` was updated with the interface changes while maintaining the same logic
- `MediaExporter` protocol's `export` now returns a throwable media async
  - The implementations `MediaAssetExporter` and `MediaImageExporter` were updated with the interface changes while maintaining the same logic
- `MediaStore.uploadMedia` now calls `MediaExportService`'s new interface

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

For confidence check:

- Log in to a store if needed
- Go to the Products tab
- Tap on an editable product
- Tap on the images header
- Tap `Add Photos`
- Select either `Choose from device` and pick some photos --> after confirming the selection, the images should be uploaded to the site's media library in core successfully
- Tap `Save` --> after the images are uploaded, the product should include the uploaded images

---

- [x] @jaclync tests the camera flow




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.