### PR TITLE
[Mobile Payments] Limit CPP "plugin not active" case to WCPay only

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -55,9 +55,13 @@ struct InPersonPaymentsView: View {
             case .pluginUnsupportedVersion(let plugin):
                 InPersonPaymentsPluginNotSupportedVersion(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .pluginNotActivated(let plugin):
-                InPersonPaymentsPluginNotActivated(plugin: plugin,
-                                                   analyticReason: viewModel.state.reasonForAnalytics,
-                                                   onActivate: viewModel.activatePlugin)
+                switch plugin {
+                case .wcPay:
+                    InPersonPaymentsPluginNotActivated(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onActivate: viewModel.activatePlugin)
+                case .stripe:
+                    // Show WCPay install flow when only Stripe is installed, but not active
+                    InPersonPaymentsPluginNotInstalled(analyticReason: viewModel.state.reasonForAnalytics, onInstall: viewModel.installPlugin)
+                }
             case .pluginInTestModeWithLiveStripeAccount(let plugin):
                 InPersonPaymentsLiveSiteInTestMode(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh:
                     viewModel.refresh)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10614
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR handles the case of prioritizing WCPay installation over Stripe activation, which happens when we have the following case: Stripe it's installed and not active + WCPay it's not installed.

When this happens, we currently show a view to "Activate Stripe,", however, we should be showing "Install WooCommerce Payments" instead. This was discussed here: p1693832778834979-slack-C025A8VV728 , and it's how Android already implements it.

## Testing instructions
1. On a US store, with both WCPay and Stripe plugins installed but not active (you can use https://atomicippwcpaytests.wpcomstaging.com/):
<img width="842" alt="Screenshot 2023-09-06 at 14 38 54" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/e474d4ea-9b0e-4af7-b4de-14107b223ae3">

2. Go to `Menu` > `Payments` > See the notice at the bottom that says that `In-Person Payments setup is incomplete. Continue setup`. Tap the link.
4. Since both plugins are installed, see we prioritize WCPay with: `Activate WooCommerce Payments` view. Do nothing.
5. Go to `wp-admin`, delete the `WooCommerce Payments` plugin, activate/deactivate some other plugin (for example MailPoet) due to the [cached API bug](https://github.com/woocommerce/woocommerce-ios/issues/10581)). Re-run the app
6. Go back to `Menu` > `Payments` > Tap on `In-Person Payments setup is incomplete. Continue setup`.
7. Since only Stripe is installed now, see we prioritize WCPay with `Install WooCommerce Payments` view. 


## Screenshots
| Before | After |
|--------|--------|
| ![case pluginNotActivated stripe](https://github.com/woocommerce/woocommerce-ios/assets/3812076/40216db2-8aa6-42bf-a37f-ea7d5101dbdb) | ![Simulator Screen Shot - iPhone 13 Pro - 2023-09-06 at 14 21 33](https://github.com/woocommerce/woocommerce-ios/assets/3812076/7c6a2235-24ce-4fda-8d1e-20e6c18e8ecf) | 



