### PR TITLE
[Manual Taxes M2] Set the Order address with the selected Tax Rate's address

### DIFF
--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -89,6 +89,7 @@ extension Address {
     /// Generates an Address object from a TaxRate object data
     ///
     static func from(taxRate: TaxRate) -> Address {
+        /// We take the first city and postcode to keep it simple, even if they don't match
         Address.empty.copy(city: taxRate.cities.first ?? "",
                            state: taxRate.state,
                            postcode: taxRate.postcodes.first ?? "",

--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -85,6 +85,15 @@ extension Address {
     var isEmpty: Bool {
         self == .empty
     }
+
+    /// Generates an Address object from a TaxRate object data
+    ///
+    static func from(taxRate: TaxRate) -> Address {
+        Address.empty.copy(city: taxRate.cities.first ?? "",
+                           state: taxRate.state,
+                           postcode: taxRate.postcodes.first ?? "",
+                           country: taxRate.country)
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -552,14 +552,13 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     func addTaxRateAddressToOrder(taxRate: TaxRate) {
-        let address = Address.from(taxRate: taxRate)
-        let input: OrderSyncAddressesInput
-
         guard let taxBasedOnSetting = taxBasedOnSetting,
-        taxBasedOnSetting != .shopBaseAddress else {
+              taxBasedOnSetting != .shopBaseAddress else {
             return
         }
 
+        let address = Address.from(taxRate: taxRate)
+        let input: OrderSyncAddressesInput
         switch taxBasedOnSetting {
         case .customerBillingAddress:
             input = OrderSyncAddressesInput(billing: address, shipping: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -552,8 +552,23 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     func addTaxRateAddressToOrder(taxRate: TaxRate) {
-        let address = Address(firstName: "", lastName: "", company: "", address1: "", address2: "", city: taxRate.city, state: taxRate.state, postcode: taxRate.postcodes.first ?? "", country: taxRate.country, phone: "", email: "")
-        let input = OrderSyncAddressesInput(billing: address, shipping: address)
+        let address = Address.from(taxRate: taxRate)
+        let input: OrderSyncAddressesInput
+
+        guard let taxBasedOnSetting = taxBasedOnSetting,
+        taxBasedOnSetting != .shopBaseAddress else {
+            return
+        }
+
+        switch taxBasedOnSetting {
+        case .customerBillingAddress:
+            input = OrderSyncAddressesInput(billing: address, shipping: nil)
+        case .customerShippingAddress:
+            input = OrderSyncAddressesInput(billing: nil, shipping: address)
+        default:
+            return
+        }
+
         orderSynchronizer.setAddresses.send(input)
         resetAddressForm()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -622,6 +622,10 @@ final class EditableOrderViewModel: ObservableObject {
         }
         stores.dispatch(action)
     }
+
+    func onTaxRateSelected(_ taxRate: TaxRate) {
+        debugPrint("tax rate", taxRate)
+    }
 }
 
 // MARK: - Types

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -552,8 +552,7 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     func addTaxRateAddressToOrder(taxRate: TaxRate) {
-        guard let taxBasedOnSetting = taxBasedOnSetting,
-              taxBasedOnSetting != .shopBaseAddress else {
+        guard let taxBasedOnSetting = taxBasedOnSetting else {
             return
         }
 
@@ -565,6 +564,7 @@ final class EditableOrderViewModel: ObservableObject {
         case .customerShippingAddress:
             input = OrderSyncAddressesInput(billing: nil, shipping: address)
         default:
+            // Do not add address if the taxes are not based on the customer's addresses
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -551,6 +551,13 @@ final class EditableOrderViewModel: ObservableObject {
         resetAddressForm()
     }
 
+    func addTaxRateAddressToOrder(taxRate: TaxRate) {
+        let address = Address(firstName: "", lastName: "", company: "", address1: "", address2: "", city: taxRate.city, state: taxRate.state, postcode: taxRate.postcodes.first ?? "", country: taxRate.country, phone: "", email: "")
+        let input = OrderSyncAddressesInput(billing: address, shipping: address)
+        orderSynchronizer.setAddresses.send(input)
+        resetAddressForm()
+    }
+
     /// Updates the order creation draft with the current set customer note.
     ///
     func updateCustomerNote() {
@@ -624,7 +631,7 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     func onTaxRateSelected(_ taxRate: TaxRate) {
-        debugPrint("tax rate", taxRate)
+        addTaxRateAddressToOrder(taxRate: taxRate)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -145,7 +145,10 @@ struct OrderForm: View {
                                     shouldShowNewTaxRateSelector = true
                                 }
                                 .sheet(isPresented: $shouldShowNewTaxRateSelector) {
-                                    NewTaxRateSelectorView(viewModel: NewTaxRateSelectorViewModel(siteID: viewModel.siteID),
+                                    NewTaxRateSelectorView(viewModel: NewTaxRateSelectorViewModel(siteID: viewModel.siteID,
+                                                                                                  onTaxRateSelected: { taxRate in
+                                        viewModel.onTaxRateSelected(taxRate)
+                                    }),
                                                            taxEducationalDialogViewModel: viewModel.paymentDataViewModel.taxEducationalDialogViewModel,
                                                            onDismissWpAdminWebView: viewModel.paymentDataViewModel.onDismissWpAdminWebViewClosure)
                                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -32,8 +32,8 @@ struct OrderSyncProductInput {
 /// Addresses input for an `OrderSynchronizer` type.
 ///
 struct OrderSyncAddressesInput {
-    let billing: Address
-    let shipping: Address
+    let billing: Address?
+    let shipping: Address?
 }
 
 /// A type that  receives "supported" order properties and keeps it synced against another source.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -48,8 +48,11 @@ struct NewTaxRateSelectorView: View {
                                                       refreshAction: { completion in
                             viewModel.onRefreshAction(completion: completion)
                         }) {
-                            ForEach(viewModel.taxRateViewModels, id: \.id) { viewModel in
-                                TaxRateRow(viewModel: viewModel)
+                            ForEach(Array(viewModel.taxRateViewModels.enumerated()), id: \.offset) { index, taxRateViewModel in
+                                TaxRateRow(viewModel: taxRateViewModel) {
+                                    viewModel.onRowSelected(with: index)
+                                    dismiss()
+                                }
                                 Divider()
                             }
                             .background(Color(.listForeground(modal: false)))
@@ -66,7 +69,7 @@ struct NewTaxRateSelectorView: View {
                         ScrollView {
                             LazyVStack(spacing: 0) {
                                 ForEach(viewModel.placeholderRowViewModels, id: \.id) { rowViewModel in
-                                    TaxRateRow(viewModel: rowViewModel)
+                                    TaxRateRow(viewModel: rowViewModel, onSelect: {})
                                         .redacted(reason: .placeholder)
                                         .shimmering()
                                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -26,16 +26,20 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     /// Trigger to perform any one time setups.
     let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
 
+    let onTaxRateSelected: (Yosemite.TaxRate) -> Void
+
     /// View models for placeholder rows. Strings are visible to the user as it is shimmering (loading)
     let placeholderRowViewModels: [TaxRateViewModel] = [Int64](0..<3).map { index in
         TaxRateViewModel(id: index, name: "placeholder", rate: "10%")
     }
 
     init(siteID: Int64,
+         onTaxRateSelected: @escaping (Yosemite.TaxRate) -> Void,
          wpAdminTaxSettingsURLProvider: WPAdminTaxSettingsURLProviderProtocol = WPAdminTaxSettingsURLProvider(),
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
+        self.onTaxRateSelected = onTaxRateSelected
         self.wpAdminTaxSettingsURLProvider = wpAdminTaxSettingsURLProvider
         self.stores = stores
         self.storageManager = storageManager
@@ -68,6 +72,14 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
         paginationTracker.resync(reason: nil) {
             completion()
         }
+    }
+
+    func onRowSelected(with index: Int) {
+        guard let taxRate = resultsController.fetchedObjects[safe: index] else {
+            return
+        }
+
+        onTaxRateSelected(taxRate)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct TaxRateRow: View {
     let viewModel: TaxRateViewModel
+    let onSelect: () -> Void
 
     var body: some View {
         HStack {
-            Button(action: { }) {
+            Button(action: onSelect) {
                 AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.generalPadding) {
                     Text(viewModel.name)
                         .foregroundColor(Color(.text))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1342,6 +1342,75 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.discardOrder()
     }
 
+    func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerBillingAddress_then_resets_addressFormViewModel_fields_with_new_data() {
+        // Given
+        stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                onCompletion(.success(.customerBillingAddress))
+            default:
+                break
+            }
+        })
+
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
+
+        viewModel.onTaxRateSelected(taxRate)
+
+        // Then
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.state, taxRate.state)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.country, taxRate.country)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.postcode, taxRate.postcodes.first)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.city, taxRate.cities.first)
+    }
+
+    func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerShippingAddress_then_resets_addressFormViewModel_secondaryFields_with_new_data() {
+        // Given
+        stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                onCompletion(.success(.customerShippingAddress))
+            default:
+                break
+            }
+        })
+
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
+
+        viewModel.onTaxRateSelected(taxRate)
+
+        // Then
+        XCTAssertEqual(viewModel.addressFormViewModel.secondaryFields.state, taxRate.state)
+        XCTAssertEqual(viewModel.addressFormViewModel.secondaryFields.country, taxRate.country)
+        XCTAssertEqual(viewModel.addressFormViewModel.secondaryFields.postcode, taxRate.postcodes.first)
+        XCTAssertEqual(viewModel.addressFormViewModel.secondaryFields.city, taxRate.cities.first)
+    }
+
+    func test_onTaxRateSelected_when_taxBasedOnSetting_is_shopBaseAddress_then_it_does_not_reset_addressFormViewModel_with_new_data() {
+        // Given
+        stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                onCompletion(.success(.shopBaseAddress))
+            default:
+                break
+            }
+        })
+
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
+
+        viewModel.onTaxRateSelected(taxRate)
+
+        // Then
+        XCTAssertTrue(viewModel.addressFormViewModel.fields.state.isEmpty)
+        XCTAssertTrue(viewModel.addressFormViewModel.fields.country.isEmpty)
+        XCTAssertTrue(viewModel.addressFormViewModel.fields.postcode.isEmpty)
+        XCTAssertTrue(viewModel.addressFormViewModel.fields.city.isEmpty)
+    }
+
     func test_addCustomerAddressToOrder_resets_addressFormViewModel_with_new_data() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
@@ -10,7 +10,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         let wpAdminTaxSettingsURL = URL(string: "https://www.site.com/wp-admin/mock-taxes-settings")
         let wpAdminTaxSettingsURLProvider = MockWPAdminTaxSettingsURLProvider(wpAdminTaxSettingsURL: wpAdminTaxSettingsURL)
 
-        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, wpAdminTaxSettingsURLProvider: wpAdminTaxSettingsURLProvider)
+        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, onTaxRateSelected: { _ in }, wpAdminTaxSettingsURLProvider: wpAdminTaxSettingsURLProvider)
 
         XCTAssertEqual(viewModel.wpAdminTaxSettingsURL, wpAdminTaxSettingsURL)
     }
@@ -25,7 +25,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
             }
             retrieveTaxRatesIsCalled = true
         }
-        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, onTaxRateSelected: { _ in }, stores: stores)
 
         // When
         viewModel.onLoadTriggerOnce.send()
@@ -50,7 +50,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
             completion(.success([taxRate]))
         }
 
-        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, onTaxRateSelected: { _ in }, stores: stores, storageManager: storageManager)
 
         // When
         viewModel.onLoadTriggerOnce.send()
@@ -80,7 +80,7 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
 
             completion(.success(firstPageTaxRates))
         }
-        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, stores: stores)
+        let viewModel = NewTaxRateSelectorViewModel(siteID: 1, onTaxRateSelected: { _ in }, stores: stores)
 
         // When
         viewModel.onLoadTriggerOnce.send()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10560 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the selection of the desired tax rate and the addition of its address elements to the order customer's address. It depends on the merchant's _tax based on setting_:
- If the _tax based on_ setting is the customer's billing address, set it as the billing address.
- If the _tax based on_ setting is the customer's shipping address, set it as the shipping address.
- If the _tax based on setting_ is the shop address, or we didn't retrieve it, don't do anything.

Setting the customer's address as the _tax based on_ address has the side effect of modifying the order taxes if 

- The products added to the order are taxable
- Their tax class matches the selected tax rate class
- There's no other tax with higher priority

See the video below to see how it works.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/41c71660-863f-429f-8e66-3bb763af4534

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
