### PR TITLE
Add Notification Content Extension identifiers to Fastlane match

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,14 +37,16 @@ APP_STORE_VERSION_BUNDLE_IDENTIFIER = 'com.automattic.woocommerce'
 # Registered in our main account, for development and App Store
 MAIN_BUNDLE_IDENTIFIERS = [
   APP_STORE_VERSION_BUNDLE_IDENTIFIER,
-  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.storewidgets"
+  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.storewidgets",
+  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.notificationcontentextension"
 ].freeze
 
 ALPHA_VERSION_BUNDLE_IDENTIFIER = 'com.automattic.alpha.woocommerce'
 # Registered in our Enterprise account, for App Center / Prototype Builds
 ALPHA_BUNDLE_IDENTIFIERS = [
   ALPHA_VERSION_BUNDLE_IDENTIFIER,
-  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgets"
+  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgets",
+  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.notificationcontentextension"
 ].freeze
 
 # Shared options to use when invoking `gym` / `build_app`.


### PR DESCRIPTION
This PR adds the identifiers that were created for this Apps Infra request to the WCiOS `match` list: pdnsEh-1hc-p2#comment-2631

I ran `bundle exec fastlane update_certs_and_profiles readonly:false` after making this change and confirmed that Fastlane successfully created and uploaded the new profiles. 