### PR TITLE
Product images: automatically show the media selector when there are no images

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [internal] Add `site_url` to Tracks events [https://github.com/woocommerce/woocommerce-ios/pull/10610]
 - [Internal] Some internal changes were made to the image upload feature to support image processing in the app, no app changes are expected. [https://github.com/woocommerce/woocommerce-ios/pull/10631]
+- [*] Automatically show the media selector sheet on the product images screen when there are no pre-existing images. [https://github.com/woocommerce/woocommerce-ios/pull/10644]
 
 15.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -35,6 +35,7 @@ final class ProductImagesViewController: UIViewController {
     }
     private var productImageStatusesObservationToken: AnyCancellable?
     private var initialProductImageStatusesObservationToken: AnyCancellable?
+    private var hasCheckedInitialProductImageStatuses: Bool = false
 
     private var allowsMultipleImages: Bool {
         product.allowsMultipleImages()
@@ -112,16 +113,19 @@ final class ProductImagesViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        initialProductImageStatusesObservationToken = productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
-            guard let self else {
-                return
-            }
+        if hasCheckedInitialProductImageStatuses == false {
+            initialProductImageStatusesObservationToken = productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
+                guard let self else {
+                    return
+                }
 
-            if productImageStatuses.isEmpty {
-                self.addTapped()
-            }
+                if productImageStatuses.isEmpty {
+                    self.addTapped()
+                }
 
-            self.initialProductImageStatusesObservationToken = nil
+                self.hasCheckedInitialProductImageStatuses = true
+                self.initialProductImageStatusesObservationToken = nil
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -34,6 +34,7 @@ final class ProductImagesViewController: UIViewController {
         }
     }
     private var productImageStatusesObservationToken: AnyCancellable?
+    private var initialProductImageStatusesObservationToken: AnyCancellable?
 
     private var allowsMultipleImages: Bool {
         product.allowsMultipleImages()
@@ -106,6 +107,22 @@ final class ProductImagesViewController: UIViewController {
         configureImagesContainerView()
         configureProductImagesObservation()
         handleSwipeBackGesture()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        initialProductImageStatusesObservationToken = productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
+            guard let self else {
+                return
+            }
+
+            if productImageStatuses.isEmpty {
+                self.addTapped()
+            }
+
+            self.initialProductImageStatusesObservationToken = nil
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Side task from HACK Week pe5pgL-3Bl-p2#comment-2957
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When a product has no images and the merchant wants to add a product image, they currently have to tap twice to see the media selector sheet. The second tap on the empty product images screen is redundant as there is no other CTA to act on. This PR aims to skip the second tap and show the media selector sheet automatically when there are no images.

## How

The image statuses observation is still using the pre-Combine way in `ProductImageActionHandlerProtocol`, it observes the image statutes once in `viewWillAppear` and then resets the cancellable.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Product without any images

- Log in to a store if needed
- Go to the Products tab
- Create a product
- Tap on the images header `Add a product image` --> the media selector action sheet should be shown automatically
- Tap `Dismiss` --> the action sheet shouldn't be shown again
- Tap `Add Photos`, then `Choose from device` to add at least one photo --> it should go back to the product form with the image being uploaded
- Quickly tap on the images header again while the image is still being uploaded --> the media selector action sheet should not be shown

### Product with images

- Go to the Products tab
- Tap on an editable product with at least one image
- Tap on the images header --> the media selector action sheet should not be shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/a2e01c55-2970-4cdb-8dd6-e9fac4add4ed




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.