### PR TITLE
[Mobile Payments] Handle plugin setup not completed

### DIFF
--- a/WooCommerce/Classes/Extensions/Site+URL.swift
+++ b/WooCommerce/Classes/Extensions/Site+URL.swift
@@ -25,6 +25,14 @@ extension Site {
     func pluginSettingsSectionURL(from plugin: CardPresentPaymentsPlugin) -> String {
         adminURL + "admin.php?page=wc-settings&tab=checkout&section=" + plugin.setupURLSectionPath
     }
+
+    /// Returns the plugin URL from wp-admin that handles pending tasks or requirements during onboarding.
+    /// Both WCPay and Stripe use the same URL.
+    ///
+    func cardPresentPluginHasPendingTasksURL() -> String {
+        return adminURL + "admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+    }
+
     /// Returns the WooCommerce admin URL, or attempts to construct it from the site URL.
     ///
     func adminURLWithFallback() -> URL? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -37,6 +37,10 @@ struct InPersonPaymentsPluginNotSetup: View {
                 }
             }
             .buttonStyle(PrimaryButtonStyle())
+            Button(Localization.refreshButton) {
+                onRefresh()
+            }
+            .buttonStyle(SecondaryButtonStyle())
             .padding(.bottom, 24.0)
 
             InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(tappedAnalyticEvent: learnMoreAnalyticEvent))
@@ -45,7 +49,7 @@ struct InPersonPaymentsPluginNotSetup: View {
     }
 
     private var setupURL: URL? {
-        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.pluginSettingsSectionURL(from: plugin) else {
+        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.cardPresentPluginHasPendingTasksURL() else {
             return nil
         }
 
@@ -68,6 +72,10 @@ private enum Localization {
         "Finish Setup in Store Admin",
         comment: "Button to set up an in-person payments plugin after activating it"
     )
+
+    static let refreshButton = NSLocalizedString(
+        "Refresh",
+        comment: "Button to refresh the state of the in-person payments setup")
 }
 
 struct InPersonPaymentsPluginNotSetup_Previews: PreviewProvider {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10626 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the URL used for IPP plugins when are installed and activated, but need further setup to be functional, by changing the previous "payments settings" URL for `admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`. 

This will automatically redirect the user to the onboarding step they need to complete in order to fully setup WCPay. We use the same handle in the case of Stripe, in which case they'll see the Finish Setup button that redirects them to their setup flow.

![Simulator Screen Recording - iPhone 13 Pro - 2023-09-07 at 11 04 29](https://github.com/woocommerce/woocommerce-ios/assets/3812076/1489745e-c715-4c63-ab1f-39d87febb7f1)

We also add a "Refresh" button that triggers a state refresh, in case the merchant prefers to perform all of this via the web rather than the app.

## Testing instructions
On a US store, with WCPay installed and active, but not setup (you can create a new business site, and install and activate WCPay, or use  [https://atomicippwcpaytests.wpcomstaging.com/](https://atomicippwcpaytests.wpcomstaging.com/) or the fresh site [anotheratomicippwcpaytests.wpcomstaging.com](https://anotheratomicippwcpaytests.wpcomstaging.com), which I sent an invite to):
1. Go to `Menu` > `Payments` > See the notice at the bottom that says that `In-Person Payments setup is incomplete. Continue setup`. Tap the link.
2. See "Finish Setup in Store Admin". Tap the link. You may need to login if is the first time.
3. See the WCPay onboarding setup screen. Dismiss without setting up.
4. Back in the app, observe the state refreshing after dismissing the web view. 
5. Tap "Refresh" and observe the state refreshing as well.

## Screenshots
| Before | After |
|--------|--------|
| <img width="400" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/ba581aa4-9b6d-4f6c-bea2-ebc048221749"> | <img width="400" alt="Screenshot 2023-09-07 at 11 27 07" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/f52241b0-be0a-4b79-92e8-c09c606e81b2"> | 
