### PR TITLE
[Manual Taxes M2] Improvements

### DIFF
--- a/Networking/Networking/Model/TaxRate.swift
+++ b/Networking/Networking/Model/TaxRate.swift
@@ -24,7 +24,7 @@ public struct TaxRate: Decodable, Equatable, GeneratedFakeable, GeneratedCopiabl
     ///
     public let country: String
 
-    /// Tax rate postcode.  Deprecated in WooCommerce 5.3 (use countries)
+    /// Tax rate postcode.  Deprecated in WooCommerce 5.3 (use postcodes)
     ///
     public let postcode: String
 
@@ -56,7 +56,7 @@ public struct TaxRate: Decodable, Equatable, GeneratedFakeable, GeneratedCopiabl
     ///
     public let compound: Bool
 
-    /// Tax rate city. Deprecated in WooCommerce 5.3 (use countries)
+    /// Tax rate city. Deprecated in WooCommerce 5.3 (use cities)
     ///
     public let city: String
 

--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -89,10 +89,11 @@ extension Address {
     /// Generates an Address object from a TaxRate object data
     ///
     static func from(taxRate: TaxRate) -> Address {
-        /// We take the first city and postcode to keep it simple, even if they don't match
-        Address.empty.copy(city: taxRate.cities.first ?? "",
+        // We take the first city and postcode to keep it simple, even if they don't match
+        // If cities and postcodes are empty we try to use the deprecated properties `city`, `postcode` in case they have an older Woo version
+        Address.empty.copy(city: taxRate.cities.first ?? taxRate.city,
                            state: taxRate.state,
-                           postcode: taxRate.postcodes.first ?? "",
+                           postcode: taxRate.postcodes.first ?? taxRate.postcode,
                            country: taxRate.country)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1212,7 +1212,7 @@ private extension EditableOrderViewModel {
 
             switch result {
                 case .success(let setting):
-                self.shouldShowNewTaxRateSection = featureFlagService.isFeatureFlagEnabled(.manualTaxesInOrderM2) &&
+                self.shouldShowNewTaxRateSection = self.featureFlagService.isFeatureFlagEnabled(.manualTaxesInOrderM2) &&
                 (setting == .customerBillingAddress || setting == .customerShippingAddress)
                 self.taxBasedOnSetting = setting
                 case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -66,10 +66,8 @@ struct NewTaxRateSelectorView: View {
                         }
                     }
                     case .empty:
-                        EmptyState(title: "",
-                                   description: "",
-                                   image: .emptyInboxNotesImage)
-                        .frame(maxHeight: .infinity)
+                    bottomNotice
+                    Spacer()
                     case .syncingFirstPage:
                         ScrollView {
                             LazyVStack(spacing: 0) {
@@ -109,13 +107,14 @@ struct NewTaxRateSelectorView: View {
 
     var bottomNotice: some View {
         Group {
-            Text(Localization.editTaxRatesInWpAdminSectionTitle)
-                .foregroundColor(Color(.textSubtle))
-                .footnoteStyle()
-                .padding(.top, Layout.editTaxRatesInWpAdminSectionTopPadding)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding([.leading, .trailing], Layout.generalPadding)
-
+            if let title = viewModel.bottomNoticeTitle {
+                Text(title)
+                    .foregroundColor(Color(.textSubtle))
+                    .footnoteStyle()
+                    .padding(.top, Layout.editTaxRatesInWpAdminSectionTopPadding)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding([.leading, .trailing], Layout.generalPadding)
+            }
             Button(action: {
                 showingWPAdminWebview = true
             }) {
@@ -153,8 +152,6 @@ extension NewTaxRateSelectorView {
         static let infoText = NSLocalizedString("This will change the customer’s address to the location of the tax rate you select.",
                                                 comment: "Explanatory text for the tax rate selector")
         static let taxRatesSectionTitle = NSLocalizedString("Select a tax rate", comment: "Title for the tax rate selector section")
-        static let editTaxRatesInWpAdminSectionTitle = NSLocalizedString("Can’t find the rate you’re looking for?",
-                                                                         comment: "Text to prompt the user to edit tax rates in the web")
         static let editTaxRatesInWpAdminButtonTitle = NSLocalizedString("Edit tax rates in admin",
                                                                          comment: "Title of the button that prompts the user to edit tax rates in the web")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -130,6 +130,7 @@ struct NewTaxRateSelectorView: View {
             }
             .padding(.top, Layout.editTaxRatesInWpAdminSectionVerticalSpacing)
             .safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminTaxSettingsURL, onDismiss: {
+                viewModel.onRefreshAction()
                 onDismissWpAdminWebView()
                 showingWPAdminWebview = false
             })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -69,7 +69,8 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     }
 
     func onRowSelected(with index: Int) {
-        guard let taxRate = resultsController.fetchedObjects[safe: index] else {
+        guard let taxRateViewModel = taxRateViewModels[safe: index],
+              let taxRate = resultsController.fetchedObjects.first(where: { $0.id == taxRateViewModel.id }) else {
             return
         }
 
@@ -136,7 +137,11 @@ private extension NewTaxRateSelectorViewModel {
 
     /// Updates row view models and sync state.
     func updateResults() {
-        taxRateViewModels = resultsController.fetchedObjects.map {
+        taxRateViewModels = resultsController.fetchedObjects
+            .filter {
+                $0.hasAddress
+            }
+            .map {
             var title = $0.name
             let titleSuffix = "\($0.country) \($0.state) \($0.postcodes.joined(separator: ",")) \($0.cities.joined(separator: ","))"
 
@@ -173,5 +178,11 @@ extension NewTaxRateSelectorViewModel {
     func transitionToResultsUpdatedState() {
         shouldShowBottomActivityIndicator = false
         syncState = taxRateViewModels.isNotEmpty ? .results: .empty
+    }
+}
+
+private extension Yosemite.TaxRate {
+    var hasAddress: Bool {
+        city.isNotEmpty || cities.isNotEmpty || postcodes.isNotEmpty || postcodes.isNotEmpty || state.isNotEmpty || country.isNotEmpty
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -89,6 +89,8 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     }
 
     func onRefreshAction() {
+        taxRateViewModels = []
+        transitionToSyncingState()
         paginationTracker.resync(reason: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -55,6 +55,17 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
         wpAdminTaxSettingsURLProvider.provideWpAdminTaxSettingsURL()
     }
 
+    var bottomNoticeTitle: String? {
+        switch syncState {
+        case .syncingFirstPage:
+            return nil
+        case .results:
+            return Localization.bottomNoticeResultsSectionTitle
+        case .empty:
+            return Localization.bottomNoticeEmptySectionTitle
+        }
+    }
+
     private lazy var resultsController: ResultsController<StorageTaxRate> = {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageTaxRate.order, ascending: true)
@@ -178,6 +189,17 @@ extension NewTaxRateSelectorViewModel {
     func transitionToResultsUpdatedState() {
         shouldShowBottomActivityIndicator = false
         syncState = taxRateViewModels.isNotEmpty ? .results: .empty
+    }
+}
+
+extension NewTaxRateSelectorViewModel {
+    enum Localization {
+        static let bottomNoticeResultsSectionTitle = NSLocalizedString("Can’t find the rate you’re looking for?",
+                                                                         comment: "Text to prompt the user to edit tax rates in the web")
+        static let bottomNoticeEmptySectionTitle = NSLocalizedString("You don't have any tax rate with a location.",
+                                                                              comment: "Text to prompt the user to edit tax rates" +
+                                                                              "in the web when there are no results")
+
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -214,7 +214,7 @@ extension NewTaxRateSelectorViewModel {
     enum Localization {
         static let bottomNoticeResultsSectionTitle = NSLocalizedString("Can’t find the rate you’re looking for?",
                                                                          comment: "Text to prompt the user to edit tax rates in the web")
-        static let bottomNoticeEmptySectionTitle = NSLocalizedString("You don't have any tax rate with a location.",
+        static let bottomNoticeEmptySectionTitle = NSLocalizedString("You don't have any tax rates with a location.",
                                                                               comment: "Text to prompt the user to edit tax rates" +
                                                                               "in the web when there are no results")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -87,6 +87,10 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
 
         onTaxRateSelected(taxRate)
     }
+
+    func onRefreshAction() {
+        paginationTracker.resync(reason: nil)
+    }
 }
 
 extension NewTaxRateSelectorViewModel: PaginationTrackerDelegate {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1668,6 +1668,7 @@
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
 		B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */; };
+		B98FF4402AAA096200326D16 /* AddressWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98FF43F2AAA096200326D16 /* AddressWooTests.swift */; };
 		B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */; };
 		B99686E02A13C8CC00D1AF62 /* ScanToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99686DF2A13C8CC00D1AF62 /* ScanToPayView.swift */; };
 		B99686E32A13C98200D1AF62 /* ScanToPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99686E22A13C98200D1AF62 /* ScanToPayViewModel.swift */; };
@@ -4119,6 +4120,7 @@
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModelTests.swift; sourceTree = "<group>"; };
+		B98FF43F2AAA096200326D16 /* AddressWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressWooTests.swift; sourceTree = "<group>"; };
 		B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineViewModel.swift; sourceTree = "<group>"; };
 		B99686DF2A13C8CC00D1AF62 /* ScanToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanToPayView.swift; sourceTree = "<group>"; };
 		B99686E22A13C98200D1AF62 /* ScanToPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanToPayViewModel.swift; sourceTree = "<group>"; };
@@ -8798,6 +8800,7 @@
 				E1068057285C787100668B46 /* BetaFeaturesTests.swift */,
 				EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */,
 				2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */,
+				B98FF43F2AAA096200326D16 /* AddressWooTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -13686,6 +13689,7 @@
 				027111422913B9FC00F5269A /* AccountCreationFormViewModelTests.swift in Sources */,
 				DE50295328BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift in Sources */,
 				D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */,
+				B98FF4402AAA096200326D16 /* AddressWooTests.swift in Sources */,
 				A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */,
 				022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */,
 				093B265927DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,6 +21,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShareProductAIEnabled: Bool
     private let isJustInTimeMessagesOnDashboardEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
+    private let manualTaxesInOrderM2: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -40,7 +41,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
          isJustInTimeMessagesOnDashboardEnabled: Bool = false,
-         betterCustomerSelectionInOrder: Bool = false) {
+         betterCustomerSelectionInOrder: Bool = false,
+         manualTaxesInOrderM2: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -60,6 +62,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.isJustInTimeMessagesOnDashboardEnabled = isJustInTimeMessagesOnDashboardEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
+        self.manualTaxesInOrderM2 = manualTaxesInOrderM2
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -100,6 +103,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isJustInTimeMessagesOnDashboardEnabled
         case .betterCustomerSelectionInOrder:
             return betterCustomerSelectionInOrder
+        case .manualTaxesInOrderM2:
+            return manualTaxesInOrderM2
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Model/AddressWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/AddressWooTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import Foundation
+@testable import WooCommerce
+@testable import Networking
+
+/// Address+Woo Tests
+///
+class AddressWooTests: XCTestCase {
+    func test_from_taxRate_when_tax_rate_location_is_empty_then_address_is_empty() {
+        let taxRate = TaxRate.fake()
+
+        XCTAssertTrue(Address.from(taxRate: taxRate).isEmpty)
+    }
+
+    func test_from_taxRate_when_tax_rate_has_location_then_prioritizes_array_properties() {
+        // Given
+        let taxRate = TaxRate.fake().copy(country: "US", state: "CA", postcode: "12345", postcodes: ["9999"], city: "Miami", cities: ["New York"])
+
+        // When
+        let address = Address.from(taxRate: taxRate)
+
+        // Then
+        XCTAssertEqual(address.state, taxRate.state)
+        XCTAssertEqual(address.country, taxRate.country)
+        XCTAssertEqual(address.city, taxRate.cities.first)
+        XCTAssertEqual(address.postcode, taxRate.postcodes.first)
+    }
+
+    /// Older woo versions before 5.3 doesn't support arrays of postcodes and cities, use the single property then
+    ///
+    func test_from_taxRate_when_tax_rate_has_location_but_array_properties_are_empty_then_ressorts_to_single_properties() {
+        // Given
+        let taxRate = TaxRate.fake().copy(country: "US", state: "CA", postcode: "12345", postcodes: [], city: "Miami", cities: [])
+
+        // When
+        let address = Address.from(taxRate: taxRate)
+
+        // Then
+        XCTAssertEqual(address.state, taxRate.state)
+        XCTAssertEqual(address.country, taxRate.country)
+        XCTAssertEqual(address.city, taxRate.city)
+        XCTAssertEqual(address.postcode, taxRate.postcode)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1342,6 +1342,60 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.discardOrder()
     }
 
+    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_customerBillingAddress_then_returns_true() {
+        // Given
+        stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                onCompletion(.success(.customerBillingAddress))
+            default:
+                break
+            }
+        })
+
+        let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowNewTaxRateSection)
+    }
+
+    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_customerShippingAddress_then_returns_true() {
+        // Given
+        stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                onCompletion(.success(.customerShippingAddress))
+            default:
+                break
+            }
+        })
+
+        let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowNewTaxRateSection)
+    }
+
+    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_shopBaseAddress_then_returns_true() {
+        // Given
+        stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                onCompletion(.success(.shopBaseAddress))
+            default:
+                break
+            }
+        })
+
+        let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowNewTaxRateSection)
+    }
+
     func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerBillingAddress_then_resets_addressFormViewModel_fields_with_new_data() {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
@@ -65,6 +65,31 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.taxRateViewModels.count, 1)
     }
 
+    func test_taxRateViewModels_when_taxRate_does_not_have_location_then_it_is_filtered() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storageManager = MockStorageManager()
+        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate")
+        stores.whenReceivingAction(ofType: TaxAction.self) { action in
+            guard case let .retrieveTaxRates(_, _, _, completion) = action else {
+                return
+            }
+
+            let newTaxRate = storageManager.viewStorage.insertNewObject(ofType: StorageTaxRate.self)
+            newTaxRate.update(with: taxRate)
+            storageManager.viewStorage.saveIfNeeded()
+            completion(.success([taxRate]))
+        }
+
+        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, onTaxRateSelected: { _ in }, stores: stores, storageManager: storageManager)
+
+        // When
+        viewModel.onLoadTriggerOnce.send()
+
+        // Then
+        XCTAssertTrue(viewModel.taxRateViewModels.isEmpty)
+    }
+
     func test_onRowSelected_then_calls_onTaxRateSelected_with_right_tax_rate() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10646 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we want to add some improvements to the Manual Taxes Milestone 2:

- We filter those tax rates that don't have a location from the list.
- We change the bottom text for the empty state.
- We support older Woo versions when converting the TaxRate to an address
- We improve some comments
- We hide the Set New Tax Rate if taxes are based on shop address
- We refresh the tax rates after the wp-admin web view is closed to refresh values

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Hide Set New Tax Rate in Order Details if taxes are based on shop address

With tax based on shop address (You can set that in wp-admin/admin.php?page=wc-settings&tab=tax)

1. Go to Orders
2. Tap on + to select a new order
3. Check that the Set New Tax Rate row is hidden

Try changing the setting to customer shipping address or billing address. The row should be there.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Filter Tax Rates without location

#### Before
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/e8bc9d90-6a8d-412f-9170-329ebc1c2114" width="375">

#### After

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/9f820b8d-bb00-44e9-b0c3-7d2059a9a481" width="375">

### Empty state

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/311c0a3a-806c-49ba-979d-5524a8750a69" width="375">

### Refresh after web view is closed

https://github.com/woocommerce/woocommerce-ios/assets/1864060/d9f52104-1ef7-4829-b36b-50a73265260c


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
