### PR TITLE
[Manual Taxes M2] Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -452,6 +452,11 @@ public enum WooAnalyticsStat: String {
         case orderProductSearchViaSKUSuccess = "product_search_via_sku_success"
         case orderProductSearchViaSKUFailure = "product_search_via_sku_failure"
 
+    // MARK: Tax Rate selector
+    //
+    case taxRateSelectorTaxRateTapped = "tax_rate_selector_tax_rate_tapped"
+    case taxRateSelectorEditInAdminTapped = "tax_rate_selector_edit_in_admin_tapped"
+
     // MARK: Shipping Labels Events
     //
     case shippingLabelRefundRequested = "shipping_label_refund_requested"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -393,6 +393,7 @@ public enum WooAnalyticsStat: String {
     case orderCreationProductSelectorConfirmButtonTapped = "order_creation_product_selector_confirm_button_tapped"
     case orderCreationProductSelectorClearSelectionButtonTapped = "order_creation_product_selector_clear_selection_button_tapped"
     case orderCreationProductSelectorSearchTriggered = "order_creation_product_selector_search_triggered"
+    case orderCreationSetNewTaxRateTapped = "order_creation_set_new_tax_rate_tapped"
     case orderContactAction = "order_contact_action"
     case orderCustomerAdd = "order_customer_add"
     case orderEditButtonTapped = "order_edit_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -647,6 +647,10 @@ final class EditableOrderViewModel: ObservableObject {
     func onTaxRateSelected(_ taxRate: TaxRate) {
         addTaxRateAddressToOrder(taxRate: taxRate)
     }
+
+    func onSetNewTaxRateTapped() {
+        analytics.track(.orderCreationSetNewTaxRateTapped)
+    }
 }
 
 // MARK: - Types

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -142,6 +142,7 @@ struct OrderForm: View {
                         VStack(spacing: Layout.noSpacing) {
                             Group {
                                 NewTaxRateSection {
+                                    viewModel.onSetNewTaxRateTapped()
                                     shouldShowNewTaxRateSelector = true
                                 }
                                 .sheet(isPresented: $shouldShowNewTaxRateSelector) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -117,6 +117,7 @@ struct NewTaxRateSelectorView: View {
                 .padding([.leading, .trailing], Layout.generalPadding)
 
             Button(action: {
+                viewModel.onShowWebView()
                 showingWPAdminWebview = true
             }) {
                 HStack {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -15,6 +15,10 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     /// Storage to fetch tax rates
     private let storageManager: StorageManagerType
 
+    /// Analytics engine.
+    ///
+    private let analytics: Analytics
+
     @Published private(set) var taxRateViewModels: [TaxRateViewModel] = []
 
     /// Current sync status; used to determine the view state.
@@ -36,6 +40,7 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     init(siteID: Int64,
          onTaxRateSelected: @escaping (Yosemite.TaxRate) -> Void,
          wpAdminTaxSettingsURLProvider: WPAdminTaxSettingsURLProviderProtocol = WPAdminTaxSettingsURLProvider(),
+         analytics: Analytics = ServiceLocator.analytics,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
@@ -44,6 +49,7 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
         self.stores = stores
         self.storageManager = storageManager
         self.paginationTracker = PaginationTracker(pageFirstIndex: 1, pageSize: 25)
+        self.analytics = analytics
 
         configureResultsController()
         configurePaginationTracker()
@@ -69,11 +75,17 @@ final class NewTaxRateSelectorViewModel: ObservableObject {
     }
 
     func onRowSelected(with index: Int) {
+        analytics.track(.taxRateSelectorTaxRateTapped)
+
         guard let taxRate = resultsController.fetchedObjects[safe: index] else {
             return
         }
 
         onTaxRateSelected(taxRate)
+    }
+
+    func onShowWebView() {
+        analytics.track(.taxRateSelectorEditInAdminTapped)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -523,6 +523,18 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderTaxHelpButtonTapped.rawValue)
     }
 
+    func test_payment_data_view_model_when_calling_onSetNewTaxRateTapped_then_calls_to_track_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+        viewModel.onSetNewTaxRateTapped()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderCreationSetNewTaxRateTapped.rawValue)
+    }
+
     // MARK: - Add Products to Order via SKU Scanner Tests
 
     func test_trackBarcodeScanningButtonTapped_tracks_right_event() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModelTests.swift
@@ -121,4 +121,28 @@ final class NewTaxRateSelectorViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(retrieveTaxRatesCallCount, 2)
     }
+
+    func test_onRowSelected_then_tracks_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+
+        // When
+        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, onTaxRateSelected: { _ in }, analytics: WooAnalytics(analyticsProvider: analytics))
+        viewModel.onRowSelected(with: 1)
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.taxRateSelectorTaxRateTapped.rawValue)
+    }
+
+    func test_onShowWebView_then_tracks_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+
+        // When
+        let viewModel = NewTaxRateSelectorViewModel(siteID: sampleSiteID, onTaxRateSelected: { _ in }, analytics: WooAnalytics(analyticsProvider: analytics))
+        viewModel.onShowWebView()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.taxRateSelectorEditInAdminTapped.rawValue)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10561 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With this PR we track the events related to the second milestone of the Manual Taxes project.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Orders
2. Tap on + to create a new order
3. Tap on Set New Tax Rate. Event is tracked:
`🔵 Tracked order_creation_set_new_tax_rate_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 205293073, AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "business-bundle", AnyHashable("site_url"): "https://thecanadianwootester.wpcomstaging.com"]`

4. On the tax selector, tap on any tax rate. Event is tracked:
`🔵 Tracked tax_rate_selector_tax_rate_tapped, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "business-bundle", AnyHashable("blog_id"): 205293073, AnyHashable("site_url"): "https://thecanadianwootester.wpcomstaging.com", AnyHashable("is_wpcom_store"): true]`
5. Go back to the tax selector
6. Tap on Edit tax rates in admin (scroll down to find it if necessary). Event is tracked:
`🔵 Tracked tax_rate_selector_edit_in_admin_tapped, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("blog_id"): 205293073, AnyHashable("plan"): "business-bundle", AnyHashable("is_wpcom_store"): true, AnyHashable("site_url"): "https://thecanadianwootester.wpcomstaging.com"]`



## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
