### PR TITLE
[Mobile Payments] Handle Stripe overdue requirements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -68,7 +68,8 @@ struct InPersonPaymentsView: View {
             case .pluginSetupNotCompleted(let plugin):
                 InPersonPaymentsPluginNotSetup(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .stripeAccountOverdueRequirement:
-                InPersonPaymentsStripeAccountOverdue(analyticReason: viewModel.state.reasonForAnalytics)
+                InPersonPaymentsStripeAccountOverdue(analyticReason: viewModel.state.reasonForAnalytics,
+                                                     onRefresh: viewModel.refresh)
             case .stripeAccountPendingRequirement(_, let deadline):
                 InPersonPaymentsStripeAccountPending(
                     deadline: deadline,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -27,6 +27,7 @@ struct InPersonPaymentsOnboardingError: View {
             if let buttonViewModel = buttonViewModel {
                 Button(buttonViewModel.text, action: buttonViewModel.action)
                     .buttonStyle(PrimaryButtonStyle())
+                    .padding(.bottom, secondaryButtonViewModel == nil ? 24.0 : 0)
             }
             if let secondaryButtonViewModel = secondaryButtonViewModel {
                 Button(secondaryButtonViewModel.text, action: secondaryButtonViewModel.action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -9,6 +9,7 @@ struct InPersonPaymentsOnboardingError: View {
     let learnMore: Bool
     let analyticReason: String
     var buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
+    var secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
 
     var body: some View {
         VStack {
@@ -26,7 +27,10 @@ struct InPersonPaymentsOnboardingError: View {
             if let buttonViewModel = buttonViewModel {
                 Button(buttonViewModel.text, action: buttonViewModel.action)
                     .buttonStyle(PrimaryButtonStyle())
-                    .padding(.bottom, 24.0)
+            }
+            if let secondaryButtonViewModel = secondaryButtonViewModel {
+                Button(secondaryButtonViewModel.text, action: secondaryButtonViewModel.action)
+                    .buttonStyle(SecondaryButtonStyle())
             }
             if learnMore {
                 InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(tappedAnalyticEvent: learnMoreAnalyticEvent))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAccountOverdue: View {
     let analyticReason: String
+    let onRefresh: () -> Void
+    @State private var presentedSetupURL: URL? = nil
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -13,9 +15,23 @@ struct InPersonPaymentsStripeAccountOverdue: View {
             ),
             supportLink: true,
             learnMore: true,
-            analyticReason: analyticReason
+            analyticReason: analyticReason,
+            buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.primaryButtonTitle,
+                                                                            analyticReason: "",
+                                                                            action: {
+                                                                                presentedSetupURL = setupURL
+                                                                            })
         )
+        .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
      }
+
+    private var setupURL: URL? {
+        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.cardPresentPluginHasPendingTasksURL() else {
+            return nil
+        }
+
+        return URL(string: pluginSectionURL)
+    }
 }
 
 private enum Localization {
@@ -28,11 +44,15 @@ private enum Localization {
          "You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments.",
          comment: "Error message when WooCommerce Payments is not supported because the Stripe account has overdue requirements"
      )
+
+    static let primaryButtonTitle = NSLocalizedString(
+        "Resolve Now",
+        comment: "Button to open a web view and resolve pending plugin requirements before using it.")
  }
 
 
 struct InPersonPaymentsStripeAccountOverdue_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountOverdue(analyticReason: "")
+        InPersonPaymentsStripeAccountOverdue(analyticReason: "", onRefresh: { })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -20,7 +20,12 @@ struct InPersonPaymentsStripeAccountOverdue: View {
                                                                             analyticReason: "",
                                                                             action: {
                                                                                 presentedSetupURL = setupURL
-                                                                            })
+                                                                            }),
+            secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.secondaryButtonTitle,
+                                                                                     analyticReason: "",
+                                                                                     action: {
+                                                                                         onRefresh()
+                                                                                     })
         )
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
      }
@@ -48,6 +53,10 @@ private enum Localization {
     static let primaryButtonTitle = NSLocalizedString(
         "Resolve Now",
         comment: "Button to open a web view and resolve pending plugin requirements before using it.")
+
+    static let secondaryButtonTitle = NSLocalizedString(
+        "Refresh",
+        comment: "Button to refresh the state of the in-person payments setup.")
  }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -17,12 +17,12 @@ struct InPersonPaymentsStripeAccountOverdue: View {
             learnMore: true,
             analyticReason: analyticReason,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.primaryButtonTitle,
-                                                                            analyticReason: "",
+                                                                            analyticReason: analyticReason,
                                                                             action: {
                                                                                 presentedSetupURL = setupURL
                                                                             }),
             secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.secondaryButtonTitle,
-                                                                                     analyticReason: "",
+                                                                                     analyticReason: analyticReason,
                                                                                      action: {
                                                                                          onRefresh()
                                                                                      })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -23,9 +23,7 @@ struct InPersonPaymentsStripeAccountOverdue: View {
                                                                             }),
             secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.secondaryButtonTitle,
                                                                                      analyticReason: analyticReason,
-                                                                                     action: {
-                                                                                         onRefresh()
-                                                                                     })
+                                                                                     action: onRefresh)
         )
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
      }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10627 

## Description
This PR handles the case where the Stripe plugin is installed and active, but payments cannot be processed due overdue requirements. Up until now we asked the merchant to resolve the issues on the web, with this PR we're adding adding two new buttons so can be resolved without leaving the app: 
1. The merchant can tap on `Resolve Now` in order to order a web view to their payments wp-admin page
2. Can tap on `Refresh` to refresh the current state of the IPP onboarding, in case they preferred to resolve it via the web and the state hasn't been refreshed yet.

## Testing instructions
Since we're handling overdue requirements (not pending requirements) is a bit tricky to test the real case due needing a real store with this state, the easiest way to test is by changing the `showOnboarding()` method in the `InPersonPaymentsMenuViewController` [here](https://github.com/woocommerce/woocommerce-ios/blob/2bad250c810142a7664812836852c84b4aac1547/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/InPersonPaymentsMenuViewController.swift#L182) to force this case:

```diff
- let onboardingViewModel = InPersonPaymentsViewModel(useCase: cardPresentPaymentsOnboardingUseCase)
+ let onboardingViewModel = InPersonPaymentsViewModel(fixedState: .stripeAccountOverdueRequirement(plugin: .stripe))
```

The limitation with this method is that tapping refresh or dismissing the web view won't actually refresh the onboarding state, since we're forcing a different one, but we can confirm it's being called correctly by adding a breakpoint in the `InPersonPaymentsViewModel` [here](https://github.com/woocommerce/woocommerce-ios/blob/2bad250c810142a7664812836852c84b4aac1547/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/InPersonPaymentsViewModel.swift#L57):
```
    /// Synchronizes the required data from the server and recalculates the state
    ///
    func refresh() {
        useCase.refresh()
    }
```

1. Make the change to `InPersonPaymentsMenuViewController`
2. Run the app. It does not matter which IPP plugins are installed/active since we're forcing state.
3. On a US store, eligible for IPP ( you can use  https://atomicippwcpaytests.wpcomstaging.com/ )
4. Go to Menu > Payments > See the notice at the bottom that says that `In-Person Payments setup is incomplete. Continue setup`. Tap the link.
5. See the `Resolve Now`, and `Refresh` buttons. 
6. Tap `Resolve Now`. See that a web view will open and redirect you to the payments screen (if no wpcom token has been saved yet, you may need to login)
7. Dismiss. Tap Refresh, see how the usecase.refresh breakpoint is triggered.

## Screenshots
| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2023-09-11 at 11 16 22](https://github.com/woocommerce/woocommerce-ios/assets/3812076/5887be90-29af-4103-a081-41d2e7656fdc) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-09-11 at 11 51 09](https://github.com/woocommerce/woocommerce-ios/assets/3812076/0c057212-e70c-4f5c-8be5-1a07ab35ee5a) | 
