### PR TITLE
[Mobile Payments] Add onboarding CTA failed events web view setup tapped

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1828,9 +1828,9 @@ extension WooAnalyticsEvent {
         /// - Parameters:
         ///   - reason: the reason why the onboarding step was shown (effectively the name of the step)
         ///   - countryCode: the country code of the store
-        ///   - error: the logged error
+        ///   - error: the logged error response from the API, if any.
         ///
-        static func cardPresentOnboardingCtaFailed(reason: String, countryCode: String, error: Error) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingCtaFailed(reason: String, countryCode: String, error: Error? = nil) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCtaFailed,
                               properties: [
                                 Keys.countryCode: countryCode,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -30,6 +30,7 @@ struct InPersonPaymentsPluginNotSetup: View {
                     event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
                         reason: analyticReason,
                         countryCode: cardPresentConfiguration.countryCode))
+                trackPluginSetupTappedEvent()
             } label: {
                 HStack {
                     Text(Localization.primaryButton)
@@ -88,5 +89,11 @@ private extension InPersonPaymentsPluginNotSetup {
     var learnMoreAnalyticEvent: WooAnalyticsEvent? {
         WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(reason: analyticReason,
                                                                                 countryCode: cardPresentConfiguration.countryCode)
+    }
+
+    private func trackPluginSetupTappedEvent() {
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaFailed(
+            reason: "plugin_setup_tapped",
+            countryCode: cardPresentConfiguration.countryCode))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -20,6 +20,7 @@ struct InPersonPaymentsStripeAccountOverdue: View {
                                                                             analyticReason: analyticReason,
                                                                             action: {
                                                                                 presentedSetupURL = setupURL
+                                                                                trackPluginSetupTappedEvent()
                                                                             }),
             secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.secondaryButtonTitle,
                                                                                      analyticReason: analyticReason,
@@ -36,6 +37,14 @@ struct InPersonPaymentsStripeAccountOverdue: View {
         }
 
         return URL(string: pluginSectionURL)
+    }
+}
+
+private extension InPersonPaymentsStripeAccountOverdue {
+    func trackPluginSetupTappedEvent() {
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaFailed(
+            reason: "stripe_account_setup_tapped",
+            countryCode: CardPresentConfigurationLoader().configuration.countryCode))
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10567, please review https://github.com/woocommerce/woocommerce-ios/pull/10663 first.

## Description
This PR adds the `card_present_onboarding_cta_failed` track event cases for those onboarding states that require to navigate to a web view after the onboarding has failed. It can happen in two cases:
- When WCPay requires further setup, if the merchant taps on the setup button we'll log `plugin_setup_tapped` 
- When Stripe has overdue requirements, if the merchant taps on the setup button we'll log `stripe_account_setup_tapped`

As we [discussed in previously in a previous PR](https://github.com/woocommerce/woocommerce-ios/pull/10601#discussion_r1314831100), we're doing it this way for consistency with Android and to avoid breaking existing tacks ( context: pdfdoF-3HA#comment-4930-p2) this also adds more granularity since the existing `card_present_onboarding_cta_tapped` event is triggered on all actions, while `card_present_onboarding_cta_failed` is only triggered when the merchant actually taps the setup button.

## Testing instructions
### Case 1: Finish Setup in Store Admin (WCPay not setup)
1. Change the `showOnboarding()` method in the `InPersonPaymentsMenuViewController` [here](https://github.com/woocommerce/woocommerce-ios/blob/2bad250c810142a7664812836852c84b4aac1547/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/InPersonPaymentsMenuViewController.swift#L182) to force the "WCPay setup not completed" case:

```diff
- let onboardingViewModel = InPersonPaymentsViewModel(useCase: cardPresentPaymentsOnboardingUseCase)
+ let onboardingViewModel = InPersonPaymentsViewModel(fixedState: .pluginSetupNotCompleted(plugin: .wcPay))
```
2. Run the app. Go to Menu > Payments > See the notice at the bottom that says that In-Person Payments setup is incomplete. Continue setup. Tap the link.
3. Tap `Finish Setup in Store Admin`
4. See both events logged:
** 🔵 Tracked card_present_onboarding_cta_tapped, 
** 🔵 Tracked card_present_onboarding_cta_failed with reason plugin_setup_tapped

### Case 2: Resolve Now (Stripe Overdue Requirements)
1. Change the `showOnboarding()` method in the `InPersonPaymentsMenuViewController` [here](https://github.com/woocommerce/woocommerce-ios/blob/2bad250c810142a7664812836852c84b4aac1547/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/InPersonPaymentsMenuViewController.swift#L182) to force the "Stripe overdue requirements" case:

```diff
- let onboardingViewModel = InPersonPaymentsViewModel(useCase: cardPresentPaymentsOnboardingUseCase)
+ let onboardingViewModel = InPersonPaymentsViewModel(fixedState: .stripeAccountOverdueRequirement(plugin: .stripe))
```
2. Run the app. Go to Menu > Payments > See the notice at the bottom that says that In-Person Payments setup is incomplete. Continue setup. Tap the link.
3. Tap `Resolve now`
4. See both events logged:
** 🔵 Tracked card_present_onboarding_cta_tapped, 
** 🔵 Tracked card_present_onboarding_cta_failed with reason stripe_account_setup_tapped
