### PR TITLE
Add support to the new Woo Subscriptions plugin name

### DIFF
--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -6,6 +6,6 @@ extension SitePlugin {
     enum SupportedPlugin {
         public static let WCShip = "WooCommerce Shipping &amp; Tax"
         public static let WCTracking = "WooCommerce Shipment Tracking"
-        public static let WCSubscriptions = "WooCommerce Subscriptions"
+        public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -736,7 +736,7 @@ extension OrderDetailsViewModel {
             return completion(false)
         }
 
-        let action = SystemStatusAction.fetchSystemPluginList(siteID: order.siteID, systemPluginNameList: plugins) { plugin in
+        let action = SystemStatusAction.fetchSystemPluginListWithNameList(siteID: order.siteID, systemPluginNameList: plugins) { plugin in
             completion(plugin?.active == true)
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -722,13 +722,21 @@ extension OrderDetailsViewModel {
     /// Additionally it logs to tracks if the plugin store is accessed without it being in sync so we can handle that edge-case if it happens recurrently.
     ///
     private func isPluginActive(_ plugin: String, completion: @escaping (Bool) -> (Void)) {
+        isPluginActive([plugin], completion: completion)
+    }
+
+    /// Helper function that returns `true` in its callback if any of the the provided plugin names are active on the order's store.
+    /// Additionally it logs to tracks if the plugin store is accessed without it being in sync so we can handle that edge-case if it happens recurrently.
+    /// Useful for when a plugin has had many names.
+    ///
+    private func isPluginActive(_ plugins: [String], completion: @escaping (Bool) -> (Void)) {
         guard arePluginsSynced() else {
             DDLogError("⚠️ SystemPlugins acceded without being in sync.")
             ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.pluginsNotSyncedYet())
             return completion(false)
         }
 
-        let action = SystemStatusAction.fetchSystemPlugin(siteID: order.siteID, systemPluginName: plugin) { plugin in
+        let action = SystemStatusAction.fetchSystemPluginList(siteID: order.siteID, systemPluginNameList: plugins) { plugin in
             completion(plugin?.active == true)
         }
         stores.dispatch(action)

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -108,13 +108,13 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         // SystemStatusAction.fetchSystemPlugin
         let firstAction = try XCTUnwrap(storesManager.receivedActions.first as? SystemStatusAction)
-        guard case let SystemStatusAction.fetchSystemPlugin(siteID, systemPluginName, _) = firstAction else {
+        guard case let SystemStatusAction.fetchSystemPluginList(siteID, systemPluginNameList, _) = firstAction else {
             XCTFail("Expected \(firstAction) to be \(SystemStatusAction.self)")
             return
         }
 
         XCTAssertEqual(siteID, order.siteID)
-        XCTAssertEqual(systemPluginName, SitePlugin.SupportedPlugin.WCShip)
+        XCTAssertEqual(systemPluginNameList, [SitePlugin.SupportedPlugin.WCShip])
 
         // ShippingLabelAction.synchronizeShippingLabels
         let secondAction = try XCTUnwrap(storesManager.receivedActions.last as? ShippingLabelAction)
@@ -186,13 +186,13 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         // SystemStatusAction.fetchSystemPlugin
         let firstAction = try XCTUnwrap(storesManager.receivedActions.first as? SystemStatusAction)
-        guard case let SystemStatusAction.fetchSystemPlugin(siteID, systemPluginName, _) = firstAction else {
+        guard case let SystemStatusAction.fetchSystemPluginList(siteID, systemPluginNameList, _) = firstAction else {
             XCTFail("Expected \(firstAction) to be \(SystemStatusAction.self)")
             return
         }
 
         XCTAssertEqual(siteID, order.siteID)
-        XCTAssertEqual(systemPluginName, SitePlugin.SupportedPlugin.WCShip)
+        XCTAssertEqual(systemPluginNameList, [SitePlugin.SupportedPlugin.WCShip])
 
         // ShippingLabelAction.synchronizeShippingLabels
         let secondAction = try XCTUnwrap(storesManager.receivedActions.last as? ShippingLabelAction)
@@ -228,11 +228,9 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(title.contains("\u{20AC}10.0"))
     }
 
-    func test_syncSubscriptions_loads_subscription_into_dataSource() throws {
+    func test_syncSubscriptions_loads_subscription_into_dataSource_with_legacy_plugin_name() throws {
         // Given
-
-        // Make sure the are plugins synced
-        let plugin = SystemPlugin.fake().copy(siteID: order.siteID, name: SitePlugin.SupportedPlugin.WCSubscriptions, active: true)
+        let plugin = SystemPlugin.fake().copy(siteID: order.siteID, name: "WooCommerce Subscriptions", active: true)
         storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
 
         storesManager.reset()
@@ -242,14 +240,39 @@ final class OrderDetailsViewModelTests: XCTestCase {
         let subscriptionsCount: Int = waitFor { promise in
 
             // Return the active WCExtensions plugin.
-            self.storesManager.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            self.whenFetchingSystemPlugin(thenReturn: plugin)
+
+            // Return the synced subscription.
+            self.storesManager.whenReceivingAction(ofType: SubscriptionAction.self) { action in
                 switch action {
-                case .fetchSystemPlugin(_, _, let onCompletion):
-                    onCompletion(plugin)
-                default:
-                    XCTFail("Unexpected action: \(action)")
+                case .loadSubscriptions(_, let onCompletion):
+                    onCompletion(.success([Subscription.fake()]))
+                    promise(self.viewModel.dataSource.orderSubscriptions.count)
                 }
             }
+
+            self.viewModel.syncSubscriptions(isFeatureFlagEnabled: true)
+        }
+
+        // Then
+        XCTAssertEqual(subscriptionsCount, 1)
+    }
+
+    func test_syncSubscriptions_loads_subscription_into_dataSource_with_current_plugin_name() throws {
+        // Given
+
+        // Make sure the are plugins synced
+        let plugin = SystemPlugin.fake().copy(siteID: order.siteID, name: "Woo Subscriptions", active: true)
+        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
+
+        storesManager.reset()
+        XCTAssertEqual(storesManager.receivedActions.count, 0)
+
+        // When
+        let subscriptionsCount: Int = waitFor { promise in
+
+            // Return the active WCExtensions plugin.
+            self.whenFetchingSystemPlugin(thenReturn: plugin)
 
             // Return the synced subscription.
             self.storesManager.whenReceivingAction(ofType: SubscriptionAction.self) { action in
@@ -382,8 +405,10 @@ private extension OrderDetailsViewModelTests {
     func whenFetchingSystemPlugin(thenReturn plugin: SystemPlugin?) {
         storesManager.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
-                case let .fetchSystemPlugin(_, _, onCompletion):
-                    onCompletion(plugin)
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(plugin)
+            case let .fetchSystemPluginList(_, _, onCompletion):
+                onCompletion(plugin)
                 default:
                     break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -108,7 +108,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         // SystemStatusAction.fetchSystemPlugin
         let firstAction = try XCTUnwrap(storesManager.receivedActions.first as? SystemStatusAction)
-        guard case let SystemStatusAction.fetchSystemPluginList(siteID, systemPluginNameList, _) = firstAction else {
+        guard case let SystemStatusAction.fetchSystemPluginListWithNameList(siteID, systemPluginNameList, _) = firstAction else {
             XCTFail("Expected \(firstAction) to be \(SystemStatusAction.self)")
             return
         }
@@ -186,7 +186,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         // SystemStatusAction.fetchSystemPlugin
         let firstAction = try XCTUnwrap(storesManager.receivedActions.first as? SystemStatusAction)
-        guard case let SystemStatusAction.fetchSystemPluginList(siteID, systemPluginNameList, _) = firstAction else {
+        guard case let SystemStatusAction.fetchSystemPluginListWithNameList(siteID, systemPluginNameList, _) = firstAction else {
             XCTFail("Expected \(firstAction) to be \(SystemStatusAction.self)")
             return
         }
@@ -407,7 +407,7 @@ private extension OrderDetailsViewModelTests {
             switch action {
             case let .fetchSystemPlugin(_, _, onCompletion):
                 onCompletion(plugin)
-            case let .fetchSystemPluginList(_, _, onCompletion):
+            case let .fetchSystemPluginListWithNameList(_, _, onCompletion):
                 onCompletion(plugin)
                 default:
                     break

--- a/Yosemite/Yosemite/Actions/SystemStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/SystemStatusAction.swift
@@ -14,7 +14,7 @@ public enum SystemStatusAction: Action {
 
     /// Fetch an specific systemPlugin by siteID and name list.
     ///
-    case fetchSystemPluginList(siteID: Int64, systemPluginNameList: [String], onCompletion: (SystemPlugin?) -> Void)
+    case fetchSystemPluginListWithNameList(siteID: Int64, systemPluginNameList: [String], onCompletion: (SystemPlugin?) -> Void)
 
     /// Fetch system status report for a site given its ID
     ///

--- a/Yosemite/Yosemite/Actions/SystemStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/SystemStatusAction.swift
@@ -12,6 +12,10 @@ public enum SystemStatusAction: Action {
     ///
     case fetchSystemPlugin(siteID: Int64, systemPluginName: String, onCompletion: (SystemPlugin?) -> Void)
 
+    /// Fetch an specific systemPlugin by siteID and name list.
+    ///
+    case fetchSystemPluginList(siteID: Int64, systemPluginNameList: [String], onCompletion: (SystemPlugin?) -> Void)
+
     /// Fetch system status report for a site given its ID
     ///
     case fetchSystemStatusReport(siteID: Int64, onCompletion: (Result<SystemStatus, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/SystemStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/SystemStatusStore.swift
@@ -31,6 +31,8 @@ public final class SystemStatusStore: Store {
             synchronizeSystemPlugins(siteID: siteID, completionHandler: onCompletion)
         case .fetchSystemPlugin(let siteID, let systemPluginName, let onCompletion):
             fetchSystemPlugin(siteID: siteID, systemPluginName: systemPluginName, completionHandler: onCompletion)
+        case .fetchSystemPluginList(let siteID, let systemPluginNameList, let onCompletion):
+            fetchSystemPlugin(siteID: siteID, systemPluginNameList: systemPluginNameList, completionHandler: onCompletion)
         case .fetchSystemStatusReport(let siteID, let onCompletion):
             fetchSystemStatusReport(siteID: siteID, completionHandler: onCompletion)
         }
@@ -101,11 +103,24 @@ private extension SystemStatusStore {
         storage.deleteStaleSystemPlugins(siteID: siteID, currentSystemPlugins: currentSystemPlugins)
     }
 
-    /// Retrieve `SystemPlugin` entitie of a specified storage by siteID and systemPluginName
+    /// Retrieve `SystemPlugin` entity of a specified storage by siteID and systemPluginName
     ///
     func fetchSystemPlugin(siteID: Int64, systemPluginName: String, completionHandler: @escaping (SystemPlugin?) -> Void) {
         let viewStorage = storageManager.viewStorage
         let systemPlugin = viewStorage.loadSystemPlugin(siteID: siteID, name: systemPluginName)?.toReadOnly()
         completionHandler(systemPlugin)
+    }
+
+    /// Retrieve a `SystemPlugin` entity from storage whose name matches any name from the provided name list.
+    /// Useful when a plugin has had multiple names.
+    ///
+    func fetchSystemPlugin(siteID: Int64, systemPluginNameList: [String], completionHandler: @escaping (SystemPlugin?) -> Void) {
+        let viewStorage = storageManager.viewStorage
+        for systemPluginName in systemPluginNameList {
+            if let systemPlugin = viewStorage.loadSystemPlugin(siteID: siteID, name: systemPluginName)?.toReadOnly() {
+                return completionHandler(systemPlugin)
+            }
+        }
+        completionHandler(nil)
     }
 }

--- a/Yosemite/Yosemite/Stores/SystemStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/SystemStatusStore.swift
@@ -30,8 +30,8 @@ public final class SystemStatusStore: Store {
         case .synchronizeSystemPlugins(let siteID, let onCompletion):
             synchronizeSystemPlugins(siteID: siteID, completionHandler: onCompletion)
         case .fetchSystemPlugin(let siteID, let systemPluginName, let onCompletion):
-            fetchSystemPlugin(siteID: siteID, systemPluginName: systemPluginName, completionHandler: onCompletion)
-        case .fetchSystemPluginList(let siteID, let systemPluginNameList, let onCompletion):
+            fetchSystemPlugin(siteID: siteID, systemPluginNameList: [systemPluginName], completionHandler: onCompletion)
+        case .fetchSystemPluginListWithNameList(let siteID, let systemPluginNameList, let onCompletion):
             fetchSystemPlugin(siteID: siteID, systemPluginNameList: systemPluginNameList, completionHandler: onCompletion)
         case .fetchSystemStatusReport(let siteID, let onCompletion):
             fetchSystemStatusReport(siteID: siteID, completionHandler: onCompletion)
@@ -101,14 +101,6 @@ private extension SystemStatusStore {
         // remove stale system plugins
         let currentSystemPlugins = readonlySystemPlugins.map(\.name)
         storage.deleteStaleSystemPlugins(siteID: siteID, currentSystemPlugins: currentSystemPlugins)
-    }
-
-    /// Retrieve `SystemPlugin` entity of a specified storage by siteID and systemPluginName
-    ///
-    func fetchSystemPlugin(siteID: Int64, systemPluginName: String, completionHandler: @escaping (SystemPlugin?) -> Void) {
-        let viewStorage = storageManager.viewStorage
-        let systemPlugin = viewStorage.loadSystemPlugin(siteID: siteID, name: systemPluginName)?.toReadOnly()
-        completionHandler(systemPlugin)
     }
 
     /// Retrieve a `SystemPlugin` entity from storage whose name matches any name from the provided name list.

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -101,6 +101,31 @@ final class SystemStatusStoreTests: XCTestCase {
         XCTAssertEqual(systemPluginResult?.name, "Plugin 3") // number of systemPlugins in storage
     }
 
+    func test_fetchSystemPluginsList_return_systemPlugins_correctly() {
+        // Given
+        let systemPlugin1 = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin1.name = "Plugin 1"
+        systemPlugin1.siteID = sampleSiteID
+
+        let systemPlugin3 = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin3.name = "Plugin 3"
+        systemPlugin3.siteID = sampleSiteID
+
+        let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let systemPluginResult: Yosemite.SystemPlugin? = waitFor { promise in
+            let action = SystemStatusAction.fetchSystemPluginList(siteID: self.sampleSiteID,
+                                                                  systemPluginNameList: ["Plugin 2", "Plugin 3"]) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(systemPluginResult?.name, "Plugin 3")
+    }
+
     func test_fetchSystemStatusReport_returns_systemStatus_correctly() {
         // Given
         network.simulateResponse(requestUrlSuffix: "system_status", filename: "systemStatus")

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -115,8 +115,8 @@ final class SystemStatusStoreTests: XCTestCase {
 
         // When
         let systemPluginResult: Yosemite.SystemPlugin? = waitFor { promise in
-            let action = SystemStatusAction.fetchSystemPluginList(siteID: self.sampleSiteID,
-                                                                  systemPluginNameList: ["Plugin 2", "Plugin 3"]) { result in
+            let action = SystemStatusAction.fetchSystemPluginListWithNameList(siteID: self.sampleSiteID,
+                                                                              systemPluginNameList: ["Plugin 2", "Plugin 3"]) { result in
                 promise(result)
             }
             store.onAction(action)


### PR DESCRIPTION
# Why

As requested in C025A8VV728-slack-p1694412818027799 the `WooCommerce Subscriptions` plugin will change its name to `Woo Subscriptions` in an upcoming plugin release.

This PR makes sure the app handles both names of the plugin.

# How

- Added a new action that searches for a plugin given multiple names.
- Updated code in `OrderDetailsViewModel` to use that new action

# Screenshot

<img width="456" alt="demo" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/a07cf2c3-73b6-48ea-b1eb-ddc935110d94">


# Test 

As the plugin version with the new name is not yet live...

- Make sure unit tests pass.
- Make sure current orders with subscriptions keep loading correctly.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
