### PR TITLE
[Mobile Payments] Add `card_present_onboarding_completed` event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -307,6 +307,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Card-Present Payments Onboarding
     case cardPresentOnboardingLearnMoreTapped = "card_present_onboarding_learn_more_tapped"
+    case cardPresentOnboardingCompleted = "card_present_onboarding_completed"
     case cardPresentOnboardingNotCompleted = "card_present_onboarding_not_completed"
     case cardPresentOnboardingStepSkipped = "card_present_onboarding_step_skipped"
     case cardPresentOnboardingCtaTapped = "card_present_onboarding_cta_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -151,10 +151,16 @@ private extension InPersonPaymentsViewModel {
         guard state.shouldTrackOnboardingStepEvents else {
             return
         }
-        ServiceLocator.analytics
-            .track(event: .InPersonPayments
-                .cardPresentOnboardingNotCompleted(reason: state.reasonForAnalytics,
-                                                   countryCode: countryCode))
+        switch state {
+        case .completed, .enabled:
+            ServiceLocator.analytics
+                .track(.cardPresentOnboardingCompleted)
+        default:
+            ServiceLocator.analytics
+                .track(event: .InPersonPayments
+                    .cardPresentOnboardingNotCompleted(reason: state.reasonForAnalytics,
+                                                       countryCode: countryCode))
+        }
     }
 
     func trackSkipped(state: CardPresentPaymentOnboardingState, remindLater: Bool) {

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -124,7 +124,7 @@ extension CardPresentPaymentOnboardingState {
 
     public var shouldTrackOnboardingStepEvents: Bool {
         switch self {
-        case .completed(_), .loading:
+        case .loading:
             return false
         default:
             return true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10678

## Description
This PR adds the `card_present_onboarding_completed` track event, which will be logged when the Card-Present Payments Onboarding state is `.completed` or `.enabled`

The tracking is not optimal, since can be invoked several times through the onboarding process, however since the intention of adding this event is just as an additional data point to support other funnels, we decided that the trade-off is alright ( Ref:  p1694587876703479-slack-C025A8VV728 )

## Testing instructions
- On an IPP-eligible store, and card present payment setup:
- Process a test payment through `Menu` > `Payments` > `Collect Payment` > `Take payment`
- See the `card_present_onboarding_completed` event is tracked as soon as we perform the state check:

```
🔵 Tracked card_present_onboarding_completed, properties: [AnyHashable("site_url"): "https://indiemelon.mystagingwebsite.com", AnyHashable("blog_id"): 215063064, AnyHashable("is_wpcom_store"): false, AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "jetpack_security_daily"]
```
