### PR TITLE
[Manual Taxes M3] Fetch single tax rate remotely

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -581,6 +581,7 @@
 		B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */; };
 		B990FA922AA1EBC600496375 /* TaxRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B990FA912AA1EBC600496375 /* TaxRate.swift */; };
 		B9CB14DE2A42DE60005912C2 /* products-sku-search-non-purchasable.json in Resources */ = {isa = PBXBuildFile; fileRef = B9CB14DD2A42DE60005912C2 /* products-sku-search-non-purchasable.json */; };
+		B9CFF6522AB2118900C2F616 /* TaxRateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CFF6512AB2118900C2F616 /* TaxRateMapper.swift */; };
 		B9DFE4BE2AA2057B00174004 /* TaxRateListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DFE4BD2AA2057B00174004 /* TaxRateListMapper.swift */; };
 		B9DFE4C22AA22B6F00174004 /* taxes.json in Resources */ = {isa = PBXBuildFile; fileRef = B9DFE4C12AA22B6F00174004 /* taxes.json */; };
 		BAB373722795A1FB00837B4A /* OrderTaxLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB373712795A1FB00837B4A /* OrderTaxLine.swift */; };
@@ -1552,6 +1553,7 @@
 		B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemRefundMetaData.swift; sourceTree = "<group>"; };
 		B990FA912AA1EBC600496375 /* TaxRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRate.swift; sourceTree = "<group>"; };
 		B9CB14DD2A42DE60005912C2 /* products-sku-search-non-purchasable.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-sku-search-non-purchasable.json"; sourceTree = "<group>"; };
+		B9CFF6512AB2118900C2F616 /* TaxRateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRateMapper.swift; sourceTree = "<group>"; };
 		B9DFE4BD2AA2057B00174004 /* TaxRateListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRateListMapper.swift; sourceTree = "<group>"; };
 		B9DFE4C12AA22B6F00174004 /* taxes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = taxes.json; sourceTree = "<group>"; };
 		BAB373712795A1FB00837B4A /* OrderTaxLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTaxLine.swift; sourceTree = "<group>"; };
@@ -2959,6 +2961,7 @@
 				EE2C09C129AF26B2009396F9 /* StoreOnboardingTaskListMapper.swift */,
 				020EF5E82A8BC957009D2169 /* ProductsTotalMapper.swift */,
 				B9DFE4BD2AA2057B00174004 /* TaxRateListMapper.swift */,
+				B9CFF6512AB2118900C2F616 /* TaxRateMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -4031,6 +4034,7 @@
 				4568E2242459D3230007E478 /* Post.swift in Sources */,
 				DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */,
 				4513382427A951B300AE5E78 /* InboxNoteMapper.swift in Sources */,
+				B9CFF6522AB2118900C2F616 /* TaxRateMapper.swift in Sources */,
 				DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */,
 				B557DA0320975500005962F4 /* Remote.swift in Sources */,
 				B53EF53C21814900003E146F /* SuccessResultMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 		B93E032E2A9613CB009CA9C1 /* setting-tax-based-on-parse-error.json in Resources */ = {isa = PBXBuildFile; fileRef = B93E032D2A9613CA009CA9C1 /* setting-tax-based-on-parse-error.json */; };
 		B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */; };
 		B990FA922AA1EBC600496375 /* TaxRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B990FA912AA1EBC600496375 /* TaxRate.swift */; };
+		B9CA4F332AB213DF00285AB9 /* tax.json in Resources */ = {isa = PBXBuildFile; fileRef = B9CA4F322AB213DF00285AB9 /* tax.json */; };
 		B9CB14DE2A42DE60005912C2 /* products-sku-search-non-purchasable.json in Resources */ = {isa = PBXBuildFile; fileRef = B9CB14DD2A42DE60005912C2 /* products-sku-search-non-purchasable.json */; };
 		B9CFF6522AB2118900C2F616 /* TaxRateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CFF6512AB2118900C2F616 /* TaxRateMapper.swift */; };
 		B9DFE4BE2AA2057B00174004 /* TaxRateListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DFE4BD2AA2057B00174004 /* TaxRateListMapper.swift */; };
@@ -1552,6 +1553,7 @@
 		B93E032D2A9613CA009CA9C1 /* setting-tax-based-on-parse-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-tax-based-on-parse-error.json"; sourceTree = "<group>"; };
 		B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemRefundMetaData.swift; sourceTree = "<group>"; };
 		B990FA912AA1EBC600496375 /* TaxRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRate.swift; sourceTree = "<group>"; };
+		B9CA4F322AB213DF00285AB9 /* tax.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tax.json; sourceTree = "<group>"; };
 		B9CB14DD2A42DE60005912C2 /* products-sku-search-non-purchasable.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-sku-search-non-purchasable.json"; sourceTree = "<group>"; };
 		B9CFF6512AB2118900C2F616 /* TaxRateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRateMapper.swift; sourceTree = "<group>"; };
 		B9DFE4BD2AA2057B00174004 /* TaxRateListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxRateListMapper.swift; sourceTree = "<group>"; };
@@ -2781,6 +2783,7 @@
 				CE12AE9A29F2AC3C0056DD17 /* subscription-without-data.json */,
 				CCE5F38E29EFFE3800087332 /* subscription-list.json */,
 				CCE5F39429F0034400087332 /* subscription-list-without-data.json */,
+				B9CA4F322AB213DF00285AB9 /* tax.json */,
 				B9DFE4C12AA22B6F00174004 /* taxes.json */,
 				45ED4F11239E8C57004F1BE3 /* taxes-classes.json */,
 				EE57C1492980CE4B00BC31E7 /* taxes-classes-without-data.json */,
@@ -3708,6 +3711,7 @@
 				CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */,
 				CEE9188129F7DC23004B23FF /* order-with-gift-cards.json in Resources */,
 				74ABA1CB213F19FE00FFAD30 /* top-performers-week.json in Resources */,
+				B9CA4F332AB213DF00285AB9 /* tax.json in Resources */,
 				456930AD2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json in Resources */,
 				B524194721AC643900D6FC0A /* device-settings.json in Resources */,
 				6846B01B2A61B590008EB143 /* iap-transaction-handled.json in Resources */,

--- a/Networking/Networking/Mapper/TaxRateMapper.swift
+++ b/Networking/Networking/Mapper/TaxRateMapper.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Mapper: TaxRate
+///
+struct TaxRateMapper: Mapper {
+
+    /// Site Identifier associated to the taxRate that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the TaxRate Endpoints.
+    ///
+    let siteID: Int64
+
+
+    /// (Attempts) to convert a dictionary into TaxRate.
+    ///
+    func map(response: Data) throws -> TaxRate {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(TaxRateEnvelope.self, from: response).taxRate
+        } else {
+            return try decoder.decode(TaxRate.self, from: response)
+        }
+    }
+}
+
+
+/// TaxRate Envelope Disposable Entity
+///
+/// `Load TaxRate` endpoint returns the requested taxRate document in the `data` key. This entity
+/// allows us to do parse all the things with JSONDecoder.
+///
+private struct TaxRateEnvelope: Decodable {
+    let taxRate: TaxRate
+
+    private enum CodingKeys: String, CodingKey {
+        case taxRate = "data"
+    }
+}

--- a/Networking/Networking/Remote/TaxRemote.swift
+++ b/Networking/Networking/Remote/TaxRemote.swift
@@ -51,6 +51,28 @@ public class TaxRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: onCompletion)
     }
+
+    /// Retrieves the tax rate identified by the tax rate id
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote tax classes.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func retrieveTaxRate(siteID: Int64,
+                                taxRateID: Int64,
+                                onCompletion: @escaping (Result<TaxRate, Error>) -> Void) {
+
+        let path = "\(Path.taxes)/\(taxRateID)"
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
+        let mapper = TaxRateMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: onCompletion)
+    }
 }
 
 // MARK: - Constants

--- a/Networking/NetworkingTests/Remote/TaxRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/TaxRemoteTests.swift
@@ -116,4 +116,35 @@ final class TaxRemoteTests: XCTestCase {
         let resultError = try XCTUnwrap(result.failure as? NetworkError)
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 403))
     }
+
+    func test_retrieveTaxRate_then_returns_parsed_data() throws {
+        // Given
+        let taxRateID: Int64 = 1
+        network.simulateResponse(requestUrlSuffix: "taxes/\(taxRateID)", filename: "tax")
+
+        let remote = TaxRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.retrieveTaxRate(siteID: self.sampleSiteID, taxRateID: taxRateID) { result in
+                promise(result)
+            }
+        }
+        let rate = try XCTUnwrap(result.get())
+
+        // Then
+        XCTAssertEqual(rate.id, 72)
+        XCTAssertEqual(rate.country, "US")
+        XCTAssertEqual(rate.state, "AL")
+        XCTAssertEqual(rate.postcode, "35041")
+        XCTAssertEqual(rate.city, "Cardiff")
+        XCTAssertEqual(rate.postcodes, ["35014", "35036", "35041"])
+        XCTAssertEqual(rate.rate, "4.0000")
+        XCTAssertEqual(rate.name, "State Tax")
+        XCTAssertEqual(rate.priority, 0)
+        XCTAssertEqual(rate.compound, false)
+        XCTAssertEqual(rate.shipping, false)
+        XCTAssertEqual(rate.order, 1)
+        XCTAssertEqual(rate.taxRateClass, "standard")
+    }
 }

--- a/Networking/NetworkingTests/Responses/tax.json
+++ b/Networking/NetworkingTests/Responses/tax.json
@@ -1,0 +1,38 @@
+{
+    "data":              {
+      "id": 72,
+      "country": "US",
+      "state": "AL",
+      "postcode": "35041",
+      "city": "Cardiff",
+      "postcodes": [
+        "35014",
+        "35036",
+        "35041"
+      ],
+      "cities": [
+        "Alpine",
+        "Brookside",
+        "Cardiff"
+      ],
+      "rate": "4.0000",
+      "name": "State Tax",
+      "priority": 0,
+      "compound": false,
+      "shipping": false,
+      "order": 1,
+      "class": "standard",
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/taxes/72"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/taxes"
+          }
+        ]
+      }
+  }
+}

--- a/Yosemite/Yosemite/Actions/TaxAction.swift
+++ b/Yosemite/Yosemite/Actions/TaxAction.swift
@@ -20,4 +20,8 @@ public enum TaxAction: Action {
                           pageNumber: Int,
                           pageSize: Int,
                           onCompletion: (Result<[TaxRate], Error>) -> Void)
+
+    /// Retrieves the specified Tax Rate.
+    ///
+    case retrieveTaxRate(siteID: Int64, taxRateID: Int64, onCompletion: (Result<TaxRate, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/TaxStore.swift
+++ b/Yosemite/Yosemite/Stores/TaxStore.swift
@@ -48,7 +48,7 @@ public class TaxStore: Store {
         case let .retrieveTaxRates(siteID, pageNumber, pageSize, onCompletion):
             retrieveTaxRates(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .retrieveTaxRate(siteID: let siteID, taxRateID: let taxRateID, onCompletion: let onCompletion):
-                    retrieveTaxRates(siteID: siteID, taxRateID: taxRateID, onCompletion: onCompletion)
+            retrieveTaxRate(siteID: siteID, taxRateID: taxRateID, onCompletion: onCompletion)
         }
     }
 }
@@ -118,7 +118,7 @@ private extension TaxStore {
         }
     }
 
-    func retrieveTaxRates(siteID: Int64,
+    func retrieveTaxRate(siteID: Int64,
                           taxRateID: Int64,
                           onCompletion: @escaping (Result<TaxRate, Error>) -> Void) {
         remote.retrieveTaxRate(siteID: siteID, taxRateID: taxRateID) { [weak self] result in

--- a/Yosemite/Yosemite/Stores/TaxStore.swift
+++ b/Yosemite/Yosemite/Stores/TaxStore.swift
@@ -47,6 +47,8 @@ public class TaxStore: Store {
             requestMissingTaxClasses(for: product, onCompletion: onCompletion)
         case let .retrieveTaxRates(siteID, pageNumber, pageSize, onCompletion):
             retrieveTaxRates(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .retrieveTaxRate(siteID: let siteID, taxRateID: let taxRateID, onCompletion: let onCompletion):
+                    retrieveTaxRates(siteID: siteID, taxRateID: taxRateID, onCompletion: onCompletion)
         }
     }
 }
@@ -109,6 +111,21 @@ private extension TaxStore {
             case .success(let taxRates):
                 self?.upsertStoredTaxRatesInBackground(readOnlyTaxRates: taxRates, siteID: siteID, shouldDeleteExistingTaxRates: pageNumber == 1) {
                     onCompletion(.success(taxRates))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func retrieveTaxRates(siteID: Int64,
+                          taxRateID: Int64,
+                          onCompletion: @escaping (Result<TaxRate, Error>) -> Void) {
+        remote.retrieveTaxRate(siteID: siteID, taxRateID: taxRateID) { [weak self] result in
+            switch result {
+            case .success(let taxRate):
+                self?.upsertStoredTaxRatesInBackground(readOnlyTaxRates: [taxRate], siteID: siteID, shouldDeleteExistingTaxRates: false) {
+                    onCompletion(.success(taxRate))
                 }
             case .failure(let error):
                 onCompletion(.failure(error))

--- a/Yosemite/YosemiteTests/Stores/TaxStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/TaxStoreTests.swift
@@ -209,6 +209,25 @@ final class TaxStoreTests: XCTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TaxRate.self), 3)
     }
+
+    func test_retrieveTaxRate_then_persists_TaxRate() {
+        let taxRateID: Int64 = 1
+        network.simulateResponse(requestUrlSuffix: "taxes/\(taxRateID)", filename: "tax")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TaxRate.self), 0)
+
+        // When
+        let result: Result<Yosemite.TaxRate, Error> = waitFor { [weak self] promise in
+            guard let self = self else { return }
+
+            let action = TaxAction.retrieveTaxRate(siteID: self.sampleSiteID, taxRateID: taxRateID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TaxRate.self), 1)
+    }
 }
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10670 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we retrieve a single tax rate remotely. This will help to the next task: applying the fetched tax rate to the order, matching the tax rate location to the order address/es so it can be applied.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
There's no way to test these changes UI-wise, but you can add the next code to any running place in our codebase and check the result. For instance, you can do it in the EditableOrderViewModel [init](https://github.com/woocommerce/woocommerce-ios/blob/bf4f602cdeb8b2a275a463b953d7361d08574427/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/EditableOrderViewModel.swift#L374) Ensure that the tax rate id matches any tax rate in your site. If you're using americanwootester.wpcomstaging.com, 6 will be a valid tax rate id:

```
stores.dispatch(TaxAction.retrieveTaxRate(siteID: siteID, taxRateID: 6) { result in
            if case let .success(taxRate) = result {
                debugPrint("tax rate", taxRate)
            }
        })
```



## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
