### PR TITLE
Update Aztec editor to prevent a crash on iOS 17

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ workspace 'WooCommerce.xcworkspace'
 ## =====================================
 ##
 def aztec
-  pod 'WordPress-Editor-iOS', '~> 1.11.0'
+  pod 'WordPress-Editor-iOS', '~> 1.19.9'
 end
 
 def tracks

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,9 +39,9 @@ PODS:
   - StripeTerminal (2.19.1)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (2.3.0)
-  - WordPress-Aztec-iOS (1.11.0)
-  - WordPress-Editor-iOS (1.11.0):
-    - WordPress-Aztec-iOS (= 1.11.0)
+  - WordPress-Aztec-iOS (1.19.9)
+  - WordPress-Editor-iOS (1.19.9):
+    - WordPress-Aztec-iOS (= 1.19.9)
   - WordPressAuthenticator (6.4.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
@@ -85,7 +85,7 @@ DEPENDENCIES:
   - Kingfisher (~> 7.6.2)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
-  - WordPress-Editor-iOS (~> 1.11.0)
+  - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 6.4.0)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
@@ -152,8 +152,8 @@ SPEC CHECKSUMS:
   StripeTerminal: 93e18a93c6f92e51ceedc5b78ab3075327075a80
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
-  WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
+  WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
+  WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: 5929076e39dd5aeebeb3ea1e985d6a53f73a984f
   WordPressKit: f4c39ae3a5949846d2d7c51843690d078711ab36
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
@@ -169,6 +169,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 9fcd94bf4d53ac23486263ea6721075e4d964920
+PODFILE CHECKSUM: 4124c9d7f2fc723d40cad8d0621b6e8b830e0ac4
 
 COCOAPODS: 1.12.1

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
@@ -79,7 +79,7 @@ private extension AztecUIConfigurator {
         textView.backgroundColor = .basicBackground
         textView.textColor = .systemColor(.label)
         textView.blockquoteBackgroundColor = .wooCommercePurple(.shade5)
-        textView.blockquoteBorderColor = .wooCommercePurple(.shade50)
+        textView.blockquoteBorderColors = [.wooCommercePurple(.shade50)]
         textView.preBackgroundColor = .wooCommercePurple(.shade5)
         textView.linkTextAttributes = linkAttributes
 


### PR DESCRIPTION
# Why

We got a heads-up p91TBi-aEV-p2 that the Aztec editor can potentially crash on iOS 17. This PR fixes that by updating to the latest Aztec version `1.19.9` which contains the crash fix.

# Screenshot

<img width="437" alt="Screenshot 2023-09-13 at 11 42 58 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/2ace8982-212b-4d11-a7e4-140711c3d3e0">

# Testing Steps

- Make sure the product editor works as normal
- If you have an iOS 17 device, also make sure it doesn't crash.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
