### PR TITLE
Networking: Update site model with new `isAIAssitantFeatureActive` property

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1671,6 +1671,7 @@ extension Networking.Site {
             isSiteOwner: .fake(),
             frameNonce: .fake(),
             plan: .fake(),
+            activeFeatures: .fake(),
             isJetpackThePluginInstalled: .fake(),
             isJetpackConnected: .fake(),
             isWooCommerceActive: .fake(),

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1671,7 +1671,7 @@ extension Networking.Site {
             isSiteOwner: .fake(),
             frameNonce: .fake(),
             plan: .fake(),
-            activeFeatures: .fake(),
+            isAIAssitantFeatureActive: .fake(),
             isJetpackThePluginInstalled: .fake(),
             isJetpackConnected: .fake(),
             isWooCommerceActive: .fake(),

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2115,6 +2115,7 @@ extension Networking.Site {
         isSiteOwner: CopiableProp<Bool> = .copy,
         frameNonce: CopiableProp<String> = .copy,
         plan: CopiableProp<String> = .copy,
+        activeFeatures: CopiableProp<[String]> = .copy,
         isJetpackThePluginInstalled: CopiableProp<Bool> = .copy,
         isJetpackConnected: CopiableProp<Bool> = .copy,
         isWooCommerceActive: CopiableProp<Bool> = .copy,
@@ -2136,6 +2137,7 @@ extension Networking.Site {
         let isSiteOwner = isSiteOwner ?? self.isSiteOwner
         let frameNonce = frameNonce ?? self.frameNonce
         let plan = plan ?? self.plan
+        let activeFeatures = activeFeatures ?? self.activeFeatures
         let isJetpackThePluginInstalled = isJetpackThePluginInstalled ?? self.isJetpackThePluginInstalled
         let isJetpackConnected = isJetpackConnected ?? self.isJetpackConnected
         let isWooCommerceActive = isWooCommerceActive ?? self.isWooCommerceActive
@@ -2158,6 +2160,7 @@ extension Networking.Site {
             isSiteOwner: isSiteOwner,
             frameNonce: frameNonce,
             plan: plan,
+            activeFeatures: activeFeatures,
             isJetpackThePluginInstalled: isJetpackThePluginInstalled,
             isJetpackConnected: isJetpackConnected,
             isWooCommerceActive: isWooCommerceActive,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2115,7 +2115,7 @@ extension Networking.Site {
         isSiteOwner: CopiableProp<Bool> = .copy,
         frameNonce: CopiableProp<String> = .copy,
         plan: CopiableProp<String> = .copy,
-        activeFeatures: CopiableProp<[String]> = .copy,
+        isAIAssitantFeatureActive: CopiableProp<Bool> = .copy,
         isJetpackThePluginInstalled: CopiableProp<Bool> = .copy,
         isJetpackConnected: CopiableProp<Bool> = .copy,
         isWooCommerceActive: CopiableProp<Bool> = .copy,
@@ -2137,7 +2137,7 @@ extension Networking.Site {
         let isSiteOwner = isSiteOwner ?? self.isSiteOwner
         let frameNonce = frameNonce ?? self.frameNonce
         let plan = plan ?? self.plan
-        let activeFeatures = activeFeatures ?? self.activeFeatures
+        let isAIAssitantFeatureActive = isAIAssitantFeatureActive ?? self.isAIAssitantFeatureActive
         let isJetpackThePluginInstalled = isJetpackThePluginInstalled ?? self.isJetpackThePluginInstalled
         let isJetpackConnected = isJetpackConnected ?? self.isJetpackConnected
         let isWooCommerceActive = isWooCommerceActive ?? self.isWooCommerceActive
@@ -2160,7 +2160,7 @@ extension Networking.Site {
             isSiteOwner: isSiteOwner,
             frameNonce: frameNonce,
             plan: plan,
-            activeFeatures: activeFeatures,
+            isAIAssitantFeatureActive: isAIAssitantFeatureActive,
             isJetpackThePluginInstalled: isJetpackThePluginInstalled,
             isJetpackConnected: isJetpackConnected,
             isWooCommerceActive: isWooCommerceActive,

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -39,11 +39,9 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     ///
     public let plan: String
 
-    /// Active features for current site plan.
+    /// Whether the site has AI assistant feature active.
     ///
-    /// Contains list of active features (e.g. ["akismet", "donations", "support", "ai-assistant"])
-    ///
-    public let activeFeatures: [String]
+    public let isAIAssitantFeatureActive: Bool
 
     /// Whether the site has Jetpack-the-plugin installed.
     ///
@@ -120,12 +118,12 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         let planContainer = try siteContainer.nestedContainer(keyedBy: PlanInfo.self, forKey: .plan)
         let plan = try planContainer.decode(String.self, forKey: .slug)
 
-        let activeFeatures: [String] = {
+        let isAIAssitantFeatureActive: Bool = {
             guard let featuresContainer = try? planContainer.nestedContainer(keyedBy: Features.self, forKey: .features),
                   let activeFeatures = try? featuresContainer.decode([String].self, forKey: .active)else {
-                return []
+                return false
             }
-            return activeFeatures
+            return activeFeatures.contains { $0 == Constants.aiAssistantFeature}
         }()
 
         self.init(siteID: siteID,
@@ -137,7 +135,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                   isSiteOwner: isSiteOwner,
                   frameNonce: frameNonce,
                   plan: plan,
-                  activeFeatures: activeFeatures,
+                  isAIAssitantFeatureActive: isAIAssitantFeatureActive,
                   isJetpackThePluginInstalled: isJetpackThePluginInstalled,
                   isJetpackConnected: isJetpackConnected,
                   isWooCommerceActive: isWooCommerceActive,
@@ -162,7 +160,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                 isSiteOwner: Bool,
                 frameNonce: String,
                 plan: String,
-                activeFeatures: [String],
+                isAIAssitantFeatureActive: Bool,
                 isJetpackThePluginInstalled: Bool,
                 isJetpackConnected: Bool,
                 isWooCommerceActive: Bool,
@@ -183,7 +181,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         self.isSiteOwner = isSiteOwner
         self.frameNonce = frameNonce
         self.plan = plan
-        self.activeFeatures = activeFeatures
+        self.isAIAssitantFeatureActive = isAIAssitantFeatureActive
         self.isJetpackThePluginInstalled = isJetpackThePluginInstalled
         self.isJetpackConnected = isJetpackConnected
         self.isWordPressComStore = isWordPressComStore
@@ -286,4 +284,10 @@ public extension Site {
         return TimeZone(secondsFromGMT: secondsFromGMT) ?? .current
     }
 
+}
+
+private extension Site {
+    enum Constants {
+        static let aiAssistantFeature = "ai-assistant"
+    }
 }

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -39,6 +39,12 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     ///
     public let plan: String
 
+    /// Active features for current site plan.
+    ///
+    /// Contains list of active features (e.g. ["akismet", "donations", "support", "ai-assistant"])
+    ///
+    public let activeFeatures: [String]
+
     /// Whether the site has Jetpack-the-plugin installed.
     ///
     public let isJetpackThePluginInstalled: Bool
@@ -114,6 +120,14 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         let planContainer = try siteContainer.nestedContainer(keyedBy: PlanInfo.self, forKey: .plan)
         let plan = try planContainer.decode(String.self, forKey: .slug)
 
+        let activeFeatures: [String] = {
+            guard let featuresContainer = try? planContainer.nestedContainer(keyedBy: Features.self, forKey: .features),
+                  let activeFeatures = try? featuresContainer.decode([String].self, forKey: .active)else {
+                return []
+            }
+            return activeFeatures
+        }()
+
         self.init(siteID: siteID,
                   name: name,
                   description: description,
@@ -123,6 +137,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                   isSiteOwner: isSiteOwner,
                   frameNonce: frameNonce,
                   plan: plan,
+                  activeFeatures: activeFeatures,
                   isJetpackThePluginInstalled: isJetpackThePluginInstalled,
                   isJetpackConnected: isJetpackConnected,
                   isWooCommerceActive: isWooCommerceActive,
@@ -147,6 +162,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
                 isSiteOwner: Bool,
                 frameNonce: String,
                 plan: String,
+                activeFeatures: [String],
                 isJetpackThePluginInstalled: Bool,
                 isJetpackConnected: Bool,
                 isWooCommerceActive: Bool,
@@ -167,6 +183,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         self.isSiteOwner = isSiteOwner
         self.frameNonce = frameNonce
         self.plan = plan
+        self.activeFeatures = activeFeatures
         self.isJetpackThePluginInstalled = isJetpackThePluginInstalled
         self.isJetpackConnected = isJetpackConnected
         self.isWordPressComStore = isWordPressComStore
@@ -228,6 +245,11 @@ private extension Site {
 
     enum PlanInfo: String, CodingKey {
         case slug = "product_slug"
+        case features = "features"
+    }
+
+    enum Features: String, CodingKey {
+        case active = "active"
     }
 
     enum CapabilitiesKeys: String, CodingKey {

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -120,10 +120,10 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
 
         let isAIAssitantFeatureActive: Bool = {
             guard let featuresContainer = try? planContainer.nestedContainer(keyedBy: Features.self, forKey: .features),
-                  let activeFeatures = try? featuresContainer.decode([String].self, forKey: .active)else {
+                  let activeFeatures = try? featuresContainer.decode([String].self, forKey: .active) else {
                 return false
             }
-            return activeFeatures.contains { $0 == Constants.aiAssistantFeature}
+            return activeFeatures.contains { $0 == Constants.aiAssistantFeature }
         }()
 
         self.init(siteID: siteID,

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -97,7 +97,7 @@ public extension WordPressSite {
               isSiteOwner: false,
               frameNonce: "",
               plan: "",
-              activeFeatures: [],
+              isAIAssitantFeatureActive: false,
               isJetpackThePluginInstalled: false,
               isJetpackConnected: false,
               isWooCommerceActive: isWooCommerceActive,

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -97,6 +97,7 @@ public extension WordPressSite {
               isSiteOwner: false,
               frameNonce: "",
               plan: "",
+              activeFeatures: [],
               isJetpackThePluginInstalled: false,
               isJetpackConnected: false,
               isWooCommerceActive: isWooCommerceActive,

--- a/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
@@ -49,6 +49,7 @@ final class AccountMapperTests: XCTestCase {
         XCTAssertEqual(first.canBlaze, true)
         XCTAssertEqual(first.isAdmin, true)
         XCTAssertTrue(first.wasEcommerceTrial)
+        XCTAssertEqual(first.activeFeatures, ["akismet", "donations", "ai-assistant"])
 
         // The second site is a Jetpack CP site (connected to Jetpack without Jetpack-the-plugin).
         let second = sites!.last!
@@ -72,6 +73,7 @@ final class AccountMapperTests: XCTestCase {
         XCTAssertEqual(second.canBlaze, false)
         XCTAssertEqual(second.isAdmin, false)
         XCTAssertFalse(second.wasEcommerceTrial)
+        XCTAssertEqual(second.activeFeatures, [])
     }
 
     /// Verifies that the Plan field for Site is properly parsed.

--- a/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
@@ -49,7 +49,7 @@ final class AccountMapperTests: XCTestCase {
         XCTAssertEqual(first.canBlaze, true)
         XCTAssertEqual(first.isAdmin, true)
         XCTAssertTrue(first.wasEcommerceTrial)
-        XCTAssertEqual(first.activeFeatures, ["akismet", "donations", "ai-assistant"])
+        XCTAssertTrue(first.isAIAssitantFeatureActive)
 
         // The second site is a Jetpack CP site (connected to Jetpack without Jetpack-the-plugin).
         let second = sites!.last!
@@ -73,7 +73,7 @@ final class AccountMapperTests: XCTestCase {
         XCTAssertEqual(second.canBlaze, false)
         XCTAssertEqual(second.isAdmin, false)
         XCTAssertFalse(second.wasEcommerceTrial)
-        XCTAssertEqual(second.activeFeatures, [])
+        XCTAssertFalse(second.isAIAssitantFeatureActive)
     }
 
     /// Verifies that the Plan field for Site is properly parsed.

--- a/Networking/NetworkingTests/Responses/sites.json
+++ b/Networking/NetworkingTests/Responses/sites.json
@@ -34,7 +34,14 @@
       "was_ecommerce_trial": true,
       "plan": {
           "product_id": 1008,
-          "product_slug": "business-bundle"
+          "product_slug": "business-bundle",
+          "features": {
+              "active": [
+                  "akismet",
+                  "donations",
+                  "ai-assistant"
+              ]
+          }
       },
       "options": {
         "timezone": "",
@@ -203,7 +210,13 @@
       "was_ecommerce_trial": false,
       "plan": {
           "product_id": 1008,
-          "product_slug": "business-bundle"
+          "product_slug": "business-bundle",
+          "features": {
+              "active": [
+                  "akismet",
+                  "donations"
+              ]
+          }
       },
       "options": {
         "timezone": "",

--- a/Networking/NetworkingTests/Responses/sites.json
+++ b/Networking/NetworkingTests/Responses/sites.json
@@ -210,13 +210,7 @@
       "was_ecommerce_trial": false,
       "plan": {
           "product_id": 1008,
-          "product_slug": "business-bundle",
-          "features": {
-              "active": [
-                  "akismet",
-                  "donations"
-              ]
-          }
+          "product_slug": "business-bundle"
       },
       "options": {
         "timezone": "",

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -46,7 +46,13 @@
                       },
                       "plan": {
                           "product_id": 1003,
-                          "product_slug": "value_bundle"
+                          "product_slug": "value_bundle",
+                          "features": {
+                              "active": [
+                                  "akismet",
+                                  "donations"
+                              ]
+                          }
                       },
                       "jetpack": true,
                       "jetpack_connection": true,

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -42,7 +42,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         isSiteOwner: false,
         frameNonce: "",
         plan: "",
-        activeFeatures: [],
+        isAIAssitantFeatureActive: false,
         isJetpackThePluginInstalled: true,
         isJetpackConnected: true,
         isWooCommerceActive: true,

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -42,6 +42,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         isSiteOwner: false,
         frameNonce: "",
         plan: "",
+        activeFeatures: [],
         isJetpackThePluginInstalled: true,
         isJetpackConnected: true,
         isWooCommerceActive: true,

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -43,7 +43,7 @@ extension Storage.Site: ReadOnlyConvertible {
                     isSiteOwner: isSiteOwner,
                     frameNonce: frameNonce ?? "",
                     plan: plan ?? "",
-                    activeFeatures: [], // TODO: 10688 - Add `activeFeatures` to core data model
+                    isAIAssitantFeatureActive: false, // TODO: 10688 - Add `isAIAssitantFeatureActive` to core data model
                     isJetpackThePluginInstalled: isJetpackThePluginInstalled,
                     isJetpackConnected: isJetpackConnected,
                     isWooCommerceActive: isWooCommerceActive?.boolValue ?? false,

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -43,6 +43,7 @@ extension Storage.Site: ReadOnlyConvertible {
                     isSiteOwner: isSiteOwner,
                     frameNonce: frameNonce ?? "",
                     plan: plan ?? "",
+                    activeFeatures: [], // TODO: 10688 - Add `activeFeatures` to core data model
                     isJetpackThePluginInstalled: isJetpackThePluginInstalled,
                     isJetpackConnected: isJetpackConnected,
                     isWooCommerceActive: isWooCommerceActive?.boolValue ?? false,


### PR DESCRIPTION
Part of #10689  

## Description
Adds a new property for the `Site` model in the Networking layer. 

Changes
- Parse the "plan -> features -> active" array from `me/sites` response
- Store AI assistant feature availability in `isAIAssitantFeatureActive` property of `Site`
- Update mocks and unit tests

## Testing instructions
CI passing is enough.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
