### PR TITLE
[Manual Taxes M3] Apply fetched tax rate

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -141,7 +141,7 @@ struct OrderForm: View {
 
                         VStack(spacing: Layout.noSpacing) {
                             Group {
-                                NewTaxRateSection {
+                                NewTaxRateSection(text: viewModel.taxRateRowText) {
                                     viewModel.onSetNewTaxRateTapped()
                                     shouldShowNewTaxRateSelector = true
                                 }
@@ -241,12 +241,13 @@ private struct MultipleLinesMessage: View {
 }
 
 private struct NewTaxRateSection: View {
+    let text: String
     let onButtonTapped: (() -> Void)
 
     var body: some View {
         Button(action: onButtonTapped,
                label: {
-                    Text(OrderForm.Localization.setNewTaxRate)
+                    Text(text)
                         .multilineTextAlignment(.center)
                         .padding(OrderForm.Layout.sectionSpacing)
                         .frame(maxWidth: .infinity)
@@ -435,7 +436,6 @@ private extension OrderForm {
                                                           "Please enable camera permissions in your device settings",
                                                           comment: "Message of the action sheet button that links to settings for camera access")
         static let permissionsOpenSettings = NSLocalizedString("Open Settings", comment: "Button title to open device settings in an action sheet")
-        static let setNewTaxRate = NSLocalizedString("Set New Tax Rate", comment: "Button title to set a new tax rate to an order")
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -268,7 +268,7 @@ private extension OrderPaymentSection {
                                                                comment: "Confirm message for navigating to coupons when creating a new order")
         static let goToCouponsAlertButtonTitle = NSLocalizedString("Go", comment: "Confirm button title for navigating to coupons when creating a new order")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button title when showing the coupon list selector")
-        static let taxRateAddedAutomaticallyRowText = NSLocalizedString("Tax rate added automatically",
+        static let taxRateAddedAutomaticallyRowText = NSLocalizedString("Tax rate location added automatically",
                                                                         comment: "Notice in editable order details when the tax rate was added to the order")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -126,6 +126,9 @@ struct OrderPaymentSection: View {
         .background(Color(.listForeground(modal: true)))
 
         Divider()
+
+        taxRateAddedAutomaticallyRow
+            .renderedIf(viewModel.shouldShowStoredTaxRateAddedAutomatically)
     }
 
     @ViewBuilder private var shippingRow: some View {
@@ -223,6 +226,25 @@ struct OrderPaymentSection: View {
             .footnoteStyle()
             .multilineTextAlignment(.leading)
     }
+
+    @ViewBuilder private var taxRateAddedAutomaticallyRow: some View {
+        VStack {
+            HStack(alignment: .top, spacing: Constants.taxRateAddedAutomaticallyRowHorizontalSpacing) {
+                Image(systemName: "info.circle")
+                    .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                Text(Localization.taxRateAddedAutomaticallyRowText)
+                    .subheadlineStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .frame(minHeight: Constants.rowMinHeight)
+
+            Divider()
+        }
+        .background(Color(.listForeground(modal: true)))
+    }
 }
 
 // MARK: Constants
@@ -246,12 +268,16 @@ private extension OrderPaymentSection {
                                                                comment: "Confirm message for navigating to coupons when creating a new order")
         static let goToCouponsAlertButtonTitle = NSLocalizedString("Go", comment: "Confirm button title for navigating to coupons when creating a new order")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button title when showing the coupon list selector")
+        static let taxRateAddedAutomaticallyRowText = NSLocalizedString("Tax rate added automatically",
+                                                                        comment: "Notice in editable order details when the tax rate was added to the order")
     }
 
     enum Constants {
         static let taxesSectionVerticalSpacing: CGFloat = 8
+        static let taxRateAddedAutomaticallyRowHorizontalSpacing: CGFloat = 8
         static let taxesAdaptativeStacksSpacing: CGFloat = 4
         static let sectionPadding: CGFloat = 16
+        static let rowMinHeight: CGFloat = 44
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/SelectedStoredTaxRateFetcher.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/SelectedStoredTaxRateFetcher.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Yosemite
+import Networking
+
+/// Provides the selected store tax rate information. If the stored information is not valid remotely anymore it clears the cache
+///
+struct SelectedStoredTaxRateFetcher {
+    private let stores: StoresManager
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+    }
+
+    func fetchSelectedStoredTaxRate(siteID: Int64) async -> TaxRate? {
+        guard let storedTaxRateID = await loadSelectedTaxRateID(siteID: siteID) else {
+            return nil
+        }
+
+        var taxRate: TaxRate?
+
+        do {
+            taxRate = try await retrieveTaxRate(siteID: siteID, taxRateID: storedTaxRateID)
+        } catch {
+            DDLogError("⛔️ Error when fetching Tax Rate with ID: \(storedTaxRateID).")
+            return nil
+        }
+
+        return taxRate
+    }
+}
+
+private extension SelectedStoredTaxRateFetcher {
+    func loadSelectedTaxRateID(siteID: Int64) async -> Int64? {
+        await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                stores.dispatch(AppSettingsAction.loadSelectedTaxRateID(siteID: siteID) { taxRateID in
+                    continuation.resume(returning: taxRateID)
+                })
+            }
+        }
+    }
+
+    func retrieveTaxRate(siteID: Int64, taxRateID: Int64) async throws -> TaxRate {
+        try await withCheckedThrowingContinuation { continuation in
+            Task { @MainActor in
+                stores.dispatch(TaxAction.retrieveTaxRate(siteID: siteID, taxRateID: taxRateID) { result in
+                    continuation.resume(with: result)
+                })
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1700,6 +1700,7 @@
 		B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */; };
 		B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */; };
 		B9C4AB2B28003481007008B8 /* MockPaymentsPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2A28003481007008B8 /* MockPaymentsPluginsDataProvider.swift */; };
+		B9CA4F352AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */; };
 		B9CB14DC2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */; };
 		B9CB14E02A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CB14DF2A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift */; };
 		B9DA153C280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DA153B280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift */; };
@@ -4176,6 +4177,7 @@
 		B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminer.swift; sourceTree = "<group>"; };
 		B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminerTests.swift; sourceTree = "<group>"; };
 		B9C4AB2A28003481007008B8 /* MockPaymentsPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentsPluginsDataProvider.swift; sourceTree = "<group>"; };
+		B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedStoredTaxRateFetcher.swift; sourceTree = "<group>"; };
 		B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerErrorNoticeFactory.swift; sourceTree = "<group>"; };
 		B9CB14DF2A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerErrorNoticeFactoryTests.swift; sourceTree = "<group>"; };
 		B9DA153B280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderRefundsOptionsDeterminer.swift; sourceTree = "<group>"; };
@@ -9057,6 +9059,7 @@
 				B93E03252A94EE63009CA9C1 /* TaxLineViewModel.swift */,
 				B998DF472A989BE100D1C6E8 /* TaxEducationalDialogView.swift */,
 				B998DF492A98AE4200D1C6E8 /* TaxEducationalDialogViewModel.swift */,
+				B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */,
 			);
 			path = Taxes;
 			sourceTree = "<group>";
@@ -12597,6 +12600,7 @@
 				DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
 				E1E649EB28461EDF0070B194 /* BetaFeaturesConfiguration.swift in Sources */,
 				26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */,
+				B9CA4F352AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift in Sources */,
 				DE4D23AA29B1B0CA003A4B5D /* WPCom2FALoginView.swift in Sources */,
 				023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */,
 				DE8FCD1A2A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2132,6 +2132,50 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(isRetrievingTaxBasedOnSetting)
     }
+
+    func test_viewModel_when_taxRate_is_stored_then_resets_addressFormViewModel_fields_with_new_data() {
+        // Given
+        stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                onCompletion(.success(.customerBillingAddress))
+            default:
+                break
+            }
+        })
+
+        stores.whenReceivingAction(ofType: AppSettingsAction.self, thenCall: { action in
+            switch action {
+            case .loadSelectedTaxRateID(_, let onCompletion):
+                onCompletion(1)
+            default:
+                break
+            }
+        })
+
+        let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
+
+        stores.whenReceivingAction(ofType: TaxAction.self, thenCall: { action in
+            switch action {
+            case .retrieveTaxRate(_, _, let onCompletion):
+                onCompletion(.success(taxRate))
+            default:
+                break
+            }
+        })
+
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+
+        waitUntil {
+            viewModel.addressFormViewModel.fields.state.isNotEmpty
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.state, taxRate.state)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.country, taxRate.country)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.postcode, taxRate.postcodes.first)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.city, taxRate.cities.first)
+    }
 }
 
 private extension MockStorageManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1365,11 +1365,22 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
         })
 
+        stores.whenReceivingAction(ofType: AppSettingsAction.self, thenCall: { action in
+            switch action {
+            case .loadSelectedTaxRateID(_, let onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        })
+
         let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
 
         // Then
-        XCTAssertTrue(viewModel.shouldShowNewTaxRateSection)
+        waitUntil {
+            viewModel.shouldShowNewTaxRateSection
+        }
     }
 
     func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_customerShippingAddress_then_returns_true() {
@@ -1383,11 +1394,22 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
         })
 
+        stores.whenReceivingAction(ofType: AppSettingsAction.self, thenCall: { action in
+            switch action {
+            case .loadSelectedTaxRateID(_, let onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        })
+
         let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
 
         // Then
-        XCTAssertTrue(viewModel.shouldShowNewTaxRateSection)
+        waitUntil {
+            viewModel.shouldShowNewTaxRateSection
+        }
     }
 
     func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_shopBaseAddress_then_returns_true() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10670 Review after https://github.com/woocommerce/woocommerce-ios/pull/10685
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we apply the stored tax rate to an order (changing its location) and reflect the action in the UI.

### Changes
- Fetch the tax rate with the stored id
- If it fetches it successfully, apply to the order by matching its location
- Change the tax selector entry point to "Edit Tax Rate ..." instead of "Set ..."
- Add a row to the payment details with text "Tax rate added automatically"
- Unit tests

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to create a new order
3. Tap on Set new tax rate
4. Turn the save switch on, and select a tax rate
5. Tap to create the order
6. Tap on + to create a new order
7. See that the stored tax rate is fetched, the address edited, and the UI changed as explained above

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/15274a34-bb39-48ec-9a12-18998ef8c2c8

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
