### PR TITLE
Product creation with AI: Eligibility checker

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Yosemite
+import Experiments
+
+/// Protocol for checking "add product using AI" eligibility for easier unit testing.
+protocol ProductCreationAIEligibilityCheckerProtocol {
+    /// Checks if the user is eligible for the "add product from image" feature.
+    func isEligible() async throws -> Bool
+}
+
+/// Checks the eligibility for the "add product using AI" feature.
+final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol {
+    private let stores: StoresManager
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+    }
+
+    func isEligible() async throws -> Bool {
+        guard let site = stores.sessionManager.defaultSite else {
+            return false
+        }
+
+        // Should be a new user with zero products
+        guard try await checkIfStoreHasProducts(siteID: site.siteID) == false else {
+            return false
+        }
+
+        return site.isWordPressComStore || site.isAIAssitantFeatureActive
+    }
+}
+
+private extension ProductCreationAIEligibilityChecker {
+    @MainActor
+    func checkIfStoreHasProducts(siteID: Int64) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(ProductAction.checkIfStoreHasProducts(siteID: siteID, onCompletion: { result in
+                switch result {
+                case .success(let hasProducts):
+                    continuation.resume(returning: hasProducts)
+                case .failure(let error):
+                    DDLogError("⛔️ ProductCreationAIEligibilityChecker — Error fetching products to check eligibility: \(error)")
+                    continuation.resume(throwing: error)
+                }
+            }))
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
@@ -5,44 +5,30 @@ import Experiments
 /// Protocol for checking "add product using AI" eligibility for easier unit testing.
 protocol ProductCreationAIEligibilityCheckerProtocol {
     /// Checks if the user is eligible for the "add product from image" feature.
-    func isEligible() async throws -> Bool
+    func isEligible() -> Bool
 }
 
 /// Checks the eligibility for the "add product using AI" feature.
 final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol {
     private let stores: StoresManager
+    private let storeHasProducts: Bool
 
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(stores: StoresManager = ServiceLocator.stores,
+         storeHasProducts: Bool) {
         self.stores = stores
+        self.storeHasProducts = storeHasProducts
     }
 
-    func isEligible() async throws -> Bool {
+    func isEligible() -> Bool {
         guard let site = stores.sessionManager.defaultSite else {
             return false
         }
 
         // Should be a new user with zero products
-        guard try await checkIfStoreHasProducts(siteID: site.siteID) == false else {
+        guard storeHasProducts == false else {
             return false
         }
 
         return site.isWordPressComStore || site.isAIAssitantFeatureActive
-    }
-}
-
-private extension ProductCreationAIEligibilityChecker {
-    @MainActor
-    func checkIfStoreHasProducts(siteID: Int64) async throws -> Bool {
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(ProductAction.checkIfStoreHasProducts(siteID: siteID, onCompletion: { result in
-                switch result {
-                case .success(let hasProducts):
-                    continuation.resume(returning: hasProducts)
-                case .failure(let error):
-                    DDLogError("⛔️ ProductCreationAIEligibilityChecker — Error fetching products to check eligibility: \(error)")
-                    continuation.resume(throwing: error)
-                }
-            }))
-        }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2323,6 +2323,8 @@
 		EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */; };
 		EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */; };
 		EE5A0A1C2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */; };
+		EE5B5BB32AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */; };
+		EE5B5BB62AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */; };
 		EE6A7BA92A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BA82A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift */; };
 		EE6A7BAB2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BAA2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift */; };
 		EE6A7BAD2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BAC2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift */; };
@@ -4810,6 +4812,8 @@
 		EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ApplicationPassword.swift"; sourceTree = "<group>"; };
 		EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandlerTests.swift; sourceTree = "<group>"; };
 		EE5A0A1B2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+LocalNotification.swift"; sourceTree = "<group>"; };
+		EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAIEligibilityChecker.swift; sourceTree = "<group>"; };
+		EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		EE6A7BA82A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionViewModel.swift; sourceTree = "<group>"; };
 		EE6A7BAA2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionView.swift; sourceTree = "<group>"; };
 		EE6A7BAC2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionOptions.swift; sourceTree = "<group>"; };
@@ -5507,6 +5511,7 @@
 		024F1450250B658F0003030A /* Add Product */ = {
 			isa = PBXGroup;
 			children = (
+				EE5B5BB42AB31C64009BCBD6 /* AddProductWithAI */,
 				028B68C12A574DA100FE03A8 /* AddProductFromImage */,
 				024F1451250B65A40003030A /* AddProductCoordinatorTests.swift */,
 				02C3FDE9251091CE009569EE /* ProductFactoryTests.swift */,
@@ -6244,6 +6249,7 @@
 		02ECD1E224FF5DDD00735BE5 /* Add Product */ = {
 			isa = PBXGroup;
 			children = (
+				EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */,
 				028B68B62A573F9500FE03A8 /* AddProductFromImage */,
 				EEBDF7E32A317BBB00EFEF47 /* FirstProductCreated */,
 				02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */,
@@ -10879,6 +10885,22 @@
 			path = StoreDetails;
 			sourceTree = "<group>";
 		};
+		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
+			isa = PBXGroup;
+			children = (
+				EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */,
+			);
+			path = AddProductWithAI;
+			sourceTree = "<group>";
+		};
+		EE5B5BB42AB31C64009BCBD6 /* AddProductWithAI */ = {
+			isa = PBXGroup;
+			children = (
+				EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */,
+			);
+			path = AddProductWithAI;
+			sourceTree = "<group>";
+		};
 		EE6A7BA72A7B7BC900D9A028 /* Features */ = {
 			isa = PBXGroup;
 			children = (
@@ -13107,6 +13129,7 @@
 				028203CF297662A200217369 /* DomainSelectorDataProvider.swift in Sources */,
 				DE74F2A327E41D650002FE59 /* EnableAnalyticsViewModel.swift in Sources */,
 				AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */,
+				EE5B5BB32AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift in Sources */,
 				0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */,
 				262EB5AE298C70EF009DCC36 /* SupportFormViewModel.swift in Sources */,
 				45B4F0262860BD0A00F3B16E /* WCShipCTAView.swift in Sources */,
@@ -13717,6 +13740,7 @@
 				4569D3F425DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
 				03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */,
+				EE5B5BB62AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift in Sources */,
 				DE2FE5832924DA2F0018040A /* JetpackSetupRequiredViewModelTests.swift in Sources */,
 				AEB4DB99290AE8F300AE4340 /* MockCookieJar.swift in Sources */,
 				02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
@@ -1,6 +1,5 @@
 import TestKit
 import XCTest
-import enum Yosemite.ProductAction
 
 @testable import WooCommerce
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
@@ -4,7 +4,6 @@ import enum Yosemite.ProductAction
 
 @testable import WooCommerce
 
-@MainActor
 final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
     private var stores: MockStoresManager!
 
@@ -18,40 +17,40 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_isEligible_is_true_for_wpcom_store() async throws {
+    func test_isEligible_is_true_for_wpcom_store() throws {
         // Given
         updateDefaultStore(isWPCOMStore: true)
-        updateHasProducts(hasProducts: false)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          storeHasProducts: false)
 
         // When
-        let isEligible = try await checker.isEligible()
+        let isEligible = checker.isEligible()
 
         // Then
         XCTAssertTrue(isEligible)
     }
 
-    func test_isEligible_is_false_for_non_wpcom_store() async throws {
+    func test_isEligible_is_false_for_non_wpcom_store() throws {
         // Given
         updateDefaultStore(isWPCOMStore: false)
-        updateHasProducts(hasProducts: false)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          storeHasProducts: false)
 
         // When
-        let isEligible = try await checker.isEligible()
+        let isEligible = checker.isEligible()
 
         // Then
         XCTAssertFalse(isEligible)
     }
 
-    func test_isEligible_is_false_for_wpcom_store_when_store_already_has_products() async throws {
+    func test_isEligible_is_false_for_wpcom_store_when_store_already_has_products() throws {
         // Given
         updateDefaultStore(isWPCOMStore: true)
-        updateHasProducts(hasProducts: true)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          storeHasProducts: true)
 
         // When
-        let isEligible = try await checker.isEligible()
+        let isEligible = checker.isEligible()
 
         // Then
         XCTAssertFalse(isEligible)
@@ -62,16 +61,5 @@ private extension ProductCreationAIEligibilityCheckerTests {
     func updateDefaultStore(isWPCOMStore: Bool) {
         stores.updateDefaultStore(storeID: 134)
         stores.updateDefaultStore(.fake().copy(siteID: 134, isWordPressComStore: isWPCOMStore))
-    }
-
-    func updateHasProducts(hasProducts: Bool) {
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .checkIfStoreHasProducts(_, _, completion):
-                completion(.success(hasProducts))
-            default:
-                XCTFail("Received unsupported action: \(action)")
-            }
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
@@ -1,0 +1,77 @@
+import TestKit
+import XCTest
+import enum Yosemite.ProductAction
+
+@testable import WooCommerce
+
+@MainActor
+final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
+
+    func test_isEligible_is_true_for_wpcom_store() async throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: true)
+        updateHasProducts(hasProducts: false)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+
+        // When
+        let isEligible = try await checker.isEligible()
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_isEligible_is_false_for_non_wpcom_store() async throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: false)
+        updateHasProducts(hasProducts: false)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+
+        // When
+        let isEligible = try await checker.isEligible()
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligible_is_false_for_wpcom_store_when_store_already_has_products() async throws {
+        // Given
+        updateDefaultStore(isWPCOMStore: true)
+        updateHasProducts(hasProducts: true)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+
+        // When
+        let isEligible = try await checker.isEligible()
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+}
+
+private extension ProductCreationAIEligibilityCheckerTests {
+    func updateDefaultStore(isWPCOMStore: Bool) {
+        stores.updateDefaultStore(storeID: 134)
+        stores.updateDefaultStore(.fake().copy(siteID: 134, isWordPressComStore: isWPCOMStore))
+    }
+
+    func updateHasProducts(hasProducts: Bool) {
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .checkIfStoreHasProducts(_, _, completion):
+                completion(.success(hasProducts))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
⚠️ Please review #10697 before this

Part of: #10689 

## Description
Adds an eligibility checker to check eligibility for product creation using AI.

Conditions checked by eligibility checker
- Should be a new user with zero products pecCkj-11e-p2#comment-532
- Should be WPCOM store or a self-hosted store with AI assistant feature

## Testing instructions
CI passing is sufficient. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.