### PR TITLE
[What's New] Fix announcement truncation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -67,8 +67,10 @@ struct IconListItem: View {
             VStack(alignment: .leading, spacing: Layout.innerSpacing) {
                 Text(title)
                     .headlineStyle()
+                    .fixedSize(horizontal: false, vertical: true)
                 Text(subtitle)
                     .secondaryBodyStyle()
+                    .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
         }

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
@@ -4,9 +4,6 @@ import SwiftUI
 final class WhatsNewHostingController: UIHostingController<ReportList> {
     override init(rootView: ReportList) {
         super.init(rootView: rootView)
-        if UIDevice.isPad() {
-            preferredContentSize = Layout.iPadContentSize
-        }
         modalPresentationStyle = .formSheet
     }
 
@@ -17,13 +14,5 @@ final class WhatsNewHostingController: UIHostingController<ReportList> {
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-}
-
-// MARK: - Constants
-//
-private extension WhatsNewHostingController {
-    enum Layout {
-        static let iPadContentSize = CGSize(width: 360, height: 574)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're using the What's New announcement in 15.3-15.6

I noticed that the announcement which we've submitted for translation gets slightly truncated, even at the default text size on an iPhone 13. There's plenty of space not to truncate, and the accessibility is better if we don't. The feature announcement will already scroll if required.

Additionally, this truncation was happening on iPads where we artificially reduce the size of the announcement screen.

This PR fixes the truncation, and changes the iPad announcements to use the default size, so that we don't add unneccesary scrolling to the view.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. If this is the first time using 15.3 on this device, you'll see the announcement – delete and reinstall the app to simulate this.
3. If not, go to `Menu > Settings > What's New in WooCommerce`
4. Observe that the announcement shows the full text for all the features.
5. Increase the dynamic text size
6. Observe that the announcement continues to show the full text, and allows scrolling

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/81347d34-a56a-49b7-9c5d-8ad1eda1e349


https://github.com/woocommerce/woocommerce-ios/assets/2472348/dc0b210d-e0fc-44d3-940f-21f3e1310ec6



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
