### PR TITLE
[Manual Taxes] Do not show the tax rate row if the order is not editable.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1223,6 +1223,11 @@ private extension EditableOrderViewModel {
     }
 
     func configureTaxRates() {
+        if case let .editing(order) = flow,
+           !order.isEditable {
+            return
+        }
+
         stores.dispatch(SettingAction.retrieveTaxBasedOnSetting(siteID: siteID,
                                                                 onCompletion: { [weak self] result in
             guard let self = self else { return }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses this https://github.com/woocommerce/woocommerce-ios/pull/10703#issuecomment-1719859807 from @joshheald, where it's mentioned that we can change the tax rate even if the order is not editable, causing a different total.

It's worth mentioning that that was possible even before, by changing the customer address (this is what we do when changing the tax rate). Even with that, we don't want to make it so prominent by showing a row to edit tax rates.

This PR is a draft to convey how to fix it. It needs a bit more testing and polish, but it should work.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.