### PR TITLE
Merge 15.4 code freeze into trunk

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -83,7 +83,7 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 7.0-beta'
+  pod 'WordPressAuthenticator', '~> 7.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
     - WordPress-Aztec-iOS (= 1.19.9)
-  - WordPressAuthenticator (7.0.0-beta.1):
+  - WordPressAuthenticator (7.0.0):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (~> 7.0-beta)
+  - WordPressAuthenticator (~> 7.0)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -131,7 +131,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: 2d352b4b74a5ee5ad056a1c93298fbbe804c6b48
+  WordPressAuthenticator: 132ccf00a41443e0ebd792d9a36ff5697a8f5414
   WordPressKit: f4c39ae3a5949846d2d7c51843690d078711ab36
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
@@ -146,6 +146,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: ab948d88186e4e53e9476188a95a507b8f80c3c2
+PODFILE CHECKSUM: 164409bdcbf6bf03dca938e0f32da1db23f8e9b7
 
 COCOAPODS: 1.12.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+15.5
+-----
+
+
 15.4
 -----
 - [*] Enable editing product details when tapping on order item on the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/10632]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
@@ -131,7 +131,7 @@ extension ShippingLabelHazmatCategory {
         static let division41 = NSLocalizedString("Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety/strike on box matches, " +
                                                   "book matches, mailable flammable solids",
                                                   comment: "A hazardous material description stating when a package can fit into this category")
-        static let division51 = NSLocalizedString("Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)",
+        static let division51 = NSLocalizedString("Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)",
                                                   comment: "A hazardous material description stating when a package can fit into this category")
         static let division52 = NSLocalizedString("Division 5.2 – Organic Peroxides Package",
                                                   comment: "A hazardous material description stating when a package can fit into this category")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelHazmatCategory.swift
@@ -131,6 +131,12 @@ extension ShippingLabelHazmatCategory {
         static let division41 = NSLocalizedString("Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety/strike on box matches, " +
                                                   "book matches, mailable flammable solids",
                                                   comment: "A hazardous material description stating when a package can fit into this category")
+        // Note: We're specifically using the `FULLWIDTH PERCENT SIGN` (U+FF05) character instead of the regular`%`
+        // To avoid issues with our string linter detecting a false positive of this string having a `% c` placeholder in it
+        // See https://github.com/woocommerce/woocommerce-ios/pull/5580
+        // See p8Qyks-2co-p2#comment-753
+        // See p1641398973203300-slack-C02AED43D
+        // See p1694580825965539-slack-C02KLTL3MKM
         static let division51 = NSLocalizedString("Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)",
                                                   comment: "A hazardous material description stating when a package can fit into this category")
         static let division52 = NSLocalizedString("Division 5.2 – Organic Peroxides Package",

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -61,9 +61,9 @@ msgctxt "app_store_promo_text"
 msgid "Run your store from anywhere"
 msgstr ""
 
-msgctxt "v15.3-whats-new"
+msgctxt "v15.4-whats-new"
 msgid ""
-"We're excited to announce the latest update to our WooCommerce Mobile App. This version brings a host of general improvements designed to make your experience smoother, faster, and more intuitive. We've worked hard to enhance the performance of the app, streamline functionalities, and squash any pesky bugs that were getting in the way of your seamless mobile commerce.\n"
+"In this update, we've prioritized improving our WooCommerce Mobile App experience. You can now delete and update product categories as part of the product editing flow. We've enhanced the In-Person Payments feature with better retry handling for failed transactions and protection against accidental double-charging in poor network conditions. Minor updates include editing product details from the order detail screen and an empty state design for the Tax Rate selector. Enjoy a more efficient WooCommerce app.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/ar.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ar.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "قسم 4.1: طرود المواد الصلبة القابلة للاشتعال وأعواد الثقاب الآمنة المسموح بإرسالها بالبريد - السلامة\/طرح علب أعواد الثقاب وأمشاط أعواد الثقاب والمواد الصلبة القابلة للاشتعال المسموح بإرسالها بالبريد";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "قسم 5.1 - طرد المواد المؤكسدة - بيروكسيد الهيدروجين (بتركيز يتراوح بين 8 و20％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "قسم 5.1 - طرد المواد المؤكسدة - بيروكسيد الهيدروجين (بتركيز يتراوح بين 8 و20％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "قسم 5.2 - طرد البيروكسيدات العضوية";

--- a/WooCommerce/Resources/de.lproj/Localizable.strings
+++ b/WooCommerce/Resources/de.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Unterkategorie 4.1 – Paket mit versendbaren, entzündbaren Feststoffen und Sicherheitsstreichhölzern (Mailable flammable solids and Safety Matches Package) – Sicherheitsstreichhölzer, durch Reiben an einer Reibfläche entzündbare Streichhölzer, Zündholzbriefchen, versendbare, entzündbare Feststoffe";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Unterkategorie 5.1 – Paket mit Oxidationsmitteln (Oxidizers Package) – Wasserstoffperoxid (Konzentration von 8 bis 20 ％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Unterkategorie 5.1 – Paket mit Oxidationsmitteln (Oxidizers Package) – Wasserstoffperoxid (Konzentration von 8 bis 20 ％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Unterkategorie 5.2 – Paket mit organischen Peroxiden (Organic Peroxides Package)";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -2498,7 +2498,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety/strike on box matches, book matches, mailable flammable solids" = "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety/strike on box matches, book matches, mailable flammable solids";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Division 5.2 – Organic Peroxides Package";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -315,6 +315,9 @@ which should be translated separately and considered part of this sentence. */
 /* Comment Attachment Label */
 "[COMMENT]" = "[COMMENT]";
 
+/* Markdown content learn more link on the product creation action sheet. Please translate the words while keeping the markdown format and URL. */
+"[Learn more.](https://automattic.com/ai-guidelines/)" = "[Learn more.](https://automattic.com/ai-guidelines/)";
+
 /* The message explaining what will happen when the merchant enables the Pay in Person payment gateway during card present payments onboarding. */
 "A \"Pay in Person\" option on your checkout lets you accept card or cash payments on collection or delivery." = "A \"Pay in Person\" option on your checkout lets you accept card or cash payments on collection or delivery.";
 
@@ -463,8 +466,12 @@ which should be translated separately and considered part of this sentence. */
 
 /* Message title of bottom sheet for selecting a template or manual product
    The action to add a product
-   Title for the button on the Products onboarding banner */
+   Title for the button on the Products onboarding banner
+   Title on the action sheet to select an option for adding new product */
 "Add a product" = "Add a product";
+
+/* Description of the option to add new product manually */
+"Add a product and the details manually" = "Add a product and the details manually";
 
 /* Cell text in Add / Edit product when there are no images. */
 "Add a product image" = "Add a product image";
@@ -552,7 +559,8 @@ which should be translated separately and considered part of this sentence. */
 /* Action to add downloadable file on the Product Downloadable Files screen */
 "Add File" = "Add File";
 
-/* Title for the option to create product manually */
+/* Title for the option to create product manually
+   Title of the option to add new product manually */
 "Add manually" = "Add manually";
 
 /* Title of the bottom sheet from the product form to add more product details.
@@ -625,8 +633,14 @@ which should be translated separately and considered part of this sentence. */
 /* Title for the button to add the Shipping Address in Order Details */
 "Add Shipping Address" = "Add Shipping Address";
 
+/* Description for the empty state on the Tax Rates selector screen */
+"Add tax rates in admin. Only tax rates with location information will be shown here." = "Add tax rates in admin. Only tax rates with location information will be shown here.";
+
 /* Placeholder text that will be shown in the view for adding the description of a coupon. */
 "Add the description of the coupon." = "Add the description of the coupon.";
+
+/* Body for the action to store selected tax rate */
+"Add this rate to all created orders" = "Add this rate to all created orders";
 
 /* Option to add item to new package on Package Details screen of Shipping Label flow. */
 "Add to new package" = "Add to new package";
@@ -950,6 +964,9 @@ which should be translated separately and considered part of this sentence. */
 
 /* Title of the alert when a user is changing the product type */
 "Are you sure you want to change the product type?" = "Are you sure you want to change the product type?";
+
+/* Message on the confirmation alert to delete product category */
+"Are you sure you want to delete this category permanently?" = "Are you sure you want to delete this category permanently?";
 
 /* Confirm message for deleting coupon on the Coupon Details screen */
 "Are you sure you want to delete this coupon?" = "Are you sure you want to delete this coupon?";
@@ -1332,6 +1349,7 @@ which should be translated separately and considered part of this sentence. */
    Button to cancel (not try again). Presented to users after a failure occurs
    Button to cancel a payment
    Button to cancel the creation of an order on the New Order screen
+   Button to dismiss an alert on the product category list screen
    Button to dismiss an error alert in the Jetpack setup flow
    Button to dismiss Select Categories screen
    Button to dismiss the action sheet on the store picker
@@ -1426,6 +1444,9 @@ which should be translated separately and considered part of this sentence. */
 
 /* Error message when no URL to WP-Admin page is found during Jetpack install flow */
 "Cannot find information about your site's WP-Admin. Please try again." = "Cannot find information about your site's WP-Admin. Please try again.";
+
+/* Title of the alert when there is an error creating a new product category */
+"Cannot Update Category" = "Cannot Update Category";
 
 /* The title of the alert when there is an error removing the image from a Product Variation if WooCommerce <4.7
    The title of the alert when there is an error updating the product */
@@ -1569,6 +1590,9 @@ which should be translated separately and considered part of this sentence. */
 
 /* Alert title for check your email during logIn/signUp. */
 "Check your email!" = "Check your email!";
+
+/* Bottom title of the alert presented with a spinner while the order is being validated */
+"Checking order" = "Checking order";
 
 /* Title of the WPCOM checkout web view. */
 "Checkout" = "Checkout";
@@ -2101,6 +2125,9 @@ which should be translated separately and considered part of this sentence. */
 /* Description for percentage discount type on the action sheet presented from Add or Edit coupon screen */
 "Create a percentage discount for selected products" = "Create a percentage discount for selected products";
 
+/* Title of the option to add new product with AI assistance */
+"Create a product with AI" = "Create a product with AI";
+
 /* Navigates to a new flow for site creation. */
 "Create a Site" = "Create a Site";
 
@@ -2338,8 +2365,12 @@ which should be translated separately and considered part of this sentence. */
 
 /* Button title Delete in Downloadable File Options Action Sheet
    Button title Delete in Edit Product More Options Action Sheet
+   Button to delete a product category
    Title for the action button on the confirm alert for deleting coupon on the Coupon Details screen */
 "Delete" = "Delete";
+
+/* Title of the confirmation alert to delete product category. Reads like: Delete Clothing */
+"Delete %1$@" = "Delete %1$@";
 
 /* Action title for deleting coupon on the Coupon Details screen */
 "Delete Coupon" = "Delete Coupon";
@@ -2467,7 +2498,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety/strike on box matches, book matches, mailable flammable solids" = "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety/strike on box matches, book matches, mailable flammable solids";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Division 5.2 – Organic Peroxides Package";
@@ -2662,6 +2693,7 @@ which should be translated separately and considered part of this sentence. */
 "Ecwid" = "Ecwid";
 
 /* Button to edit a customer on the New Order screen
+   Button to edit a product category
    Button to edit an order on Order Details screen
    Button to edit an order status on the New Order screen
    Button to edit the customer note on the New Order screen
@@ -2711,6 +2743,9 @@ which should be translated separately and considered part of this sentence. */
 
 /* VoiceOver accessibility hint, informing the user the button can be used to bulk edit products */
 "Edit status or price for multiple products at once" = "Edit status or price for multiple products at once";
+
+/* Button title to edit the selected tax rate to apply to the order */
+"Edit Tax Rate Setting" = "Edit Tax Rate Setting";
 
 /* Button title for the edit tax rates button in the tax educational dialog */
 "Edit Tax Rates in Admin" = "Edit Tax Rates in Admin";
@@ -4267,6 +4302,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* The required number of items in the cart to apply a coupon in plural form, reads like: Limited to 10 items in cart */
 "Limited to %1$d items in cart" = "Limited to %1$d items in cart";
 
+/* A hazardous material description stating when a package can fit into this category */
+"limited_quantity_category" = "LTD QTY Ground Package - Aerosols, spray disinfectants, spray paint, hair spray, propane, butane, cleaning products, etc. - Fragrances, nail polish, nail polish remover, solvents, hand sanitizer, rubbing alcohol, ethanol base products, etc. - Other limited quantity surface materials (cosmetics, cleaning products, paints, etc.)";
+
 /* Description of the Action sheet option when the user wants to change the Product type to external product */
 "Link a product to an external website" = "Link a product to an external website";
 
@@ -4414,9 +4452,6 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* No comment provided by engineer. */
 "Loyalty points programs" = "Loyalty points programs";
-
-/* A hazardous material description stating when a package can fit into this category */
-"limited_quantity_category" = "LTD QTY Ground Package - Aerosols, spray disinfectants, spray paint, hair spray, propane, butane, cleaning products, etc. - Fragrances, nail polish, nail polish remover, solvents, hand sanitizer, rubbing alcohol, ethanol base products, etc. - Other limited quantity surface materials (cosmetics, cleaning products, paints, etc.)";
 
 /* Country option for a site address. */
 "Luxembourg" = "Luxembourg";
@@ -4717,7 +4752,8 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Title of multiple stores as part of Jetpack benefits. */
 "Multiple Stores" = "Multiple Stores";
 
-/* Title of the 'My Store' tab - used for spotlight indexing on iOS.
+/* Placeholder store name on a notification
+   Title of the 'My Store' tab - used for spotlight indexing on iOS.
    Title of the hub menu view in case there is no title for the store */
 "My Store" = "My Store";
 
@@ -4809,6 +4845,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Title for the order creation screen */
 "New Order" = "New Order";
+
+/* Rich order notification text, will read as: New order for MyCustom store */
+"New order for" = "New order for";
 
 /* Message for the mocked order notification needed for the AppStore listing screenshot. 'Your WooCommerce Store' is the name of the mocked store. */
 "New order for $13.98 on Your WooCommerce Store" = "New order for $13.98 on Your WooCommerce Store";
@@ -4911,6 +4950,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Message on the detail view of the Orders tab before any order is selected */
 "No order selected" = "No order selected";
+
+/* Button to remove parent category for the existing category */
+"No Parent Category" = "No Parent Category";
 
 /* Bolded message confirming that no payment has been taken when the upgrade failed. */
 "No payment has been taken" = "No payment has been taken";
@@ -5292,6 +5334,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* The title for the customer payment cell */
 "Paid" = "Paid";
+
+/* Rich order notification text, will read as: Paid with Visa credit card */
+"Paid with %@" = "Paid with %@";
 
 /* Country option for a site address. */
 "Pakistan" = "Pakistan";
@@ -5697,6 +5742,9 @@ This part is the link to the website, and forms part of a longer sentence which 
    The text is followed by a WordPress.com logo on the store creation plan screen. */
 "Powered by" = "Powered by";
 
+/* Label to indicate AI-generated content on the product creation action sheet. */
+"Powered by AI." = "Powered by AI.";
+
 /* Label to indicate AI-generated content in the product detail screen. Reads: Powered by AI. Learn more. */
 "Powered by AI. %1$@." = "Powered by AI. %1$@.";
 
@@ -6019,6 +6067,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Title of the Analytics Hub Quarter to Date selection range */
 "Quarter to Date" = "Quarter to Date";
 
+/* Description of the option to add new product with AI assistance */
+"Quickly generate details for you" = "Quickly generate details for you";
+
 /* Subtitle displayed during the Login flow, whenever the user has no woo stores associated. */
 "Quickly get up and selling with a beautiful online store." = "Quickly get up and selling with a beautiful online store.";
 
@@ -6066,7 +6117,8 @@ This part is the link to the website, and forms part of a longer sentence which 
 "Referral programs" = "Referral programs";
 
 /* Button label to refresh a web page
-   Button to refresh the state of the in-person payments setup */
+   Button to refresh the state of the in-person payments setup
+   Button to refresh the state of the in-person payments setup. */
 "Refresh" = "Refresh";
 
 /* Button to reload plugin data after updating a Card Present Payments extension plugin
@@ -6255,6 +6307,9 @@ This part is the link to the website, and forms part of a longer sentence which 
    Button to reset password on the WPCom password login screen of the Jetpack setup flow.
    The button title for a secondary call-to-action button. When the user can't remember their password. */
 "Reset your password" = "Reset your password";
+
+/* Button to open a web view and resolve pending plugin requirements before using it. */
+"Resolve Now" = "Resolve Now";
 
 /* Restriction for customers with specified emails to use a coupon, reads like: Restricted to customers with emails: *@a8c.com, *@vip.com */
 "Restricted to customers with emails: %1$@" = "Restricted to customers with emails: %1$@";
@@ -7120,6 +7175,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Error message when the app can't create a zendesk identity. */
 "Sorry, we cannot create support requests right now, please try again later." = "Sorry, we cannot create support requests right now, please try again later.";
 
+/* Underlying error message for actions which require an active payment, such as cancellation, when none is found. Unlikely to be shown. */
+"Sorry, we could not complete this action, as no active payment was found." = "Sorry, we could not complete this action, as no active payment was found.";
+
 /* Error message shown when an in-progress connection is cancelled by the system */
 "Sorry, we could not connect to the reader. Please try again." = "Sorry, we could not connect to the reader. Please try again.";
 
@@ -7590,6 +7648,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Navigation bar title of the Product tax class selector screen */
 "Tax classes" = "Tax classes";
 
+/* Notice in editable order details when the tax rate was added to the order */
+"Tax rate location added automatically" = "Tax rate location added automatically";
+
 /* Second paragraph of the body for the tax educational dialog */
 "Tax rates for different locations can be managed in your store’s admin." = "Tax rates for different locations can be managed in your store’s admin.";
 
@@ -7814,6 +7875,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Error message when the cancel button on the reader is used. */
 "The payment was canceled on the reader" = "The payment was canceled on the reader";
 
+/* Message shown if a payment cancellation is shown as an error. */
+"The payment was cancelled." = "The payment was cancelled.";
+
 /* Error shown when the built-in card reader payment is interrupted by activity on the phone */
 "The payment was interrupted and cannot be continued. You can retry the payment from the order screen." = "The payment was interrupted and cannot be continued. You can retry the payment from the order screen.";
 
@@ -7972,6 +8036,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Text of the notice that is displayed while the refund creation fails. */
 "There was an error issuing the refund" = "There was an error issuing the refund";
 
+/* Error shown when there's an unrecoverable issue while retrying a payment, and it needs to berestarted from the beginning. */
+"There was an error retrying this payment. Please go back and start again." = "There was an error retrying this payment. Please go back and start again.";
+
 /* Notice title when there is an error saving the privacy banner choice */
 "There was an error saving your privacy choices." = "There was an error saving your privacy choices.";
 
@@ -8054,6 +8121,9 @@ This part is the link to the website, and forms part of a longer sentence which 
    Shipping notice row label when there is more than one shipping method */
 "This order is using extensions to calculate shipping. The shipping methods shown might be incomplete." = "This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.";
 
+/* Explanation in the alert shown when a retry fails because the payment already completed */
+"This payment has already been completed – please check the order details." = "This payment has already been completed – please check the order details.";
+
 /* Message displayed when loading a specific product fails */
 "This product couldn't be loaded" = "This product couldn't be loaded";
 
@@ -8093,6 +8163,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Alert info when selecting the cash payment method during payments */
 "This will mark your order as complete if you received \(total) outside of WooCommerce" = "This will mark your order as complete if you received \(total) outside of WooCommerce";
+
+/* Footnote for the action to store selected tax rate */
+"This will not affect online orders" = "This will not affect online orders";
 
 /* Tab selector title that shows the statistics for this year
    Top Performers section title - this year */
@@ -8467,6 +8540,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Notice message when loading product categories fails */
 "Unable to load categories" = "Unable to load categories";
 
+/* Text when failing to load a notification after long pressing on it. */
+"Unable to load notification" = "Unable to load notification";
+
 /* Text displayed when there is an error loading order stats data. */
 "Unable to load order analytics" = "Unable to load order analytics";
 
@@ -8526,6 +8602,21 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Error message when the order amount is not valid. */
 "Unable to process payment. Order total amount is not valid." = "Unable to process payment. Order total amount is not valid.";
+
+/* Error message shown during In-Person Payments when the order is found to be paid after it's refreshed. */
+"Unable to process payment. This order is already paid, taking a further payment would result in the customer being charged twice for their order." = "Unable to process payment. This order is already paid, taking a further payment would result in the customer being charged twice for their order.";
+
+/* Error message when retrying an In-Person Payment and an unknown error is received. */
+"Unable to process payment. We could not complete this payment while retrying. Underlying error: %1$@" = "Unable to process payment. We could not complete this payment while retrying. Underlying error: %1$@";
+
+/* Error message shown during In-Person Payments when the payment gateway is not available. */
+"Unable to process payment. We could not connect to the payment system. Please contact support if this error continues." = "Unable to process payment. We could not connect to the payment system. Please contact support if this error continues.";
+
+/* Error message when collecting an In-Person Payment and unable to update the order. */
+"Unable to process payment. We could not fetch the latest order details. Please check your network connection and try again." = "Unable to process payment. We could not fetch the latest order details. Please check your network connection and try again.";
+
+/* Error message when collecting an In-Person Payment and unable to update the order. %!$@ will be replaced with further error details. */
+"Unable to process payment. We could not fetch the latest order details. Please check your network connection and try again. Underlying error: %1$@" = "Unable to process payment. We could not fetch the latest order details. Please check your network connection and try again. Underlying error: %1$@";
 
 /* Error message when the card reader times out while reading a card. */
 "Unable to read card - the system timed out - please try again" = "Unable to read card - the system timed out - please try again";
@@ -8680,6 +8771,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* String shown to indicate the latest version of a plugin when an update is available and highlighted to the user */
 "Update available" = "Update available";
+
+/* Product Update Category navigation title */
+"Update Category" = "Update Category";
 
 /* Update instructions button title shown in alert warning users to upgrade to WC 3.5. */
 "Update Instructions" = "Update Instructions";
@@ -9019,6 +9113,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 /* Title for the default store picker error screen */
 "We couldn't load your site" = "We couldn't load your site";
 
+/* Title for the empty state on the Tax Rates selector screen */
+"We couldn’t find any tax rates" = "We couldn’t find any tax rates";
+
 /* Error message. Presented to users when updating the card reader software fails */
 "We couldn’t update your reader’s software" = "We couldn’t update your reader’s software";
 
@@ -9084,6 +9181,9 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Banner caption in Shipping Label Address Validation when the destination address can't be verified and no customer phone number is found. */
 "We were unable to automatically verify the shipping address. View on Apple Maps to make sure the address is correct." = "We were unable to automatically verify the shipping address. View on Apple Maps to make sure the address is correct.";
+
+/* Explanation in the alert presented when a retry of a payment fails */
+"We were unable to retry the payment – please start again." = "We were unable to retry the payment – please start again.";
 
 /* Error message displayed when an error occurred sending the magic link email. */
 "We were unable to send you an email at this time. Please try again later." = "We were unable to send you an email at this time. Please try again later.";
@@ -9426,9 +9526,6 @@ This part is the link to the website, and forms part of a longer sentence which 
 
 /* Title in Woo Payments setup celebration screen. */
 "You did it!" = "You did it!";
-
-/* Text to prompt the user to edit tax ratesin the web when there are no results */
-"You don't have any tax rates with a location." = "You don't have any tax rates with a location.";
 
 /* Message to be displayed when the user encounters a permission error during Jetpack setup */
 "You don't have permission to manage plugins on this store." = "You don't have permission to manage plugins on this store.";

--- a/WooCommerce/Resources/es.lproj/Localizable.strings
+++ b/WooCommerce/Resources/es.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "División 4.1 - Paquete de cerillas de seguridad y sólidos inflamables que se pueden enviar: seguridad\/fricción en las cajas de cerillas, en los cartones de cerillas o en sólidos inflamables que se pueden enviar";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "División 5.1 - Paquete de oxidantes: peróxido de hidrógeno (concentración de 8 a 20 ％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "División 5.1 - Paquete de oxidantes: peróxido de hidrógeno (concentración de 8 a 20 ％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "División 5.2 - Paquete de peróxidos orgánicos";

--- a/WooCommerce/Resources/fr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/fr.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Division 4.1 : matières solides inflammables, matières autoréactives, matières explosibles désensibilisées solides et matières qui polymérisent - allumettes de sûreté ou de survie, pochettes d’allumettes, matières solides inflammables";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Division 5.1 : matières comburantes - peroxyde d’hydrogène (teneur entre 8 et 20 ％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Division 5.1 : matières comburantes - peroxyde d’hydrogène (teneur entre 8 et 20 ％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Division 5.2 : peroxydes organiques";

--- a/WooCommerce/Resources/he.lproj/Localizable.strings
+++ b/WooCommerce/Resources/he.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "סיווג 4.1 – חבילה עם חומרים מוצקים דליקים שניתנים לשליחה בדואר וגפרורים – גפרורים עם פס בטיחות על האריזה, גפרורים נתלשים, חומרים מוצקים דליקים שניתנים לשליחה בדואר";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "סיווג 5.1 – חבילה עם חומרים מחמצנים – מימן על-חמצני (בריכוז של 8 עד ‎20‎)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "סיווג 5.1 – חבילה עם חומרים מחמצנים – מימן על-חמצני (בריכוז של 8 עד ‎20‎)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "סיווג 5.2 – חבילה עם על-תחמוצת אורגנית";

--- a/WooCommerce/Resources/id.lproj/Localizable.strings
+++ b/WooCommerce/Resources/id.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Bagian 4.1 – Zat padat mudah terbakar yang bisa dikirim dan Paket Korek Api - Korek api bungkus kotak, korek api bungkus lipat, zat padat mudah terbakar yang bisa dikirim";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Bagian 5.1 – Paket Oksidator - Hidrogen peroksida (konsentrasi 8 hingga 20％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Bagian 5.1 – Paket Oksidator - Hidrogen peroksida (konsentrasi 8 hingga 20％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Bagian 5.2 – Paket Peroksida Organik";

--- a/WooCommerce/Resources/it.lproj/Localizable.strings
+++ b/WooCommerce/Resources/it.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Divisione 4.1 - Pacchetto spedibile di solidi infiammabili e fiammiferi - Sicurezza\/accensione su fiammiferi in scatola, in bustina e su solidi infiammabili spedibili";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Divisione 5.1 - Pacchetto di ossidanti - Perossido di idrogeno (concentrazione da 8 a 20)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Divisione 5.1 - Pacchetto di ossidanti - Perossido di idrogeno (concentrazione da 8 a 20)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Divisione 5.2 - Pacchetto di perossidi organici";

--- a/WooCommerce/Resources/ja.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ja.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "区分4.1 – 郵送可能な可燃性固体および安全マッチパッケージ - 安全なボックスマッチ、ブックマッチ、郵送可能な可燃性固体";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "区分5.1 – 酸化剤パッケージ - 過酸化水素 (濃度8～20％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "区分5.1 – 酸化剤パッケージ - 過酸化水素 (濃度8～20％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "区分5.2 – 有機過酸化物パッケージ";

--- a/WooCommerce/Resources/ko.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ko.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Division 4.1 - 우송 가능한 가연성 고체 및 안전성냥 패키지 - 곽성냥, 성냥첩, 우송 가능한 가연성 고체에 대한 안전성\/타격";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Division 5.1 - 산화제 패키지 - 과산화수소(농도 8~20％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Division 5.1 - 산화제 패키지 - 과산화수소(농도 8~20％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Division 5.2 - 유기과산화물 패키지";

--- a/WooCommerce/Resources/nl.lproj/Localizable.strings
+++ b/WooCommerce/Resources/nl.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Divisie 4.1 - Verzendbare vlambare vaste stoffen en veiligheidslucifers-pakket - veiligheids-\/striklucifers, luciferboekjes, verzendbare vlambare vaste stoffen";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Divisie 5.1 - Oxidatiemiddel-pakket - Waterstofperoxide (concentratie van 8 tot 20％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Divisie 5.1 - Oxidatiemiddel-pakket - Waterstofperoxide (concentratie van 8 tot 20％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Divisie 5.2 - Organische peroxiden-pakket";

--- a/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
+++ b/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Divisão 4.1 - Sólidos inflamáveis que podem ser enviados por correio e pacote com caixas de fósforo - Caixas de fósforo, sólidos inflamáveis que podem ser enviados por correio";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Divisão 5.1 - Pacote com oxidadores - Peróxido de hidrogênio (concentração de 8 a 20％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Divisão 5.1 - Pacote com oxidadores - Peróxido de hidrogênio (concentração de 8 a 20％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Divisão 5.2 - Pacote com peróxidos orgânicos";

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,1 +1,9 @@
-We're excited to announce the latest update to our WooCommerce Mobile App. This version brings a host of general improvements designed to make your experience smoother, faster, and more intuitive. We've worked hard to enhance the performance of the app, streamline functionalities, and squash any pesky bugs that were getting in the way of your seamless mobile commerce.
+- [*] Enable editing product details when tapping on order item on the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/10632]
+- [*] Taxes in orders: Add empty state design for the Tax Rate selector. [https://github.com/woocommerce/woocommerce-ios/pull/10665]
+- [*] Added protection against accidental double-charging with In-Person Payments in poor network conditions [https://github.com/woocommerce/woocommerce-ios/pull/10647]
+- [**] Improved retry handling for In-Person Payments that fail [https://github.com/woocommerce/woocommerce-ios/pull/10673]
+- [*] See more of your order by long pressing an order push notification. [https://github.com/woocommerce/woocommerce-ios/pull/10658]
+- [*] Order details: product add-ons for a line item are shown in separate lines for better readability. [https://github.com/woocommerce/woocommerce-ios/pull/10661]
+- [**] Product categories now can be deleted as part of the product editing flow. [https://github.com/woocommerce/woocommerce-ios/pull/10643]
+- [**] Product categories can now be updated as part of the product editing flow. [https://github.com/woocommerce/woocommerce-ios/pull/10648]
+

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,9 +1,1 @@
-- [*] Enable editing product details when tapping on order item on the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/10632]
-- [*] Taxes in orders: Add empty state design for the Tax Rate selector. [https://github.com/woocommerce/woocommerce-ios/pull/10665]
-- [*] Added protection against accidental double-charging with In-Person Payments in poor network conditions [https://github.com/woocommerce/woocommerce-ios/pull/10647]
-- [**] Improved retry handling for In-Person Payments that fail [https://github.com/woocommerce/woocommerce-ios/pull/10673]
-- [*] See more of your order by long pressing an order push notification. [https://github.com/woocommerce/woocommerce-ios/pull/10658]
-- [*] Order details: product add-ons for a line item are shown in separate lines for better readability. [https://github.com/woocommerce/woocommerce-ios/pull/10661]
-- [**] Product categories now can be deleted as part of the product editing flow. [https://github.com/woocommerce/woocommerce-ios/pull/10643]
-- [**] Product categories can now be updated as part of the product editing flow. [https://github.com/woocommerce/woocommerce-ios/pull/10648]
-
+In this update, we've prioritized improving our WooCommerce Mobile App experience. You can now delete and update product categories as part of the product editing flow. We've enhanced the In-Person Payments feature with better retry handling for failed transactions and protection against accidental double-charging in poor network conditions. Minor updates include editing product details from the order detail screen and an empty state design for the Tax Rate selector. Enjoy a more efficient WooCommerce app.

--- a/WooCommerce/Resources/ru.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ru.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "П. 4.1 — разрешённые к пересылке воспламеняющиеся твёрдые вещества и безопасные спички — безопасные спички в коробке и разрешённые к пересылке воспламеняющиеся твёрдые вещества";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "П. 5.1 — посылка с окислителями — перекись водорода в концентрации от 8 до 20 ％";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "П. 5.1 — посылка с окислителями — перекись водорода в концентрации от 8 до 20 ％";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "П. 5.2 — посылка с органическими пероксидами";

--- a/WooCommerce/Resources/sv.lproj/Localizable.strings
+++ b/WooCommerce/Resources/sv.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Avdelning 4.1 – Paketet med postbara brandfarliga fasta ämnen och säkerhetständstickor – Säkerhetständstickor\/tändstickor som tänds på asken, boktändstickor, postbara brandfarliga fasta ämnen";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Avdelning 5.1 – Paket med oxidationsmedel – Väteperoxid (koncentration: 8 till 20 ％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Avdelning 5.1 – Paket med oxidationsmedel – Väteperoxid (koncentration: 8 till 20 ％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Avdelning 5.2 – Paket med organiska peroxider";

--- a/WooCommerce/Resources/tr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/tr.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "Bölüm 4.1 - Postayla gönderilebilen yanıcı katılar ve Emniyet Kibritleri Paketi - Kutu kibritler, kitap kibritleri, postayla gönderilebilir yanıcı katılar üzerinde güvenlik\/çakma testi";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "Bölüm 5.1 - Oksitleyici Paketi - Hidrojen peroksit (8 ila 20 konsantrasyon)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "Bölüm 5.1 - Oksitleyici Paketi - Hidrojen peroksit (8 ila 20 konsantrasyon)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "Bölüm 5.2 - Organik Peroksitler Paketi";

--- a/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "类别 4.1 — 可邮寄的易燃固体和安全火柴包装 — 安全\/火柴盒、卡纸夹式火柴、可邮寄的易燃固体";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "类别 5.1 — 氧化剂包装 — 过氧化氢（8-20％ 浓度）";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "类别 5.1 — 氧化剂包装 — 过氧化氢（8-20％ 浓度）";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "类别 5.2 — 有机过氧化物包装";

--- a/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
@@ -2421,7 +2421,7 @@ which should be translated separately and considered part of this sentence. */
 "Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety\/strike on box matches, book matches, mailable flammable solids" = "第 4.1 類：可郵寄的易燃固體和安全火柴包裹。可安全擦劃盒裝火柴、紙板火柴、可郵寄的易燃固體";
 
 /* A hazardous material description stating when a package can fit into this category */
-"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20% concentration)" = "第 5.1 類：氧化劑包裹 - 過氧化氫 (濃度為 8％ 到 20％)";
+"Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20％ concentration)" = "第 5.1 類：氧化劑包裹 - 過氧化氫 (濃度為 8％ 到 20％)";
 
 /* A hazardous material description stating when a package can fit into this category */
 "Division 5.2 – Organic Peroxides Package" = "第 5.2 類：有機過氧化物包裹";

--- a/config/Version.Public.xcconfig
+++ b/config/Version.Public.xcconfig
@@ -1,7 +1,7 @@
-VERSION_SHORT=15.3
+VERSION_SHORT=15.4
 
 // Public long version example: VERSION_LONG=1.2.0.0
-VERSION_LONG=15.3.0.2
+VERSION_LONG=15.4.0.0
 
 // Re-map our custom version values (used by release-toolkit) to the Xcode ones
 MARKETING_VERSION=$VERSION_SHORT


### PR DESCRIPTION
This PR merges the changes from the 15.4 code freeze into `trunk`. Includes: 
- Version bump
- Frozen app strings for translation
- Updated release notes
- Updated WordPressAuthenticator from `7.0.0-beta-1` to `7.0.0` 
- Replaced the regular percent signs in a string with `％` to workaround a linter issue (see p1694580825965539-slack-C02KLTL3MKM for context)