### PR TITLE
Use xcconfig values for notification extension

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -14235,7 +14235,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(VERSION_LONG)";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -14248,7 +14248,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(VERSION_SHORT)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.notificationcontentextension;
@@ -14272,7 +14272,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(VERSION_LONG)";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -14285,7 +14285,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(VERSION_SHORT)";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.notificationcontentextension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -14308,7 +14308,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(VERSION_LONG)";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99KV9Z6BKV;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -14321,7 +14321,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(VERSION_SHORT)";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.notificationcontentextension;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This PR addresses this warning we received from App Store Connect after uploading the `15.4.0.0` build: 

> We identified one or more issues with a recent delivery for your app, "WooCommerce" 15.4 (15.4.0.0). Your delivery was successful, but you may wish to correct the following issues in your next delivery:
> 
> ITMS-90473: CFBundleVersion Mismatch - The CFBundleVersion value '1' of extension '[WooCommerce.app/PlugIns/NotificationExtension.appex](https://woocommerce.app/PlugIns/NotificationExtension.appex)' does not match the CFBundleVersion value '15.4.0.0' of its containing iOS application '[WooCommerce.app](https://woocommerce.app/)'.
> 
> ITMS-90473: CFBundleShortVersionString Mismatch - The CFBundleShortVersionString value '1.0' of extension '[WooCommerce.app/PlugIns/NotificationExtension.appex](https://woocommerce.app/PlugIns/NotificationExtension.appex)' does not match the CFBundleShortVersionString value '15.4' of its containing iOS application '[WooCommerce.app](https://woocommerce.app/)'.

A new target was added to the WCiOS project: "NotificationExtension". It wasn't pointing to the version `xcconfig` file, so the version and build number were set to 1.0 and 1. This PR switches those to point to the `xcconfig` file instead. 