### PR TITLE
Product Creation AI: Update logic checking whether store has product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -96,7 +96,7 @@ final class AddProductCoordinator: Coordinator {
     func start() {
         switch source {
         case .productsTab, .productOnboarding:
-            ServiceLocator.analytics.track(event: .ProductsOnboarding.productListAddProductButtonTapped(templateEligible: isTemplateOptionsEligible()))
+            ServiceLocator.analytics.track(event: .ProductsOnboarding.productListAddProductButtonTapped(templateEligible: isTemplateOptionsEligible))
         default:
             break
         }
@@ -129,7 +129,7 @@ private extension AddProductCoordinator {
     /// Currently returns `true` when the store is eligible for displaying template options.
     ///
     var shouldPresentProductCreationBottomSheet: Bool {
-        isTemplateOptionsEligible()
+        isTemplateOptionsEligible
     }
 
     /// Defines if it should skip the bottom sheet before the product form is shown.
@@ -147,7 +147,7 @@ private extension AddProductCoordinator {
 
     /// Returns `true` when the number of non-sample products is fewer than 3.
     ///
-    func isTemplateOptionsEligible() -> Bool {
+    var isTemplateOptionsEligible: Bool {
         productsResultsController.fetchedObjects.filter { $0.isSampleItem == false }.count < 3
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -116,12 +116,13 @@ final class AddProductCoordinator: Coordinator {
     }
 }
 
-// MARK: Navigation checks
-extension AddProductCoordinator {
+// MARK: Navigation
+private extension AddProductCoordinator {
+
     /// Whether the action sheet with the option for product creation with AI should be presented.
     ///
     var shouldShowAIActionSheet: Bool {
-        addProductWithAIEligibilityChecker.isEligible(storeHasProducts: storeHasProducts)
+        !storeHasProducts && addProductWithAIEligibilityChecker.isEligible
     }
 
     /// Defines if the product creation bottom sheet should be presented.
@@ -143,10 +144,6 @@ extension AddProductCoordinator {
     var shouldShowGroupedProductType: Bool {
         storeHasProducts
     }
-}
-
-// MARK: Navigation
-private extension AddProductCoordinator {
 
     /// Returns `true` when the number of non-sample products is fewer than 3.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -47,7 +47,8 @@ final class AddProductCoordinator: Coordinator {
     var onProductCreated: (Product) -> Void = { _ in }
 
     private var storeHasProducts: Bool {
-        !productsResultsController.isEmpty
+        let objects = productsResultsController.fetchedObjects
+        return objects.contains(where: { $0.isSampleItem == false })
     }
 
     private var addProductWithAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol
@@ -127,10 +128,10 @@ private extension AddProductCoordinator {
         isTemplateOptionsEligible()
     }
 
-    /// Returns `true` when the number of products is fewer than 3.
+    /// Returns `true` when the number of non-sample products is fewer than 3.
     ///
     func isTemplateOptionsEligible() -> Bool {
-        productsResultsController.numberOfObjects < 3
+        productsResultsController.fetchedObjects.filter { $0.isSampleItem == false }.count < 3
     }
 
     /// Defines if it should skip the bottom sheet before the product form is shown.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
@@ -5,7 +5,7 @@ import Experiments
 /// Protocol for checking "add product using AI" eligibility for easier unit testing.
 protocol ProductCreationAIEligibilityCheckerProtocol {
     /// Checks if the user is eligible for the "add product using AI" feature.
-    func isEligible(storeHasProducts: Bool) -> Bool
+    var isEligible: Bool { get }
 }
 
 /// Checks the eligibility for the "add product using AI" feature.
@@ -19,17 +19,12 @@ final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityChe
         self.featureFlagService = featureFlagService
     }
 
-    func isEligible(storeHasProducts: Bool) -> Bool {
+    var isEligible: Bool {
         guard featureFlagService.isFeatureFlagEnabled(.productCreationAI) else {
             return false
         }
 
         guard let site = stores.sessionManager.defaultSite else {
-            return false
-        }
-
-        // Should be a new user with zero products
-        guard storeHasProducts == false else {
             return false
         }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductCreationAIEligibilityChecker.swift
@@ -9,7 +9,7 @@ final class MockProductCreationAIEligibilityChecker: ProductCreationAIEligibilit
         self.eligible = isEligible
     }
 
-    func isEligible(storeHasProducts: Bool) -> Bool {
+    var isEligible: Bool {
         eligible
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
@@ -90,15 +90,32 @@ final class AddProductCoordinatorTests: XCTestCase {
         // Then
         assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
     }
+
+    func test_it_presents_product_form_on_start_when_the_source_is_announcement_modal() {
+        // Given
+        let coordinator = makeAddProductCoordinator(
+            source: .productDescriptionAIAnnouncementModal,
+            addProductWithAIEligibilityChecker: MockProductCreationAIEligibilityChecker(isEligible: true)
+        )
+
+        // When
+        coordinator.start()
+
+        // Then
+        waitUntil {
+            coordinator.navigationController.topViewController is ProductFormViewController<ProductFormViewModel>
+        }
+    }
 }
 
 private extension AddProductCoordinatorTests {
     func makeAddProductCoordinator(
+        source: AddProductCoordinator.Source = .productsTab,
         addProductWithAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol = MockProductCreationAIEligibilityChecker()
     ) -> AddProductCoordinator {
         let view = UIView()
         return AddProductCoordinator(siteID: sampleSiteID,
-                                     source: .productsTab,
+                                     source: source,
                                      sourceView: view,
                                      sourceNavigationController: navigationController,
                                      storage: storageManager,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
@@ -7,10 +7,13 @@ import WordPressUI
 
 final class AddProductCoordinatorTests: XCTestCase {
     private var navigationController: UINavigationController!
+    private var storageManager: MockStorageManager!
+    private let sampleSiteID: Int64 = 100
 
     override func setUp() {
         super.setUp()
         navigationController = UINavigationController()
+        storageManager = MockStorageManager()
 
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
@@ -20,10 +23,11 @@ final class AddProductCoordinatorTests: XCTestCase {
 
     override func tearDown() {
         navigationController = nil
+        storageManager = nil
         super.tearDown()
     }
 
-    func test_it_presents_bottom_sheet_on_start() throws {
+    func test_it_presents_bottom_sheet_on_start() {
         // Arrange
         let coordinator = makeAddProductCoordinator()
 
@@ -37,7 +41,7 @@ final class AddProductCoordinatorTests: XCTestCase {
         assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
     }
 
-    func test_it_presents_AddProductWithAIActionSheet_on_start_when_eligible_for_ProductCreationAI() throws {
+    func test_it_presents_AddProductWithAIActionSheet_on_start_when_eligible_for_ProductCreationAI_and_store_has_no_products() {
         // Given
         let coordinator = makeAddProductCoordinator(
             addProductWithAIEligibilityChecker: MockProductCreationAIEligibilityChecker(isEligible: true)
@@ -52,6 +56,40 @@ final class AddProductCoordinatorTests: XCTestCase {
         // Then
         assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: AddProductWithAIActionSheetHostingController.self)
     }
+
+    func test_it_presents_AddProductWithAIActionSheet_on_start_when_eligible_for_ProductCreationAI_and_store_has_only_sample_products() {
+        // Given
+        storageManager.insertSampleProduct(readOnlyProduct: .fake().copy(siteID: sampleSiteID, isSampleItem: true))
+        let coordinator = makeAddProductCoordinator(
+            addProductWithAIEligibilityChecker: MockProductCreationAIEligibilityChecker(isEligible: true)
+        )
+
+        // When
+        coordinator.start()
+        waitUntil {
+            coordinator.navigationController.presentedViewController != nil
+        }
+
+        // Then
+        assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: AddProductWithAIActionSheetHostingController.self)
+    }
+
+    func test_it_presents_other_bottom_sheet_on_start_when_eligible_for_ProductCreationAI_but_store_has_non_sample_products() {
+        // Given
+        storageManager.insertSampleProduct(readOnlyProduct: .fake().copy(siteID: sampleSiteID, isSampleItem: false))
+        let coordinator = makeAddProductCoordinator(
+            addProductWithAIEligibilityChecker: MockProductCreationAIEligibilityChecker(isEligible: true)
+        )
+
+        // When
+        coordinator.start()
+        waitUntil {
+            coordinator.navigationController.presentedViewController != nil
+        }
+
+        // Then
+        assertThat(coordinator.navigationController.presentedViewController, isAnInstanceOf: BottomSheetViewController.self)
+    }
 }
 
 private extension AddProductCoordinatorTests {
@@ -59,10 +97,11 @@ private extension AddProductCoordinatorTests {
         addProductWithAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol = MockProductCreationAIEligibilityChecker()
     ) -> AddProductCoordinator {
         let view = UIView()
-        return AddProductCoordinator(siteID: 100,
+        return AddProductCoordinator(siteID: sampleSiteID,
                                      source: .productsTab,
                                      sourceView: view,
                                      sourceNavigationController: navigationController,
+                                     storage: storageManager,
                                      addProductWithAIEligibilityChecker: addProductWithAIEligibilityChecker,
                                      isFirstProduct: false)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
@@ -23,7 +23,7 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
                                                           featureFlagService: MockFeatureFlagService(productCreationAI: true))
 
         // When
-        let isEligible = checker.isEligible(storeHasProducts: false)
+        let isEligible = checker.isEligible
 
         // Then
         XCTAssertTrue(isEligible)
@@ -35,7 +35,7 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
         let checker = ProductCreationAIEligibilityChecker(stores: stores,
                                                           featureFlagService: MockFeatureFlagService(productCreationAI: true))
         // When
-        let isEligible = checker.isEligible(storeHasProducts: false)
+        let isEligible = checker.isEligible
 
         // Then
         XCTAssertFalse(isEligible)
@@ -47,22 +47,10 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
         let checker = ProductCreationAIEligibilityChecker(stores: stores,
                                                           featureFlagService: MockFeatureFlagService(productCreationAI: true))
         // When
-        let isEligible = checker.isEligible(storeHasProducts: false)
+        let isEligible = checker.isEligible
 
         // Then
         XCTAssertTrue(isEligible)
-    }
-
-    func test_isEligible_is_false_for_wpcom_store_when_store_already_has_products() throws {
-        // Given
-        updateDefaultStore(isWPCOMStore: true)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores,
-                                                          featureFlagService: MockFeatureFlagService(productCreationAI: true))
-        // When
-        let isEligible = checker.isEligible(storeHasProducts: true)
-
-        // Then
-        XCTAssertFalse(isEligible)
     }
 
     func test_isEligible_is_false_when_feature_flag_is_false() throws {
@@ -71,7 +59,7 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
         let checker = ProductCreationAIEligibilityChecker(stores: stores,
                                                           featureFlagService: MockFeatureFlagService(productCreationAI: false))
         // When
-        let isEligible = checker.isEligible(storeHasProducts: false)
+        let isEligible = checker.isEligible
 
         // Then
         XCTAssertFalse(isEligible)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10711 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the coordinator for adding products to filter out sample products when checking whether a store has any product.

Also, the `ProductCreationAIEligibilityChecker` has also been updated to not include the parameter `storeHasProduct`. This makes `AddProductCoordinator` more testable, and also prepares for phase 2 of the project when we don't limit the product creation AI action sheet to stores without any product only.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `productCreationAI` and build the app.
- Log in to a store without any product or with only sample products (e.g: a free trial store).
- Switch to the Products tab and select "+" to add a new product.
- Notice that the action sheet product creation AI is presented.
- Publish a new product to that store and then tap "+" to add another product.
- Notice that another bottom sheet is presented this time, with an option for template products.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/d5ae6691-b0d3-438f-a1eb-fa262e95fabe



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
