### PR TITLE
Product creation AI: Add product name UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -61,29 +61,7 @@ struct AddProductNameWithAIView: View {
                             .foregroundColor(Color(.label))
                             .subheadlineStyle()
 
-                        ZStack(alignment: .topLeading) {
-                            VStack(spacing: 0) {
-                                TextEditor(text: $viewModel.productNameContent)
-                                    .bodyStyle()
-                                    .foregroundColor(.secondary)
-                                    .padding(insets: Layout.messageContentInsets)
-                                    .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
-                                    .focused($editorIsFocused)
-
-                                Divider()
-                                    .frame(height: Layout.dividerHeight)
-                                    .foregroundColor(Color(.separator))
-
-                                suggestNameField
-                                    .padding(insets: Layout.suggestButtonInsets)
-                            }
-                            .overlay(
-                                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
-                            )
-
-                            // Placeholder text
-                            placeholderText
-                        }
+                        textEditor
                     }
 
                     usePackagePhoto
@@ -103,6 +81,55 @@ struct AddProductNameWithAIView: View {
 }
 
 private extension AddProductNameWithAIView {
+    @ViewBuilder
+    var textEditor: some View {
+        if #available(iOS 16.0, *) {
+            VStack(spacing: 0) {
+                TextField(Localization.placeholder, text: $viewModel.productNameContent, axis: .vertical)
+                .lineLimit(3...)
+                .bodyStyle()
+                .foregroundColor(.secondary)
+                .textFieldStyle(.plain)
+                .focused($editorIsFocused)
+                .padding(insets: Layout.messageContentInsets)
+
+                Divider()
+                    .frame(height: Layout.dividerHeight)
+                    .foregroundColor(Color(.separator))
+
+                suggestNameField
+                    .padding(insets: Layout.suggestButtonInsets)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
+            )
+        } else {
+            ZStack(alignment: .topLeading) {
+                VStack(spacing: 0) {
+                    TextEditor(text: $viewModel.productNameContent)
+                        .bodyStyle()
+                        .foregroundColor(.secondary)
+                        .padding(insets: Layout.messageContentInsets)
+                        .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
+                        .focused($editorIsFocused)
+
+                    Divider()
+                        .frame(height: Layout.dividerHeight)
+                        .foregroundColor(Color(.separator))
+
+                    suggestNameField
+                        .padding(insets: Layout.suggestButtonInsets)
+                }
+                .overlay(
+                    RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
+                )
+
+                // Placeholder text
+                placeholderText
+            }
+        }
+    }
+
     var suggestNameField: some View {
         HStack {
             // Suggest a name

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -117,6 +117,7 @@ private extension AddProductNameWithAIView {
                         .frame(width: Layout.sparkleIconSize * scale, height: Layout.sparkleIconSize * scale)
 
                     Text(Localization.suggestName)
+                        .fontWeight(.semibold)
                         .foregroundColor(Color(.brand))
                         .bodyStyle()
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -147,6 +147,7 @@ private extension AddProductNameWithAIView {
                         .bodyStyle()
 
                     Text(Localization.usePackagePhoto)
+                        .multilineTextAlignment(.leading)
                         .bodyStyle()
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -78,7 +78,7 @@ struct AddProductNameWithAIView: View {
                                     .padding(insets: Layout.suggestButtonInsets)
                             }
                             .overlay(
-                                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.brand))
+                                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
                             )
 
                             // Placeholder text

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -1,0 +1,226 @@
+import SwiftUI
+
+final class AddProductNameWithAIHostingController: UIHostingController<AddProductNameWithAIView> {
+    init(viewModel: AddProductNameWithAIViewModel) {
+        super.init(rootView: AddProductNameWithAIView(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTransparentNavigationBar()
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
+    }
+
+    @objc
+    private func dismissView() {
+        dismiss(animated: true)
+    }
+}
+
+private extension AddProductNameWithAIHostingController {
+    enum Localization {
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss Add product name screen")
+    }
+}
+
+struct AddProductNameWithAIView: View {
+    @ObservedObject private var viewModel: AddProductNameWithAIViewModel
+    @ScaledMetric private var scale: CGFloat = 1.0
+    @FocusState private var editorIsFocused: Bool
+
+    init(viewModel: AddProductNameWithAIViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                    // Title label.
+                    Text(Localization.title)
+                        .fontWeight(.bold)
+                        .titleStyle()
+
+                    // Subtitle label.
+                    Text(Localization.subtitle)
+                        .foregroundColor(Color(.secondaryLabel))
+                        .bodyStyle()
+                }
+                .padding(.bottom, Layout.titleBlockBottomPadding)
+
+                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                    VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
+                        Text(Localization.productName)
+                            .foregroundColor(Color(.label))
+                            .subheadlineStyle()
+
+                        ZStack(alignment: .topLeading) {
+                            VStack(spacing: 0) {
+                                TextEditor(text: $viewModel.productNameContent)
+                                    .bodyStyle()
+                                    .foregroundColor(.secondary)
+                                    .padding(insets: Layout.messageContentInsets)
+                                    .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
+                                    .focused($editorIsFocused)
+
+                                Divider()
+                                    .frame(height: Layout.dividerHeight)
+                                    .foregroundColor(Color(.separator))
+
+                                suggestNameField
+                                    .padding(insets: Layout.suggestButtonInsets)
+                            }
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.brand))
+                            )
+
+                            // Placeholder text
+                            placeholderText
+                        }
+                    }
+
+                    usePackagePhoto
+                }
+            }
+            .padding(insets: Layout.insets)
+        }
+        .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                // CTA to continue to next screen.
+                continueButton
+                    .padding()
+            }
+            .background(Color(uiColor: .systemBackground))
+        }
+    }
+}
+
+private extension AddProductNameWithAIView {
+    var suggestNameField: some View {
+        HStack {
+            // Suggest a name
+            Button {
+                viewModel.didTapSuggestName()
+            } label: {
+                HStack(alignment: .top) {
+                    Image(uiImage: .sparklesImage)
+                        .renderingMode(.template)
+                        .resizable()
+                        .foregroundColor(Color(.brand))
+                        .frame(width: Layout.sparkleIconSize * scale, height: Layout.sparkleIconSize * scale)
+
+                    Text(Localization.suggestName)
+                        .foregroundColor(Color(.brand))
+                        .bodyStyle()
+                }
+            }
+            Spacer()
+        }
+    }
+
+    var placeholderText: some View {
+        Text(Localization.placeholder)
+            .foregroundColor(Color(.placeholderText))
+            .bodyStyle()
+            .padding(insets: Layout.placeholderInsets)
+            // Allows gestures to pass through to the `TextEditor`.
+            .allowsHitTesting(false)
+            .renderedIf(viewModel.productNameContent.isEmpty)
+    }
+
+    var usePackagePhoto: some View {
+        HStack {
+            // Use package photo
+            Button {
+                viewModel.didTapUsePackagePhoto()
+            } label: {
+                HStack(spacing: Layout.UsePackagePhoto.spacing) {
+                    Image(systemName: Layout.UsePackagePhoto.cameraSFSymbol)
+                        .bodyStyle()
+
+                    Text(Localization.usePackagePhoto)
+                        .bodyStyle()
+                }
+            }
+            Spacer()
+        }
+    }
+
+    var continueButton: some View {
+        Button {
+            // continue
+            editorIsFocused = false
+            viewModel.didTapContinue()
+        } label: {
+            Text(Localization.continueText)
+        }
+        .buttonStyle(PrimaryButtonStyle())
+        .disabled(viewModel.productNameContent.isEmpty)
+    }
+}
+private extension AddProductNameWithAIView {
+    enum Layout {
+        static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+
+        static let titleBlockBottomPadding: CGFloat = 40
+
+        static let titleBlockSpacing: CGFloat = 16
+        static let horizontalPadding: CGFloat = 16
+
+        static let editorBlockSpacing: CGFloat = 8
+        static let minimumEditorHeight: CGFloat = 70
+        static let cornerRadius: CGFloat = 8
+        static let messageContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
+        static let placeholderInsets: EdgeInsets = .init(top: 18, leading: 16, bottom: 18, trailing: 16)
+        static let dividerHeight: CGFloat = 1
+        static let sparkleIconSize: CGFloat = 24
+        static let suggestButtonInsets: EdgeInsets = .init(top: 11, leading: 16, bottom: 11, trailing: 16)
+
+        enum UsePackagePhoto {
+            static let cameraSFSymbol = "camera"
+            static let spacing: CGFloat = 8
+        }
+    }
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Add your product name",
+            comment: "Title on the add product name screen."
+        )
+        static let subtitle = NSLocalizedString(
+            "Or, expand your choices by tapping for more name suggestions.",
+            comment: "Subtitle on the add product name screen."
+        )
+        static let productName = NSLocalizedString(
+            "Product name",
+            comment: "Product name text field's label on the add product name screen."
+        )
+        static let placeholder = NSLocalizedString(
+            "For example, Soft fabric, durable stitching, unique design",
+            comment: "Placeholder text on the product name field"
+        )
+        static let suggestName = NSLocalizedString(
+            "Suggest a name",
+            comment: "Suggest name button on the product name field"
+        )
+        static let usePackagePhoto = NSLocalizedString(
+            "Use package photo (Optional)",
+            comment: "Use package photo button on the add product name screen."
+        )
+        static let continueText = NSLocalizedString(
+            "Continue",
+            comment: "Continue button on the product name field"
+        )
+    }
+}
+
+struct AddProductNameWithAIView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddProductNameWithAIView(viewModel: .init(siteID: 123, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in }))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -28,6 +28,8 @@ private extension AddProductNameWithAIHostingController {
     }
 }
 
+/// View for setting name for a new product with AI.
+///
 struct AddProductNameWithAIView: View {
     @ObservedObject private var viewModel: AddProductNameWithAIViewModel
     @ScaledMetric private var scale: CGFloat = 1.0

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -142,7 +142,7 @@ private extension AddProductNameWithAIView {
             Button {
                 viewModel.didTapUsePackagePhoto()
             } label: {
-                HStack(spacing: Layout.UsePackagePhoto.spacing) {
+                HStack(alignment: .top, spacing: Layout.UsePackagePhoto.spacing) {
                     Image(systemName: Layout.UsePackagePhoto.cameraSFSymbol)
                         .bodyStyle()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -61,7 +61,29 @@ struct AddProductNameWithAIView: View {
                             .foregroundColor(Color(.label))
                             .subheadlineStyle()
 
-                        textEditor
+                        VStack(spacing: 0) {
+                            ZStack(alignment: .topLeading) {
+                                TextEditor(text: $viewModel.productNameContent)
+                                    .bodyStyle()
+                                    .foregroundColor(.secondary)
+                                    .padding(insets: Layout.messageContentInsets)
+                                    .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
+                                    .focused($editorIsFocused)
+
+                                // Placeholder text
+                                placeholderText
+                            }
+
+                            Divider()
+                                .frame(height: Layout.dividerHeight)
+                                .foregroundColor(Color(.separator))
+
+                            suggestNameField
+                                .padding(insets: Layout.suggestButtonInsets)
+                        }
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
+                        )
                     }
 
                     usePackagePhoto
@@ -81,55 +103,6 @@ struct AddProductNameWithAIView: View {
 }
 
 private extension AddProductNameWithAIView {
-    @ViewBuilder
-    var textEditor: some View {
-        if #available(iOS 16.0, *) {
-            VStack(spacing: 0) {
-                TextField(Localization.placeholder, text: $viewModel.productNameContent, axis: .vertical)
-                .lineLimit(3...)
-                .bodyStyle()
-                .foregroundColor(.secondary)
-                .textFieldStyle(.plain)
-                .focused($editorIsFocused)
-                .padding(insets: Layout.messageContentInsets)
-
-                Divider()
-                    .frame(height: Layout.dividerHeight)
-                    .foregroundColor(Color(.separator))
-
-                suggestNameField
-                    .padding(insets: Layout.suggestButtonInsets)
-            }
-            .overlay(
-                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
-            )
-        } else {
-            ZStack(alignment: .topLeading) {
-                VStack(spacing: 0) {
-                    TextEditor(text: $viewModel.productNameContent)
-                        .bodyStyle()
-                        .foregroundColor(.secondary)
-                        .padding(insets: Layout.messageContentInsets)
-                        .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
-                        .focused($editorIsFocused)
-
-                    Divider()
-                        .frame(height: Layout.dividerHeight)
-                        .foregroundColor(Color(.separator))
-
-                    suggestNameField
-                        .padding(insets: Layout.suggestButtonInsets)
-                }
-                .overlay(
-                    RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
-                )
-
-                // Placeholder text
-                placeholderText
-            }
-        }
-    }
-
     var suggestNameField: some View {
         HStack {
             // Suggest a name

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -89,7 +89,6 @@ struct AddProductNameWithAIView: View {
             }
             .padding(insets: Layout.insets)
         }
-        .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .safeAreaInset(edge: .bottom) {
             VStack {
                 // CTA to continue to next screen.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+final class AddProductNameWithAIViewModel: ObservableObject {
+    @Published var productNameContent: String = ""
+    private let onUsePackagePhoto: (String?) -> Void
+    private let onContinueWithProductName: (String) -> Void
+
+    init(siteID: Int64,
+         onUsePackagePhoto: @escaping (String?) -> Void,
+         onContinueWithProductName: @escaping (String) -> Void) {
+        self.onUsePackagePhoto = onUsePackagePhoto
+        self.onContinueWithProductName = onContinueWithProductName
+    }
+
+    func didTapUsePackagePhoto() {
+        let productName: String? = {
+            guard productNameContent.isNotEmpty else {
+                return nil
+            }
+            return productNameContent
+        }()
+        onUsePackagePhoto(productName)
+    }
+
+    func didTapSuggestName() {
+        // TODO: Present suggest name sheet
+    }
+
+    func didTapContinue() {
+        onContinueWithProductName(productNameContent)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// View model for `AddProductNameWithAIView`.
+///
 final class AddProductNameWithAIViewModel: ObservableObject {
     @Published var productNameContent: String = ""
     private let onUsePackagePhoto: (String?) -> Void

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAICoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAICoordinator.swift
@@ -24,6 +24,20 @@ final class AddProductWithAICoordinator: Coordinator {
     }
 
     func start() {
-        // TODO-10688: present form for adding product name
+        showAddProductNameWithAIView()
+    }
+}
+
+private extension AddProductWithAICoordinator {
+    /// Presents the Add  product name with AI view.
+    ///
+    func showAddProductNameWithAIView() {
+        let viewController = AddProductNameWithAIHostingController(viewModel: .init(siteID: siteID,
+                                                                                    onUsePackagePhoto: { _ in
+            // TODO: Launch UsePackagePhoto flow
+        }, onContinueWithProductName: { _ in
+            // TODO: Continue to About your product screen
+        }))
+        navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2326,6 +2326,8 @@
 		EE5B5BB32AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */; };
 		EE5B5BB62AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */; };
 		EE5B5BBD2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */; };
+		EE5B5BC12AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BBF2AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift */; };
+		EE5B5BC22AB42F21009BCBD6 /* AddProductNameWithAIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BC02AB42F21009BCBD6 /* AddProductNameWithAIView.swift */; };
 		EE6A7BA92A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BA82A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift */; };
 		EE6A7BAB2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BAA2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift */; };
 		EE6A7BAD2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BAC2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift */; };
@@ -4818,6 +4820,8 @@
 		EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAIEligibilityChecker.swift; sourceTree = "<group>"; };
 		EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductCreationAIEligibilityChecker.swift; sourceTree = "<group>"; };
+		EE5B5BBF2AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModel.swift; sourceTree = "<group>"; };
+		EE5B5BC02AB42F21009BCBD6 /* AddProductNameWithAIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIView.swift; sourceTree = "<group>"; };
 		EE6A7BA82A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionViewModel.swift; sourceTree = "<group>"; };
 		EE6A7BAA2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionView.swift; sourceTree = "<group>"; };
 		EE6A7BAC2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionOptions.swift; sourceTree = "<group>"; };
@@ -10901,6 +10905,7 @@
 		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				EE5B5BBE2AB42F21009BCBD6 /* AddProductName */,
 				DE85E4EB2AB416F5008789E1 /* EntryPoint */,
 				EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */,
 				DE85E4E92AB41690008789E1 /* AddProductWithAICoordinator.swift */,
@@ -10914,6 +10919,15 @@
 				EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */,
 			);
 			path = AddProductWithAI;
+			sourceTree = "<group>";
+		};
+		EE5B5BBE2AB42F21009BCBD6 /* AddProductName */ = {
+			isa = PBXGroup;
+			children = (
+				EE5B5BBF2AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift */,
+				EE5B5BC02AB42F21009BCBD6 /* AddProductNameWithAIView.swift */,
+			);
+			path = AddProductName;
 			sourceTree = "<group>";
 		};
 		EE6A7BA72A7B7BC900D9A028 /* Features */ = {
@@ -12932,6 +12946,7 @@
 				68E674A92A4DAB1A0034BA1E /* OwnerUpgradesView.swift in Sources */,
 				DE4D23A429B0A9FA003A4B5D /* WPComPasswordLoginView.swift in Sources */,
 				45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */,
+				EE5B5BC12AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift in Sources */,
 				0201E4272945B01800C793C7 /* StoreCreationProfilerQuestionView.swift in Sources */,
 				EEAB47662A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift in Sources */,
 				2667BFE1252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift in Sources */,
@@ -13386,6 +13401,7 @@
 				ABC35528D2D6BE6F516E5CEF /* InPersonPaymentsOnboardingError.swift in Sources */,
 				3F1FA84C28B60126009E246C /* StoreWidgets.intentdefinition in Sources */,
 				ABC3521A374A2355001E3CD6 /* CardReaderSettingsSearchingViewController.swift in Sources */,
+				EE5B5BC22AB42F21009BCBD6 /* AddProductNameWithAIView.swift in Sources */,
 				532842FC64B572D4545BD98E /* OrderFormCustomerNoteViewModel.swift in Sources */,
 				532846FAFFFCA93169B5E0BC /* WaitingTimeTracker.swift in Sources */,
 				53284299BA881E53CBF30F94 /* FreeTrialFeatures.swift in Sources */,


### PR DESCRIPTION
Part of: #10701

## Description
Adds SwiftUI view for "Add product name" screen
Sgacycoxaxh8EbKoi5FklH-fi-32_34930

I didn't add the progress view at the top of the screen in this PR. I will add a container view and a progress view in another PR.

## Testing instructions
- Create a JN site with Jetpack AI plugin. (Checkbox available in JN home page to install this plugin)
- Switch to Products tab, select the "+" button to add a new product. The same AI action sheet should be displayed.
- Tap on "Create a product with AI"
- You can see the "Add your product name" screen

## Screenshots

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/a4c40bb2-7a46-443e-b6a1-d4e9ffae84a2" width="320"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.