### PR TITLE
Product Creation AI: Add view for generating product name

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -12,46 +12,56 @@ struct ProductNameGenerationView: View {
     var body: some View {
         ScrollableVStack(alignment: .leading, spacing: Constants.defaultSpacing) {
 
-            // View title
-            Text(Localization.title)
-                .headlineStyle()
+            // View title and subtitle
+            VStack(alignment: .leading, spacing: Constants.textVerticalSpacing) {
+                Text(Localization.title)
+                    .headlineStyle()
+                Text(Localization.subtitle)
+                    .subheadlineStyle()
+            }
 
             Divider()
 
-            // Generated message text field
-            ZStack(alignment: .topLeading) {
-                TextEditor(text: $viewModel.messageContent)
-                    .bodyStyle()
-                    .foregroundColor(.secondary)
-                    .disabled(viewModel.generationInProgress)
-                    .opacity(viewModel.generationInProgress ? 0 : 1)
-                    .padding(insets: Constants.messageContentInsets)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Constants.cornerRadius).stroke(Color(.separator))
-                    )
-
-                // Placeholder text
-                Text(Localization.placeholder)
-                    .foregroundColor(Color(.placeholderText))
-                    .bodyStyle()
-                    .padding(insets: Constants.placeholderInsets)
-                    // Allows gestures to pass through to the `TextEditor`.
-                    .allowsHitTesting(false)
-                    .renderedIf(viewModel.messageContent.isEmpty &&
-                                viewModel.generationInProgress == false)
-            }
-            .overlay(
-                VStack {
-                    // Skeleton view for loading state
-                    Text(Constants.dummyText)
+            VStack(alignment: .leading, spacing: Constants.textVerticalSpacing) {
+                // Generated message text field
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $viewModel.messageContent)
                         .bodyStyle()
-                        .redacted(reason: .placeholder)
-                        .shimmering()
+                        .foregroundColor(.secondary)
+                        .disabled(viewModel.generationInProgress)
+                        .opacity(viewModel.generationInProgress ? 0 : 1)
+                        .padding(insets: Constants.messageContentInsets)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Constants.cornerRadius).stroke(Color(.separator))
+                        )
+                    
+                    // Placeholder text
+                    Text(Localization.placeholder)
+                        .foregroundColor(Color(.placeholderText))
+                        .bodyStyle()
                         .padding(insets: Constants.placeholderInsets)
-                        .renderedIf(viewModel.generationInProgress)
-                    Spacer()
+                    // Allows gestures to pass through to the `TextEditor`.
+                        .allowsHitTesting(false)
+                        .renderedIf(viewModel.messageContent.isEmpty &&
+                                    viewModel.generationInProgress == false)
                 }
-            )
+                .overlay(
+                    VStack {
+                        // Skeleton view for loading state
+                        Text(Constants.dummyText)
+                            .bodyStyle()
+                            .redacted(reason: .placeholder)
+                            .shimmering()
+                            .padding(insets: Constants.placeholderInsets)
+                            .renderedIf(viewModel.generationInProgress)
+                        Spacer()
+                    }
+                )
+
+                Text(Localization.detailDescription)
+                    .footnoteStyle()
+                    .multilineTextAlignment(.leading)
+            }
 
             // Error message
             viewModel.errorMessage.map { message in
@@ -88,6 +98,7 @@ struct ProductNameGenerationView: View {
 private extension ProductNameGenerationView {
     enum Constants {
         static let defaultSpacing: CGFloat = 16
+        static let textVerticalSpacing: CGFloat = 4
         static let cornerRadius: CGFloat = 8
         static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
         static let messageContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
@@ -102,23 +113,27 @@ private extension ProductNameGenerationView {
     enum Localization {
         static let title = NSLocalizedString(
             "Product name",
-            comment: "Title on the product title generation screen"
+            comment: "Title on the product name generation screen"
+        )
+        static let subtitle = NSLocalizedString(
+            "Let AI generate captivating titles for you.",
+            comment: "Subtitle on the product name generation screen"
         )
         static let generateInProgress = NSLocalizedString(
             "Generating...",
-            comment: "Text to show the loading state on the product title generation screen"
+            comment: "Text to show the loading state on the product name generation screen"
         )
         static let apply = NSLocalizedString(
             "Apply",
-            comment: "Action button to apply the generated title for the new product"
+            comment: "Action button to apply the generated name for the new product"
         )
         static let detailDescription = NSLocalizedString(
-            "For example, Soft fabric, durable stitching, unique design",
-            comment: "Placeholder text on the product title generation screen"
+            "Tell us what your product is and what makes it unique!",
+            comment: "Description text on the product name generation screen"
         )
         static let placeholder = NSLocalizedString(
             "For example, Soft fabric, durable stitching, unique design",
-            comment: "Placeholder text on the product title generation screen"
+            comment: "Placeholder text on the product name generation screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// View for generating product name with AI.
+///
+struct ProductNameGenerationView: View {
+    @ObservedObject private var viewModel: ProductNameGenerationViewModel
+
+    init(viewModel: ProductNameGenerationViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollableVStack(alignment: .leading, spacing: Constants.defaultSpacing) {
+
+            // View title
+            Text(Localization.title)
+                .headlineStyle()
+
+            Divider()
+
+            // Generated message text field
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $viewModel.messageContent)
+                    .bodyStyle()
+                    .foregroundColor(.secondary)
+                    .disabled(viewModel.generationInProgress)
+                    .opacity(viewModel.generationInProgress ? 0 : 1)
+                    .padding(insets: Constants.messageContentInsets)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Constants.cornerRadius).stroke(Color(.separator))
+                    )
+
+                // Placeholder text
+                Text(Localization.placeholder)
+                    .foregroundColor(Color(.placeholderText))
+                    .bodyStyle()
+                    .padding(insets: Constants.placeholderInsets)
+                    // Allows gestures to pass through to the `TextEditor`.
+                    .allowsHitTesting(false)
+                    .renderedIf(viewModel.messageContent.isEmpty &&
+                                viewModel.generationInProgress == false)
+            }
+            .overlay(
+                VStack {
+                    // Skeleton view for loading state
+                    Text(Constants.dummyText)
+                        .bodyStyle()
+                        .redacted(reason: .placeholder)
+                        .shimmering()
+                        .padding(insets: Constants.placeholderInsets)
+                        .renderedIf(viewModel.generationInProgress)
+                    Spacer()
+                }
+            )
+
+            // Error message
+            viewModel.errorMessage.map { message in
+                Text(message).errorStyle()
+            }
+
+            HStack(spacing: Constants.horizontalSpacing) {
+                // Action button to generate message
+                Button(action: {
+                    // TODO
+                }, label: {
+                    Label {
+                        Text(viewModel.generateButtonTitle)
+                    } icon: {
+                        Image(uiImage: viewModel.generateButtonImage)
+                            .renderingMode(.template)
+                    }
+                })
+                .buttonStyle(SecondaryLoadingButtonStyle(isLoading: viewModel.generationInProgress, loadingText: Localization.generateInProgress))
+
+                Spacer()
+
+                Button(Localization.apply) {
+                    // TODO
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .renderedIf(viewModel.hasGeneratedMessage)
+            }
+            .renderedIf(viewModel.generationInProgress == false)
+        }
+    }
+}
+
+private extension ProductNameGenerationView {
+    enum Constants {
+        static let defaultSpacing: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
+        static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+        static let messageContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
+        static let placeholderInsets: EdgeInsets = .init(top: 18, leading: 16, bottom: 18, trailing: 16)
+        static let dummyText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit," +
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam," +
+        "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." +
+        "nisi ut aliquip ex ea commodo consequat."
+        static let dummyTextInsets: EdgeInsets = .init(top: 12, leading: 16, bottom: 12, trailing: 16)
+        static let horizontalSpacing: CGFloat = 8
+    }
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Product name",
+            comment: "Title on the product title generation screen"
+        )
+        static let generateInProgress = NSLocalizedString(
+            "Generating...",
+            comment: "Text to show the loading state on the product title generation screen"
+        )
+        static let apply = NSLocalizedString(
+            "Apply",
+            comment: "Action button to apply the generated title for the new product"
+        )
+        static let detailDescription = NSLocalizedString(
+            "For example, Soft fabric, durable stitching, unique design",
+            comment: "Placeholder text on the product title generation screen"
+        )
+        static let placeholder = NSLocalizedString(
+            "For example, Soft fabric, durable stitching, unique design",
+            comment: "Placeholder text on the product title generation screen"
+        )
+    }
+}
+
+struct ProductNameAIBottomSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductNameGenerationView(viewModel: .init(siteID: 123))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -148,7 +148,7 @@ struct ProductNameGenerationView: View {
 private extension ProductNameGenerationView {
     enum Constants {
         static let defaultSpacing: CGFloat = 16
-        static let textVerticalSpacing: CGFloat = 4
+        static let textVerticalSpacing: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
         static let messageContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -66,8 +66,6 @@ struct ProductNameGenerationView: View {
                     Text(suggestedText)
                         .fixedSize(horizontal: false, vertical: true)
                         .textSelection(.enabled)
-                        .redacted(reason: viewModel.generationInProgress ? .placeholder : [])
-                        .shimmering(active: viewModel.generationInProgress)
 
                     HStack {
                         Spacer()
@@ -81,10 +79,12 @@ struct ProductNameGenerationView: View {
                         }
                         .buttonStyle(PlainButtonStyle())
                         .fixedSize(horizontal: true, vertical: false)
+                        .renderedIf(viewModel.generationInProgress == false)
                     }
-                    .renderedIf(viewModel.generationInProgress == false)
                 }
                 .padding(Constants.defaultSpacing)
+                .redacted(reason: viewModel.generationInProgress ? .placeholder : [])
+                .shimmering(active: viewModel.generationInProgress)
                 .background(
                     Color(uiColor: .secondarySystemBackground)
                         .cornerRadius(Constants.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -104,7 +104,7 @@ struct ProductNameGenerationView: View {
             HStack(spacing: Constants.horizontalSpacing) {
                 // Action button to generate message
                 Button(action: {
-                    // TODO
+                    viewModel.generateProductName()
                 }, label: {
                     Label {
                         Text(viewModel.generateButtonTitle)
@@ -118,7 +118,7 @@ struct ProductNameGenerationView: View {
                 Spacer()
 
                 Button(Localization.apply) {
-                    // TODO
+                    viewModel.applyGeneratedName()
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .fixedSize(horizontal: true, vertical: false)
@@ -126,7 +126,7 @@ struct ProductNameGenerationView: View {
             .renderedIf(viewModel.generationInProgress == false && viewModel.hasGeneratedMessage)
 
             Button(action: {
-                // TODO
+                viewModel.generateProductName()
             }, label: {
                 Label {
                     Text(viewModel.generateButtonTitle)
@@ -139,6 +139,7 @@ struct ProductNameGenerationView: View {
             .disabled(viewModel.detailContent.isEmpty)
             .renderedIf(viewModel.hasGeneratedMessage == false)
         }
+        .notice($copyTextNotice, autoDismiss: true)
     }
 }
 
@@ -190,6 +191,6 @@ private extension ProductNameGenerationView {
 
 struct ProductNameAIBottomSheet_Previews: PreviewProvider {
     static var previews: some View {
-        ProductNameGenerationView(viewModel: .init(siteID: 123, detailContent: ""))
+        ProductNameGenerationView(viewModel: .init(siteID: 123, detailContent: "Thai essential oil"))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -34,7 +34,7 @@ struct ProductNameGenerationView: View {
             VStack(alignment: .leading, spacing: Constants.textVerticalSpacing) {
                 // Product keyword text field
                 ZStack(alignment: .topLeading) {
-                    TextEditor(text: $viewModel.detailContent)
+                    TextEditor(text: $viewModel.keywords)
                         .bodyStyle()
                         .disabled(viewModel.generationInProgress)
                         .opacity(viewModel.generationInProgress ? 0 : 1)
@@ -51,7 +51,7 @@ struct ProductNameGenerationView: View {
                         .padding(insets: Constants.placeholderInsets)
                     // Allows gestures to pass through to the `TextEditor`.
                         .allowsHitTesting(false)
-                        .renderedIf(viewModel.detailContent.isEmpty &&
+                        .renderedIf(viewModel.keywords.isEmpty &&
                                     viewModel.generationInProgress == false)
                 }
 
@@ -102,7 +102,7 @@ struct ProductNameGenerationView: View {
                 .renderedIf(viewModel.generationInProgress == false && viewModel.hasGeneratedMessage)
 
             HStack(spacing: Constants.horizontalSpacing) {
-                // Action button to generate message
+                // Action button to regenerate product name
                 Button(action: {
                     viewModel.generateProductName()
                 }, label: {
@@ -117,6 +117,7 @@ struct ProductNameGenerationView: View {
 
                 Spacer()
 
+                // Action button to apply product name
                 Button(Localization.apply) {
                     viewModel.applyGeneratedName()
                 }
@@ -125,6 +126,7 @@ struct ProductNameGenerationView: View {
             }
             .renderedIf(viewModel.generationInProgress == false && viewModel.hasGeneratedMessage)
 
+            // Action button to generate product name - displayed initially.
             Button(action: {
                 viewModel.generateProductName()
             }, label: {
@@ -136,7 +138,7 @@ struct ProductNameGenerationView: View {
                 }
             })
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.generationInProgress))
-            .disabled(viewModel.detailContent.isEmpty)
+            .disabled(viewModel.keywords.isEmpty)
             .renderedIf(viewModel.hasGeneratedMessage == false)
         }
         .notice($copyTextNotice, autoDismiss: true)
@@ -191,6 +193,6 @@ private extension ProductNameGenerationView {
 
 struct ProductNameAIBottomSheet_Previews: PreviewProvider {
     static var previews: some View {
-        ProductNameGenerationView(viewModel: .init(siteID: 123, detailContent: "Thai essential oil"))
+        ProductNameGenerationView(viewModel: .init(siteID: 123, keywords: "Thai essential oil"))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
@@ -13,7 +13,7 @@ final class ProductNameGenerationViewModel: ObservableObject {
         hasGeneratedMessage ? UIImage(systemName: "arrow.counterclockwise")! : .sparklesImage
     }
 
-    @Published var detailContent: String = ""
+    @Published var keywords: String = ""
     @Published private(set) var suggestedText: String?
     @Published private(set) var generationInProgress: Bool = false
     @Published private(set) var errorMessage: String?
@@ -29,11 +29,11 @@ final class ProductNameGenerationViewModel: ObservableObject {
     }
 
     init(siteID: Int64,
-         detailContent: String,
+         keywords: String,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
-        self.detailContent = detailContent
+        self.keywords = keywords
         self.stores = stores
         self.analytics = analytics
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
@@ -13,7 +13,8 @@ final class ProductNameGenerationViewModel: ObservableObject {
         hasGeneratedMessage ? UIImage(systemName: "arrow.counterclockwise")! : .sparklesImage
     }
 
-    @Published var messageContent: String = ""
+    @Published var detailContent: String = ""
+    @Published private(set) var suggestedText: String?
     @Published private(set) var generationInProgress: Bool = false
     @Published private(set) var errorMessage: String?
 
@@ -23,16 +24,16 @@ final class ProductNameGenerationViewModel: ObservableObject {
 
     /// Whether a message has been successfully generated.
     /// This is needed to identify whether the next request is a retry.
-    private(set) var hasGeneratedMessage = false
-
-    /// Language used in product identified by AI
-    ///
-    private var languageIdentifiedUsingAI: String?
+    var hasGeneratedMessage: Bool {
+        suggestedText != nil
+    }
 
     init(siteID: Int64,
+         detailContent: String,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
+        self.detailContent = detailContent
         self.stores = stores
         self.analytics = analytics
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
@@ -13,7 +13,7 @@ final class ProductNameGenerationViewModel: ObservableObject {
         hasGeneratedMessage ? UIImage(systemName: "arrow.counterclockwise")! : .sparklesImage
     }
 
-    @Published var keywords: String = ""
+    @Published var keywords: String
     @Published private(set) var suggestedText: String?
     @Published private(set) var generationInProgress: Bool = false
     @Published private(set) var errorMessage: String?

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
@@ -1,0 +1,52 @@
+import UIKit
+import Yosemite
+
+/// View model for `ProductNameGenerationView`.
+///
+final class ProductNameGenerationViewModel {
+
+    var generateButtonTitle: String {
+        hasGeneratedMessage ? Localization.regenerate : Localization.generate
+    }
+
+    var generateButtonImage: UIImage {
+        hasGeneratedMessage ? UIImage(systemName: "arrow.counterclockwise")! : .sparklesImage
+    }
+
+    @Published var messageContent: String = ""
+    @Published private(set) var generationInProgress: Bool = false
+    @Published private(set) var errorMessage: String?
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let analytics: Analytics
+
+    /// Whether a message has been successfully generated.
+    /// This is needed to identify whether the next request is a retry.
+    private var hasGeneratedMessage = false
+
+    /// Language used in product identified by AI
+    ///
+    private var languageIdentifiedUsingAI: String?
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.stores = stores
+        self.analytics = analytics
+    }
+}
+
+extension ProductNameGenerationViewModel {
+    enum Localization {
+        static let generate = NSLocalizedString(
+            "Write with AI",
+            comment: "Action button to generate title for a new product with AI."
+        )
+        static let regenerate = NSLocalizedString(
+            "Regenerate",
+            comment: "Action button to regenerate title for a new product with AI."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
@@ -37,6 +37,14 @@ final class ProductNameGenerationViewModel: ObservableObject {
         self.stores = stores
         self.analytics = analytics
     }
+
+    func applyGeneratedName() {
+        // TODO-10688
+    }
+
+    func generateProductName() {
+        // TODO-10688
+    }
 }
 
 extension ProductNameGenerationViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// View model for `ProductNameGenerationView`.
 ///
-final class ProductNameGenerationViewModel {
+final class ProductNameGenerationViewModel: ObservableObject {
 
     var generateButtonTitle: String {
         hasGeneratedMessage ? Localization.regenerate : Localization.generate
@@ -23,7 +23,7 @@ final class ProductNameGenerationViewModel {
 
     /// Whether a message has been successfully generated.
     /// This is needed to identify whether the next request is a retry.
-    private var hasGeneratedMessage = false
+    private(set) var hasGeneratedMessage = false
 
     /// Language used in product identified by AI
     ///

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2180,6 +2180,7 @@
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
 		DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */; };
 		DE8BEB8A2AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */; };
+		DE8BEB8C2AB840DD00F5E56C /* ProductNameGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE8FCD1A2A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */; };
@@ -4675,6 +4676,7 @@
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
 		DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AIFeedback.swift"; sourceTree = "<group>"; };
 		DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationViewModel.swift; sourceTree = "<group>"; };
+		DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationView.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerQuestionContainerView.swift; sourceTree = "<group>"; };
@@ -10605,6 +10607,7 @@
 		DE8BEB882AB83F2B00F5E56C /* ProductNameGeneration */ = {
 			isa = PBXGroup;
 			children = (
+				DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */,
 				DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */,
 			);
 			path = ProductNameGeneration;
@@ -13382,6 +13385,7 @@
 				D8815B0126385E3F00EDAD62 /* CardPresentModalTapCard.swift in Sources */,
 				773077EE251E943700178696 /* ProductDownloadFileViewController.swift in Sources */,
 				DE5FBB912A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift in Sources */,
+				DE8BEB8C2AB840DD00F5E56C /* ProductNameGenerationView.swift in Sources */,
 				B958B4DA2983E3F40010286B /* OrderDurationRecorder.swift in Sources */,
 				CC3B35DB28E5A6830036B097 /* ReviewReply.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2179,6 +2179,7 @@
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
 		DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */; };
+		DE8BEB8A2AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE8FCD1A2A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */; };
@@ -4673,6 +4674,7 @@
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
 		DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AIFeedback.swift"; sourceTree = "<group>"; };
+		DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationViewModel.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerQuestionContainerView.swift; sourceTree = "<group>"; };
@@ -10600,6 +10602,14 @@
 			path = EntryPoint;
 			sourceTree = "<group>";
 		};
+		DE8BEB882AB83F2B00F5E56C /* ProductNameGeneration */ = {
+			isa = PBXGroup;
+			children = (
+				DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */,
+			);
+			path = ProductNameGeneration;
+			sourceTree = "<group>";
+		};
 		DE8C9464264698E800C94823 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -10901,6 +10911,7 @@
 		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				DE8BEB882AB83F2B00F5E56C /* ProductNameGeneration */,
 				DE85E4EB2AB416F5008789E1 /* EntryPoint */,
 				EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */,
 				DE85E4E92AB41690008789E1 /* AddProductWithAICoordinator.swift */,
@@ -12695,6 +12706,7 @@
 				26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */,
 				7421344A210A323C00C13890 /* WooAnalyticsStat.swift in Sources */,
 				4567389D2745497C00743054 /* OrderStatusFilterViewController.swift in Sources */,
+				DE8BEB8A2AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift in Sources */,
 				268D7C9C2984752A00D38709 /* SupportForm.swift in Sources */,
 				02A275BA23FE50AA005C560F /* ProductUIImageLoader.swift in Sources */,
 				02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10722 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new screen for generating product names from provided keywords. The screen has not been integrated yet so it can only be tested through SwiftUI preview.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please update the `ProductNameGenerationViewModel` file's properties: `keywords`, `suggestedText`, `generationInProgress`, and `errorMessage` to see what the view looks like in different states.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Initial | With keywords | With suggested text |
| ----- | ----- | ----- |
| <img width="244" alt="Screenshot 2023-09-18 at 17 55 50" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/5bd6da30-4c63-4d84-be83-9bbbe12b55c9"> | <img width="238" alt="Screenshot 2023-09-18 at 17 56 22" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/55ed166a-4de4-4c7e-899b-0c81cbd31e6d"> | <img width="237" alt="Screenshot 2023-09-18 at 17 59 08" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/eb231919-9237-47e2-8f21-1381b9e3c5bd"> |

| Initial loading state | Loading state with suggested text | 
| ----- | ----- | 
| <img width="217" alt="Screenshot 2023-09-19 at 09 31 22" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/79b70c31-3811-4df0-8c25-fe669386b4c2"> | <img width="220" alt="Screenshot 2023-09-19 at 09 32 39" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/6d831159-be6b-4d7a-ab3c-c8acc1cefb21"> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
