### PR TITLE
Product Creation AI: Show product name view from container view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -1,33 +1,5 @@
 import SwiftUI
 
-final class AddProductNameWithAIHostingController: UIHostingController<AddProductNameWithAIView> {
-    init(viewModel: AddProductNameWithAIViewModel) {
-        super.init(rootView: AddProductNameWithAIView(viewModel: viewModel))
-    }
-
-    @available(*, unavailable)
-    required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        configureTransparentNavigationBar()
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
-    }
-
-    @objc
-    private func dismissView() {
-        dismiss(animated: true)
-    }
-}
-
-private extension AddProductNameWithAIHostingController {
-    enum Localization {
-        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss Add product name screen")
-    }
-}
-
 /// View for setting name for a new product with AI.
 ///
 struct AddProductNameWithAIView: View {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -7,6 +7,13 @@ final class AddProductNameWithAIViewModel: ObservableObject {
     private let onUsePackagePhoto: (String?) -> Void
     private let onContinueWithProductName: (String) -> Void
 
+    private var productName: String? {
+        guard productNameContent.isNotEmpty else {
+            return nil
+        }
+        return productNameContent
+    }
+
     init(siteID: Int64,
          onUsePackagePhoto: @escaping (String?) -> Void,
          onContinueWithProductName: @escaping (String) -> Void) {
@@ -15,12 +22,6 @@ final class AddProductNameWithAIViewModel: ObservableObject {
     }
 
     func didTapUsePackagePhoto() {
-        let productName: String? = {
-            guard productNameContent.isNotEmpty else {
-                return nil
-            }
-            return productNameContent
-        }()
         onUsePackagePhoto(productName)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAICoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAICoordinator.swift
@@ -32,11 +32,12 @@ private extension AddProductWithAICoordinator {
     /// Presents the Add  product name with AI view.
     ///
     func showAddProductNameWithAIView() {
-        let viewController = AddProductNameWithAIHostingController(viewModel: .init(siteID: siteID,
-                                                                                    onUsePackagePhoto: { _ in
-            // TODO: Launch UsePackagePhoto flow
-        }, onContinueWithProductName: { _ in
-            // TODO: Continue to About your product screen
+        let viewController = AddProductWithAIContainerHostingController(viewModel: .init(siteID: siteID,
+                                                                                         onCancel: { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+        },
+                                                                                         onCompletion: {
+            // TODO: Product saved
         }))
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -48,7 +48,7 @@ struct AddProductWithAIContainerView: View {
             ToolbarItem(placement: .cancellationAction) {
                 Button(action: {
                     withAnimation {
-                        viewModel.backtrackOrDismissProfiler()
+                        viewModel.backtrackOrDismiss()
                     }
                 }, label: {
                     if viewModel.currentStep.previousStep == nil {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Hosting controller for `AddProductWithAIContainerView`
+final class AddProductWithAIContainerHostingController: UIHostingController<AddProductWithAIContainerView> {
+    init(viewModel: AddProductWithAIContainerViewModel) {
+        super.init(rootView: AddProductWithAIContainerView(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTransparentNavigationBar()
+    }
+}
+
+/// Container view for the product creation with AI flow.
+struct AddProductWithAIContainerView: View {
+
+    @ObservedObject private var viewModel: AddProductWithAIContainerViewModel
+
+    init(viewModel: AddProductWithAIContainerViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            progressView
+
+            switch viewModel.currentStep {
+            case .productName:
+                AddProductNameWithAIView(viewModel: .init(siteID: viewModel.siteID,
+                                                          onUsePackagePhoto: viewModel.onUsePackagePhoto,
+                                                          onContinueWithProductName: viewModel.onContinueWithProductName))
+            default:
+                // TODO: Add other AI views
+               Text("Add other AI views")
+            }
+        }
+        .onAppear() {
+            viewModel.onAppear()
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(action: {
+                    withAnimation {
+                        viewModel.backtrackOrDismissProfiler()
+                    }
+                }, label: {
+                    if viewModel.currentStep.previousStep == nil {
+                        Text(Localization.cancel)
+                    } else {
+                        Image(systemName: "chevron.backward")
+                            .headlineLinkStyle()
+                    }
+                })
+            }
+        }
+    }
+}
+
+
+private extension AddProductWithAIContainerView {
+    var progressView: some View {
+        ProgressView(value: viewModel.currentStep.progress)
+            .frame(height: Layout.ProgressView.height)
+            .tint(.init(uiColor: .accent))
+            .progressViewStyle(.linear)
+    }
+}
+
+private extension AddProductWithAIContainerView {
+    enum Localization {
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the AI product creation flow.")
+    }
+
+
+    enum Layout {
+        enum ProgressView {
+            static let height: CGFloat = 2
+        }
+    }
+}
+
+struct AddProductWithAIContainerView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddProductWithAIContainerView(viewModel: .init(siteID: 123,
+                                                       onCancel: { },
+                                                       onCompletion: { }))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum AddProductWithAIStep: Int, CaseIterable {
+    case productName = 1
+    case aboutProduct
+    case preview
+
+    /// Progress to display
+    var progress: Double {
+        let incrementBy = 1.0 / Double(Self.allCases.count)
+        return Double(self.rawValue) * incrementBy
+    }
+
+    var previousStep: AddProductWithAIStep? {
+        .init(rawValue: self.rawValue - 1)
+    }
+}
+
+/// View model for `AddProductWithAIContainerView`.
+final class AddProductWithAIContainerViewModel: ObservableObject {
+
+    let siteID: Int64
+    private let analytics: Analytics
+    private let onCancel: () -> Void
+    private let completionHandler: () -> Void
+
+    @Published private(set) var currentStep: AddProductWithAIStep = .productName
+
+    init(siteID: Int64,
+         analytics: Analytics = ServiceLocator.analytics,
+         onCancel: @escaping () -> Void,
+         onCompletion: @escaping () -> Void) {
+        self.siteID = siteID
+        self.analytics = analytics
+        self.onCancel = onCancel
+        self.completionHandler = onCompletion
+    }
+
+    func onAppear() {
+        //
+    }
+
+    func onContinueWithProductName(name: String) {
+        // TODO: Continue to About your product screen
+    }
+
+    func onUsePackagePhoto(_ name: String?) {
+        // TODO: Launch UsePackagePhoto flow
+    }
+
+    func backtrackOrDismissProfiler() {
+        if let previousStep = currentStep.previousStep {
+            currentStep = previousStep
+        } else {
+            onCancel()
+        }
+    }
+}
+
+private extension AddProductWithAIContainerViewModel {
+    func handleCompletion() {
+        completionHandler()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -48,7 +48,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         // TODO: Launch UsePackagePhoto flow
     }
 
-    func backtrackOrDismissProfiler() {
+    func backtrackOrDismiss() {
         if let previousStep = currentStep.previousStep {
             currentStep = previousStep
         } else {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2328,6 +2328,8 @@
 		EE5B5BBD2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */; };
 		EE5B5BC12AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BBF2AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift */; };
 		EE5B5BC22AB42F21009BCBD6 /* AddProductNameWithAIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BC02AB42F21009BCBD6 /* AddProductNameWithAIView.swift */; };
+		EE5B5BC42AB83749009BCBD6 /* AddProductWithAIContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BC32AB83749009BCBD6 /* AddProductWithAIContainerView.swift */; };
+		EE5B5BC72AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BC62AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift */; };
 		EE6A7BA92A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BA82A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift */; };
 		EE6A7BAB2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BAA2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift */; };
 		EE6A7BAD2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BAC2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift */; };
@@ -4822,6 +4824,8 @@
 		EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductCreationAIEligibilityChecker.swift; sourceTree = "<group>"; };
 		EE5B5BBF2AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModel.swift; sourceTree = "<group>"; };
 		EE5B5BC02AB42F21009BCBD6 /* AddProductNameWithAIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIView.swift; sourceTree = "<group>"; };
+		EE5B5BC32AB83749009BCBD6 /* AddProductWithAIContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIContainerView.swift; sourceTree = "<group>"; };
+		EE5B5BC62AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIContainerViewModel.swift; sourceTree = "<group>"; };
 		EE6A7BA82A7B7BE600D9A028 /* StoreCreationFeaturesQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionViewModel.swift; sourceTree = "<group>"; };
 		EE6A7BAA2A7B7C0100D9A028 /* StoreCreationFeaturesQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionView.swift; sourceTree = "<group>"; };
 		EE6A7BAC2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationFeaturesQuestionOptions.swift; sourceTree = "<group>"; };
@@ -10905,6 +10909,7 @@
 		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				EE5B5BC52AB8374D009BCBD6 /* Container */,
 				EE5B5BBE2AB42F21009BCBD6 /* AddProductName */,
 				DE85E4EB2AB416F5008789E1 /* EntryPoint */,
 				EE5B5BB22AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift */,
@@ -10928,6 +10933,15 @@
 				EE5B5BC02AB42F21009BCBD6 /* AddProductNameWithAIView.swift */,
 			);
 			path = AddProductName;
+			sourceTree = "<group>";
+		};
+		EE5B5BC52AB8374D009BCBD6 /* Container */ = {
+			isa = PBXGroup;
+			children = (
+				EE5B5BC32AB83749009BCBD6 /* AddProductWithAIContainerView.swift */,
+				EE5B5BC62AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift */,
+			);
+			path = Container;
 			sourceTree = "<group>";
 		};
 		EE6A7BA72A7B7BC900D9A028 /* Features */ = {
@@ -13262,6 +13276,7 @@
 				FE28F7182684EE6A004465C7 /* RoleErrorViewModel.swift in Sources */,
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				03E471C8293A3076001A58AD /* CardPresentModalBuiltInConnectingToReader.swift in Sources */,
+				EE5B5BC72AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift in Sources */,
 				0365986529AF942700F297D3 /* PaymentSettingsFlowHint.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				02E3B62F2906322B007E0F13 /* AuthenticationFormFieldView.swift in Sources */,
@@ -13375,6 +13390,7 @@
 				03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */,
 				023930612918F36400B2632F /* DomainSelectorView.swift in Sources */,
 				DEACB8872A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift in Sources */,
+				EE5B5BC42AB83749009BCBD6 /* AddProductWithAIContainerView.swift in Sources */,
 				02C8876D24501FAC00E4470F /* FilterListViewController.swift in Sources */,
 				02B2828E27C35061004A332A /* RefreshableInfiniteScrollList.swift in Sources */,
 				021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */,


### PR DESCRIPTION
Closes: #10701

## Description

Presents the add product name screen from a container view to add a progress view at the top of the screen.

## Testing instructions
- Create a JN site with Jetpack AI plugin. (Checkbox available in JN home page to install this plugin)
- Switch to Products tab, select the "+" button to add a new product. The same AI action sheet should be displayed.
- Tap on "Create a product with AI"
- You can see the "Add your product name" screen with a progress view on top

## Screenshots
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/c3bad714-28ee-45b3-b4d9-e5fcd3dfef2c" width="320"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
