### PR TITLE
Remove "Shipping Zones" row from settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -278,7 +278,7 @@ private extension SettingsViewModel {
 
         // Store settings
         let storeSettingsSection: Section? = {
-            var rows: [Row] = [.storeName, .shippingZones]
+            var rows: [Row] = [.storeName]
 
             let site = stores.sessionManager.defaultSite
             if site?.isJetpackCPConnected == true ||


### PR DESCRIPTION
# Why

As per the latest React Native announcement pe5pgL-3H5-p2, this PR disables the "Shipping Zones" feature built in React Native. 

I will be removing all the RN code in a separate PR pointing `trunk`.

# Screenshots

Before | After
--- | ---
<img width="422" alt="with-sz" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/2a55e973-85b8-44fc-b29d-5d864fc0c721"> | <img width="436" alt="without-sz" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/972bc127-cfbd-42aa-8989-94ea47ecf1e6">


# Testing Instructions
- Navigate to settings
- Make sure the "Shipping Zones" row under the "Store Settings" section is not visible


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
