### PR TITLE
Start store creation flow after sign up.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 15.5
 -----
+- [*] Store creation: Start store creation flow after a new WPCOM account sign up. [https://github.com/woocommerce/woocommerce-ios/pull/10729]
 
 
 15.4

--- a/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
@@ -15,6 +15,7 @@ final class LoggedOutStoreCreationCoordinator: Coordinator {
     let navigationController: UINavigationController
 
     private var storePickerCoordinator: StorePickerCoordinator?
+    private var storeCreationCoordinator: StoreCreationCoordinator?
 
     private let analytics: Analytics
     private let source: Source
@@ -69,5 +70,10 @@ private extension LoggedOutStoreCreationCoordinator {
         let coordinator = StorePickerCoordinator(navigationController, config: .storeCreationFromLogin(source: source))
         storePickerCoordinator = coordinator
         coordinator.start()
+
+        // Start store creation
+        storeCreationCoordinator = StoreCreationCoordinator(source: .loggedOut(source: source),
+                                                            navigationController: navigationController)
+        storeCreationCoordinator?.start()
     }
 }


### PR DESCRIPTION
Closes: #10727 

## Description
Starts store creation flow after new WPCOM account creation. 

## Testing instructions
1. Launch the app
2. Logout if needed
3. Tap on "Create a New Store"
4. Enter an email which doesn't have a WPCOM account
5. Tap "Continue" and enter a password to sign up
6. After your account is created, you will land in an empty store picker screen
7. From that screen, the store creation flow should start automatically, and you should see a screen with a "Try For Free" button to start a store

## Screenshots


https://github.com/woocommerce/woocommerce-ios/assets/524475/02a9bc7e-91aa-48c0-bb2d-b5e01a8bdd32


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
