### PR TITLE
Product creation AI: Present bottom sheet for generating product name

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -7,6 +7,8 @@ struct AddProductNameWithAIView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
     @FocusState private var editorIsFocused: Bool
 
+    @State private var showingNameGeneratingView: Bool = false
+
     init(viewModel: AddProductNameWithAIViewModel) {
         self.viewModel = viewModel
     }
@@ -71,6 +73,13 @@ struct AddProductNameWithAIView: View {
             }
             .background(Color(uiColor: .systemBackground))
         }
+        .sheet(isPresented: $showingNameGeneratingView) {
+            if #available(iOS 16, *) {
+                productNameGeneratingView.presentationDetents([.medium, .large])
+            } else {
+                productNameGeneratingView
+            }
+        }
     }
 }
 
@@ -79,7 +88,7 @@ private extension AddProductNameWithAIView {
         HStack {
             // Suggest a name
             Button {
-                viewModel.didTapSuggestName()
+                showingNameGeneratingView = true
             } label: {
                 HStack(alignment: .top) {
                     Image(uiImage: .sparklesImage)
@@ -137,6 +146,13 @@ private extension AddProductNameWithAIView {
         }
         .buttonStyle(PrimaryButtonStyle())
         .disabled(viewModel.productNameContent.isEmpty)
+    }
+
+    var productNameGeneratingView: some View {
+        ProductNameGenerationView(viewModel: .init(siteID: viewModel.siteID, keywords: viewModel.productNameContent)) { suggestedName in
+            viewModel.productNameContent = suggestedName
+            showingNameGeneratingView = false
+        }
     }
 }
 private extension AddProductNameWithAIView {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -4,6 +4,8 @@ import Foundation
 ///
 final class AddProductNameWithAIViewModel: ObservableObject {
     @Published var productNameContent: String = ""
+    
+    let siteID: Int64
     private let onUsePackagePhoto: (String?) -> Void
     private let onContinueWithProductName: (String) -> Void
 
@@ -17,16 +19,13 @@ final class AddProductNameWithAIViewModel: ObservableObject {
     init(siteID: Int64,
          onUsePackagePhoto: @escaping (String?) -> Void,
          onContinueWithProductName: @escaping (String) -> Void) {
+        self.siteID = siteID
         self.onUsePackagePhoto = onUsePackagePhoto
         self.onContinueWithProductName = onContinueWithProductName
     }
 
     func didTapUsePackagePhoto() {
         onUsePackagePhoto(productName)
-    }
-
-    func didTapSuggestName() {
-        // TODO: Present suggest name sheet
     }
 
     func didTapContinue() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 final class AddProductNameWithAIViewModel: ObservableObject {
     @Published var productNameContent: String = ""
-    
+
     let siteID: Int64
     private let onUsePackagePhoto: (String?) -> Void
     private let onContinueWithProductName: (String) -> Void

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -7,8 +7,11 @@ struct ProductNameGenerationView: View {
     @FocusState private var isDetailInFocus: Bool
     @State private var copyTextNotice: Notice?
 
-    init(viewModel: ProductNameGenerationViewModel) {
+    private let onCompletion: (String) -> Void
+
+    init(viewModel: ProductNameGenerationViewModel, onCompletion: @escaping (String) -> Void) {
         self.viewModel = viewModel
+        self.onCompletion = onCompletion
     }
 
     var body: some View {
@@ -98,33 +101,33 @@ struct ProductNameGenerationView: View {
 
             Spacer()
 
-            Divider()
-                .renderedIf(viewModel.generationInProgress == false && viewModel.hasGeneratedMessage)
-
-            HStack(spacing: Constants.horizontalSpacing) {
-                // Action button to regenerate product name
-                Button(action: {
-                    viewModel.generateProductName()
-                }, label: {
-                    Label {
-                        Text(viewModel.generateButtonTitle)
-                    } icon: {
-                        Image(uiImage: viewModel.generateButtonImage)
-                            .renderingMode(.template)
+            if let suggestedText = viewModel.suggestedText,
+               viewModel.generationInProgress == false {
+                Divider()
+                HStack(spacing: Constants.horizontalSpacing) {
+                    // Action button to regenerate product name
+                    Button(action: {
+                        viewModel.generateProductName()
+                    }, label: {
+                        Label {
+                            Text(viewModel.generateButtonTitle)
+                        } icon: {
+                            Image(uiImage: viewModel.generateButtonImage)
+                                .renderingMode(.template)
+                        }
+                    })
+                    .buttonStyle(.plain)
+                    
+                    Spacer()
+                    
+                    // Action button to apply product name
+                    Button(Localization.apply) {
+                        onCompletion(suggestedText)
                     }
-                })
-                .buttonStyle(.plain)
-
-                Spacer()
-
-                // Action button to apply product name
-                Button(Localization.apply) {
-                    viewModel.applyGeneratedName()
+                    .buttonStyle(PrimaryButtonStyle())
+                    .fixedSize(horizontal: true, vertical: false)
                 }
-                .buttonStyle(PrimaryButtonStyle())
-                .fixedSize(horizontal: true, vertical: false)
             }
-            .renderedIf(viewModel.generationInProgress == false && viewModel.hasGeneratedMessage)
 
             // Action button to generate product name - displayed initially.
             Button(action: {
@@ -193,6 +196,6 @@ private extension ProductNameGenerationView {
 
 struct ProductNameAIBottomSheet_Previews: PreviewProvider {
     static var previews: some View {
-        ProductNameGenerationView(viewModel: .init(siteID: 123, keywords: "Thai essential oil"))
+        ProductNameGenerationView(viewModel: .init(siteID: 123, keywords: "Thai essential oil")) { _ in }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -103,7 +103,9 @@ struct ProductNameGenerationView: View {
 
             if let suggestedText = viewModel.suggestedText,
                viewModel.generationInProgress == false {
+
                 Divider()
+
                 HStack(spacing: Constants.horizontalSpacing) {
                     // Action button to regenerate product name
                     Button(action: {
@@ -117,9 +119,9 @@ struct ProductNameGenerationView: View {
                         }
                     })
                     .buttonStyle(.plain)
-                    
+
                     Spacer()
-                    
+
                     // Action button to apply product name
                     Button(Localization.apply) {
                         onCompletion(suggestedText)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationViewModel.swift
@@ -38,10 +38,6 @@ final class ProductNameGenerationViewModel: ObservableObject {
         self.analytics = analytics
     }
 
-    func applyGeneratedName() {
-        // TODO-10688
-    }
-
     func generateProductName() {
         // TODO-10688
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10734 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR connects the two screens: add product name & product name generation bottom sheet. For simplicity, I use SwiftUI `presentationDetents` for devices with iOS 16 and above while keeping a simple full screen sheet for those with iOS 15. With the keyboard displayed, users will need the full screen anyway.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a JN site with Jetpack AI plugin. (Checkbox available in JN home page to install this plugin).
- Switch to Products tab, select the "+" button to add a new product. The same AI action sheet should be displayed.
- Tap on "Create a product with AI"
- On the "Add your product name" screen, select "Suggest a name".
- A bottom sheet for generating product name with AI should be displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/8a27f72a-de75-4225-b1e1-860b4cb9b4f3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
