### PR TITLE
Add `product_types` to `order_create_button_tapped` event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -495,6 +495,7 @@ extension WooAnalyticsEvent {
             static let hasDifferentShippingDetails = "has_different_shipping_details"
             static let orderStatus = "order_status"
             static let productCount = "product_count"
+            static let hasAddOns = "has_addons"
             static let hasCustomerDetails = "has_customer_details"
             static let hasFees = "has_fees"
             static let hasShippingMethod = "has_shipping_method"
@@ -503,6 +504,7 @@ extension WooAnalyticsEvent {
             static let to = "to"
             static let from = "from"
             static let orderID = "id"
+            static let productTypes = "product_types"
             static let hasMultipleShippingLines = "has_multiple_shipping_lines"
             static let hasMultipleFeeLines = "has_multiple_fee_lines"
             static let itemType = "item_type"
@@ -529,14 +531,11 @@ extension WooAnalyticsEvent {
         }
 
         static func orderProductsLoaded(order: Order, products: [Product], addOnGroups: [AddOnGroup]) -> WooAnalyticsEvent {
-            let productIDs = order.items.map { $0.productID }
-            let productTypes = productIDs.compactMap { productID in
-                products.first(where: { $0.productID == productID })?.productType.rawValue
-            }.uniqued().joined(separator: ",")
+            let productTypes = productTypes(order: order, products: products)
             let hasAddOns = hasAddOns(order: order, products: products, addOnGroups: addOnGroups)
-            return WooAnalyticsEvent(statName: .orderProductsLoaded, properties: ["id": order.orderID,
-                                                                                  "product_types": productTypes,
-                                                                                  "has_addons": hasAddOns])
+            return WooAnalyticsEvent(statName: .orderProductsLoaded, properties: [Keys.orderID: order.orderID,
+                                                                                  Keys.productTypes: productTypes,
+                                                                                  Keys.hasAddOns: hasAddOns])
         }
 
         private static func hasAddOns(order: Order, products: [Product], addOnGroups: [AddOnGroup]) -> Bool {
@@ -556,6 +555,13 @@ extension WooAnalyticsEvent {
                 }
             }
             return false
+        }
+
+        private static func productTypes(order: Order, products: [Product]) -> String {
+            let productIDs = order.items.map { $0.productID }
+            return productIDs.compactMap { productID in
+                products.first(where: { $0.productID == productID })?.productType.rawValue
+            }.uniqued().sorted().joined(separator: ",")
         }
 
         static func orderAddNewFromBarcodeScanningTapped() -> WooAnalyticsEvent {
@@ -693,17 +699,20 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .orderStatusChange, properties: properties.compactMapValues { $0 })
         }
 
-        static func orderCreateButtonTapped(status: OrderStatusEnum,
+        static func orderCreateButtonTapped(order: Order,
+                                            status: OrderStatusEnum,
                                             productCount: Int,
                                             hasCustomerDetails: Bool,
                                             hasFees: Bool,
-                                            hasShippingMethod: Bool) -> WooAnalyticsEvent {
+                                            hasShippingMethod: Bool,
+                                            products: [Product]) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreateButtonTapped, properties: [
                 Keys.orderStatus: status.rawValue,
                 Keys.productCount: Int64(productCount),
                 Keys.hasCustomerDetails: hasCustomerDetails,
                 Keys.hasFees: hasFees,
-                Keys.hasShippingMethod: hasShippingMethod
+                Keys.hasShippingMethod: hasShippingMethod,
+                Keys.productTypes: productTypes(order: order, products: products)
             ])
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1286,11 +1286,13 @@ private extension EditableOrderViewModel {
     ///
     func trackCreateButtonTapped() {
         let hasCustomerDetails = customerDataViewModel.isDataAvailable
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(status: orderSynchronizer.order.status,
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(order: orderSynchronizer.order,
+                                                                                status: orderSynchronizer.order.status,
                                                                                 productCount: orderSynchronizer.order.items.count,
                                                                                 hasCustomerDetails: hasCustomerDetails,
                                                                                 hasFees: orderSynchronizer.order.fees.isNotEmpty,
-                                                                                hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty))
+                                                                                hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
+                                                                                products: Array(allProducts)))
     }
 
     /// Tracks an order creation success


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10706 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We want to track the usage of extensions through order creation. This involves adding the `product_types` property to the order creation event `order_create_button_tapped`.

## How

Because the logic is the same in the `order_products_loaded` event, a private static function was created to return the product types string from `Order` and `[Product]`. The list of product type strings is sorted so that the order of products does not matter.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the site has at least 2 different types of products

- Go to the Orders tab
- Tap `+` in the navigation bar to create an order
- Add at least two products of different types (e.g. simple, variable)
- Tap `Create` --> the `order_create_button_tapped` event should have a `product_types` property of the product types above in alphabetical order like `🔵 Tracked order_create_button_tapped, properties: [AnyHashable("product_types"): "simple,variable,variable-subscription", ...]`. Shortly after it navigates to the order details, another event `order_products_loaded` should also include the same `product_types` property: `🔵 Tracked order_products_loaded, properties: [AnyHashable("product_types"): "simple,variable,variable-subscription", ...]`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
