### PR TITLE
Fix flaky tests for `ProductFormRemoteActionUseCase`

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -35,9 +35,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 2)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
-        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: password)))
     }
 
@@ -57,9 +56,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 2)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
-        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.passwordCannotBeUpdated))
     }
 
@@ -77,8 +75,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-        XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: nil)))
     }
 
@@ -96,8 +94,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-        XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.invalidSKU))
     }
 
@@ -123,7 +121,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 0)
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: password)))
     }
 
@@ -152,9 +151,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 2)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
-        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: password)))
     }
 
@@ -183,9 +181,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 2)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
-        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.passwordCannotBeUpdated))
     }
 
@@ -214,9 +211,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 2)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
-        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.invalidSKU))
     }
 
@@ -245,9 +241,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 2)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
-        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.invalidSKU))
     }
 
@@ -267,8 +262,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: nil)))
     }
 
@@ -286,8 +281,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-        XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.unexpected))
     }
 
@@ -336,9 +331,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(storesManager.receivedActions.count, 2)
-        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
-        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.passwordCannotBeUpdated))
     }
 
@@ -356,8 +350,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-        XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .success(ResultData(product: model, password: nil)))
     }
 
@@ -375,8 +369,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-        XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
+        XCTAssertTrue(storesManager.receivedActions.contains(where: { $0 is ProductAction }))
+        XCTAssertFalse(storesManager.receivedActions.contains(where: { $0 is SitePostAction }))
         XCTAssertEqual(result, .failure(.invalidSKU))
     }
 
@@ -426,7 +420,7 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(retrievedVariationIDs, testVariationIDs)
+        XCTAssertEqual(retrievedVariationIDs.sorted(), testVariationIDs.sorted())
         XCTAssertEqual(result?.isSuccess, true)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Internal discussion: p1695133173966549-slack-C6H8C3G23
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the flaky tests that show up since Xcode 14.3.1.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.