### PR TITLE
Gift card support in order form: check feature flag and Gift Cards plugin state for eligibility

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -658,6 +658,13 @@ public extension StorageType {
         return firstObject(ofType: SystemPlugin.self, matching: predicate)
     }
 
+    /// Returns a system plugin with a specified `siteID` and `path`.
+    ///
+    func loadSystemPlugin(siteID: Int64, path: String) -> SystemPlugin? {
+        let predicate = \SystemPlugin.siteID == siteID && \SystemPlugin.plugin == path
+        return firstObject(ofType: SystemPlugin.self, matching: predicate)
+    }
+
     // MARK: - Inbox Notes
 
     /// Returns a single Inbox Note given a `siteID` and `id`

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1251,6 +1251,23 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(foundSystemPlugin, systemPlugin2)
     }
 
+    func test_loadSystemPlugin_by_siteID_and_path() throws {
+        // Given
+        let systemPlugin1 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin1.plugin = "woocommerce-payments/woocommerce-payments.php"
+        systemPlugin1.siteID = sampleSiteID
+
+        let systemPlugin2 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin2.plugin = "woocommerce-gift-cards/woocommerce-gift-cards.php"
+        systemPlugin2.siteID = sampleSiteID
+
+        // When
+        let foundSystemPlugin = try XCTUnwrap(storage.loadSystemPlugin(siteID: sampleSiteID, path: "woocommerce-gift-cards/woocommerce-gift-cards.php"))
+
+        // Then
+        XCTAssertEqual(foundSystemPlugin, systemPlugin2)
+    }
+
     func test_load_WCPayCharge_by_siteID_and_chargeID() throws {
         // Given
         let charge1 = storage.insertNewObject(ofType: WCPayCharge.self)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1312,7 +1312,7 @@ private extension EditableOrderViewModel {
 
     func configureGiftCardSupport() {
         Task { @MainActor in
-            isGiftCardSupported = try await checkIfGiftCardsPluginIsActive()
+            isGiftCardSupported = await checkIfGiftCardsPluginIsActive()
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2177,6 +2177,78 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.addressFormViewModel.fields.city, taxRate.cities.first)
     }
 
+    func test_isGiftCardEnabled_becomes_true_when_gift_cards_plugin_is_active() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+
+        var viewModel: EditableOrderViewModel?
+        waitFor { promise in
+            stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+                guard case let .fetchSystemPluginWithPath(_, pluginPath, onCompletion) = action else {
+                    return
+                }
+                XCTAssertEqual(pluginPath, "woocommerce-gift-cards/woocommerce-gift-cards.php")
+                onCompletion(.fake().copy(active: true))
+                promise(())
+            }
+
+            // When
+            viewModel = EditableOrderViewModel(siteID: self.sampleSiteID, stores: stores, storageManager: self.storageManager)
+            XCTAssertEqual(viewModel?.paymentDataViewModel.isGiftCardEnabled, false)
+        }
+
+        // Then
+        XCTAssertEqual(viewModel?.paymentDataViewModel.isGiftCardEnabled, true)
+    }
+
+    func test_isGiftCardEnabled_stays_false_when_gift_cards_plugin_is_not_active() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+
+        var viewModel: EditableOrderViewModel?
+        waitFor { promise in
+            stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+                guard case let .fetchSystemPluginWithPath(_, pluginPath, onCompletion) = action else {
+                    return
+                }
+                XCTAssertEqual(pluginPath, "woocommerce-gift-cards/woocommerce-gift-cards.php")
+                onCompletion(.fake().copy(active: false))
+                promise(())
+            }
+
+            // When
+            viewModel = EditableOrderViewModel(siteID: self.sampleSiteID, stores: stores, storageManager: self.storageManager)
+            XCTAssertEqual(viewModel?.paymentDataViewModel.isGiftCardEnabled, false)
+        }
+
+        // Then
+        XCTAssertEqual(viewModel?.paymentDataViewModel.isGiftCardEnabled, false)
+    }
+
+    func test_isGiftCardEnabled_stays_false_when_gift_cards_plugin_is_not_installed() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+
+        var viewModel: EditableOrderViewModel?
+        waitFor { promise in
+            stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+                guard case let .fetchSystemPluginWithPath(_, pluginPath, onCompletion) = action else {
+                    return
+                }
+                XCTAssertEqual(pluginPath, "woocommerce-gift-cards/woocommerce-gift-cards.php")
+                onCompletion(nil)
+                promise(())
+            }
+
+            // When
+            viewModel = EditableOrderViewModel(siteID: self.sampleSiteID, stores: stores, storageManager: self.storageManager)
+            XCTAssertEqual(viewModel?.paymentDataViewModel.isGiftCardEnabled, false)
+        }
+
+        // Then
+        XCTAssertEqual(viewModel?.paymentDataViewModel.isGiftCardEnabled, false)
+    }
+
     func test_appliedGiftCards_have_negative_formatted_amount() {
         // Given
         let order = Order.fake().copy(orderID: sampleOrderID, appliedGiftCards: [

--- a/Yosemite/Yosemite/Actions/SystemStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/SystemStatusAction.swift
@@ -16,6 +16,10 @@ public enum SystemStatusAction: Action {
     ///
     case fetchSystemPluginListWithNameList(siteID: Int64, systemPluginNameList: [String], onCompletion: (SystemPlugin?) -> Void)
 
+    /// Fetch a specific systemPlugin by path.
+    ///
+    case fetchSystemPluginWithPath(siteID: Int64, pluginPath: String, onCompletion: (SystemPlugin?) -> Void)
+
     /// Fetch system status report for a site given its ID
     ///
     case fetchSystemStatusReport(siteID: Int64, onCompletion: (Result<SystemStatus, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/SystemStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/SystemStatusStore.swift
@@ -33,6 +33,10 @@ public final class SystemStatusStore: Store {
             fetchSystemPlugin(siteID: siteID, systemPluginNameList: [systemPluginName], completionHandler: onCompletion)
         case .fetchSystemPluginListWithNameList(let siteID, let systemPluginNameList, let onCompletion):
             fetchSystemPlugin(siteID: siteID, systemPluginNameList: systemPluginNameList, completionHandler: onCompletion)
+        case .fetchSystemPluginWithPath(let siteID, let pluginPath, let onCompletion):
+            fetchSystemPluginWithPath(siteID: siteID,
+                                      pluginPath: pluginPath,
+                                      onCompletion: onCompletion)
         case .fetchSystemStatusReport(let siteID, let onCompletion):
             fetchSystemStatusReport(siteID: siteID, completionHandler: onCompletion)
         }
@@ -114,5 +118,10 @@ private extension SystemStatusStore {
             }
         }
         completionHandler(nil)
+    }
+
+    func fetchSystemPluginWithPath(siteID: Int64, pluginPath: String, onCompletion: @escaping (SystemPlugin?) -> Void) {
+        let viewStorage = storageManager.viewStorage
+        onCompletion(viewStorage.loadSystemPlugin(siteID: siteID, path: pluginPath)?.toReadOnly())
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -126,6 +126,54 @@ final class SystemStatusStoreTests: XCTestCase {
         XCTAssertEqual(systemPluginResult?.name, "Plugin 3")
     }
 
+    func test_fetchSystemPluginWithPath_returns_plugin_when_matching_plugin_is_in_storage() {
+        // Given
+        let systemPlugin1 = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin1.name = "WCPay"
+        systemPlugin1.plugin = "woocommerce-payments/woocommerce-payments.php"
+        systemPlugin1.siteID = sampleSiteID
+
+        let systemPlugin2 = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin2.name = "Gift Cards"
+        systemPlugin2.plugin = "woocommerce-gift-cards/woocommerce-gift-cards.php"
+        systemPlugin2.siteID = sampleSiteID
+
+        let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let fetchedPlugin = waitFor { promise in
+            store.onAction(SystemStatusAction.fetchSystemPluginWithPath(siteID: self.sampleSiteID,
+                                                                      pluginPath: "woocommerce-gift-cards/woocommerce-gift-cards.php") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertEqual(fetchedPlugin?.name, "Gift Cards")
+        XCTAssertEqual(fetchedPlugin?.plugin, "woocommerce-gift-cards/woocommerce-gift-cards.php")
+    }
+
+    func test_fetchSystemPluginWithPath_returns_nil_when_no_matching_plugin() {
+        // Given
+        let systemPlugin = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin.name = "WCPay"
+        systemPlugin.plugin = "woocommerce-payments/woocommerce-payments.php"
+        systemPlugin.siteID = sampleSiteID
+
+        let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let fetchedPlugin = waitFor { promise in
+            store.onAction(SystemStatusAction.fetchSystemPluginWithPath(siteID: self.sampleSiteID,
+                                                                      pluginPath: "woocommerce-gift-cards/woocommerce-gift-cards.php") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertNil(fetchedPlugin)
+    }
+
     func test_fetchSystemStatusReport_returns_systemStatus_correctly() {
         // Given
         network.simulateResponse(requestUrlSuffix: "system_status", filename: "systemStatus")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10518 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/10732

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For the gift card support in order form, we only want to make the CTA available for sites with the Gift Cards extension/plugin. Otherwise, merchants might spend the time to add a gift card but realize this doesn't work.

## How

In order to check the Gift Cards plugin, I decided to check the plugin path instead of the name to avoid future renaming of the plugin (it's certainly more likely to change the name than the plugin path and we have a dashboard to find plugin usage by path). This requires a new storage extension helper and a new action `SystemStatusAction.fetchSystemPluginWithPath` to return a storage plugin that matches the path. Then in `EditableOrderViewModel`, it checks the feature flag and the plugin state with the new action to update an internal @Published variable.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: have two sites, one site has the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension/plugin active, and the other site doesn't have the plugin.

- Switch to a site with the Gift Cards plugin
- Go to the Orders tab
- Tap `+` in the navigation bar to create an order --> `Add Gift Card` CTA should be shown
- Feel free to continue adding a gift card to the order and create the order if you like
- Dismiss the order form
- Switch to a site without the Gift Cards plugin
- Go to the Orders tab
- Tap `+` in the navigation bar to create an order --> `Add Gift Card` CTA shouldn't be shown

---
- [x] @jaclync tests that when the feature flag is off, the CTA isn't shown for sites with the plugin active

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
