### PR TITLE
Product Creation AI: UI for about your product screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// View for adding product features in the product creation with AI flow.
+///
+struct AddProductFeaturesView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct AddProductDetailsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddProductFeaturesView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -12,7 +12,7 @@ struct AddProductFeaturesView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: Layout.blockBottomPadding) {
+            VStack(alignment: .leading, spacing: Layout.blockVerticalSpacing) {
                 VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
                     // Title label.
                     Text(Localization.title)
@@ -89,7 +89,7 @@ private extension AddProductFeaturesView {
     enum Layout {
         static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
 
-        static let blockBottomPadding: CGFloat = 40
+        static let blockVerticalSpacing: CGFloat = 40
         static let titleBlockSpacing: CGFloat = 16
 
         static let editorBlockSpacing: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -12,7 +12,7 @@ struct AddProductFeaturesView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: Layout.blockBottomPadding) {
                 VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
                     // Title label.
                     Text(Localization.title)
@@ -24,38 +24,46 @@ struct AddProductFeaturesView: View {
                         .foregroundColor(Color(.secondaryLabel))
                         .bodyStyle()
                 }
-                .padding(.bottom, Layout.titleBlockBottomPadding)
 
-                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
-                    VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
-                        Text(Localization.myProduct)
-                            .foregroundColor(Color(.label))
-                            .subheadlineStyle()
+                VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
+                    Text(Localization.textFieldTitle)
+                        .foregroundColor(Color(.label))
+                        .subheadlineStyle()
 
-                        ZStack(alignment: .topLeading) {
-                            TextEditor(text: $viewModel.productFeatures)
-                                .bodyStyle()
-                                .foregroundColor(.secondary)
-                                .padding(insets: Layout.textFieldContentInsets)
-                                .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
-                                .focused($editorIsFocused)
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(text: $viewModel.productFeatures)
+                            .bodyStyle()
+                            .foregroundColor(.secondary)
+                            .padding(insets: Layout.textFieldContentInsets)
+                            .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
+                            .focused($editorIsFocused)
 
-                            // Placeholder text
-                            Text(Localization.placeholder)
-                                .foregroundColor(Color(.placeholderText))
-                                .bodyStyle()
-                                .padding(insets: Layout.placeholderInsets)
-                                // Allows gestures to pass through to the `TextEditor`.
-                                .allowsHitTesting(false)
-                                .renderedIf(viewModel.productFeatures.isEmpty)
+                        // Placeholder text
+                        Text(Localization.placeholder)
+                            .foregroundColor(Color(.placeholderText))
+                            .bodyStyle()
+                            .padding(insets: Layout.placeholderInsets)
+                            // Allows gestures to pass through to the `TextEditor`.
+                            .allowsHitTesting(false)
+                            .renderedIf(viewModel.productFeatures.isEmpty)
 
-                        }
-                        .overlay(
-                            RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
-                        )
                     }
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
+                    )
 
+                    Text(Localization.textFieldDescription)
+                        .footnoteStyle()
                 }
+
+                Button(action: {
+                    // TODO: show tone bottom sheet
+                }, label: {
+                    Text(Localization.setToneButton)
+                        .foregroundColor(.accentColor)
+                        .subheadlineStyle()
+                })
+                .buttonStyle(.plain)
             }
             .padding(insets: Layout.insets)
         }
@@ -63,7 +71,7 @@ struct AddProductFeaturesView: View {
             VStack {
                 // CTA to continue to next screen.
                 Button {
-                    // TODO
+                    // TODO: start product detail generation
                     editorIsFocused = false
                 } label: {
                     Text(Localization.continueText)
@@ -81,10 +89,8 @@ private extension AddProductFeaturesView {
     enum Layout {
         static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
 
-        static let titleBlockBottomPadding: CGFloat = 40
-
+        static let blockBottomPadding: CGFloat = 40
         static let titleBlockSpacing: CGFloat = 16
-        static let horizontalPadding: CGFloat = 16
 
         static let editorBlockSpacing: CGFloat = 8
         static let minimumEditorHeight: CGFloat = 70
@@ -101,13 +107,21 @@ private extension AddProductFeaturesView {
             "Highlight what makes your product unique, and let AI do the magic.",
             comment: "Subtitle on the add product features screen."
         )
-        static let myProduct = NSLocalizedString(
+        static let textFieldTitle = NSLocalizedString(
             "My Product",
             comment: "Text field's label on the add product features screen."
         )
         static let placeholder = NSLocalizedString(
             "For example, Soft fabric, durable stitching, unique design",
             comment: "Placeholder text on the product features field"
+        )
+        static let textFieldDescription = NSLocalizedString(
+            "Add key features, benefits, or details to help your product get found online.",
+            comment: "Description for the text field on the add product features screen"
+        )
+        static let setToneButton = NSLocalizedString(
+            "Set tone and voice",
+            comment: "Button to select tone and voice for generating product details with AI"
         )
         static let continueText = NSLocalizedString(
             "Create Product Details",

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -26,7 +26,7 @@ struct AddProductFeaturesView: View {
                 }
 
                 VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
-                    Text(Localization.textFieldTitle)
+                    Text(viewModel.productName)
                         .foregroundColor(Color(.label))
                         .subheadlineStyle()
 
@@ -107,10 +107,6 @@ private extension AddProductFeaturesView {
             "Highlight what makes your product unique, and let AI do the magic.",
             comment: "Subtitle on the add product features screen."
         )
-        static let textFieldTitle = NSLocalizedString(
-            "My Product",
-            comment: "Text field's label on the add product features screen."
-        )
         static let placeholder = NSLocalizedString(
             "For example, Soft fabric, durable stitching, unique design",
             comment: "Placeholder text on the product features field"
@@ -132,6 +128,6 @@ private extension AddProductFeaturesView {
 
 struct AddProductDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductFeaturesView(viewModel: .init(siteID: 123, onProductDetailsCreated: {}))
+        AddProductFeaturesView(viewModel: .init(siteID: 123, productName: "iPhone 15", onProductDetailsCreated: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -3,8 +3,110 @@ import SwiftUI
 /// View for adding product features in the product creation with AI flow.
 ///
 struct AddProductFeaturesView: View {
+    @FocusState private var editorIsFocused: Bool
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                    // Title label.
+                    Text(Localization.title)
+                        .fontWeight(.bold)
+                        .titleStyle()
+
+                    // Subtitle label.
+                    Text(Localization.subtitle)
+                        .foregroundColor(Color(.secondaryLabel))
+                        .bodyStyle()
+                }
+                .padding(.bottom, Layout.titleBlockBottomPadding)
+
+                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                    VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
+                        Text(Localization.myProduct)
+                            .foregroundColor(Color(.label))
+                            .subheadlineStyle()
+
+                        ZStack(alignment: .topLeading) {
+                            TextEditor(text: .constant("Test"))
+                                .bodyStyle()
+                                .foregroundColor(.secondary)
+                                .padding(insets: Layout.textFieldContentInsets)
+                                .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
+                                .focused($editorIsFocused)
+
+                            // Placeholder text
+                            Text(Localization.placeholder)
+                                .foregroundColor(Color(.placeholderText))
+                                .bodyStyle()
+                                .padding(insets: Layout.placeholderInsets)
+                                // Allows gestures to pass through to the `TextEditor`.
+                                .allowsHitTesting(false)
+
+                        }
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
+                        )
+                    }
+
+                }
+            }
+            .padding(insets: Layout.insets)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                // CTA to continue to next screen.
+                Button {
+                    // TODO
+                    editorIsFocused = false
+                } label: {
+                    Text(Localization.continueText)
+                }
+                .buttonStyle(PrimaryButtonStyle())
+//                .disabled(viewModel.productNameContent.isEmpty)
+                .padding()
+            }
+            .background(Color(uiColor: .systemBackground))
+        }
+    }
+}
+
+private extension AddProductFeaturesView {
+    enum Layout {
+        static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+
+        static let titleBlockBottomPadding: CGFloat = 40
+
+        static let titleBlockSpacing: CGFloat = 16
+        static let horizontalPadding: CGFloat = 16
+
+        static let editorBlockSpacing: CGFloat = 8
+        static let minimumEditorHeight: CGFloat = 70
+        static let cornerRadius: CGFloat = 8
+        static let textFieldContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
+        static let placeholderInsets: EdgeInsets = .init(top: 18, leading: 16, bottom: 18, trailing: 16)
+    }
+    enum Localization {
+        static let title = NSLocalizedString(
+            "About your product",
+            comment: "Title on the add product features screen."
+        )
+        static let subtitle = NSLocalizedString(
+            "Highlight what makes your product unique, and let AI do the magic.",
+            comment: "Subtitle on the add product features screen."
+        )
+        static let myProduct = NSLocalizedString(
+            "My Product",
+            comment: "Text field's label on the add product features screen."
+        )
+        static let placeholder = NSLocalizedString(
+            "For example, Soft fabric, durable stitching, unique design",
+            comment: "Placeholder text on the product features field"
+        )
+        static let continueText = NSLocalizedString(
+            "Create Product Details",
+            comment: "Continue button on the add product features screen"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -4,6 +4,11 @@ import SwiftUI
 ///
 struct AddProductFeaturesView: View {
     @FocusState private var editorIsFocused: Bool
+    @ObservedObject private var viewModel: AddProductFeaturesViewModel
+
+    init(viewModel: AddProductFeaturesViewModel) {
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         ScrollView {
@@ -28,7 +33,7 @@ struct AddProductFeaturesView: View {
                             .subheadlineStyle()
 
                         ZStack(alignment: .topLeading) {
-                            TextEditor(text: .constant("Test"))
+                            TextEditor(text: $viewModel.productFeatures)
                                 .bodyStyle()
                                 .foregroundColor(.secondary)
                                 .padding(insets: Layout.textFieldContentInsets)
@@ -42,6 +47,7 @@ struct AddProductFeaturesView: View {
                                 .padding(insets: Layout.placeholderInsets)
                                 // Allows gestures to pass through to the `TextEditor`.
                                 .allowsHitTesting(false)
+                                .renderedIf(viewModel.productFeatures.isEmpty)
 
                         }
                         .overlay(
@@ -63,7 +69,7 @@ struct AddProductFeaturesView: View {
                     Text(Localization.continueText)
                 }
                 .buttonStyle(PrimaryButtonStyle())
-//                .disabled(viewModel.productNameContent.isEmpty)
+                .disabled(viewModel.productFeatures.isEmpty)
                 .padding()
             }
             .background(Color(uiColor: .systemBackground))
@@ -112,6 +118,6 @@ private extension AddProductFeaturesView {
 
 struct AddProductDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductFeaturesView()
+        AddProductFeaturesView(viewModel: .init(siteID: 123, onProductDetailsCreated: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -6,6 +6,7 @@ import Yosemite
 final class AddProductFeaturesViewModel: ObservableObject {
 
     @Published var productFeatures: String = ""
+    let productName: String
 
     private let siteID: Int64
     private let stores: StoresManager
@@ -14,10 +15,12 @@ final class AddProductFeaturesViewModel: ObservableObject {
     private let onProductDetailsCreated: () -> Void
 
     init(siteID: Int64,
+         productName: String,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          onProductDetailsCreated: @escaping () -> Void) {
         self.siteID = siteID
+        self.productName = productName
         self.stores = stores
         self.analytics = analytics
         self.onProductDetailsCreated = onProductDetailsCreated

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Yosemite
+
+/// View model for `AddProductFeaturesView`.
+///
+final class AddProductFeaturesViewModel: ObservableObject {
+
+    @Published var productFeatures: String = ""
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let analytics: Analytics
+    // TODO: add new type for product details and return it here.
+    private let onProductDetailsCreated: () -> Void
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
+         onProductDetailsCreated: @escaping () -> Void) {
+        self.siteID = siteID
+        self.stores = stores
+        self.analytics = analytics
+        self.onProductDetailsCreated = onProductDetailsCreated
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -63,9 +63,17 @@ struct AddProductWithAIContainerView: View {
             case .productName:
                 AddProductNameWithAIView(viewModel: .init(siteID: viewModel.siteID,
                                                           onUsePackagePhoto: onUsePackagePhoto,
-                                                          onContinueWithProductName: viewModel.onContinueWithProductName))
+                                                          onContinueWithProductName: { name in
+                    withAnimation {
+                        viewModel.onContinueWithProductName(name: name)
+                    }
+                }))
             case .aboutProduct:
-                AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID, onProductDetailsCreated: viewModel.onProductDetailsCreated))
+                AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID) {
+                    withAnimation {
+                        viewModel.onProductDetailsCreated()
+                    }
+                })
             case .preview:
                 // TODO: Add other AI views
                Text("Add other AI views")

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -64,7 +64,9 @@ struct AddProductWithAIContainerView: View {
                 AddProductNameWithAIView(viewModel: .init(siteID: viewModel.siteID,
                                                           onUsePackagePhoto: onUsePackagePhoto,
                                                           onContinueWithProductName: viewModel.onContinueWithProductName))
-            default:
+            case .aboutProduct:
+                AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID, onProductDetailsCreated: viewModel.onProductDetailsCreated))
+            case .preview:
                 // TODO: Add other AI views
                Text("Add other AI views")
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -69,7 +69,8 @@ struct AddProductWithAIContainerView: View {
                     }
                 }))
             case .aboutProduct:
-                AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID) {
+                AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
+                                                        productName: viewModel.productName) {
                     withAnimation {
                         viewModel.onProductDetailsCreated()
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -27,6 +27,8 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private let onCancel: () -> Void
     private let completionHandler: (Product) -> Void
 
+    private var productName: String = ""
+
     @Published private(set) var currentStep: AddProductWithAIStep = .productName
 
     init(siteID: Int64,
@@ -46,7 +48,12 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     }
 
     func onContinueWithProductName(name: String) {
-        // TODO: Continue to About your product screen
+        productName = name
+        currentStep = .aboutProduct
+    }
+
+    func onProductDetailsCreated() {
+        currentStep = .preview
     }
 
     func didGenerateDataFromPackage(_ data: AddProductFromImageData?) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -27,7 +27,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private let onCancel: () -> Void
     private let completionHandler: (Product) -> Void
 
-    private var productName: String = ""
+    private(set) var productName: String = ""
 
     @Published private(set) var currentStep: AddProductWithAIStep = .productName
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2178,6 +2178,7 @@
 		DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */; };
 		DE8BEB8A2AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */; };
 		DE8BEB8C2AB840DD00F5E56C /* ProductNameGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */; };
+		DE8BEB912ABAEBF800F5E56C /* AddProductFeaturesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE8FCD1A2A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */; };
@@ -4675,6 +4676,7 @@
 		DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AIFeedback.swift"; sourceTree = "<group>"; };
 		DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationViewModel.swift; sourceTree = "<group>"; };
 		DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationView.swift; sourceTree = "<group>"; };
+		DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesView.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerQuestionContainerView.swift; sourceTree = "<group>"; };
@@ -10612,6 +10614,14 @@
 			path = ProductNameGeneration;
 			sourceTree = "<group>";
 		};
+		DE8BEB8F2ABAEBD600F5E56C /* AddProductFeatures */ = {
+			isa = PBXGroup;
+			children = (
+				DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */,
+			);
+			path = AddProductFeatures;
+			sourceTree = "<group>";
+		};
 		DE8C9464264698E800C94823 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -10913,6 +10923,7 @@
 		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				DE8BEB8F2ABAEBD600F5E56C /* AddProductFeatures */,
 				EE5B5BC52AB8374D009BCBD6 /* Container */,
 				EE5B5BBE2AB42F21009BCBD6 /* AddProductName */,
 				DE8BEB882AB83F2B00F5E56C /* ProductNameGeneration */,
@@ -12775,6 +12786,7 @@
 				0235BFD9246E959500778909 /* ProductFormActionsFactory.swift in Sources */,
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
 				02EAF5BE29FA04750058071C /* ProductDescriptionGenerationView.swift in Sources */,
+				DE8BEB912ABAEBF800F5E56C /* AddProductFeaturesView.swift in Sources */,
 				CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
 				2677B559299F322300862180 /* SupportForm+Presentation.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2179,6 +2179,7 @@
 		DE8BEB8A2AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */; };
 		DE8BEB8C2AB840DD00F5E56C /* ProductNameGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */; };
 		DE8BEB912ABAEBF800F5E56C /* AddProductFeaturesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */; };
+		DE8BEB932ABAF07700F5E56C /* AddProductFeaturesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB922ABAF07700F5E56C /* AddProductFeaturesViewModel.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE8FCD1A2A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */; };
@@ -4677,6 +4678,7 @@
 		DE8BEB892AB83F4F00F5E56C /* ProductNameGenerationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationViewModel.swift; sourceTree = "<group>"; };
 		DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationView.swift; sourceTree = "<group>"; };
 		DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesView.swift; sourceTree = "<group>"; };
+		DE8BEB922ABAF07700F5E56C /* AddProductFeaturesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModel.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerQuestionContainerView.swift; sourceTree = "<group>"; };
@@ -10618,6 +10620,7 @@
 			isa = PBXGroup;
 			children = (
 				DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */,
+				DE8BEB922ABAF07700F5E56C /* AddProductFeaturesViewModel.swift */,
 			);
 			path = AddProductFeatures;
 			sourceTree = "<group>";
@@ -13382,6 +13385,7 @@
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
 				B94403C9289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift in Sources */,
+				DE8BEB932ABAF07700F5E56C /* AddProductFeaturesViewModel.swift in Sources */,
 				7E7C5F872719A93C00315B61 /* ProductCategoryListViewController.swift in Sources */,
 				2631D4FE29F2141D00F13F20 /* StorePlanBannerPresenter.swift in Sources */,
 				DEC51B06276B3F3C009F3DF4 /* Int64+Helpers.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10745 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the UI for the about your product screen and updates the navigation from the add product name screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a JN site with Jetpack AI plugin. (Checkbox available in JN home page to install this plugin)
- Switch to Products tab, select the "+" button to add a new product. An action sheet for product creation with AI should be displayed.
- Tap on "Create a product with AI" to launch "Add your product name" screen.
- Enter any name on the text field and tap Continue.
- A new screen for entering product features should be displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/a2b10d04-8e70-4bac-80fb-75d6e87e4ec0



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
