### PR TITLE
Gift card support in order form: handle 3 known gift card errors

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		02EF166E292F0C5800D90AD6 /* PaymentRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF166D292F0C5800D90AD6 /* PaymentRemoteTests.swift */; };
 		02EF1670292F0CF400D90AD6 /* create-cart-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02EF166F292F0CF400D90AD6 /* create-cart-success.json */; };
 		02EF1672292F0D1900D90AD6 /* load-plan-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02EF1671292F0D1900D90AD6 /* load-plan-success.json */; };
+		02EFF81D2ABC3D0E0015ABB2 /* order-gift-card-invalid-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 02EFF81B2ABC3D0E0015ABB2 /* order-gift-card-invalid-error.json */; };
+		02EFF81E2ABC3D0E0015ABB2 /* order-gift-card-cannot-apply-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 02EFF81C2ABC3D0E0015ABB2 /* order-gift-card-cannot-apply-error.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
 		02F4AA2929791623002AA0E8 /* create-doman-cart-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F4AA2829791623002AA0E8 /* create-doman-cart-success.json */; };
 		0313651928AE559D00EEE571 /* PaymentGatewayMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651828AE559D00EEE571 /* PaymentGatewayMapper.swift */; };
@@ -1096,6 +1098,8 @@
 		02EF166D292F0C5800D90AD6 /* PaymentRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRemoteTests.swift; sourceTree = "<group>"; };
 		02EF166F292F0CF400D90AD6 /* create-cart-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-cart-success.json"; sourceTree = "<group>"; };
 		02EF1671292F0D1900D90AD6 /* load-plan-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "load-plan-success.json"; sourceTree = "<group>"; };
+		02EFF81B2ABC3D0E0015ABB2 /* order-gift-card-invalid-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-gift-card-invalid-error.json"; sourceTree = "<group>"; };
+		02EFF81C2ABC3D0E0015ABB2 /* order-gift-card-cannot-apply-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-gift-card-cannot-apply-error.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
 		02F4AA2829791623002AA0E8 /* create-doman-cart-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-doman-cart-success.json"; sourceTree = "<group>"; };
 		0313651828AE559D00EEE571 /* PaymentGatewayMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayMapper.swift; sourceTree = "<group>"; };
@@ -2624,6 +2628,8 @@
 				AE2D6624272A941C004A2C3A /* null-data.json */,
 				B5C6FCD520A3768900A4F8E4 /* order.json */,
 				CE2678422A26102A00FD9AEB /* order-alternative-types.json */,
+				02EFF81C2ABC3D0E0015ABB2 /* order-gift-card-cannot-apply-error.json */,
+				02EFF81B2ABC3D0E0015ABB2 /* order-gift-card-invalid-error.json */,
 				DEF13C5F29668C420024A02B /* order-without-data.json */,
 				034480C227A42F9100DFACD2 /* order-with-charge.json */,
 				02C254D62563999200A04423 /* order-shipping-labels.json */,
@@ -3559,6 +3565,7 @@
 				CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */,
 				2683D70E24456DB8002A1589 /* categories-empty.json in Resources */,
 				D865CE67278CA225002C8520 /* stripe-payment-intent-succeeded.json in Resources */,
+				02EFF81E2ABC3D0E0015ABB2 /* order-gift-card-cannot-apply-error.json in Resources */,
 				DE66C5652977CC4300DAA978 /* shipping-label-purchase-success-without-data.json in Resources */,
 				DE74F2A027E3137F0002FE59 /* setting-analytics.json in Resources */,
 				0272E3F5254AA48F00436277 /* order-with-line-item-attributes.json in Resources */,
@@ -3645,6 +3652,7 @@
 				DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */,
 				74A1D263211898F000931DFA /* site-visits-day.json in Resources */,
 				31054710262E2EE400C5C02B /* wcpay-payment-intent-succeeded.json in Resources */,
+				02EFF81D2ABC3D0E0015ABB2 /* order-gift-card-invalid-error.json in Resources */,
 				02C54CC624D3E938007D658F /* product-variations-load-all-manage-stock-two-states.json in Resources */,
 				D823D90722376B4800C90817 /* shipment_tracking_new_custom_provider.json in Resources */,
 				74A1D264211898F000931DFA /* site-visits-week.json in Resources */,

--- a/Networking/NetworkingTests/Responses/order-gift-card-cannot-apply-error.json
+++ b/Networking/NetworkingTests/Responses/order-gift-card-cannot-apply-error.json
@@ -1,0 +1,4 @@
+{
+  "error" : "woocommerce_rest_gift_card_cannot_apply",
+  "message" : "Requested amount for gift card code Z exceeded the order total."
+}

--- a/Networking/NetworkingTests/Responses/order-gift-card-invalid-error.json
+++ b/Networking/NetworkingTests/Responses/order-gift-card-invalid-error.json
@@ -1,0 +1,4 @@
+{
+  "error": "woocommerce_rest_gift_card_cannot_parse_data",
+  "message": "Gift card code Z not found."
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1668,6 +1668,11 @@ extension EditableOrderViewModel {
             guard !isEmailError(error, order: order) else {
                 return Notice(title: Localization.invalidBillingParameters, message: Localization.invalidBillingSuggestion, feedbackType: .error)
             }
+
+            if let giftCardErrorNotice = giftCardErrorNotice(from: error) {
+                return giftCardErrorNotice
+            }
+
             return Notice(title: Localization.errorMessageOrderCreation, feedbackType: .error)
         }
 
@@ -1696,6 +1701,10 @@ extension EditableOrderViewModel {
                         // Syncs the order without the failing coupon
                         orderSynchronizer.retryTrigger.send()
                 }
+            }
+
+            if let giftCardErrorNotice = giftCardErrorNotice(from: error) {
+                return giftCardErrorNotice
             }
 
             let errorMessage: String
@@ -1729,6 +1738,13 @@ extension EditableOrderViewModel {
             }
 
             return false
+        }
+
+        private static func giftCardErrorNotice(from error: Error) -> Notice? {
+            guard let giftCardError = error as? OrderStore.GiftCardError else {
+                return nil
+            }
+            return Notice(title: giftCardError.noticeTitle, message: giftCardError.noticeMessage, feedbackType: .error)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/GiftCardError+Description.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/GiftCardError+Description.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Yosemite
+
+extension OrderStore.GiftCardError {
+    /// Title of the error notice in order form.
+    var noticeTitle: String {
+        switch self {
+            case .cannotApply:
+                return Localization.Notice.cannotApplyTitle
+            case .invalid:
+                return Localization.Notice.invalidTitle
+            case .notApplied:
+                return Localization.Notice.notAppliedTitle
+        }
+    }
+
+    /// Message of the error notice in order form.
+    var noticeMessage: String {
+        switch self {
+            case let .cannotApply(reason):
+                return reason ?? Localization.Notice.cannotApplyMessage
+            case let .invalid(reason):
+                return reason ?? Localization.Notice.invalidMessage
+            case .notApplied:
+                return Localization.Notice.notAppliedMessage
+        }
+    }
+}
+
+extension OrderStore.GiftCardError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+            case let .cannotApply(reason):
+                return String.localizedStringWithFormat(Localization.Description.cannotApplyFormat, reason ?? "")
+            case let .invalid(reason):
+                return String.localizedStringWithFormat(Localization.Description.invalidFormat, reason ?? "")
+            case .notApplied:
+                return Localization.Description.notApplied
+        }
+    }
+}
+
+private extension OrderStore.GiftCardError {
+    enum Localization {
+        enum Description {
+            static let cannotApplyFormat = NSLocalizedString(
+                "Cannot apply gift card to order error: %1$@",
+                comment: "Order gift card error thrown when the gift card cannot be applied. %1$@ is the detailed reason."
+            )
+            static let invalidFormat = NSLocalizedString(
+                "Invalid gift card error: %1$@",
+                comment: "Order gift card error thrown when the gift card is invalid. %1$@ is the detailed reason."
+            )
+            static let notApplied = NSLocalizedString(
+                "The gift card is not applied.",
+                comment: "Order gift card error thrown when the gift card is not applied."
+            )
+        }
+
+        enum Notice {
+            static let cannotApplyTitle = NSLocalizedString(
+                "Cannot apply gift card to order",
+                comment: "Order gift card error notice title when the gift card cannot be applied."
+            )
+            static let invalidTitle = NSLocalizedString(
+                "Gift card is invalid",
+                comment: "Order gift card error notice title when the gift card is invalid."
+            )
+            static let notAppliedTitle = NSLocalizedString(
+                "Gift card is not applied",
+                comment: "Order gift card error notice title when the gift card is invalid."
+            )
+            static let cannotApplyMessage = NSLocalizedString(
+                "Cannot apply gift card to order",
+                comment: "Order gift card error notice message when the gift card cannot be applied."
+            )
+            static let invalidMessage = NSLocalizedString(
+                "Gift card is invalid",
+                comment: "Order gift card error notice message when the gift card is invalid."
+            )
+            static let notAppliedMessage = NSLocalizedString(
+                "Please check the remaining balance of the gift card.",
+                comment: "Order gift card error notice message when the gift card is invalid."
+            )
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -539,6 +539,7 @@
 		02EEB5C42424AFAA00B8A701 /* TextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */; };
 		02EEB5C52424AFAA00B8A701 /* TextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */; };
 		02EF166C292DFE9A00D90AD6 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */; };
+		02EFF8172ABBEBED0015ABB2 /* GiftCardError+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */; };
 		02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */; };
 		02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */; };
 		02F3A6842A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift */; };
@@ -3021,6 +3022,7 @@
 		02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewCell.swift; sourceTree = "<group>"; };
 		02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextFieldTableViewCell.xib; sourceTree = "<group>"; };
 		02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
+		02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GiftCardError+Description.swift"; sourceTree = "<group>"; };
 		02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAICoordinatorTests.swift; sourceTree = "<group>"; };
 		02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPurchaseSuccessView.swift; sourceTree = "<group>"; };
 		02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMediaLibraryImagePickerCoordinator.swift; sourceTree = "<group>"; };
@@ -9571,6 +9573,7 @@
 				CC53FB3627551A8700C4CA4F /* ProductsSection */,
 				AE9E04732776034B003FA09E /* CustomerSection */,
 				AE264C04275A493800B52996 /* StatusSection */,
+				02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -13153,6 +13156,7 @@
 				DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */,
 				035DBA45292D0164003E5125 /* CollectOrderPaymentUseCase.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
+				02EFF8172ABBEBED0015ABB2 /* GiftCardError+Description.swift in Sources */,
 				027F83ED29B046D2002688C6 /* DashboardTopPerformersViewModel.swift in Sources */,
 				DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -700,7 +700,7 @@ extension OrderStore {
         case orderNotFoundInStorage
     }
 
-    public enum GiftCardError: Error {
+    public enum GiftCardError: Error, Equatable {
         /// When the gift card cannot be applied (e.g. the order total is 0).
         case cannotApply(reason: String?)
         /// When the gift card is invalid (e.g. invalid code).

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1028,6 +1028,59 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertNotNil(storedOrder)
     }
 
+    func test_create_order_with_gift_card_returns_notApplied_error_when_error_response_does_not_include_gift_card() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "order")
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(OrderAction.createOrder(siteID: self.sampleSiteID, order: self.sampleOrder(), giftCard: "134") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? OrderStore.GiftCardError, .notApplied)
+    }
+
+    func test_create_order_with_gift_card_returns_cannotApply_error_when_error_is_returned() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "order-gift-card-cannot-apply-error")
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(OrderAction.createOrder(siteID: self.sampleSiteID, order: self.sampleOrder(), giftCard: "134") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? OrderStore.GiftCardError,
+                       .cannotApply(reason: "Requested amount for gift card code Z exceeded the order total."))
+    }
+
+    func test_create_order_with_gift_card_returns_invalid_error_when_error_is_returned() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "order-gift-card-invalid-error")
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(OrderAction.createOrder(siteID: self.sampleSiteID, order: self.sampleOrder(), giftCard: "134") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? OrderStore.GiftCardError,
+                       .invalid(reason: "Gift card code Z not found."))
+    }
+
     func test_update_simple_payments_order_sends_correct_values() throws {
         // Given
         let feeID: Int64 = 1234
@@ -1182,6 +1235,59 @@ final class OrderStoreTests: XCTestCase {
             "gift_cards"
         ]
         assertEqual(expectedKeys, receivedKeys)
+    }
+
+    func test_update_order_with_gift_card_returns_notApplied_error_when_error_response_does_not_include_gift_card() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(OrderAction.updateOrder(siteID: self.sampleSiteID, order: self.sampleOrder(), giftCard: "134", fields: []) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? OrderStore.GiftCardError, .notApplied)
+    }
+
+    func test_update_order_with_gift_card_returns_cannotApply_error_when_error_is_returned() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order-gift-card-cannot-apply-error")
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(OrderAction.updateOrder(siteID: self.sampleSiteID, order: self.sampleOrder(), giftCard: "134", fields: []) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? OrderStore.GiftCardError,
+                       .cannotApply(reason: "Requested amount for gift card code Z exceeded the order total."))
+    }
+
+    func test_update_order_with_gift_card_returns_invalid_error_when_error_is_returned() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order-gift-card-invalid-error")
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(OrderAction.updateOrder(siteID: self.sampleSiteID, order: self.sampleOrder(), giftCard: "134", fields: []) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? OrderStore.GiftCardError,
+                       .invalid(reason: "Gift card code Z not found."))
     }
 
     // MARK: Tests for `markOrderAsPaidLocally`


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10518 

⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/10732

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There are 3 known errors from applying a gift card in the order form:

1. When a gift card code is invalid

```
{
  "error": "woocommerce_rest_gift_card_cannot_parse_data",
  "message": "Gift card code 1212 not found."
}
```

2. When the order total is 0

```
{
  "error" : "woocommerce_rest_gift_card_cannot_apply",
  "message" : "Requested amount for gift card code ZU3A-HW9W-GVAJ-W9AA exceeded the order total."
}
```

3. When applying a gift card with 0 balance to an order with a positive order total (before this PR, this results in success without the gift card applied) (thanks to @Ecarrion for https://github.com/woocommerce/woocommerce-ios/pull/10732#pullrequestreview-1633647176)

We want to handle the 3 known error cases and show the appropriate error notice to the merchant.

## How

In `OrderStore`, a helper function was created for handling the network result when creating and updating an order as they share the same logic. A new error enum was created `GiftCardError`, and for error cases 1 and 2 above, we can identify these 2 errors by the DotCom error code. For error case 3, it's when the network result is successful but the gift card isn't in the returned order's `appliedGiftCards`.

To show these 3 error cases to the merchant, the error is checked in `EditableOrderViewModel` against `OrderStore.GiftCardError` for a custom error notice.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the site has the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension/plugin active.

### Create order

- Switch to the site with the Gift Cards plugin if needed
- Go to the Orders tab
- Tap `+` in the navigation bar to create an order --> `Add Gift Card` CTA should be shown
- Tap `Add Gift Card`
- Enter some random code and tap `Apply`
- Tap `Create` --> an error notice should be shown saying the code is invalid
- Tap the gift card row to edit the code
- Update the code to a valid gift card (with any remaining balance), and tap `Apply`
- Tap `Create` --> an error notice should be shown saying "Cannot apply gift card to order" because the amount exceeds the order total (which is 0)
- Add a product with a price, or add a non-zero fee
- Tap the gift card row to edit the code
- Update the code to a valid gift card **with 0 remaining balance**, and tap `Apply`
- Tap `Create` --> an error notice should be shown saying "Gift card is not applied" and to check the gift card balance

### Update order

- Go to the Orders tab
- Tap on an order whose payment data is still editable
- Tap `Edit`
- Tap `Add Gift Card`
- Enter some random code and tap `Apply` --> after a bit, an error notice should be shown saying the code is invalid
- If the order total is 0, add a non-zero fee
- Tap the gift card row to edit the code
- Update the code to a valid gift card **with 0 remaining balance**, and tap `Apply` --> after a bit, an error notice should be shown saying "Gift card is not applied" and to check the gift card balance
- Go to the Orders tab
- Tap on an editable order whose order total is 0
- Tap `Edit`
- Tap `Add Gift Card`
- Enter a valid gift card (with any remaining balance), and tap `Apply` --> after a bit, an error notice should be shown saying "Cannot apply gift card to order" because the amount exceeds the order total (which is 0) (in a future subtask, the gift card CTA will be disabled when the order total is 0)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

case 1 | case 2 | case 3
-- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/a18c6dd1-37a4-4f5a-b56d-c3562bde3b41" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/e03e2bfb-c184-4703-91f8-b46578f3c351" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/ad25f14f-8537-41ef-871a-b0198fbef786" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.