### PR TITLE
[UI Tests] - Fix flaky payments tests

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -50,7 +50,7 @@ public final class PasswordScreen: ScreenObject {
         continueButton.tap()
 
         // As of Xcode 14.3, the Simulator might ask to save the password which, of course, we don't want to do.
-        if app.buttons["Save Password"].waitForExistence(timeout: 5) {
+        if app.buttons["Save Password"].waitForExistence(timeout: 10) {
             // There should be no need to wait for this button to exist since it's part of the same
             // alert where "Save Password" is.
             app.buttons["Not Now"].tap()

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -33,11 +33,16 @@ public final class PaymentsScreen: ScreenObject {
     private let IPPDocumentationHeaderTextGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["Getting started with In-Person Payments with WooPayments"]
     }
+    
+    private let paymentsNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Payments"]
+    }
 
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
     private var cardReaderManualsButton: XCUIElement { cardReaderManualsButtonGetter(app) }
     private var learnMoreButton: XCUIElement { learnMoreButtonGetter(app) }
     private var nextButton: XCUIElement { nextButtonGetter(app) }
+    private var paymentsNavigationBar: XCUIElement { paymentsNavigationBarGetter(app) }
     private var takePaymentButton: XCUIElement { takePaymentButtonGetter(app) }
     private var cashPaymentButton: XCUIElement { cashPaymentButtonGetter(app) }
     private var markAsPaidButton: XCUIElement { markAsPaidButtonGetter(app) }
@@ -45,7 +50,11 @@ public final class PaymentsScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ collectPaymentButtonGetter, cardReaderManualsButtonGetter ],
+            expectedElementGetters: [
+                paymentsNavigationBarGetter,
+                collectPaymentButtonGetter,
+                cardReaderManualsButtonGetter
+            ],
             app: app
         )
     }
@@ -90,8 +99,7 @@ public final class PaymentsScreen: ScreenObject {
 
     @discardableResult
     public func verifyPaymentsScreenLoaded() throws -> PaymentsScreen {
-        collectPaymentButton.waitForExistence(timeout: 15)
-        XCTAssertTrue(isLoaded)
+        XCTAssertTrue(collectPaymentButton.waitForExistence(timeout: 5))
         return self
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -33,7 +33,7 @@ public final class PaymentsScreen: ScreenObject {
     private let IPPDocumentationHeaderTextGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["Getting started with In-Person Payments with WooPayments"]
     }
-    
+
     private let paymentsNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
         $0.navigationBars["Payments"]
     }


### PR DESCRIPTION
### Description
Payments-related tests have been flaky in the CI since Xcode was updated to 14.3.1. I wasn't able to reproduce it locally, so this has the possibility of still being flaky in CI. This PR updates the first element that is being validated during screen `init` to an element that is higher in the element tree to see if it helps with the flakiness.

### Testing
CI should be 🟢 and `PaymentsTests` should not be flaky.