### PR TITLE
Gift card support in order form: code validation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
@@ -14,13 +14,20 @@ struct GiftCardInputView: View {
                 Section {
                     TextField(Localization.placeholder, text: $viewModel.code)
                         .focused()
+
+                    if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundColor(Color(.error))
+                    }
+
                     Button {
                         viewModel.apply()
                     } label: {
                         Text(Localization.apply)
                     }
                     .buttonStyle(PrimaryButtonStyle())
-                    .disabled(viewModel.code.isEmpty)
+                    .disabled(!viewModel.isValid)
                 }
             }
             .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputViewModel.swift
@@ -4,6 +4,8 @@ import Yosemite
 /// View model for `GiftCardInputView`.
 final class GiftCardInputViewModel: ObservableObject {
     @Published var code: String
+    @Published private(set) var isValid: Bool = false
+    @Published private(set) var errorMessage: String?
 
     private let addGiftCard: (_ code: String) -> Void
     private let dismiss: () -> Void
@@ -12,6 +14,7 @@ final class GiftCardInputViewModel: ObservableObject {
         self.code = code
         self.addGiftCard = addGiftCard
         self.dismiss = dismiss
+        observeCodeForValidCheck()
     }
 
     /// Applies the gift card code to the order.
@@ -22,5 +25,37 @@ final class GiftCardInputViewModel: ObservableObject {
     /// Cancels the gift card input form.
     func cancel() {
         dismiss()
+    }
+}
+
+private extension GiftCardInputViewModel {
+    func observeCodeForValidCheck() {
+        $code.removeDuplicates()
+            .map { self.isCodeValid($0) }
+            .assign(to: &$isValid)
+
+        $isValid.combineLatest($code)
+            .map { isValid, code in
+                isValid || code.isEmpty ? nil: Localization.errorMessage
+            }
+            .assign(to: &$errorMessage)
+    }
+
+    func isCodeValid(_ code: String) -> Bool {
+        let format = "^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$"
+
+        let regex = try? NSRegularExpression(pattern: format, options: .caseInsensitive)
+        let range = NSRange(location: 0, length: code.count)
+
+        return regex?.firstMatch(in: code, options: [], range: range) != nil
+    }
+}
+
+private extension GiftCardInputViewModel {
+    enum Localization {
+        static let errorMessage = NSLocalizedString(
+            "The code should be in XXXX-XXXX-XXXX-XXXX format",
+            comment: "Message in the gift card input form when the code is not valid."
+        )
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -539,6 +539,7 @@
 		02EEB5C42424AFAA00B8A701 /* TextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */; };
 		02EEB5C52424AFAA00B8A701 /* TextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */; };
 		02EF166C292DFE9A00D90AD6 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */; };
+		02EFF81A2ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */; };
 		02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */; };
 		02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */; };
 		02F3A6842A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift */; };
@@ -3021,6 +3022,7 @@
 		02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewCell.swift; sourceTree = "<group>"; };
 		02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextFieldTableViewCell.xib; sourceTree = "<group>"; };
 		02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
+		02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardInputViewModelTests.swift; sourceTree = "<group>"; };
 		02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAICoordinatorTests.swift; sourceTree = "<group>"; };
 		02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPurchaseSuccessView.swift; sourceTree = "<group>"; };
 		02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMediaLibraryImagePickerCoordinator.swift; sourceTree = "<group>"; };
@@ -6280,6 +6282,14 @@
 			path = Plan;
 			sourceTree = "<group>";
 		};
+		02EFF8182ABC28A50015ABB2 /* GiftCards */ = {
+			isa = PBXGroup;
+			children = (
+				02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */,
+			);
+			path = GiftCards;
+			sourceTree = "<group>";
+		};
 		02F4F50C237AFBB700E13A9C /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -9045,6 +9055,7 @@
 		B98968542A98F1DF007A2FBE /* PaymentSection */ = {
 			isa = PBXGroup;
 			children = (
+				02EFF8182ABC28A50015ABB2 /* GiftCards */,
 				B98968552A98F219007A2FBE /* Taxes */,
 			);
 			path = PaymentSection;
@@ -13997,6 +14008,7 @@
 				26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */,
 				0201E4312946FFDB00C793C7 /* StoreCreationCategoryQuestionViewModelTests.swift in Sources */,
 				EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */,
+				02EFF81A2ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift in Sources */,
 				B9CB14E02A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift in Sources */,
 				6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */,
 				4569D3C925DC065B00CDC3E2 /* SiteAddressTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/GiftCards/GiftCardInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/GiftCards/GiftCardInputViewModelTests.swift
@@ -76,4 +76,38 @@ final class GiftCardInputViewModelTests: XCTestCase {
         // Then
         XCTAssertNil(viewModel.errorMessage)
     }
+
+    // MARK: - `apply`
+
+    func test_apply_invokes_addGiftCard_with_code() throws {
+        let code = waitFor { promise in
+            // Given
+            let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { code in
+                promise(code)
+            }, dismiss: {})
+
+            // When
+            viewModel.code = "a7WP"
+            viewModel.apply()
+        }
+
+        // Then
+        XCTAssertEqual(code, "a7WP")
+    }
+
+    // MARK: - `cancel`
+
+    func test_cancel_invokes_dismiss() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {
+                // Then
+                promise(())
+            })
+
+            // When
+            viewModel.code = "a7WP"
+            viewModel.cancel()
+        }
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/GiftCards/GiftCardInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/GiftCards/GiftCardInputViewModelTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import WooCommerce
+
+final class GiftCardInputViewModelTests: XCTestCase {
+
+    // MARK: - `isValid`
+
+    func test_isValid_is_false_when_initial_code_is_empty() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {})
+
+        // Then
+        XCTAssertFalse(viewModel.isValid)
+    }
+
+    func test_isValid_is_true_when_initial_code_is_valid() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC-Z5F6", addGiftCard: { _ in }, dismiss: {})
+
+        // Then
+        XCTAssertTrue(viewModel.isValid)
+    }
+
+    func test_isValid_is_false_when_initial_code_is_invalid() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", addGiftCard: { _ in }, dismiss: {})
+
+        // Then
+        XCTAssertFalse(viewModel.isValid)
+    }
+
+    func test_isValid_becomes_true_when_code_is_valid() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {})
+
+        // When
+        viewModel.code = "a7WP-MYVG-KNDC-Z5F6"
+
+        // Then
+        XCTAssertTrue(viewModel.isValid)
+    }
+
+    // MARK: - `errorMessage`
+
+    func test_errorMessage_is_nil_when_initial_code_is_empty() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {})
+
+        // Then
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    func test_errorMessage_is_nil_when_initial_code_is_valid() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC-Z5F6", addGiftCard: { _ in }, dismiss: {})
+
+        // Then
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    func test_errorMessage_is_not_nil_when_initial_code_is_invalid() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", addGiftCard: { _ in }, dismiss: {})
+
+        // Then
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    func test_errorMessage_becomes_nil_when_code_is_valid() throws {
+        // Given
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", addGiftCard: { _ in }, dismiss: {})
+
+        // When
+        viewModel.code = "a7WP-MYVG-KNDC-Z5F6"
+
+        // Then
+        XCTAssertNil(viewModel.errorMessage)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10518 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/10732

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The gift card code [follows a format](https://woocommerce.com/document/gift-cards/store-owners-guide/#importing-exporting-gift-card-codes) `XXXX-XXXX-XXXX-XXXX`. When the merchant enters a code that doesn't follow this format, an error message should be shown and they can't apply the code until it's valid.

## How

Two @Published variables were added to `GiftCardInputViewModel` - `isValid: Bool` and `errorMessage: String?`. `isValid` is true only if the code is valid. `errorMessage` is set to an error message about the expected format when the code is non-empty and invalid. Then in the SwiftUI view `GiftCardInputView`, the error message is shown when non-nil and the button disabled state follows the view model's `isValid`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Switch to the site with the Gift Cards plugin if needed
- Go to the Orders tab
- Tap `+` in the navigation bar to create an order --> `Add Gift Card` CTA should be shown
- Tap `Add Gift Card` --> the `Apply` CTA should be disabled by default
- Enter some code that doesn't follow the format (e.g. 1234) --> an error message should be shown, and the `Apply` CTA should be disabled
- Enter a code in the correct format --> the error message should be gone, and the `Apply` CTA should be enabled

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

empty code | invalid code | valid code
-- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/b9aafc9b-6fe0-4bc0-bf84-802d39750a91" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/538ff2d0-286f-4b37-a1da-bd00f09732cf" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/984353bc-120d-408c-8260-f9d30331436f" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
