### PR TITLE
Product creation AI: Present sheet to select AI tone

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -42,6 +42,9 @@ extension UserDefaults {
 
         // Store profiler answers
         case storeProfilerAnswers
+
+        // AI prompt tone
+        case aiPromptTone
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -175,6 +175,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.hasDismissedWriteWithAITooltip] = nil
         defaults[.numberOfTimesWriteWithAITooltipIsShown] = nil
         defaults[.storeProfilerAnswers] = nil
+        defaults[.aiPromptTone] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 /// View to select AI tone and voice
 ///
 struct AIToneVoiceView: View {
-    @StateObject private var viewModel: AIToneVoiceViewModel
+    @ObservedObject private var viewModel: AIToneVoiceViewModel
 
     @Environment(\.dismiss) private var dismiss
 
     init(viewModel: AIToneVoiceViewModel) {
-        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Hosting controller for `AIToneVoiceView`.
+///
+final class AIToneVoiceHostingController: UIHostingController<AIToneVoiceView> {
+    init(viewModel: AIToneVoiceViewModel) {
+        super.init(rootView: AIToneVoiceView(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// View to select AI tone and voice
+///
+struct AIToneVoiceView: View {
+    @StateObject private var viewModel: AIToneVoiceViewModel
+
+    @Environment(\.presentationMode) var presentation
+
+    init(viewModel: AIToneVoiceViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Layout.blockVerticalSpacing) {
+                    // Subtitle label.
+                    Text(Localization.subtitle)
+                        .foregroundColor(Color(.secondaryLabel))
+                        .bodyStyle()
+                        .padding(.horizontal, Layout.subtitleExtraHorizontalPadding)
+
+                    // List of AI tones.
+                    ForEach(viewModel.tones, id: \.self) { tone in
+                        VStack(alignment: .leading, spacing: 0) {
+                            SelectableItemRow(
+                                title: tone.rawValue,
+                                selected: tone == viewModel.selectedTone,
+                                displayMode: .compact,
+                                alignment: .trailing)
+                            .onTapGesture {
+                                viewModel.onSelectTone(tone)
+                            }
+
+                            Divider()
+                        }
+                    }
+
+                    Spacer()
+                }
+                .padding(Layout.defaultPadding)
+            }
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar(content: {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: {
+                        presentation.wrappedValue.dismiss()
+                    }, label: {
+                        Image(systemName: "chevron.backward")
+                            .headlineLinkStyle()
+                    })
+                }
+            })
+            .navigationViewStyle(StackNavigationViewStyle())
+            .wooNavigationBarStyle()
+        }
+    }
+}
+
+private extension AIToneVoiceView {
+    enum Localization {
+        static let title = NSLocalizedString("Tone and voice",
+                                             comment: "Title of the AI tone and voice selection sheet.")
+
+        static let subtitle = NSLocalizedString("Set the tone and voice to shape your product's presentation that aligns with your brand.",
+                                                comment: "Subtitle of the AI tone and voice selection sheet.")
+    }
+
+    enum Layout {
+        static let blockVerticalSpacing: CGFloat = 16
+        static let defaultPadding: EdgeInsets = .init(top: 16, leading: 8, bottom: 16, trailing: 8)
+        static let subtitleExtraHorizontalPadding: CGFloat = 8
+    }
+}
+
+struct AIToneVoiceView_Previews: PreviewProvider {
+    static var previews: some View {
+        AIToneVoiceView(viewModel: .init(siteID: 123))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
@@ -12,49 +12,68 @@ struct AIToneVoiceView: View {
     }
 
     var body: some View {
-        NavigationView {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Layout.blockVerticalSpacing) {
-                    // Subtitle label.
-                    Text(Localization.subtitle)
-                        .foregroundColor(Color(.secondaryLabel))
-                        .bodyStyle()
-                        .padding(.horizontal, Layout.subtitleExtraHorizontalPadding)
+        ScrollView {
+            VStack(alignment: .leading, spacing: Layout.blockVerticalSpacing) {
+                titleBlock
 
-                    // List of AI tones.
-                    ForEach(viewModel.tones, id: \.self) { tone in
-                        VStack(alignment: .leading, spacing: 0) {
-                            SelectableItemRow(
-                                title: tone.rawValue,
-                                selected: tone == viewModel.selectedTone,
-                                displayMode: .compact,
-                                alignment: .trailing)
-                            .onTapGesture {
-                                viewModel.onSelectTone(tone)
-                            }
+                // Subtitle label.
+                Text(Localization.subtitle)
+                    .foregroundColor(Color(.secondaryLabel))
+                    .bodyStyle()
+                    .padding(.horizontal, Layout.subtitleExtraHorizontalPadding)
 
-                            Divider()
+                // List of AI tones.
+                ForEach(viewModel.tones, id: \.self) { tone in
+                    VStack(alignment: .leading, spacing: 0) {
+                        SelectableItemRow(
+                            title: tone.rawValue,
+                            selected: tone == viewModel.selectedTone,
+                            displayMode: .compact,
+                            alignment: .trailing)
+                        .onTapGesture {
+                            viewModel.onSelectTone(tone)
                         }
+
+                        Divider()
                     }
+                }
+
+                Spacer()
+            }
+            .padding(Layout.defaultPadding)
+        }
+    }
+}
+
+private extension AIToneVoiceView {
+    var titleBlock: some View {
+        ZStack {
+            HStack {
+                Button(action: {
+                    presentation.wrappedValue.dismiss()
+                }, label: {
+                    Image(systemName: "chevron.backward")
+                        .headlineLinkStyle()
+                })
+
+                Spacer()
+            }
+            .padding(.horizontal, Layout.backButtonHorizontalPadding)
+
+            VStack(spacing: 0) {
+                HStack {
+                    Spacer()
+
+                    Text(Localization.title)
+                        .fontWeight(.semibold)
+                        .headlineStyle()
 
                     Spacer()
                 }
-                .padding(Layout.defaultPadding)
+                .padding(.vertical, Layout.titleVerticalPadding)
+
+                Divider()
             }
-            .navigationTitle(Localization.title)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar(content: {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(action: {
-                        presentation.wrappedValue.dismiss()
-                    }, label: {
-                        Image(systemName: "chevron.backward")
-                            .headlineLinkStyle()
-                    })
-                }
-            })
-            .navigationViewStyle(StackNavigationViewStyle())
-            .wooNavigationBarStyle()
         }
     }
 }
@@ -69,6 +88,8 @@ private extension AIToneVoiceView {
     }
 
     enum Layout {
+        static let backButtonHorizontalPadding: CGFloat = 16
+        static let titleVerticalPadding: CGFloat = 16
         static let blockVerticalSpacing: CGFloat = 16
         static let defaultPadding: EdgeInsets = .init(top: 16, leading: 8, bottom: 16, trailing: 8)
         static let subtitleExtraHorizontalPadding: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
@@ -18,7 +18,7 @@ final class AIToneVoiceHostingController: UIHostingController<AIToneVoiceView> {
 struct AIToneVoiceView: View {
     @StateObject private var viewModel: AIToneVoiceViewModel
 
-    @Environment(\.presentationMode) var presentation
+    @Environment(\.presentationMode) private var presentation
 
     init(viewModel: AIToneVoiceViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct AIToneVoiceView: View {
     @StateObject private var viewModel: AIToneVoiceViewModel
 
-    @Environment(\.presentationMode) private var presentation
+    @Environment(\.dismiss) private var dismiss
 
     init(viewModel: AIToneVoiceViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
@@ -50,7 +50,7 @@ private extension AIToneVoiceView {
         ZStack {
             HStack {
                 Button(action: {
-                    presentation.wrappedValue.dismiss()
+                    dismiss()
                 }, label: {
                     Image(systemName: "chevron.backward")
                         .headlineLinkStyle()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceView.swift
@@ -1,18 +1,5 @@
 import SwiftUI
 
-/// Hosting controller for `AIToneVoiceView`.
-///
-final class AIToneVoiceHostingController: UIHostingController<AIToneVoiceView> {
-    init(viewModel: AIToneVoiceViewModel) {
-        super.init(rootView: AIToneVoiceView(viewModel: viewModel))
-    }
-
-    @available(*, unavailable)
-    required dynamic init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
 /// View to select AI tone and voice
 ///
 struct AIToneVoiceView: View {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModel.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+public enum AIToneVoice: String, CaseIterable {
+    case casual = "Casual"
+    case formal = "Formal"
+    case flowery = "Flowery"
+    case convincing = "Convincing"
+}
+
+/// View model for `AIToneVoiceView`.
+///
+final class AIToneVoiceViewModel: ObservableObject {
+    let tones = AIToneVoice.allCases
+
+    @Published var selectedTone: AIToneVoice
+
+    private let siteID: Int64
+    private let analytics: Analytics
+    private let userDefaults: UserDefaults
+
+    init(siteID: Int64,
+         userDefaults: UserDefaults = .standard,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.analytics = analytics
+        self.userDefaults = userDefaults
+        if let storedPrompt = userDefaults.aiTone(for: siteID) {
+            self.selectedTone = storedPrompt
+        } else {
+            self.selectedTone = .casual
+            userDefaults.setAITone(.casual, for: siteID)
+        }
+    }
+
+    func onSelectTone(_ aiPromptTone: AIToneVoice) {
+        self.selectedTone = aiPromptTone
+        userDefaults.setAITone(aiPromptTone, for: siteID)
+    }
+}
+
+// MARK: - AI tone helpers
+extension UserDefaults {
+    /// Returns AI tone for the site ID
+    ///
+    func aiTone(for siteID: Int64) -> AIToneVoice? {
+        let aiPromptTone = self[.aiPromptTone] as? [String: String]
+        let idAsString = "\(siteID)"
+        guard let rawValue = aiPromptTone?[idAsString],
+              let tone = AIToneVoice(rawValue: rawValue) else {
+            return nil
+        }
+        return tone
+    }
+
+    /// Stores the AI tone for the given site ID
+    ///
+    func setAITone(_ tone: AIToneVoice, for siteID: Int64) {
+        let idAsString = "\(siteID)"
+        if var aiPromptToneDictionary = self[.aiPromptTone] as? [String: String] {
+            aiPromptToneDictionary[idAsString] = tone.rawValue
+            self[.aiPromptTone] = aiPromptToneDictionary
+        } else {
+            self[.aiPromptTone] = [idAsString: tone.rawValue]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct AddProductFeaturesView: View {
     @FocusState private var editorIsFocused: Bool
     @ObservedObject private var viewModel: AddProductFeaturesViewModel
+    @State private var showingAIToneVoiceView: Bool = false
 
     init(viewModel: AddProductFeaturesViewModel) {
         self.viewModel = viewModel
@@ -57,7 +58,7 @@ struct AddProductFeaturesView: View {
                 }
 
                 Button(action: {
-                    viewModel.onSetToneAndVoice()
+                    showingAIToneVoiceView = true
                 }, label: {
                     Text(Localization.setToneButton)
                         .foregroundColor(.accentColor)
@@ -82,6 +83,19 @@ struct AddProductFeaturesView: View {
             }
             .background(Color(uiColor: .systemBackground))
         }
+        .sheet(isPresented: $showingAIToneVoiceView) {
+            if #available(iOS 16, *) {
+                aiToneVoiceView.presentationDetents([.medium, .large])
+            } else {
+                aiToneVoiceView
+            }
+        }
+    }
+}
+
+private extension AddProductFeaturesView {
+    var aiToneVoiceView: some View {
+        AIToneVoiceView(viewModel: AIToneVoiceViewModel.init(siteID: viewModel.siteID))
     }
 }
 
@@ -130,7 +144,6 @@ struct AddProductDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         AddProductFeaturesView(viewModel: .init(siteID: 123,
                                                 productName: "iPhone 15",
-                                                onSetToneAndVoice: {},
                                                 onProductDetailsCreated: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -57,7 +57,7 @@ struct AddProductFeaturesView: View {
                 }
 
                 Button(action: {
-                    // TODO: show tone bottom sheet
+                    viewModel.onSetToneAndVoice()
                 }, label: {
                     Text(Localization.setToneButton)
                         .foregroundColor(.accentColor)
@@ -132,6 +132,8 @@ private extension AddProductFeaturesView {
 
 struct AddProductDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductFeaturesView(viewModel: .init(siteID: 123, onProductDetailsCreated: {}))
+        AddProductFeaturesView(viewModel: .init(siteID: 123,
+                                                onSetToneAndVoice: {},
+                                                onProductDetailsCreated: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -5,6 +5,10 @@ import Yosemite
 ///
 final class AddProductFeaturesViewModel: ObservableObject {
 
+    /// Closure fired when tapping "Set tone and voice" to launch the AI tone sheet
+    ///
+    let onSetToneAndVoice: () -> Void
+
     @Published var productFeatures: String = ""
 
     private let siteID: Int64
@@ -13,13 +17,16 @@ final class AddProductFeaturesViewModel: ObservableObject {
     // TODO: add new type for product details and return it here.
     private let onProductDetailsCreated: () -> Void
 
+
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
+         onSetToneAndVoice: @escaping () -> Void,
          onProductDetailsCreated: @escaping () -> Void) {
         self.siteID = siteID
         self.stores = stores
         self.analytics = analytics
+        self.onSetToneAndVoice = onSetToneAndVoice
         self.onProductDetailsCreated = onProductDetailsCreated
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -4,32 +4,25 @@ import Yosemite
 /// View model for `AddProductFeaturesView`.
 ///
 final class AddProductFeaturesViewModel: ObservableObject {
-
-    /// Closure fired when tapping "Set tone and voice" to launch the AI tone sheet
-    ///
-    let onSetToneAndVoice: () -> Void
-
-    @Published var productFeatures: String = ""
+    let siteID: Int64
     let productName: String
 
-    private let siteID: Int64
+    @Published var productFeatures: String = ""
+
     private let stores: StoresManager
     private let analytics: Analytics
     // TODO: add new type for product details and return it here.
     private let onProductDetailsCreated: () -> Void
 
-
     init(siteID: Int64,
          productName: String,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
-         onSetToneAndVoice: @escaping () -> Void,
          onProductDetailsCreated: @escaping () -> Void) {
         self.siteID = siteID
         self.productName = productName
         self.stores = stores
         self.analytics = analytics
-        self.onSetToneAndVoice = onSetToneAndVoice
         self.onProductDetailsCreated = onProductDetailsCreated
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -12,7 +12,6 @@ final class AddProductWithAIContainerHostingController: UIHostingController<AddP
         rootView.onUsePackagePhoto = { [weak self] productName in
             self?.presentPackageFlow(productName: productName)
         }
-        rootView.onSetToneAndVoice = presentSetToneAndVoice
     }
 
     @available(*, unavailable)
@@ -44,29 +43,6 @@ private extension AddProductWithAIContainerHostingController {
         self.addProductFromImageCoordinator = coordinator
         coordinator.start()
     }
-
-    /// Presents the tone and voice sheet
-    /// 
-    func presentSetToneAndVoice() {
-        guard let navigationController else {
-            return
-        }
-        setToneAndVoiceBottomSheetPresenter = buildBottomSheetPresenter()
-        let controller = AIToneVoiceHostingController(viewModel: .init(siteID: viewModel.siteID))
-        setToneAndVoiceBottomSheetPresenter?.present(controller, from: navigationController)
-    }
-
-    // MARK: Bottom sheet helpers
-    //
-    func buildBottomSheetPresenter() -> BottomSheetPresenter {
-        BottomSheetPresenter(configure: { bottomSheet in
-            var sheet = bottomSheet
-            sheet.prefersEdgeAttachedInCompactHeight = true
-            sheet.largestUndimmedDetentIdentifier = .none
-            sheet.prefersGrabberVisible = true
-            sheet.detents = [.medium(), .large()]
-        })
-    }
 }
 
 /// Container view for the product creation with AI flow.
@@ -74,10 +50,6 @@ struct AddProductWithAIContainerView: View {
     /// Closure invoked when the close button is pressed
     ///
     var onUsePackagePhoto: (String?) -> Void = { _ in }
-
-    /// Closure invoked when the "Set tone and voice" button is pressed
-    ///
-    var onSetToneAndVoice: () -> Void = {  }
 
     @ObservedObject private var viewModel: AddProductWithAIContainerViewModel
 
@@ -100,8 +72,7 @@ struct AddProductWithAIContainerView: View {
                 }))
             case .aboutProduct:
                 AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
-                                                        productName: viewModel.productName,
-                                                        onSetToneAndVoice: onSetToneAndVoice) {
+                                                        productName: viewModel.productName) {
                     withAnimation {
                         viewModel.onProductDetailsCreated()
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 final class AddProductWithAIContainerHostingController: UIHostingController<AddProductWithAIContainerView> {
     private let viewModel: AddProductWithAIContainerViewModel
     private var addProductFromImageCoordinator: AddProductFromImageCoordinator?
-    private var setToneAndVoiceBottomSheetPresenter: BottomSheetPresenter?
 
     init(viewModel: AddProductWithAIContainerViewModel) {
         self.viewModel = viewModel

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -12,6 +12,7 @@ final class AddProductWithAIContainerHostingController: UIHostingController<AddP
         rootView.onUsePackagePhoto = { [weak self] productName in
             self?.presentPackageFlow(productName: productName)
         }
+        rootView.onSetToneAndVoice = presentSetToneAndVoice
     }
 
     @available(*, unavailable)
@@ -74,6 +75,10 @@ struct AddProductWithAIContainerView: View {
     ///
     var onUsePackagePhoto: (String?) -> Void = { _ in }
 
+    /// Closure invoked when the "Set tone and voice" button is pressed
+    ///
+    var onSetToneAndVoice: () -> Void = {  }
+
     @ObservedObject private var viewModel: AddProductWithAIContainerViewModel
 
     init(viewModel: AddProductWithAIContainerViewModel) {
@@ -94,7 +99,8 @@ struct AddProductWithAIContainerView: View {
                     }
                 }))
             case .aboutProduct:
-                AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID) {
+                AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
+                                                        onSetToneAndVoice: onSetToneAndVoice) {
                     withAnimation {
                         viewModel.onProductDetailsCreated()
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 final class AddProductWithAIContainerHostingController: UIHostingController<AddProductWithAIContainerView> {
     private let viewModel: AddProductWithAIContainerViewModel
     private var addProductFromImageCoordinator: AddProductFromImageCoordinator?
+    private var setToneAndVoiceBottomSheetPresenter: BottomSheetPresenter?
 
     init(viewModel: AddProductWithAIContainerViewModel) {
         self.viewModel = viewModel
@@ -41,6 +42,29 @@ private extension AddProductWithAIContainerHostingController {
         })
         self.addProductFromImageCoordinator = coordinator
         coordinator.start()
+    }
+
+    /// Presents the tone and voice sheet
+    /// 
+    func presentSetToneAndVoice() {
+        guard let navigationController else {
+            return
+        }
+        setToneAndVoiceBottomSheetPresenter = buildBottomSheetPresenter()
+        let controller = AIToneVoiceHostingController(viewModel: .init(siteID: viewModel.siteID))
+        setToneAndVoiceBottomSheetPresenter?.present(controller, from: navigationController)
+    }
+
+    // MARK: Bottom sheet helpers
+    //
+    func buildBottomSheetPresenter() -> BottomSheetPresenter {
+        BottomSheetPresenter(configure: { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.largestUndimmedDetentIdentifier = .none
+            sheet.prefersGrabberVisible = true
+            sheet.detents = [.medium(), .large()]
+        })
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2339,6 +2339,9 @@
 		EE6B2AD329DD285A00048A8F /* StoreCreationProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */; };
 		EE6F08662A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */; };
 		EE6F08682A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F08672A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift */; };
+		EE7707C52ABB3F55009FD564 /* AIToneVoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7707C42ABB3F55009FD564 /* AIToneVoiceView.swift */; };
+		EE7707C82ABBF4BB009FD564 /* AIToneVoiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7707C72ABBF4BB009FD564 /* AIToneVoiceViewModel.swift */; };
+		EE7707CB2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7707CA2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift */; };
 		EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */; };
 		EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */; };
 		EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */; };
@@ -4836,6 +4839,9 @@
 		EE6B2AD229DD285900048A8F /* StoreCreationProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModel.swift; sourceTree = "<group>"; };
 		EE6F08652A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyViewModelTests.swift; sourceTree = "<group>"; };
 		EE6F08672A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyCoordinatorTests.swift; sourceTree = "<group>"; };
+		EE7707C42ABB3F55009FD564 /* AIToneVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToneVoiceView.swift; sourceTree = "<group>"; };
+		EE7707C72ABBF4BB009FD564 /* AIToneVoiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToneVoiceViewModel.swift; sourceTree = "<group>"; };
+		EE7707CA2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToneVoiceViewModelTests.swift; sourceTree = "<group>"; };
 		EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdaterTests.swift; sourceTree = "<group>"; };
 		EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthentication.swift; sourceTree = "<group>"; };
 		EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModelTests.swift; sourceTree = "<group>"; };
@@ -10926,6 +10932,7 @@
 		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				EE7707C62ABBF473009FD564 /* AIToneVoice */,
 				DE8BEB8F2ABAEBD600F5E56C /* AddProductFeatures */,
 				EE5B5BC52AB8374D009BCBD6 /* Container */,
 				EE5B5BBE2AB42F21009BCBD6 /* AddProductName */,
@@ -10939,6 +10946,7 @@
 		EE5B5BB42AB31C64009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				EE7707C92ABC4C82009FD564 /* AIToneVoice */,
 				EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */,
 			);
 			path = AddProductWithAI;
@@ -10996,6 +11004,23 @@
 				EE6F08672A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift */,
 			);
 			path = FreeTrialSurvey;
+			sourceTree = "<group>";
+		};
+		EE7707C62ABBF473009FD564 /* AIToneVoice */ = {
+			isa = PBXGroup;
+			children = (
+				EE7707C42ABB3F55009FD564 /* AIToneVoiceView.swift */,
+				EE7707C72ABBF4BB009FD564 /* AIToneVoiceViewModel.swift */,
+			);
+			path = AIToneVoice;
+			sourceTree = "<group>";
+		};
+		EE7707C92ABC4C82009FD564 /* AIToneVoice */ = {
+			isa = PBXGroup;
+			children = (
+				EE7707CA2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift */,
+			);
+			path = AIToneVoice;
 			sourceTree = "<group>";
 		};
 		EE94258D29DDA4300063B499 /* Progress */ = {
@@ -12219,6 +12244,7 @@
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,
 				26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */,
+				EE7707C52ABB3F55009FD564 /* AIToneVoiceView.swift in Sources */,
 				31FC8CE727B47591004B9456 /* CardReaderSettingsDataSource.swift in Sources */,
 				02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,
@@ -12479,6 +12505,7 @@
 				CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */,
 				26AC0DD92941081500859074 /* AnalyticsHubCustomRangeData.swift in Sources */,
 				CECC759723D607C900486676 /* OrderItemRefund+Woo.swift in Sources */,
+				EE7707C82ABBF4BB009FD564 /* AIToneVoiceViewModel.swift in Sources */,
 				03EF250228C615A5006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */,
 				AEFF77A629783CA600667F7A /* PriceInputViewModel.swift in Sources */,
 				0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */,
@@ -13999,6 +14026,7 @@
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
 				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */,
+				EE7707CB2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift in Sources */,
 				261E91A329C9882600A5C118 /* SubscriptionsViewModelTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,
 				4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -275,6 +275,28 @@ class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.storeProfilerAnswers])
     }
 
+    /// Verifies that `aiPromptTone` is set to `nil` upon reset
+    ///
+    func test_aiPromptTone_is_set_to_nil_upon_reset() throws {
+        // Given
+        let siteID: Int64 = 123
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.convincing.rawValue]
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults.aiTone(for: siteID)), .convincing)
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.aiPromptTone])
+    }
+
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
     func testDefaultCredentialsAreEffectivelyNuked() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
@@ -1,0 +1,72 @@
+import TestKit
+import XCTest
+
+@testable import WooCommerce
+
+final class AIToneVoiceViewModelTests: XCTestCase {
+    private let siteID: Int64 = 123
+
+    func test_casual_is_the_default_tone() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+
+        // When
+        let viewModel = AIToneVoiceViewModel(siteID: siteID, userDefaults: defaults)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedTone, .casual)
+    }
+
+    func test_tone_is_restored_from_user_defaults() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        defaults.setAITone(.flowery, for: siteID)
+
+        // When
+        let viewModel = AIToneVoiceViewModel(siteID: siteID, userDefaults: defaults)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedTone, .flowery)
+    }
+
+    func test_tone_gets_stored_on_selection() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = AIToneVoiceViewModel(siteID: siteID, userDefaults: defaults)
+
+        // When
+        viewModel.onSelectTone(.flowery)
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults.aiTone(for: siteID)), .flowery)
+    }
+
+    // MARK: - AI tone helpers
+    func test_stored_tone_is_restored_as_expected() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        defaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.convincing.rawValue]
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults.aiTone(for: siteID)), .convincing)
+    }
+
+    func test_tone_gets_stored_as_expected() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        defaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.convincing.rawValue]
+        XCTAssertEqual(try XCTUnwrap(defaults.aiTone(for: siteID)), .convincing)
+
+        // When
+        defaults.setAITone(.convincing, for: siteID)
+
+        // Then
+        let dictionary = try XCTUnwrap(defaults[.aiPromptTone] as? [String: String])
+        XCTAssertEqual(dictionary["\(siteID)"], AIToneVoice.convincing.rawValue)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
@@ -45,6 +45,15 @@ final class AIToneVoiceViewModelTests: XCTestCase {
     }
 
     // MARK: - AI tone helpers
+    func test_nil_is_returned_when_no_tone_stored() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+
+        // Then
+        XCTAssertNil(defaults.aiTone(for: siteID))
+    }
+
     func test_stored_tone_is_restored_as_expected() throws {
         // Given
         let uuid = UUID().uuidString


### PR DESCRIPTION
Closes: #10749 Closes: #10755

## Description

Adds a way to select AI tone and voice from the features screen.

- Presents a bottom sheet to select AI tones.
- Stores the selected tone in user defaults.
- Clear the value upon logout. 

## Testing instructions
- Create a JN site with the Jetpack AI plugin. (Checkbox available on JN home page to install this plugin)
- Login into the app using the JN site
- Switch to the Products tab and select the "+" button to add a new product. 
- Tap "Create a product with AI" option
- Enter a product name and tap "Continue"
- Tap on "Set tone and voice" and validate that the AI tone selection sheet is launched
- Select a tone and dismiss the sheet
- Reopen the sheet and ensure that the selection is restored

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/4e7d3ea3-069d-4796-8a90-8a74be9ed685


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
