### PR TITLE
Product Creation AI: UI for preview screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -71,7 +71,7 @@ struct AddProductFeaturesView: View {
             VStack {
                 // CTA to continue to next screen.
                 Button {
-                    // TODO: start product detail generation
+                    viewModel.proceedToPreview()
                     editorIsFocused = false
                 } label: {
                     Text(Localization.continueText)
@@ -128,6 +128,6 @@ private extension AddProductFeaturesView {
 
 struct AddProductDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductFeaturesView(viewModel: .init(siteID: 123, productName: "iPhone 15", onProductDetailsCreated: {}))
+        AddProductFeaturesView(viewModel: .init(siteID: 123, productName: "iPhone 15", onCompletion: { _ in }))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -12,17 +12,22 @@ final class AddProductFeaturesViewModel: ObservableObject {
     private let stores: StoresManager
     private let analytics: Analytics
     // TODO: add new type for product details and return it here.
-    private let onProductDetailsCreated: () -> Void
+    private let onCompletion: (String) -> Void
 
     init(siteID: Int64,
          productName: String,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
-         onProductDetailsCreated: @escaping () -> Void) {
+         onCompletion: @escaping (String) -> Void) {
         self.siteID = siteID
         self.productName = productName
         self.stores = stores
         self.analytics = analytics
-        self.onProductDetailsCreated = onProductDetailsCreated
+        self.onCompletion = onCompletion
+    }
+
+    func proceedToPreview() {
+        // TODO: analytics
+        onCompletion(productFeatures)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -76,7 +76,7 @@ struct AddProductWithAIContainerView: View {
                     }
                 })
             case .preview:
-                ProductDetailPreviewView()
+                ProductDetailPreviewView(viewModel: .init(siteID: viewModel.siteID))
             }
         }
         .onAppear() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -70,14 +70,13 @@ struct AddProductWithAIContainerView: View {
                 }))
             case .aboutProduct:
                 AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
-                                                        productName: viewModel.productName) {
+                                                        productName: viewModel.productName) { features in
                     withAnimation {
-                        viewModel.onProductDetailsCreated()
+                        viewModel.onProductFeaturesAdded(features: features)
                     }
                 })
             case .preview:
-                // TODO: Add other AI views
-               Text("Add other AI views")
+                ProductDetailPreviewView()
             }
         }
         .onAppear() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -5,13 +5,13 @@ enum AddProductWithAIStep: Int, CaseIterable {
     case productName = 1
     case aboutProduct
     case preview
-
+    
     /// Progress to display
     var progress: Double {
         let incrementBy = 1.0 / Double(Self.allCases.count)
         return Double(self.rawValue) * incrementBy
     }
-
+    
     var previousStep: AddProductWithAIStep? {
         .init(rawValue: self.rawValue - 1)
     }
@@ -28,6 +28,9 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private let completionHandler: (Product) -> Void
 
     private(set) var productName: String = ""
+    private var productFeatures: String = ""
+    private var productDescription: String?
+    private var packagingImage: MediaPickerImage?
 
     @Published private(set) var currentStep: AddProductWithAIStep = .productName
 
@@ -52,12 +55,16 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         currentStep = .aboutProduct
     }
 
-    func onProductDetailsCreated() {
+    func onProductFeaturesAdded(features: String) {
+        productFeatures = features
         currentStep = .preview
     }
 
     func didGenerateDataFromPackage(_ data: AddProductFromImageData?) {
-        // TODO: Show preview
+        productName = data?.name ?? ""
+        productDescription = data?.description
+        packagingImage = data?.image
+        currentStep = .preview
     }
 
     func backtrackOrDismiss() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -5,13 +5,13 @@ enum AddProductWithAIStep: Int, CaseIterable {
     case productName = 1
     case aboutProduct
     case preview
-    
+
     /// Progress to display
     var progress: Double {
         let incrementBy = 1.0 / Double(Self.allCases.count)
         return Double(self.rawValue) * incrementBy
     }
-    
+
     var previousStep: AddProductWithAIStep? {
         .init(rawValue: self.rawValue - 1)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -208,7 +208,7 @@ fileprivate extension ProductDetailPreviewView {
             comment: "Title on the add product with AI Preview screen."
         )
         static let subtitle = NSLocalizedString(
-            "Don't worry. You can always change those details later.",
+            "Don't worry. You can always change below details later.",
             comment: "Subtitle on the add product with AI Preview screen."
         )
         static let feedbackQuestion = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -3,10 +3,47 @@ import SwiftUI
 /// View for previewing product details generated with AI.
 ///
 struct ProductDetailPreviewView: View {
+
     var body: some View {
-        Text("Hello, World!")
+        ScrollView {
+            VStack(alignment: .leading, spacing: Layout.blockVerticalSpacing) {
+                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                    // Title label.
+                    Text(Localization.title)
+                        .fontWeight(.bold)
+                        .titleStyle()
+
+                    // Subtitle label.
+                    Text(Localization.subtitle)
+                        .foregroundColor(Color(.secondaryLabel))
+                        .bodyStyle()
+                }
+
+            }
+            .padding(insets: Layout.insets)
+        }
     }
 }
+
+private extension ProductDetailPreviewView {
+    enum Layout {
+        static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+
+        static let blockVerticalSpacing: CGFloat = 40
+        static let titleBlockSpacing: CGFloat = 16
+    }
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Preview",
+            comment: "Title on the add product with AI Preview screen."
+        )
+        static let subtitle = NSLocalizedString(
+            "Don't worry. You can always change those details later.",
+            comment: "Subtitle on the add product with AI Preview screen."
+        )
+    }
+}
+
 
 struct ProductDetailPreviewView_Previews: PreviewProvider {
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -21,7 +21,7 @@ struct ProductDetailPreviewView: View {
 
                     // Subtitle label.
                     Text(Localization.subtitle)
-                        .foregroundColor(Color(.secondaryLabel))
+                        .foregroundColor(.secondary)
                         .bodyStyle()
                 }
                 .padding(.bottom, Layout.titleBlockBottomSpacing)
@@ -63,21 +63,25 @@ struct ProductDetailPreviewView: View {
                                                image: UIImage.priceImage,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
+                            .background(Color(.separator))
                         TitleAndValueDetailRow(title: Localization.inventory,
                                                value: Localization.inStock,
                                                image: UIImage.inventoryImage,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
+                            .background(Color(.separator))
                         TitleAndValueDetailRow(title: Localization.categories,
                                                value: "Food, snack, sweet",
                                                image: UIImage.categoriesIcon,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
+                            .background(Color(.separator))
                         TitleAndValueDetailRow(title: Localization.tags,
                                                value: "yummy, candy, chocolate",
                                                image: UIImage.tagsIcon,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
+                            .background(Color(.separator))
                         TitleAndValueDetailRow(title: Localization.shipping,
                                                value: "Weight: 1kg\nDimension: 15 x 10 x 3 cm",
                                                image: UIImage.shippingImage,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -13,7 +13,7 @@ struct ProductDetailPreviewView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Layout.blockVerticalSpacing) {
-                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                VStack(alignment: .leading, spacing: Layout.contentPadding) {
                     // Title label.
                     Text(Localization.title)
                         .fontWeight(.bold)
@@ -24,11 +24,72 @@ struct ProductDetailPreviewView: View {
                         .foregroundColor(Color(.secondaryLabel))
                         .bodyStyle()
                 }
+                .padding(.bottom, Layout.titleBlockBottomSpacing)
+
+                // Product name
+                VStack(alignment: .leading, spacing: Layout.contentVerticalSpacing) {
+                    Text(Localization.productName)
+                        .foregroundColor(.primary)
+                        .subheadlineStyle()
+                    BasicDetailRow(content: viewModel.generatedProduct?.name,
+                                   isLoading: viewModel.isGeneratingDetails)
+                }
+
+                // Product description
+                VStack(alignment: .leading, spacing: Layout.contentVerticalSpacing) {
+                    Text(Localization.productDescription)
+                        .foregroundColor(.primary)
+                        .subheadlineStyle()
+                    BasicDetailRow(content: viewModel.generatedProduct?.fullDescription,
+                                   isLoading: viewModel.isGeneratingDetails)
+                }
+
+                // TODO: update values based on product
+                // Other details
+                VStack(alignment: .leading, spacing: Layout.contentVerticalSpacing) {
+                    Text(Localization.details)
+                        .foregroundColor(.primary)
+                        .subheadlineStyle()
+                    TitleAndValueDetailRow(title: Localization.productType,
+                                           value: "Physical",
+                                           image: UIImage.productImage,
+                                           isLoading: viewModel.isGeneratingDetails,
+                                           cornerRadius: Layout.cornerRadius)
+                    .padding(.bottom, Layout.contentPadding)
+
+                    VStack(spacing: 0) {
+                        TitleAndValueDetailRow(title: Localization.price,
+                                               value: "Regular price: $15",
+                                               image: UIImage.priceImage,
+                                               isLoading: viewModel.isGeneratingDetails)
+                        Divider()
+                        TitleAndValueDetailRow(title: Localization.inventory,
+                                               value: Localization.inStock,
+                                               image: UIImage.inventoryImage,
+                                               isLoading: viewModel.isGeneratingDetails)
+                        Divider()
+                        TitleAndValueDetailRow(title: Localization.categories,
+                                               value: "Food, snack, sweet",
+                                               image: UIImage.categoriesIcon,
+                                               isLoading: viewModel.isGeneratingDetails)
+                        Divider()
+                        TitleAndValueDetailRow(title: Localization.tags,
+                                               value: "yummy, candy, chocolate",
+                                               image: UIImage.tagsIcon,
+                                               isLoading: viewModel.isGeneratingDetails)
+                        Divider()
+                        TitleAndValueDetailRow(title: Localization.shipping,
+                                               value: "Weight: 1kg\nDimension: 15 x 10 x 3 cm",
+                                               image: UIImage.shippingImage,
+                                               isLoading: viewModel.isGeneratingDetails)
+                    }
+                    .cornerRadius(Layout.cornerRadius)
+                }
 
                 // Feedback banner
                 FeedbackView(title: Localization.feedbackQuestion,
                              backgroundColor: .init(uiColor: .init(light: .withColorStudio(.wooCommercePurple, shade: .shade0),
-                                                                   dark: .systemGray6)),
+                                                                   dark: .tertiarySystemBackground)),
                              onVote: { vote in
                     viewModel.handleFeedback(vote)
                 })
@@ -53,12 +114,75 @@ struct ProductDetailPreviewView: View {
     }
 }
 
+// MARK: - Subtypes
 private extension ProductDetailPreviewView {
+    /// View to contain basic product details
+    struct BasicDetailRow: View {
+        let content: String?
+        let isLoading: Bool
+        let dummyText = ProductDetailPreviewView.Constants.dummyText
+
+        typealias Layout = ProductDetailPreviewView.Layout
+
+        var body: some View {
+            Text(content ?? dummyText)
+                .bodyStyle()
+                .multilineTextAlignment(.leading)
+                .padding(Layout.contentPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.init(light: .systemGray6, dark: .tertiarySystemBackground)))
+                .cornerRadius(Layout.cornerRadius)
+                .redacted(reason: isLoading ? .placeholder : [])
+                .shimmering(active: isLoading)
+        }
+    }
+
+    /// View to contain product details with title, value and image.
+    struct TitleAndValueDetailRow: View {
+        let title: String
+        let value: String?
+        let image: UIImage
+        let isLoading: Bool
+        var cornerRadius: CGFloat = 0
+        let dummyText = ProductDetailPreviewView.Constants.dummyText
+
+        typealias Layout = ProductDetailPreviewView.Layout
+
+        var body: some View {
+            HStack(alignment: .top, spacing: Layout.contentPadding) {
+                Image(uiImage: image)
+                    .renderingMode(.template)
+                    .foregroundColor(.secondary)
+                VStack(alignment: .leading, spacing: Layout.detailVerticalSpacing) {
+                    Text(title)
+                        .bodyStyle()
+                    Text(value ?? dummyText)
+                        .subheadlineStyle()
+                        .multilineTextAlignment(.leading)
+                }
+            }
+            .padding(Layout.contentPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.init(light: .systemGray6, dark: .tertiarySystemBackground)))
+            .cornerRadius(cornerRadius)
+            .redacted(reason: isLoading ? .placeholder : [])
+            .shimmering(active: isLoading)
+        }
+    }
+}
+
+fileprivate extension ProductDetailPreviewView {
     enum Layout {
         static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
-
-        static let blockVerticalSpacing: CGFloat = 40
-        static let titleBlockSpacing: CGFloat = 16
+        static let titleBlockBottomSpacing: CGFloat = 24
+        static let blockVerticalSpacing: CGFloat = 24
+        static let contentVerticalSpacing: CGFloat = 8
+        static let contentPadding: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
+        static let detailVerticalSpacing: CGFloat = 4
+    }
+    enum Constants {
+        static let dummyText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
     }
     enum Localization {
         static let title = NSLocalizedString(
@@ -72,6 +196,46 @@ private extension ProductDetailPreviewView {
         static let feedbackQuestion = NSLocalizedString(
             "Is the result helpful?",
             comment: "Question to ask for feedback for the AI-generated content on the add product with AI Preview screen."
+        )
+        static let productName = NSLocalizedString(
+            "Product name",
+            comment: "Title of the name field on the add product with AI Preview screen."
+        )
+        static let productDescription = NSLocalizedString(
+            "Product description",
+            comment: "Title of the description field on the add product with AI Preview screen."
+        )
+        static let details = NSLocalizedString(
+            "Details",
+            comment: "Title of the details field on the add product with AI Preview screen."
+        )
+        static let productType = NSLocalizedString(
+            "Product type",
+            comment: "Title of the product type field on the add product with AI Preview screen."
+        )
+        static let price = NSLocalizedString(
+            "Price",
+            comment: "Title of the price field on the add product with AI Preview screen."
+        )
+        static let inventory = NSLocalizedString(
+            "Inventory",
+            comment: "Title of the inventory field on the add product with AI Preview screen."
+        )
+        static let inStock = NSLocalizedString(
+            "In stock",
+            comment: "Value of the inventory field on the add product with AI Preview screen."
+        )
+        static let categories = NSLocalizedString(
+            "Categories",
+            comment: "Title of the categories field on the add product with AI Preview screen."
+        )
+        static let tags = NSLocalizedString(
+            "Tags",
+            comment: "Title of the tags field on the add product with AI Preview screen."
+        )
+        static let shipping = NSLocalizedString(
+            "Shipping",
+            comment: "Title of the shipping field on the add product with AI Preview screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -50,6 +50,8 @@ struct ProductDetailPreviewView: View {
                     Text(Localization.details)
                         .foregroundColor(.primary)
                         .subheadlineStyle()
+
+                    // Product type
                     TitleAndValueDetailRow(title: Localization.productType,
                                            value: "Physical",
                                            image: UIImage.productImage,
@@ -58,30 +60,39 @@ struct ProductDetailPreviewView: View {
                     .padding(.bottom, Layout.contentPadding)
 
                     VStack(spacing: 0) {
+                        // Price
                         TitleAndValueDetailRow(title: Localization.price,
                                                value: "Regular price: $15",
                                                image: UIImage.priceImage,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
                             .background(Color(.separator))
+
+                        // Inventory
                         TitleAndValueDetailRow(title: Localization.inventory,
                                                value: Localization.inStock,
                                                image: UIImage.inventoryImage,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
                             .background(Color(.separator))
+
+                        // Categories
                         TitleAndValueDetailRow(title: Localization.categories,
                                                value: "Food, snack, sweet",
                                                image: UIImage.categoriesIcon,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
                             .background(Color(.separator))
+
+                        // Tags
                         TitleAndValueDetailRow(title: Localization.tags,
                                                value: "yummy, candy, chocolate",
                                                image: UIImage.tagsIcon,
                                                isLoading: viewModel.isGeneratingDetails)
                         Divider()
                             .background(Color(.separator))
+
+                        // Shipping details
                         TitleAndValueDetailRow(title: Localization.shipping,
                                                value: "Weight: 1kg\nDimension: 15 x 10 x 3 cm",
                                                image: UIImage.shippingImage,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// View for previewing product details generated with AI.
+///
+struct ProductDetailPreviewView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct ProductDetailPreviewView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductDetailPreviewView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -105,7 +105,7 @@ struct ProductDetailPreviewView: View {
                     if viewModel.isGeneratingDetails {
                         ActivityIndicator(isAnimating: .constant(true), style: .medium)
                     } else {
-                        Button("Save as draft") {
+                        Button(Localization.saveAsDraft) {
                             viewModel.saveProductAsDraft()
                         }
                     }
@@ -243,6 +243,10 @@ fileprivate extension ProductDetailPreviewView {
         static let shipping = NSLocalizedString(
             "Shipping",
             comment: "Title of the shipping field on the add product with AI Preview screen."
+        )
+        static let saveAsDraft = NSLocalizedString(
+            "Save as draft",
+            comment: "Button to save product details on the add product with AI Preview screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -124,9 +124,10 @@ private extension ProductDetailPreviewView {
     struct BasicDetailRow: View {
         let content: String?
         let isLoading: Bool
-        let dummyText = ProductDetailPreviewView.Constants.dummyText
+        let dummyText = Constants.dummyText
 
         typealias Layout = ProductDetailPreviewView.Layout
+        typealias Constants = ProductDetailPreviewView.Constants
 
         var body: some View {
             Text(content ?? dummyText)
@@ -134,7 +135,7 @@ private extension ProductDetailPreviewView {
                 .multilineTextAlignment(.leading)
                 .padding(Layout.contentPadding)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(.init(light: .systemGray6, dark: .tertiarySystemBackground)))
+                .background(Constants.detailRowColor)
                 .cornerRadius(Layout.cornerRadius)
                 .redacted(reason: isLoading ? .placeholder : [])
                 .shimmering(active: isLoading)
@@ -148,9 +149,10 @@ private extension ProductDetailPreviewView {
         let image: UIImage
         let isLoading: Bool
         var cornerRadius: CGFloat = 0
-        let dummyText = ProductDetailPreviewView.Constants.dummyText
+        let dummyText = Constants.dummyText
 
         typealias Layout = ProductDetailPreviewView.Layout
+        typealias Constants = ProductDetailPreviewView.Constants
 
         var body: some View {
             HStack(alignment: .top, spacing: Layout.contentPadding) {
@@ -167,7 +169,7 @@ private extension ProductDetailPreviewView {
             }
             .padding(Layout.contentPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(.init(light: .systemGray6, dark: .tertiarySystemBackground)))
+            .background(Constants.detailRowColor)
             .cornerRadius(cornerRadius)
             .redacted(reason: isLoading ? .placeholder : [])
             .shimmering(active: isLoading)
@@ -187,6 +189,7 @@ fileprivate extension ProductDetailPreviewView {
     }
     enum Constants {
         static let dummyText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+        static let detailRowColor = Color(.init(light: .systemGray6, dark: .tertiarySystemBackground))
     }
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -4,6 +4,12 @@ import SwiftUI
 ///
 struct ProductDetailPreviewView: View {
 
+    @ObservedObject private var viewModel: ProductDetailPreviewViewModel
+
+    init(viewModel: ProductDetailPreviewViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Layout.blockVerticalSpacing) {
@@ -18,9 +24,22 @@ struct ProductDetailPreviewView: View {
                         .foregroundColor(Color(.secondaryLabel))
                         .bodyStyle()
                 }
-
             }
             .padding(insets: Layout.insets)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    if viewModel.isGeneratingDetails {
+                        ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                    } else {
+                        Button("Save as draft") {
+                            viewModel.saveProductAsDraft()
+                        }
+                    }
+                }
+            }
+            .onAppear {
+                viewModel.generateProductDetails()
+            }
         }
     }
 }
@@ -47,6 +66,6 @@ private extension ProductDetailPreviewView {
 
 struct ProductDetailPreviewView_Previews: PreviewProvider {
     static var previews: some View {
-        ProductDetailPreviewView()
+        ProductDetailPreviewView(viewModel: .init(siteID: 123))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -24,6 +24,15 @@ struct ProductDetailPreviewView: View {
                         .foregroundColor(Color(.secondaryLabel))
                         .bodyStyle()
                 }
+
+                // Feedback banner
+                FeedbackView(title: Localization.feedbackQuestion,
+                             backgroundColor: .init(uiColor: .init(light: .withColorStudio(.wooCommercePurple, shade: .shade0),
+                                                                   dark: .systemGray6)),
+                             onVote: { vote in
+                    viewModel.handleFeedback(vote)
+                })
+                .renderedIf(viewModel.isGeneratingDetails == false)
             }
             .padding(insets: Layout.insets)
             .toolbar {
@@ -59,6 +68,10 @@ private extension ProductDetailPreviewView {
         static let subtitle = NSLocalizedString(
             "Don't worry. You can always change those details later.",
             comment: "Subtitle on the add product with AI Preview screen."
+        )
+        static let feedbackQuestion = NSLocalizedString(
+            "Is the result helpful?",
+            comment: "Question to ask for feedback for the AI-generated content on the add product with AI Preview screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -6,6 +6,7 @@ import Yosemite
 final class ProductDetailPreviewViewModel: ObservableObject {
 
     @Published private(set) var isGeneratingDetails: Bool = false
+    @Published private(set) var generatedProduct: Product?
 
     private let siteID: Int64
     private let stores: StoresManager
@@ -21,6 +22,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
 
     func generateProductDetails() {
         // TODO
+        isGeneratingDetails = true
     }
 
     func saveProductAsDraft() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -6,7 +6,7 @@ import Yosemite
 final class ProductDetailPreviewViewModel: ObservableObject {
 
     @Published private(set) var isGeneratingDetails: Bool = false
-    
+
     private let siteID: Int64
     private let stores: StoresManager
     private let analytics: Analytics
@@ -20,11 +20,14 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     }
 
     func generateProductDetails() {
-        isGeneratingDetails = true
         // TODO
     }
 
     func saveProductAsDraft() {
+        // TODO
+    }
+
+    func handleFeedback(_ vote: FeedbackView.Vote) {
         // TODO
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Yosemite
+
+/// View model for `ProductDetailPreviewView`
+///
+final class ProductDetailPreviewViewModel: ObservableObject {
+
+    @Published private(set) var isGeneratingDetails: Bool = false
+    
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let analytics: Analytics
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.stores = stores
+        self.analytics = analytics
+    }
+
+    func generateProductDetails() {
+        isGeneratingDetails = true
+        // TODO
+    }
+
+    func saveProductAsDraft() {
+        // TODO
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -22,7 +22,6 @@ final class ProductDetailPreviewViewModel: ObservableObject {
 
     func generateProductDetails() {
         // TODO
-        isGeneratingDetails = true
     }
 
     func saveProductAsDraft() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackView.swift
@@ -45,8 +45,8 @@ struct FeedbackView: View {
         }
         .padding(Layout.contentInsets)
         .background(
-            RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                .foregroundColor(backgroundColor)
+            backgroundColor
+                .cornerRadius(Layout.cornerRadius)
         )
         .onChange(of: vote) { newValue in
             if let newValue {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2203,6 +2203,7 @@
 		DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */; };
 		DEC0293A29C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */; };
 		DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */; };
+		DEC1A3EA2ABC2C2E0022CC85 /* ProductDetailPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1A3E92ABC2C2E0022CC85 /* ProductDetailPreviewViewModel.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
 		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
 		DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */; };
@@ -4702,6 +4703,7 @@
 		DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationWebViewController.swift; sourceTree = "<group>"; };
 		DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationViewModel.swift; sourceTree = "<group>"; };
 		DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmails.swift; sourceTree = "<group>"; };
+		DEC1A3E92ABC2C2E0022CC85 /* ProductDetailPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailPreviewViewModel.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
 		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
 		DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInput.swift; sourceTree = "<group>"; };
@@ -10631,6 +10633,7 @@
 			isa = PBXGroup;
 			children = (
 				DE8BEB952ABC19B100F5E56C /* ProductDetailPreviewView.swift */,
+				DEC1A3E92ABC2C2E0022CC85 /* ProductDetailPreviewViewModel.swift */,
 			);
 			path = Preview;
 			sourceTree = "<group>";
@@ -12305,6 +12308,7 @@
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
 				EE3B17AF2A9EFE97004D3E0C /* WooPaymentsSetupInstructionsView.swift in Sources */,
+				DEC1A3EA2ABC2C2E0022CC85 /* ProductDetailPreviewViewModel.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
 				3190D61B26D6D82900EF364D /* CardPresentRetryableError.swift in Sources */,
 				021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2180,6 +2180,7 @@
 		DE8BEB8C2AB840DD00F5E56C /* ProductNameGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */; };
 		DE8BEB912ABAEBF800F5E56C /* AddProductFeaturesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */; };
 		DE8BEB932ABAF07700F5E56C /* AddProductFeaturesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB922ABAF07700F5E56C /* AddProductFeaturesViewModel.swift */; };
+		DE8BEB962ABC19B100F5E56C /* ProductDetailPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEB952ABC19B100F5E56C /* ProductDetailPreviewView.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE8FCD1A2A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */; };
@@ -4679,6 +4680,7 @@
 		DE8BEB8B2AB840DD00F5E56C /* ProductNameGenerationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductNameGenerationView.swift; sourceTree = "<group>"; };
 		DE8BEB902ABAEBF800F5E56C /* AddProductFeaturesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesView.swift; sourceTree = "<group>"; };
 		DE8BEB922ABAF07700F5E56C /* AddProductFeaturesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModel.swift; sourceTree = "<group>"; };
+		DE8BEB952ABC19B100F5E56C /* ProductDetailPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailPreviewView.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE8FCD192A80FBBD00CB707D /* StoreCreationProfilerQuestionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerQuestionContainerView.swift; sourceTree = "<group>"; };
@@ -10625,6 +10627,14 @@
 			path = AddProductFeatures;
 			sourceTree = "<group>";
 		};
+		DE8BEB942ABC195C00F5E56C /* Preview */ = {
+			isa = PBXGroup;
+			children = (
+				DE8BEB952ABC19B100F5E56C /* ProductDetailPreviewView.swift */,
+			);
+			path = Preview;
+			sourceTree = "<group>";
+		};
 		DE8C9464264698E800C94823 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -10926,6 +10936,7 @@
 		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				DE8BEB942ABC195C00F5E56C /* Preview */,
 				DE8BEB8F2ABAEBD600F5E56C /* AddProductFeatures */,
 				EE5B5BC52AB8374D009BCBD6 /* Container */,
 				EE5B5BBE2AB42F21009BCBD6 /* AddProductName */,
@@ -13124,6 +13135,7 @@
 				B57C744E20F56E3800EEFC87 /* UITableViewCell+Helpers.swift in Sources */,
 				0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */,
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
+				DE8BEB962ABC19B100F5E56C /* ProductDetailPreviewView.swift in Sources */,
 				260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */,
 				4521397027FF53E400964ED3 /* CouponExpiryDateView.swift in Sources */,
 				DE0A2EAA281BA083007A8015 /* ProductCategoryList.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10750
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI for the preview screen of the product creation AI flow and updates navigation to display the screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store or a self-hosted store with Jetpack AI installed.
- Switch to Products tab and select "+" to add a new product.
- Select add product with AI.
- Enter product name and features to get to the preview screen.
- Notice that the UI matches the design. The values will need to be updated in a subsequent PR.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| \ | Top details | Bottom details | Loading |
| - | - | - | - |
| Light mode | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/8c7d1ba2-9ee3-4ba3-b063-afe356766df6" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/021c35b5-4cd5-45e4-889a-8dfc47db8582" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/8d837440-cdda-4cbd-8bcc-e67d40553a23" width=320 /> |
| Dark mode | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/22ee783b-1795-469e-9c84-305683637177" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/441a219b-523e-48a3-8117-0a370c724896" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/7854550a-a560-4863-9ada-d069d249650a" width=320 /> |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
