### PR TITLE
Gift card support in order form: disable gift card usage when order total is 0

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -782,6 +782,8 @@ extension EditableOrderViewModel {
 
         /// Enabled when gift cards plugin is active (woocommerce-gift-cards/woocommerce-gift-cards.php).
         let isGiftCardEnabled: Bool
+        /// Whether the Add Gift Card CTA is enabled, when the order total is greater than zero.
+        let isAddGiftCardActionEnabled: Bool
         /// Optional gift card code to apply to the order.
         let giftCardToApply: String?
         /// Gift cards that have been applied to the order.
@@ -817,6 +819,7 @@ extension EditableOrderViewModel {
              shouldDisableAddingCoupons: Bool = false,
              couponLineViewModels: [CouponLineViewModel] = [],
              isGiftCardEnabled: Bool = false,
+             isAddGiftCardActionEnabled: Bool = false,
              giftCardToApply: String? = nil,
              appliedGiftCards: [AppliedGiftCard] = [],
              taxBasedOnSetting: TaxBasedOnSetting? = nil,
@@ -854,6 +857,7 @@ extension EditableOrderViewModel {
             self.shouldDisableAddingCoupons = shouldDisableAddingCoupons
             self.couponLineViewModels = couponLineViewModels
             self.isGiftCardEnabled = isGiftCardEnabled
+            self.isAddGiftCardActionEnabled = isAddGiftCardActionEnabled
             self.giftCardToApply = giftCardToApply
             self.appliedGiftCards = appliedGiftCards
             self.taxBasedOnSetting = taxBasedOnSetting
@@ -1189,6 +1193,8 @@ private extension EditableOrderViewModel {
                     }
                 }()
 
+                let isAddGiftCardActionEnabled = currencyFormatter.convertToDecimal(order.total)?.compare(NSDecimalNumber.zero) == .orderedDescending
+
                 return PaymentDataViewModel(siteID: self.siteID,
                                             itemsTotal: orderTotals.itemsTotal.stringValue,
                                             shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
@@ -1205,6 +1211,7 @@ private extension EditableOrderViewModel {
                                             shouldDisableAddingCoupons: order.items.isEmpty,
                                             couponLineViewModels: self.couponLineViewModels(from: order.coupons),
                                             isGiftCardEnabled: isGiftCardEnabled,
+                                            isAddGiftCardActionEnabled: isAddGiftCardActionEnabled,
                                             giftCardToApply: giftCardToApply,
                                             appliedGiftCards: appliedGiftCards,
                                             taxBasedOnSetting: taxBasedOnSetting,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -194,6 +194,7 @@ struct OrderPaymentSection: View {
         .buttonStyle(PlusButtonStyle())
         .padding()
         .accessibilityIdentifier("add-gift-card-button")
+        .disabled(!viewModel.isAddGiftCardActionEnabled)
         .sheet(isPresented: $shouldShowAddGiftCard) {
             giftCardInput
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2249,6 +2249,28 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel?.paymentDataViewModel.isGiftCardEnabled, false)
     }
 
+    func test_isAddGiftCardActionEnabled_is_false_when_order_total_is_zero() {
+        // Given
+        let order = Order.fake().copy(orderID: sampleOrderID)
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), currencySettings: .init())
+
+        // Then
+        XCTAssertEqual(viewModel.paymentDataViewModel.isAddGiftCardActionEnabled, false)
+    }
+
+    func test_isAddGiftCardActionEnabled_is_true_when_order_total_is_positive() {
+        // Given
+        let order = Order.fake().copy(orderID: sampleOrderID, total: "0.01")
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), currencySettings: .init())
+
+        // Then
+        XCTAssertEqual(viewModel.paymentDataViewModel.isAddGiftCardActionEnabled, true)
+    }
+
     func test_appliedGiftCards_have_negative_formatted_amount() {
         // Given
         let order = Order.fake().copy(orderID: sampleOrderID, appliedGiftCards: [


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10518 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the order total is 0, applying a gift card results in an error:

```
{
  "error" : "woocommerce_rest_gift_card_cannot_apply",
  "message" : "Requested amount for gift card code ZU3A-HW9W-GVAJ-W9AA exceeded the order total."
}
```

To minimize this confusing error, disabling the Add Gift Card CTA seems like the best option. In order creation, the merchant can still update the payment data back to zero after a gift card is added. I think this is a very edge case, and the merchant can still remove the gift card when they see the error when they create the order with 0 total and a gift card.

## How

Added `isAddGiftCardActionEnabled` to order payment view model `EditableOrderViewModel.PaymentDataViewModel` to enable/disable the Add Gift Card CTA in `OrderPaymentSection`'s Add Gift Card row.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the site has the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension/plugin, and at least one gift card code available with some remaining amount.

### Create order

- Go to the Orders tab
- Tap `+` to create an order --> the `Add Gift Card` row should be disabled because the order total is 0
- Add a product with a price, shipping, or fee so that the order total is positive --> the `Add Gift Card` row should be enabled
- Tap `Add Gift Card`, enter a valid gift card with a non-zero remaining balance, then tap `Apply`
- Tap `Create` --> the order should be created remotely with the gift card applied

### Update order

- Go to the Orders tab
- Create two orders if needed: one with 0 order total, and the other with a positive order total. Both orders need to be editable
- Tap on the order with 0 order total --> the `Add Gift Card` row should be disabled
- Add a product with a price, shipping, or fee so that the order total is positive --> the `Add Gift Card` row should be enabled
- Tap `Add Gift Card`, enter a valid gift card with a non-zero remaining balance, then tap `Apply` --> the order should be updated remotely with the gift card applied
- Go back to the Orders tab
- Tap on the order with a positive order total --> the `Add Gift Card` row should be enabled
- Update the products, shipping, or fee so that the order total is zero --> the `Add Gift Card` row should be disabled

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

disabled | enabled
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/d313c2b8-1ef3-4e2f-8cd7-4a6a7624be7a" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/cecd7a42-d2d8-4eb2-9044-d2d0ea6cc2ff" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
