### PR TITLE
Promote extensions on Product Filter

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductListFilter.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductListFilter.swift
@@ -4,6 +4,7 @@ extension WooAnalyticsEvent {
         private enum Key {
             static let source = "source"
             static let filters = "filters"
+            static let type = "type"
         }
 
         /// Tracked when the user taps on the button to filter products.
@@ -20,6 +21,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productFilterListShowProductsButtonTapped,
                               properties: [Key.source: source.rawValue,
                                            Key.filters: filters.analyticsDescription])
+        }
+
+        static func productFilterListExploreButtonTapped(type: PromotableProductType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productFilterListExploreButtonTapped, properties: [Key.type: type.description])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -756,6 +756,7 @@ public enum WooAnalyticsStat: String {
     case productFilterListShowProductsButtonTapped = "product_filter_list_show_products_button_tapped"
     case productFilterListClearMenuButtonTapped = "product_filter_list_clear_menu_button_tapped"
     case productFilterListDismissButtonTapped = "product_filter_list_dismiss_button_tapped"
+    case productFilterListExploreButtonTapped = "product_filter_list_explore_button_tapped"
 
     // MARK: Readonly Product Variations Events
     //

--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -7,5 +7,7 @@ extension SitePlugin {
         public static let WCShip = "WooCommerce Shipping &amp; Tax"
         public static let WCTracking = "WooCommerce Shipment Tracking"
         public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
+        public static let WCProductBundles = "WooCommerce Product Bundles"
+        public static let WCCompositeProducts = "WooCommerce Composite Products"
     }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -328,11 +328,11 @@ extension WooConstants {
         ///
         case dhlExpressInstructions = "https://www.dhl.com/global-en/home/our-divisions/freight/customer-service/dangerous-goods-and-prohibited-items.html"
 
-        case subscriptionsExtensionURL = "https://woocommerce.com/products/woocommerce-subscriptions/"
+        case subscriptionsExtension = "https://woocommerce.com/products/woocommerce-subscriptions/"
 
-        case productBundlesExtensionUrl = "https://woocommerce.com/products/product-bundles/"
+        case productBundlesExtension = "https://woocommerce.com/products/product-bundles/"
 
-        case compositeProductsExtensionUrl = "https://woocommerce.com/products/composite-products/"
+        case compositeProductsExtension = "https://woocommerce.com/products/composite-products/"
 
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -328,6 +328,12 @@ extension WooConstants {
         ///
         case dhlExpressInstructions = "https://www.dhl.com/global-en/home/our-divisions/freight/customer-service/dangerous-goods-and-prohibited-items.html"
 
+        case subscriptionsExtensionURL = "https://woocommerce.com/products/woocommerce-subscriptions/"
+
+        case productBundlesExtensionUrl = "https://woocommerce.com/products/product-bundles/"
+
+        case compositeProductsExtensionUrl = "https://woocommerce.com/products/composite-products/"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -400,6 +400,7 @@ private extension FilterListViewController {
             let action = UIAction { action in
                 if let url = promotableType.promoteUrl, let viewController = self.hostViewController {
                     WebviewHelper.launch(url, with: viewController)
+                    ServiceLocator.analytics.track(event: .ProductListFilter.productFilterListExploreButtonTapped(type: promotableType))
                 }
             }
 

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -221,7 +221,8 @@ private extension FilterListViewController {
             case .staticOptions(let options):
                 let command = StaticListSelectorCommand(navigationBarTitle: selected.title,
                                                         data: options,
-                                                        selected: selected.selectedValue)
+                                                        selected: selected.selectedValue,
+                                                        hostViewController: self)
                 self.selectedFilterValueSubscription = command.onItemSelected.sink { selectedValueAction($0) }
                 let staticListSelector = ListSelectorViewController(command: command, tableViewStyle: .plain) { _ in }
                 self.listSelector.navigationController?.pushViewController(staticListSelector, animated: true)
@@ -348,15 +349,20 @@ private extension FilterListViewController {
 
         let data: [FilterType]
 
+        /// Parent view controller. Used to launch the promoted url web view.
+        ///
+        private weak var hostViewController: UIViewController?
+
         private let onItemSelectedSubject = PassthroughSubject<FilterType, Never>()
         var onItemSelected: AnyPublisher<FilterType, Never> {
             onItemSelectedSubject.eraseToAnyPublisher()
         }
 
-        init(navigationBarTitle: String, data: [FilterType], selected: FilterType) {
+        init(navigationBarTitle: String, data: [FilterType], selected: FilterType, hostViewController: UIViewController? = nil) {
             self.navigationBarTitle = navigationBarTitle
             self.data = data
             self.selected = selected
+            self.hostViewController = hostViewController
         }
 
         func isSelected(model: FilterType) -> Bool {
@@ -364,6 +370,11 @@ private extension FilterListViewController {
         }
 
         func handleSelectedChange(selected: FilterType, viewController: ViewController) {
+            // Do not allow selection for an unavailable promotable type.
+            if let promotable = selected as? PromotableProductType, !promotable.isAvailable {
+                return
+            }
+
             onItemSelectedSubject.send(selected)
             self.selected = selected
         }
@@ -371,6 +382,31 @@ private extension FilterListViewController {
         func configureCell(cell: BasicTableViewCell, model: FilterType) {
             cell.textLabel?.text = model.description
             cell.accessibilityIdentifier = model.description
+            cell.accessoryView = nil
+
+            if let promotable = model as? PromotableProductType, !promotable.isAvailable {
+                cell.accessoryView = createPromoteButton(promotableType: promotable)
+            }
+        }
+
+        func createPromoteButton(promotableType: PromotableProductType) -> UIButton {
+            var configuration = UIButton.Configuration.tinted()
+            configuration.cornerStyle = .small
+            configuration.baseForegroundColor = .primary
+            configuration.baseBackgroundColor = .primary
+            configuration.buttonSize = .small
+            configuration.title = NSLocalizedString("Explore!", comment: "Button title to explore an extension that isn't installed")
+
+            let action = UIAction { action in
+                if let url = promotableType.promoteUrl, let viewController = self.hostViewController {
+                    WebviewHelper.launch(url, with: viewController)
+                }
+            }
+
+            let button = UIButton(configuration: configuration, primaryAction: action)
+            button.sizeToFit()
+
+            return button
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -395,7 +395,7 @@ private extension FilterListViewController {
             configuration.baseForegroundColor = .primary
             configuration.baseBackgroundColor = .primary
             configuration.buttonSize = .mini
-            configuration.title = NSLocalizedString("Explore!", comment: "Button title to explore an extension that isn't installed")
+            configuration.title = NSLocalizedString("Explore", comment: "Button title to explore an extension that isn't installed")
 
             let action = UIAction { action in
                 if let url = promotableType.promoteUrl, let viewController = self.hostViewController {

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -394,7 +394,7 @@ private extension FilterListViewController {
             configuration.cornerStyle = .small
             configuration.baseForegroundColor = .primary
             configuration.baseBackgroundColor = .primary
-            configuration.buttonSize = .small
+            configuration.buttonSize = .mini
             configuration.title = NSLocalizedString("Explore!", comment: "Button title to explore an extension that isn't installed")
 
             let action = UIAction { action in

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Yosemite
 import Experiments
+import WooFoundation
 
 /// `FilterListViewModel` for filtering a list of products.
 final class FilterProductListViewModel: FilterListViewModel {
@@ -10,7 +11,7 @@ final class FilterProductListViewModel: FilterListViewModel {
     struct Filters: Equatable {
         let stockStatus: ProductStockStatus?
         let productStatus: ProductStatus?
-        let productType: ProductType?
+        let promotableProductType: PromotableProductType?
         let productCategory: ProductCategory?
 
         let numberOfActiveFilters: Int
@@ -18,26 +19,26 @@ final class FilterProductListViewModel: FilterListViewModel {
         init() {
             stockStatus = nil
             productStatus = nil
-            productType = nil
+            promotableProductType = nil
             productCategory = nil
             numberOfActiveFilters = 0
         }
 
         init(stockStatus: ProductStockStatus?,
              productStatus: ProductStatus?,
-             productType: ProductType?,
+             promotableProductType: PromotableProductType?,
              productCategory: ProductCategory?,
              numberOfActiveFilters: Int) {
             self.stockStatus = stockStatus
             self.productStatus = productStatus
-            self.productType = productType
+            self.promotableProductType = promotableProductType
             self.productCategory = productCategory
             self.numberOfActiveFilters = numberOfActiveFilters
         }
 
         // Generate a string based on populated filters, like "instock,publish,simple,clothes"
         var analyticsDescription: String {
-            let elements: [String?] = [stockStatus?.rawValue, productStatus?.rawValue, productType?.rawValue, productCategory?.slug]
+            let elements: [String?] = [stockStatus?.rawValue, productStatus?.rawValue, promotableProductType?.productType.rawValue, productCategory?.slug]
             return elements.compactMap { $0 }.joined(separator: ",")
         }
     }
@@ -56,7 +57,7 @@ final class FilterProductListViewModel: FilterListViewModel {
     init(filters: Filters, siteID: Int64) {
         self.stockStatusFilterViewModel = ProductListFilter.stockStatus.createViewModel(filters: filters)
         self.productStatusFilterViewModel = ProductListFilter.productStatus.createViewModel(filters: filters)
-        self.productTypeFilterViewModel = ProductListFilter.productType.createViewModel(filters: filters)
+        self.productTypeFilterViewModel = ProductListFilter.productType(siteID: siteID).createViewModel(filters: filters)
         self.productCategoryFilterViewModel = ProductListFilter.productCategory(siteID: siteID).createViewModel(filters: filters)
 
         self.filterTypeViewModels = [
@@ -70,14 +71,14 @@ final class FilterProductListViewModel: FilterListViewModel {
     var criteria: Filters {
         let stockStatus = stockStatusFilterViewModel.selectedValue as? ProductStockStatus ?? nil
         let productStatus = productStatusFilterViewModel.selectedValue as? ProductStatus ?? nil
-        let productType = productTypeFilterViewModel.selectedValue as? ProductType ?? nil
+        let promotableProductType = productTypeFilterViewModel.selectedValue as? PromotableProductType ?? nil
         let productCategory = productCategoryFilterViewModel.selectedValue as? ProductCategory ?? nil
 
         let numberOfActiveFilters = filterTypeViewModels.numberOfActiveFilters
 
         return Filters(stockStatus: stockStatus,
                        productStatus: productStatus,
-                       productType: productType,
+                       promotableProductType: promotableProductType,
                        productCategory: productCategory,
                        numberOfActiveFilters: numberOfActiveFilters)
     }
@@ -89,7 +90,7 @@ final class FilterProductListViewModel: FilterListViewModel {
         let clearedProductStatus: ProductStatus? = nil
         productStatusFilterViewModel.selectedValue = clearedProductStatus
 
-        let clearedProductType: ProductType? = nil
+        let clearedProductType: PromotableProductType? = nil
         productTypeFilterViewModel.selectedValue = clearedProductType
 
         let clearedProductCategory: ProductCategory? = nil
@@ -103,7 +104,7 @@ extension FilterProductListViewModel {
     enum ProductListFilter {
         case stockStatus
         case productStatus
-        case productType
+        case productType(siteID: Int64)
         case productCategory(siteID: Int64)
     }
 }
@@ -136,15 +137,53 @@ extension FilterProductListViewModel.ProductListFilter {
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: options),
                                        selectedValue: filters.productStatus)
-        case .productType:
-            let options: [ProductType?] = [nil, .simple, .variable, .grouped, .affiliate, .subscription, .variableSubscription, .bundle, .composite]
+        case let .productType(siteID):
+            let options = buildPromotableTypes(siteID: siteID)
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: options),
-                                       selectedValue: filters.productType)
+                                       selectedValue: filters.promotableProductType)
         case let .productCategory(siteID):
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .productCategories(siteID: siteID),
                                        selectedValue: filters.productCategory)
         }
+    }
+
+    /// Builds the products types filter array identifying which extension is available or not.
+    ///
+    private func buildPromotableTypes(siteID: Int64) -> [PromotableProductType?] {
+        let activePluginNames = fetchActivePluginNames(siteID: siteID)
+        let isSubscriptionsAvailable = Set(activePluginNames).intersection(SitePlugin.SupportedPlugin.WCSubscriptions).count > 0
+        let isCompositeProductsAvailable = activePluginNames.contains(SitePlugin.SupportedPlugin.WCCompositeProducts)
+        let isProductBundlesAvailable = activePluginNames.contains(SitePlugin.SupportedPlugin.WCProductBundles)
+
+        return [nil,
+                .init(productType: .simple, isAvailable: true, promoteUrl: nil),
+                .init(productType: .variable, isAvailable: true, promoteUrl: nil),
+                .init(productType: .grouped, isAvailable: true, promoteUrl: nil),
+                .init(productType: .affiliate, isAvailable: true, promoteUrl: nil),
+                .init(productType: .subscription,
+                      isAvailable: isSubscriptionsAvailable,
+                      promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+                .init(productType: .variableSubscription,
+                      isAvailable: isSubscriptionsAvailable,
+                      promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+                .init(productType: .bundle,
+                      isAvailable: isProductBundlesAvailable,
+                      promoteUrl: WooConstants.URLs.productBundlesExtensionUrl.asURL()),
+                .init(productType: .composite,
+                      isAvailable: isCompositeProductsAvailable,
+                      promoteUrl: WooConstants.URLs.compositeProductsExtensionUrl.asURL())]
+    }
+
+    /// Fetches the active plugin names for the provided site IDs using a `ResultsController`
+    ///
+    private func fetchActivePluginNames(siteID: Int64) -> [String] {
+        let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.active == true
+        let resultsController = ResultsController<StorageSystemPlugin>(storageManager: ServiceLocator.storageManager, sortedBy: [])
+        resultsController.predicate = predicate
+
+        try? resultsController.performFetch()
+        return resultsController.fetchedObjects.map { $0.name }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -166,16 +166,16 @@ extension FilterProductListViewModel.ProductListFilter {
                 .init(productType: .affiliate, isAvailable: true, promoteUrl: nil),
                 .init(productType: .subscription,
                       isAvailable: isSubscriptionsAvailable,
-                      promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+                      promoteUrl: WooConstants.URLs.subscriptionsExtension.asURL()),
                 .init(productType: .variableSubscription,
                       isAvailable: isSubscriptionsAvailable,
-                      promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+                      promoteUrl: WooConstants.URLs.subscriptionsExtension.asURL()),
                 .init(productType: .bundle,
                       isAvailable: isProductBundlesAvailable,
-                      promoteUrl: WooConstants.URLs.productBundlesExtensionUrl.asURL()),
+                      promoteUrl: WooConstants.URLs.productBundlesExtension.asURL()),
                 .init(productType: .composite,
                       isAvailable: isCompositeProductsAvailable,
-                      promoteUrl: WooConstants.URLs.compositeProductsExtensionUrl.asURL())]
+                      promoteUrl: WooConstants.URLs.compositeProductsExtension.asURL())]
     }
 
     /// Fetches the active plugin names for the provided site IDs using a `ResultsController`

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
@@ -1,6 +1,22 @@
 import Foundation
 import Yosemite
 
+/// ProductType promotable on filter lists.
+///
+struct PromotableProductType: Equatable {
+    /// Product Type
+    ///
+    let productType: ProductType
+
+    /// Wether the product is available in the store
+    ///
+    let isAvailable: Bool
+
+    /// Associated extension URL to promote.
+    ///
+    let promoteUrl: URL?
+}
+
 extension Optional: FilterType where Wrapped: FilterType {
     var description: String {
         return self?.description ?? NSLocalizedString("Any", comment: "Title when there is no filter set.")
@@ -20,6 +36,16 @@ extension ProductStockStatus: FilterType {
 extension ProductStatus: FilterType {
     var isActive: Bool {
         return true
+    }
+}
+
+extension PromotableProductType: FilterType {
+    var description: String {
+        productType.description
+    }
+
+    var isActive: Bool {
+        productType.isActive
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -362,7 +362,7 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
                                                        pageSize: pageSize,
                                                        stockStatus: filtersSubject.value.stockStatus,
                                                        productStatus: filtersSubject.value.productStatus,
-                                                       productType: filtersSubject.value.productType,
+                                                       productType: filtersSubject.value.promotableProductType?.productType,
                                                        productCategory: filtersSubject.value.productCategory,
                                                        sortOrder: .nameAscending,
                                                        shouldDeleteStoredProductsOnFirstPage: true) { [weak self] result in
@@ -396,7 +396,7 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
                                                   pageSize: pageSize,
                                                   stockStatus: filtersSubject.value.stockStatus,
                                                   productStatus: filtersSubject.value.productStatus,
-                                                  productType: filtersSubject.value.productType,
+                                                  productType: filtersSubject.value.promotableProductType?.productType,
                                                   productCategory: filtersSubject.value.productCategory) { [weak self] result in
             // Don't continue if this isn't the latest search.
             guard let self = self, keyword == self.searchTerm else {
@@ -579,7 +579,7 @@ private extension ProductSelectorViewModel {
         productsResultsController.updatePredicate(siteID: siteID,
                                                   stockStatus: filters.stockStatus,
                                                   productStatus: filters.productStatus,
-                                                  productType: filters.productType)
+                                                  productType: filters.promotableProductType?.productType)
         if searchTerm.isNotEmpty {
             // When the search query changes, also includes the original results predicate in addition to the search keyword and filter key.
             let searchResultsPredicate = NSPredicate(format: "SUBQUERY(searchResults, $result, $result.keyword = %@ AND $result.filterKey = %@).@count > 0",

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -162,7 +162,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
                 resultsController.updatePredicate(siteID: siteID,
                                                   stockStatus: filters.stockStatus,
                                                   productStatus: filters.productStatus,
-                                                  productType: filters.productType)
+                                                  productType: filters.promotableProductType?.productType)
 
                 /// Reload because `updatePredicate` calls `performFetch` when creating a new predicate
                 tableView.reloadData()
@@ -795,7 +795,7 @@ private extension ProductsViewController {
         let predicate = NSPredicate.createProductPredicate(siteID: siteID,
                                                            stockStatus: filters.stockStatus,
                                                            productStatus: filters.productStatus,
-                                                           productType: filters.productType)
+                                                           productType: filters.promotableProductType?.productType)
 
         return ResultsController<StorageProduct>(storageManager: storageManager,
                                                  matching: predicate,
@@ -1215,7 +1215,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                  pageSize: pageSize,
                                  stockStatus: filters.stockStatus,
                                  productStatus: filters.productStatus,
-                                 productType: filters.productType,
+                                 productType: filters.promotableProductType?.productType,
                                  productCategory: filters.productCategory,
                                  sortOrder: sortOrder) { [weak self] result in
                                     guard let self = self else {
@@ -1246,7 +1246,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                                               sort: sort?.rawValue,
                                                               stockStatusFilter: filters.stockStatus,
                                                               productStatusFilter: filters.productStatus,
-                                                              productTypeFilter: filters.productType,
+                                                              productTypeFilter: filters.promotableProductType?.productType,
                                                               productCategoryFilter: filters.productCategory) { (error) in
         }
         ServiceLocator.stores.dispatch(action)
@@ -1263,9 +1263,10 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                         self?.sortOrder = ProductsSortOrder(rawValue: sort) ?? .default
                     }
 
+                    let promotableProductType = settings.productTypeFilter.map { PromotableProductType(productType: $0, isAvailable: true, promoteUrl: nil) }
                     self?.filters = FilterProductListViewModel.Filters(stockStatus: settings.stockStatusFilter,
                                                                        productStatus: settings.productStatusFilter,
-                                                                       productType: settings.productTypeFilter,
+                                                                       promotableProductType: promotableProductType,
                                                                        productCategory: settings.productCategoryFilter,
                                                                        numberOfActiveFilters: settings.numberOfActiveFilters())
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -366,7 +366,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: .outOfStock,
             productStatus: .draft,
-            productType: .simple,
+            promotableProductType: PromotableProductType(productType: .simple, isAvailable: true, promoteUrl: nil),
             productCategory: nil,
             numberOfActiveFilters: 3)
 
@@ -417,7 +417,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.searchTerm, "")
         XCTAssertNil(currentFilters.stockStatus)
         XCTAssertNil(currentFilters.productCategory)
-        XCTAssertNil(currentFilters.productType)
+        XCTAssertNil(currentFilters.promotableProductType)
         XCTAssertNil(currentFilters.productCategory)
         XCTAssertEqual(currentFilters.numberOfActiveFilters, 0)
     }
@@ -746,7 +746,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: ProductStockStatus.outOfStock,
             productStatus: ProductStatus.draft,
-            productType: ProductType.simple,
+            promotableProductType: PromotableProductType(productType: .simple, isAvailable: true, promoteUrl: nil),
             productCategory: nil,
             numberOfActiveFilters: 3
         )
@@ -909,7 +909,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: ProductStockStatus.outOfStock,
             productStatus: ProductStatus.draft,
-            productType: ProductType.simple,
+            promotableProductType: PromotableProductType(productType: .simple, isAvailable: true, promoteUrl: nil),
             productCategory: nil,
             numberOfActiveFilters: 3
         )
@@ -933,7 +933,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: nil,
             productStatus: nil,
-            productType: ProductType.simple,
+            promotableProductType: PromotableProductType(productType: .simple, isAvailable: true, promoteUrl: nil),
             productCategory: nil,
             numberOfActiveFilters: 1
         )
@@ -1017,7 +1017,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: .outOfStock,
             productStatus: .draft,
-            productType: ProductType.simple,
+            promotableProductType: PromotableProductType(productType: .simple, isAvailable: true, promoteUrl: nil),
             productCategory: .init(categoryID: 123, siteID: sampleSiteID, parentID: 1, name: "Test", slug: "test"),
             numberOfActiveFilters: 1
         )
@@ -1042,7 +1042,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         assertEqual(filteredStockStatus, filters.stockStatus)
-        assertEqual(filteredProductType, filters.productType)
+        assertEqual(filteredProductType, filters.promotableProductType?.productType)
         assertEqual(filteredProductStatus, filters.productStatus)
         assertEqual(filteredProductCategory, filters.productCategory)
     }
@@ -1057,7 +1057,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: .outOfStock,
             productStatus: .draft,
-            productType: ProductType.simple,
+            promotableProductType: PromotableProductType(productType: .simple, isAvailable: true, promoteUrl: nil),
             productCategory: .init(categoryID: 123, siteID: sampleSiteID, parentID: 1, name: "Test", slug: "test"),
             numberOfActiveFilters: 1
         )
@@ -1081,7 +1081,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         assertEqual(filteredStockStatus, filters.stockStatus)
-        assertEqual(filteredProductType, filters.productType)
+        assertEqual(filteredProductType, filters.promotableProductType?.productType)
         assertEqual(filteredProductStatus, filters.productStatus)
         assertEqual(filteredProductCategory, filters.productCategory)
     }
@@ -1111,7 +1111,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: nil,
             productStatus: nil,
-            productType: ProductType.variable,
+            promotableProductType: PromotableProductType(productType: .variable, isAvailable: true, promoteUrl: nil),
             productCategory: nil,
             numberOfActiveFilters: 1
         )
@@ -1299,7 +1299,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(
             stockStatus: nil,
             productStatus: nil,
-            productType: ProductType.simple,
+            promotableProductType: PromotableProductType(productType: .simple, isAvailable: true, promoteUrl: nil),
             productCategory: nil,
             numberOfActiveFilters: 1
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
@@ -12,7 +12,7 @@ final class FilterProductListViewModel_numberOfActiveFiltersTests: XCTestCase {
     func testOneActiveFilter() {
         let filters = FilterProductListViewModel.Filters(stockStatus: nil,
                                                          productStatus: .draft,
-                                                         productType: nil,
+                                                         promotableProductType: nil,
                                                          productCategory: nil,
                                                          numberOfActiveFilters: 0)
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
@@ -22,7 +22,7 @@ final class FilterProductListViewModel_numberOfActiveFiltersTests: XCTestCase {
     func testTwoActiveFilters() {
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .published,
-                                                         productType: nil,
+                                                         promotableProductType: nil,
                                                          productCategory: nil,
                                                          numberOfActiveFilters: 0)
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
@@ -32,7 +32,9 @@ final class FilterProductListViewModel_numberOfActiveFiltersTests: XCTestCase {
     func testThreeActiveFilters() {
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .published,
-                                                         productType: .variable,
+                                                         promotableProductType: PromotableProductType(productType: .variable,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: nil,
                                                          numberOfActiveFilters: 0)
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
@@ -43,7 +45,9 @@ final class FilterProductListViewModel_numberOfActiveFiltersTests: XCTestCase {
         let filterProductCategory = ProductCategory(categoryID: 0, siteID: 0, parentID: 0, name: "", slug: "")
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .published,
-                                                         productType: .variable,
+                                                         promotableProductType: PromotableProductType(productType: .variable,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: filterProductCategory,
                                                          numberOfActiveFilters: 0)
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
@@ -56,7 +60,7 @@ private extension FilterProductListViewModel_numberOfActiveFiltersTests {
         return [
             FilterProductListViewModel.ProductListFilter.stockStatus.createViewModel(filters: filters),
             FilterProductListViewModel.ProductListFilter.productStatus.createViewModel(filters: filters),
-            FilterProductListViewModel.ProductListFilter.productType.createViewModel(filters: filters),
+            FilterProductListViewModel.ProductListFilter.productType(siteID: 123).createViewModel(filters: filters),
             FilterProductListViewModel.ProductListFilter.productCategory(siteID: 0).createViewModel(filters: filters)
         ]
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -87,10 +87,10 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
             .init(productType: .variable, isAvailable: true, promoteUrl: nil),
             .init(productType: .grouped, isAvailable: true, promoteUrl: nil),
             .init(productType: .affiliate, isAvailable: true, promoteUrl: nil),
-            .init(productType: .subscription, isAvailable: false, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
-            .init(productType: .variableSubscription, isAvailable: false, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
-            .init(productType: .bundle, isAvailable: false, promoteUrl: WooConstants.URLs.productBundlesExtensionUrl.asURL()),
-            .init(productType: .composite, isAvailable: false, promoteUrl: WooConstants.URLs.compositeProductsExtensionUrl.asURL())
+            .init(productType: .subscription, isAvailable: false, promoteUrl: WooConstants.URLs.subscriptionsExtension.asURL()),
+            .init(productType: .variableSubscription, isAvailable: false, promoteUrl: WooConstants.URLs.subscriptionsExtension.asURL()),
+            .init(productType: .bundle, isAvailable: false, promoteUrl: WooConstants.URLs.productBundlesExtension.asURL()),
+            .init(productType: .composite, isAvailable: false, promoteUrl: WooConstants.URLs.compositeProductsExtension.asURL())
         ])
     }
 
@@ -130,10 +130,10 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
             .init(productType: .variable, isAvailable: true, promoteUrl: nil),
             .init(productType: .grouped, isAvailable: true, promoteUrl: nil),
             .init(productType: .affiliate, isAvailable: true, promoteUrl: nil),
-            .init(productType: .subscription, isAvailable: true, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
-            .init(productType: .variableSubscription, isAvailable: true, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
-            .init(productType: .bundle, isAvailable: true, promoteUrl: WooConstants.URLs.productBundlesExtensionUrl.asURL()),
-            .init(productType: .composite, isAvailable: false, promoteUrl: WooConstants.URLs.compositeProductsExtensionUrl.asURL())
+            .init(productType: .subscription, isAvailable: true, promoteUrl: WooConstants.URLs.subscriptionsExtension.asURL()),
+            .init(productType: .variableSubscription, isAvailable: true, promoteUrl: WooConstants.URLs.subscriptionsExtension.asURL()),
+            .init(productType: .bundle, isAvailable: true, promoteUrl: WooConstants.URLs.productBundlesExtension.asURL()),
+            .init(productType: .composite, isAvailable: false, promoteUrl: WooConstants.URLs.compositeProductsExtension.asURL())
         ])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -9,7 +9,9 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
         let filterType = FilterProductListViewModel.ProductListFilter.stockStatus
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
-                                                         productType: .grouped,
+                                                         promotableProductType: PromotableProductType(productType: .grouped,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: filterProductCategory,
                                                          numberOfActiveFilters: 4)
         let viewModel = filterType.createViewModel(filters: filters)
@@ -20,7 +22,9 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
         let filterType = FilterProductListViewModel.ProductListFilter.productStatus
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
-                                                         productType: .grouped,
+                                                         promotableProductType: PromotableProductType(productType: .grouped,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: filterProductCategory,
                                                          numberOfActiveFilters: 4)
         let viewModel = filterType.createViewModel(filters: filters)
@@ -28,14 +32,16 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
     }
 
     func testCreatingProductTypeFilterTypeViewModel() {
-        let filterType = FilterProductListViewModel.ProductListFilter.productType
+        let filterType = FilterProductListViewModel.ProductListFilter.productType(siteID: 123)
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
-                                                         productType: .grouped,
+                                                         promotableProductType: PromotableProductType(productType: .grouped,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: filterProductCategory,
                                                          numberOfActiveFilters: 4)
         let viewModel = filterType.createViewModel(filters: filters)
-        XCTAssertEqual(viewModel.selectedValue as? ProductType, .grouped)
+        XCTAssertEqual((viewModel.selectedValue as? PromotableProductType)?.productType, .grouped)
     }
 
     func testCreatingProductCategoryFilterTypeViewModel() {
@@ -43,10 +49,91 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
 
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
-                                                         productType: .grouped,
+                                                         promotableProductType: PromotableProductType(productType: .grouped,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: filterProductCategory,
                                                          numberOfActiveFilters: 4)
         let viewModel = filterType.createViewModel(filters: filters)
         XCTAssertEqual(viewModel.selectedValue as? ProductCategory, filterProductCategory)
+    }
+
+    func test_creating_promotable_product_types_with_no_plugins_outputs_correct_types() throws {
+        // Given
+        let filterType = FilterProductListViewModel.ProductListFilter.productType(siteID: 123)
+        let filters = FilterProductListViewModel.Filters(stockStatus: nil,
+                                                         productStatus: nil,
+                                                         promotableProductType: nil,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 0)
+        let mockStorage = MockStorageManager()
+
+        // When
+        let viewModel = filterType.createViewModel(filters: filters, storageManager: mockStorage)
+        let options: [PromotableProductType?] = try {
+            switch viewModel.listSelectorConfig {
+            case .staticOptions(let options):
+                return try XCTUnwrap(options as? [PromotableProductType?])
+            default:
+                XCTFail("Unexpected selector config")
+                return []
+            }
+        }()
+
+        // Then
+        XCTAssertEqual(options, [
+            nil,
+            .init(productType: .simple, isAvailable: true, promoteUrl: nil),
+            .init(productType: .variable, isAvailable: true, promoteUrl: nil),
+            .init(productType: .grouped, isAvailable: true, promoteUrl: nil),
+            .init(productType: .affiliate, isAvailable: true, promoteUrl: nil),
+            .init(productType: .subscription, isAvailable: false, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+            .init(productType: .variableSubscription, isAvailable: false, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+            .init(productType: .bundle, isAvailable: false, promoteUrl: WooConstants.URLs.productBundlesExtensionUrl.asURL()),
+            .init(productType: .composite, isAvailable: false, promoteUrl: WooConstants.URLs.compositeProductsExtensionUrl.asURL())
+        ])
+    }
+
+    func test_creating_promotable_product_types_with_plugins_outputs_correct_types() throws {
+        // Given
+        let sampleSiteID: Int64 = 123
+        let filterType = FilterProductListViewModel.ProductListFilter.productType(siteID: sampleSiteID)
+        let filters = FilterProductListViewModel.Filters(stockStatus: nil,
+                                                         productStatus: nil,
+                                                         promotableProductType: nil,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 0)
+        let mockStorage = MockStorageManager()
+        mockStorage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                                name: SitePlugin.SupportedPlugin.WCSubscriptions[0],
+                                                                                active: true))
+        mockStorage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                                name: SitePlugin.SupportedPlugin.WCProductBundles,
+                                                                                active: true))
+
+        // When
+        let viewModel = filterType.createViewModel(filters: filters, storageManager: mockStorage)
+        let options: [PromotableProductType?] = try {
+            switch viewModel.listSelectorConfig {
+            case .staticOptions(let options):
+                return try XCTUnwrap(options as? [PromotableProductType?])
+            default:
+                XCTFail("Unexpected selector config")
+                return []
+            }
+        }()
+
+        // Then
+        XCTAssertEqual(options, [
+            nil,
+            .init(productType: .simple, isAvailable: true, promoteUrl: nil),
+            .init(productType: .variable, isAvailable: true, promoteUrl: nil),
+            .init(productType: .grouped, isAvailable: true, promoteUrl: nil),
+            .init(productType: .affiliate, isAvailable: true, promoteUrl: nil),
+            .init(productType: .subscription, isAvailable: true, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+            .init(productType: .variableSubscription, isAvailable: true, promoteUrl: WooConstants.URLs.subscriptionsExtensionURL.asURL()),
+            .init(productType: .bundle, isAvailable: true, promoteUrl: WooConstants.URLs.productBundlesExtensionUrl.asURL()),
+            .init(productType: .composite, isAvailable: false, promoteUrl: WooConstants.URLs.compositeProductsExtensionUrl.asURL())
+        ])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -15,7 +15,7 @@ final class FilterProductListViewModelTests: XCTestCase {
         // Then
         let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil,
                                                                   productStatus: nil,
-                                                                  productType: nil,
+                                                                  promotableProductType: nil,
                                                                   productCategory: nil,
                                                                   numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
@@ -25,7 +25,9 @@ final class FilterProductListViewModelTests: XCTestCase {
         // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
-                                                         productType: .grouped,
+                                                         promotableProductType: PromotableProductType(productType: .grouped,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: filterProductCategory,
                                                          numberOfActiveFilters: 4)
 
@@ -41,7 +43,9 @@ final class FilterProductListViewModelTests: XCTestCase {
         // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
-                                                         productType: .grouped,
+                                                         promotableProductType: PromotableProductType(productType: .grouped,
+                                                                                                      isAvailable: true,
+                                                                                                      promoteUrl: nil),
                                                          productCategory: filterProductCategory,
                                                          numberOfActiveFilters: 4)
 
@@ -52,7 +56,7 @@ final class FilterProductListViewModelTests: XCTestCase {
         // Then
         let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil,
                                                                   productStatus: nil,
-                                                                  productType: nil,
+                                                                  promotableProductType: nil,
                                                                   productCategory: nil,
                                                                   numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)


### PR DESCRIPTION
Closes: #10435 

# Why

As part of the product extension project, this PR adds an "Explore button" to the product types filter whose correspondent extension is not yet installed on the store.

This button will redirect the user to the extension's webpage with the idea of promoting it.

# How

- Create a new `PromotableProductType` to be used in the product filters instead of the current `ProductType`
- Show an "Explore" button only to the `PromotableProduct` types.
- Makes use of a `ResultsController` to fetch the plugin status synchronously.

I ended up abstracting the `PromotableProductType` behind the existing `FilterType`. I'm not very sure if this is the correct way to extend the product filters. 

They are meant to behave quite generically so adding specificity to the `FilterType` protocols didn't feel good. In the same way, creating a specific view controller only for this change felt like an overkill 🤷 

# Demo


https://github.com/woocommerce/woocommerce-ios/assets/562080/355377e5-633d-470c-82fb-ff254264fc22

# Testing Steps

- Launch the app and navigate to the products tab
- Tap on the filter button then on the Product Type section.
- See that types that are part of an extension that you don't have installed are not selectable and have an explore button.
- Tap the explore button and see that you are redirected to the extension webpage

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
