### PR TITLE
Gift card support in order form: code scanner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardCodeScannerNavigationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardCodeScannerNavigationView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// SwiftUI view from UIKit view controller `GiftCardCodeScannerViewController`.
+struct GiftCardCodeScannerView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = GiftCardCodeScannerViewController
+
+    let onCodeScanned: (String) -> Void
+
+    func makeUIViewController(context: Context) -> GiftCardCodeScannerViewController {
+        GiftCardCodeScannerViewController(onCodeScanned: { code in
+            onCodeScanned(code)
+        })
+    }
+
+    func updateUIViewController(_ uiViewController: GiftCardCodeScannerViewController, context: Context) {
+        // no-op
+    }
+}
+
+/// `GiftCardCodeScannerViewController` in a navigation controller.
+struct GiftCardCodeScannerNavigationView: View {
+    let onCodeScanned: (String) -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        NavigationView {
+            GiftCardCodeScannerView(onCodeScanned: { code in
+                onCodeScanned(code)
+            })
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.close, action: {
+                        onClose()
+                    })
+                }
+            }
+        }
+    }
+}
+
+struct GiftCardCodeScannerNavigationView_Previews: PreviewProvider {
+    static var previews: some View {
+        GiftCardCodeScannerNavigationView(onCodeScanned: { _ in }, onClose: {})
+    }
+}
+
+private extension GiftCardCodeScannerNavigationView {
+    enum Localization {
+        static let title = NSLocalizedString("Scan gift card", comment: "Navigation bar title of the gift card code scanner.")
+        static let close = NSLocalizedString("Close", comment: "Navigation bar action to close the gift card code scanner.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Allows the user to enter a gift card code.
 struct GiftCardInputView: View {
     @StateObject private var viewModel: GiftCardInputViewModel
+    @State private var showsScanner: Bool = false
 
     init(viewModel: GiftCardInputViewModel) {
         self._viewModel = .init(wrappedValue: viewModel)
@@ -12,8 +13,25 @@ struct GiftCardInputView: View {
         NavigationView {
             Form {
                 Section {
-                    TextField(Localization.placeholder, text: $viewModel.code)
-                        .focused()
+                    HStack {
+                        TextField(Localization.placeholder, text: $viewModel.code)
+                            .focused()
+                        Spacer()
+                        Button {
+                            showsScanner = true
+                        } label: {
+                            Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                                .foregroundColor(Color(.accent))
+                        }
+                        .sheet(isPresented: $showsScanner) {
+                            GiftCardCodeScannerNavigationView(onCodeScanned: { code in
+                                viewModel.code = code
+                                showsScanner = false
+                            }, onClose: {
+                                showsScanner = false
+                            })
+                        }
+                    }
 
                     if let errorMessage = viewModel.errorMessage {
                         Text(errorMessage)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputViewModel.swift
@@ -28,10 +28,21 @@ final class GiftCardInputViewModel: ObservableObject {
     }
 }
 
+extension GiftCardInputViewModel {
+    static func isCodeValid(_ code: String) -> Bool {
+        let format = "^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$"
+
+        let regex = try? NSRegularExpression(pattern: format, options: .caseInsensitive)
+        let range = NSRange(location: 0, length: code.count)
+
+        return regex?.firstMatch(in: code, options: [], range: range) != nil
+    }
+}
+
 private extension GiftCardInputViewModel {
     func observeCodeForValidCheck() {
         $code.removeDuplicates()
-            .map { self.isCodeValid($0) }
+            .map { Self.isCodeValid($0) }
             .assign(to: &$isValid)
 
         $isValid.combineLatest($code)
@@ -39,15 +50,6 @@ private extension GiftCardInputViewModel {
                 isValid || code.isEmpty ? nil: Localization.errorMessage
             }
             .assign(to: &$errorMessage)
-    }
-
-    func isCodeValid(_ code: String) -> Bool {
-        let format = "^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$"
-
-        let regex = try? NSRegularExpression(pattern: format, options: .caseInsensitive)
-        let range = NSRange(location: 0, length: code.count)
-
-        return regex?.firstMatch(in: code, options: [], range: range) != nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -12,7 +12,7 @@ struct ScannedBarcode: Equatable, Hashable {
 /// Format of the code scanning result with a completion handler of the corresponding return type.
 enum ScannedCodeFormat {
     case barcode(completion: (Result<[ScannedBarcode], Error>) -> Void)
-    case text(completion: (Result<[String], Error>) -> Void)
+    case text(recognitionLevel: VNRequestTextRecognitionLevel?, completion: (Result<[String], Error>) -> Void)
 }
 
 /// Starts live stream video for scanning codes (barcodes or text codes).
@@ -177,9 +177,12 @@ private extension CodeScannerViewController {
                     self?.handleBarcodeDetectionResults(request: request, error: error, completion: completion)
                 }
                 requests = [barcodeRequest]
-            case let .text(completion):
+            case let .text(recognitionLevel, completion):
                 let textRequest = VNRecognizeTextRequest { [weak self] request, error in
                     self?.handleTextDetectionResults(request: request, error: error, completion: completion)
+                }
+                if let recognitionLevel {
+                    textRequest.recognitionLevel = recognitionLevel
                 }
                 requests = [textRequest]
         }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -15,9 +15,9 @@ enum ScannedCodeFormat {
     case text(completion: (Result<[String], Error>) -> Void)
 }
 
-/// Starts live stream video for scanning barcodes.
+/// Starts live stream video for scanning codes (barcodes or text codes).
 /// This view controller is meant to be embedded as a child view controller for navigation customization.
-final class BarcodeScannerViewController: UIViewController {
+final class CodeScannerViewController: UIViewController {
     @IBOutlet private weak var videoOutputImageView: UIImageView!
 
     // Subviews of `videoOutputImageView`.
@@ -71,7 +71,7 @@ final class BarcodeScannerViewController: UIViewController {
     }
 }
 
-extension BarcodeScannerViewController: AVCaptureVideoDataOutputSampleBufferDelegate {
+extension CodeScannerViewController: AVCaptureVideoDataOutputSampleBufferDelegate {
     /// Performs Vision request from live video stream.
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         // For barcode scanning, it is not necessary to perform detection on each frame. Here we throttle the sampling from the video output.
@@ -108,7 +108,7 @@ extension BarcodeScannerViewController: AVCaptureVideoDataOutputSampleBufferDele
 
 // MARK: Video Processing
 //
-private extension BarcodeScannerViewController {
+private extension CodeScannerViewController {
     /// Returns a `CIImage` for barcode detection Vision request, if available. This has to be run on the main thread due to frame access.
     /// - Parameters:
     ///   - videoSampleBuffer: sample buffer from video.
@@ -133,7 +133,7 @@ private extension BarcodeScannerViewController {
 
 // MARK: Video Setup
 //
-private extension BarcodeScannerViewController {
+private extension CodeScannerViewController {
     /// Enables and starts live stream video, if available.
     func startLiveVideo() {
         session.sessionPreset = .photo
@@ -168,7 +168,7 @@ private extension BarcodeScannerViewController {
 
 // MARK: Barcode Detection
 //
-private extension BarcodeScannerViewController {
+private extension CodeScannerViewController {
     func configureBarcodeDetection() {
         let requests: [VNRequest]
         switch format {
@@ -227,7 +227,7 @@ private extension BarcodeScannerViewController {
 
 // MARK: Configurations
 //
-private extension BarcodeScannerViewController {
+private extension CodeScannerViewController {
     func configureMainView() {
         view.backgroundColor = .basicBackground
     }
@@ -256,7 +256,7 @@ private extension BarcodeScannerViewController {
 
 // MARK: Orientation Handling
 //
-private extension BarcodeScannerViewController {
+private extension CodeScannerViewController {
     func updatePreviewLayerOrientation() {
         if let connection = previewLayer?.connection, connection.isVideoOrientationSupported {
             let orientation = view.window?.windowScene?.interfaceOrientation
@@ -282,7 +282,7 @@ private extension BarcodeScannerViewController {
     }
 }
 
-private extension BarcodeScannerViewController {
+private extension CodeScannerViewController {
     func imageOrientationFromDeviceOrientation() -> CGImagePropertyOrientation {
         let orientation = UIDevice.current.orientation
         let imageOrientation: CGImagePropertyOrientation
@@ -305,7 +305,7 @@ private extension BarcodeScannerViewController {
     }
 }
 
-private extension BarcodeScannerViewController {
+private extension CodeScannerViewController {
     enum Constants {
         static let dimmingColor = UIColor(white: 0.0, alpha: 0.5)
         static let instructionTextInsets = UIEdgeInsets(top: 11, left: 0, bottom: 11, right: 0)

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.xib
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BarcodeScannerViewController" customModule="WooCommerce" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CodeScannerViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
                 <outlet property="bottomDimmingView" destination="XpR-Bg-LX0" id="b5g-m9-dBW"/>
                 <outlet property="instructionLabel" destination="WDY-yE-Pa7" id="lA1-tM-wwa"/>

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/GiftCardCodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/GiftCardCodeScannerViewController.swift
@@ -1,0 +1,65 @@
+import UIKit
+
+/// Container view controller of gift card code scanner for an order.
+final class GiftCardCodeScannerViewController: UIViewController {
+    private lazy var codeScannerChildViewController: BarcodeScannerViewController = {
+        return BarcodeScannerViewController(instructionText: Localization.instructionText, format: .text { [weak self] result in
+            guard let self = self else { return }
+            guard self.hasDetectedCode == false else {
+                return
+            }
+            guard let code = try? result.get().first(where: {
+                self.isCodeValid($0)
+            }) else {
+                return
+            }
+            self.hasDetectedCode = true
+            self.onCodeScanned(code)
+        })
+    }()
+
+    func isCodeValid(_ code: String) -> Bool {
+        GiftCardInputViewModel.isCodeValid(code)
+    }
+
+    private let onCodeScanned: (String) -> Void
+
+    /// Tracks whether a code has been detected because the code detection callback is only handled once.
+    private var hasDetectedCode: Bool = false
+
+    init(onCodeScanned: @escaping (String) -> Void) {
+        self.onCodeScanned = onCodeScanned
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureCodeScannerChildViewController()
+    }
+}
+
+private extension GiftCardCodeScannerViewController {
+    func configureCodeScannerChildViewController() {
+        guard let contentView = codeScannerChildViewController.view else {
+            return
+        }
+        addChild(codeScannerChildViewController)
+        view.addSubview(contentView)
+        codeScannerChildViewController.didMove(toParent: self)
+
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(contentView)
+    }
+}
+
+private extension GiftCardCodeScannerViewController {
+    enum Localization {
+        static let instructionText = NSLocalizedString("Scan code like XXXX-XXXX-XXXX-XXXX",
+                                                       comment: "The instruction text below the scan area in the barcode scanner for product SKU.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/GiftCardCodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/GiftCardCodeScannerViewController.swift
@@ -3,7 +3,8 @@ import UIKit
 /// Container view controller of gift card code scanner for an order.
 final class GiftCardCodeScannerViewController: UIViewController {
     private lazy var codeScannerChildViewController: CodeScannerViewController = {
-        return CodeScannerViewController(instructionText: Localization.instructionText, format: .text { [weak self] result in
+        return CodeScannerViewController(instructionText: Localization.instructionText,
+                                         format: .text(recognitionLevel: .accurate) { [weak self] result in
             guard let self = self else { return }
             guard self.hasDetectedCode == false else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/GiftCardCodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/GiftCardCodeScannerViewController.swift
@@ -2,8 +2,8 @@ import UIKit
 
 /// Container view controller of gift card code scanner for an order.
 final class GiftCardCodeScannerViewController: UIViewController {
-    private lazy var codeScannerChildViewController: BarcodeScannerViewController = {
-        return BarcodeScannerViewController(instructionText: Localization.instructionText, format: .text { [weak self] result in
+    private lazy var codeScannerChildViewController: CodeScannerViewController = {
+        return CodeScannerViewController(instructionText: Localization.instructionText, format: .text { [weak self] result in
             guard let self = self else { return }
             guard self.hasDetectedCode == false else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
@@ -2,8 +2,8 @@ import UIKit
 
 /// Container view controller of barcode scanner for product SKU input.
 final class ProductSKUInputScannerViewController: UIViewController {
-    private lazy var barcodeScannerChildViewController: BarcodeScannerViewController = {
-        return BarcodeScannerViewController(instructionText: Localization.instructionText,
+    private lazy var barcodeScannerChildViewController: CodeScannerViewController = {
+        return CodeScannerViewController(instructionText: Localization.instructionText,
                                             format: .barcode { [weak self] result in
             guard let self = self else { return }
             guard self.hasDetectedBarcode == false else {

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
@@ -3,7 +3,8 @@ import UIKit
 /// Container view controller of barcode scanner for product SKU input.
 final class ProductSKUInputScannerViewController: UIViewController {
     private lazy var barcodeScannerChildViewController: BarcodeScannerViewController = {
-        return BarcodeScannerViewController(instructionText: Localization.instructionText) { [weak self] result in
+        return BarcodeScannerViewController(instructionText: Localization.instructionText,
+                                            format: .barcode { [weak self] result in
             guard let self = self else { return }
             guard self.hasDetectedBarcode == false else {
                 return
@@ -13,7 +14,7 @@ final class ProductSKUInputScannerViewController: UIViewController {
             }
             self.hasDetectedBarcode = true
             self.onBarcodeScanned(barcode)
-        }
+        })
     }()
 
     private let onBarcodeScanned: (ScannedBarcode) -> Void

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -240,9 +240,9 @@
 		025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */; };
 		025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1749237AA49D00C780B4 /* Product+ProductForm.swift */; };
 		025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */; };
-		025C00692550DE4700FAC222 /* BarcodeScannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 025C00652550DE4700FAC222 /* BarcodeScannerViewController.xib */; };
+		025C00692550DE4700FAC222 /* CodeScannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 025C00652550DE4700FAC222 /* CodeScannerViewController.xib */; };
 		025C006A2550DE4700FAC222 /* ProductSKUInputScannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */; };
-		025C006B2550DE4700FAC222 /* BarcodeScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00672550DE4700FAC222 /* BarcodeScannerViewController.swift */; };
+		025C006B2550DE4700FAC222 /* CodeScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00672550DE4700FAC222 /* CodeScannerViewController.swift */; };
 		025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00B925514A7100FAC222 /* BarcodeScannerFrameScaler.swift */; };
 		025C00CC2551524300FAC222 /* BarcodeScannerFrameScalerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00CB2551524300FAC222 /* BarcodeScannerFrameScalerTests.swift */; };
 		025CA1A62887D17A00CCBB25 /* LoggedOutAppSettingsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA1A52887D17A00CCBB25 /* LoggedOutAppSettingsProtocol.swift */; };
@@ -2733,9 +2733,9 @@
 		025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormSection+ReusableTableRow.swift"; sourceTree = "<group>"; };
 		025B1749237AA49D00C780B4 /* Product+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductForm.swift"; sourceTree = "<group>"; };
 		025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductSKUInputScannerViewController.swift; sourceTree = "<group>"; };
-		025C00652550DE4700FAC222 /* BarcodeScannerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BarcodeScannerViewController.xib; sourceTree = "<group>"; };
+		025C00652550DE4700FAC222 /* CodeScannerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CodeScannerViewController.xib; sourceTree = "<group>"; };
 		025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductSKUInputScannerViewController.xib; sourceTree = "<group>"; };
-		025C00672550DE4700FAC222 /* BarcodeScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarcodeScannerViewController.swift; sourceTree = "<group>"; };
+		025C00672550DE4700FAC222 /* CodeScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeScannerViewController.swift; sourceTree = "<group>"; };
 		025C00B925514A7100FAC222 /* BarcodeScannerFrameScaler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerFrameScaler.swift; sourceTree = "<group>"; };
 		025C00CB2551524300FAC222 /* BarcodeScannerFrameScalerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerFrameScalerTests.swift; sourceTree = "<group>"; };
 		025CA1A52887D17A00CCBB25 /* LoggedOutAppSettingsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutAppSettingsProtocol.swift; sourceTree = "<group>"; };
@@ -5578,8 +5578,8 @@
 		025C00572550DDDD00FAC222 /* SKU Scanner */ = {
 			isa = PBXGroup;
 			children = (
-				025C00672550DE4700FAC222 /* BarcodeScannerViewController.swift */,
-				025C00652550DE4700FAC222 /* BarcodeScannerViewController.xib */,
+				025C00672550DE4700FAC222 /* CodeScannerViewController.swift */,
+				025C00652550DE4700FAC222 /* CodeScannerViewController.xib */,
 				025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */,
 				025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */,
 				02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */,
@@ -11702,7 +11702,7 @@
 				D89CFFDE25B44468000E4683 /* ULAccountMismatchViewController.xib in Resources */,
 				452FE64C25657EC100EB54A0 /* LinkedProductsViewController.xib in Resources */,
 				0286B27A23C7051F003D784B /* ProductImagesCollectionViewController.xib in Resources */,
-				025C00692550DE4700FAC222 /* BarcodeScannerViewController.xib in Resources */,
+				025C00692550DE4700FAC222 /* CodeScannerViewController.xib in Resources */,
 				4512055324655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib in Resources */,
 				B59D1EE821908A08009D1978 /* Noticons.ttf in Resources */,
 				D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */,
@@ -13307,7 +13307,7 @@
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,
 				26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */,
 				02279587237A50C900787C63 /* AztecHeaderFormatBarCommand.swift in Sources */,
-				025C006B2550DE4700FAC222 /* BarcodeScannerViewController.swift in Sources */,
+				025C006B2550DE4700FAC222 /* CodeScannerViewController.swift in Sources */,
 				09885C8727C6947A00910A62 /* ProductPriceSettingsValidator.swift in Sources */,
 				02D7E7C12A4CA9030003049A /* LocalAnnouncementsProvider.swift in Sources */,
 				A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -269,6 +269,8 @@
 		02645D8A27BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8927BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift */; };
 		02645D8C27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8B27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift */; };
 		02660504293D8D24004084EA /* PaymentCaptureCelebration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02660503293D8D24004084EA /* PaymentCaptureCelebration.swift */; };
+		02667A1A2ABDD44200C77B56 /* GiftCardCodeScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02667A192ABDD44200C77B56 /* GiftCardCodeScannerViewController.swift */; };
+		02667A1C2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02667A1B2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */; };
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
@@ -539,8 +541,8 @@
 		02EEB5C42424AFAA00B8A701 /* TextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */; };
 		02EEB5C52424AFAA00B8A701 /* TextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */; };
 		02EF166C292DFE9A00D90AD6 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */; };
-		02EFF81A2ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */; };
 		02EFF8172ABBEBED0015ABB2 /* GiftCardError+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */; };
+		02EFF81A2ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */; };
 		02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */; };
 		02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */; };
 		02F3A6842A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift */; };
@@ -2760,6 +2762,8 @@
 		02645D8927BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+AttributesTests.swift"; sourceTree = "<group>"; };
 		02645D8B27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNoteRowViewModelTests.swift; sourceTree = "<group>"; };
 		02660503293D8D24004084EA /* PaymentCaptureCelebration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCaptureCelebration.swift; sourceTree = "<group>"; };
+		02667A192ABDD44200C77B56 /* GiftCardCodeScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardCodeScannerViewController.swift; sourceTree = "<group>"; };
+		02667A1B2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardCodeScannerNavigationView.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
@@ -3031,8 +3035,8 @@
 		02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewCell.swift; sourceTree = "<group>"; };
 		02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextFieldTableViewCell.xib; sourceTree = "<group>"; };
 		02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
-		02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardInputViewModelTests.swift; sourceTree = "<group>"; };
 		02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GiftCardError+Description.swift"; sourceTree = "<group>"; };
+		02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardInputViewModelTests.swift; sourceTree = "<group>"; };
 		02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAICoordinatorTests.swift; sourceTree = "<group>"; };
 		02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPurchaseSuccessView.swift; sourceTree = "<group>"; };
 		02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMediaLibraryImagePickerCoordinator.swift; sourceTree = "<group>"; };
@@ -5582,6 +5586,7 @@
 				02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */,
 				B90DACBF2A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift */,
 				B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */,
+				02667A192ABDD44200C77B56 /* GiftCardCodeScannerViewController.swift */,
 			);
 			path = "SKU Scanner";
 			sourceTree = "<group>";
@@ -9228,6 +9233,7 @@
 				B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */,
 				02A723252AB2E1A6003AEC7E /* GiftCardInputView.swift */,
 				02A723272AB2E1C2003AEC7E /* GiftCardInputViewModel.swift */,
+				02667A1B2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift */,
 			);
 			path = PaymentSection;
 			sourceTree = "<group>";
@@ -12248,6 +12254,7 @@
 				03B9E5212A13971F005C77F5 /* TapToPayReconnectionController.swift in Sources */,
 				26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
+				02667A1C2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,
 				027EB56E29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift in Sources */,
@@ -12708,6 +12715,7 @@
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
 				263EAF9A2A15D513008C66CB /* PrivacyBannerViewModel.swift in Sources */,
 				EE45E29F2A381A2E0085F227 /* ProductDescriptionGenerationCelebrationViewModel.swift in Sources */,
+				02667A1A2ABDD44200C77B56 /* GiftCardCodeScannerViewController.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				B9E4364C287587D300883CFA /* FeatureAnnouncementCardView.swift in Sources */,
 				267F60132A0C24D700CD1E4E /* PrivacyBannerViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10518 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The gift card consists of 16 characters with 3 dashes in between and could be time-consuming for a merchant to type manually. From a time-boxed effort, we can adapt the existing `BarcodeScannerViewController` to support text recognition other than barcodes to be a gift card code scanner.

## How

`BarcodeScannerViewController` was renamed to `CodeScannerViewController` to allow more flexible code types than just barcodes. To allow the text code type, an enum was created `ScannedCodeFormat` and the pre-existing usage is the `barcode` case with minimal changes. Each enum case has a completion handler when a code is detected.

Then a new `GiftCardCodeScannerViewController` was created as a wrapper of the `CodeScannerViewController` child view controller, and the SwiftUI view with navigation bar support is in `GiftCardCodeScannerNavigationView`. When the view controller receives a list of scanned text strings, it checks if the code is in the gift card code format reusing `GiftCardInputViewModel`'s code check function in a static function now.

For the UI changes, a scan button was added to the text field row in `GiftCardInputView` that shows a sheet of `GiftCardCodeScannerNavigationView` when it's tapped.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the site has the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension/plugin, and at least one gift card code available with some remaining amount.

📱 For camera support, please test this on a physical device.

- Switch to a store with the Gift Cards plugin if needed
- Go to the Orders tab
- Tap `+` in the navigation bar
- Tap `Add Gift Card`
- Tap the scan button
- Scan the gift card code (in the gift card email, or in wp-admin)
  - 🗒️ I noticed the gift card email goes to the Spam folder for the store admin email account since the email can't be sent. You can check the Spam folder if you don't find the gift card email

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/080ed946-c0ee-4ca6-a798-bc35c91e0b6d

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/70a907e1-942c-4183-b195-61bdba47b7c3" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
