### PR TITLE
Product Creation AI: Save product as draft

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -286,7 +286,7 @@ private extension AddProductCoordinator {
                                                                                          onCompletion: { [weak self] product in
             self?.onProductCreated(product)
             self?.navigationController.dismiss(animated: true) {
-                self?.presentProduct(product)
+                self?.presentProduct(product, formType: .edit)
             }
         }))
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
@@ -294,7 +294,7 @@ private extension AddProductCoordinator {
 
     /// Presents a product onto the current navigation stack.
     ///
-    func presentProduct(_ product: Product) {
+    func presentProduct(_ product: Product, formType: ProductFormType = .add) {
         let model = EditableProductModel(product: product)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
@@ -304,7 +304,7 @@ private extension AddProductCoordinator {
                                       isLocalID: true),
                            originalStatuses: model.imageStatuses)
         let viewModel = ProductFormViewModel(product: model,
-                                             formType: .add,
+                                             formType: formType,
                                              productImageActionHandler: productImageActionHandler)
         viewModel.onProductCreated = { [weak self] product in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -284,8 +284,10 @@ private extension AddProductCoordinator {
             self?.navigationController.dismiss(animated: true)
         },
                                                                                          onCompletion: { [weak self] product in
-            // TODO: Product saved
             self?.onProductCreated(product)
+            self?.navigationController.dismiss(animated: true) {
+                self?.presentProduct(product)
+            }
         }))
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -15,7 +15,6 @@ final class AddProductFromImageCoordinator: Coordinator {
     private let siteID: Int64
     private let source: AddProductCoordinator.Source
     private let productName: String?
-    private let productImageUploader: ProductImageUploaderProtocol
     private let productImageLoader: ProductUIImageLoader
 
     /// Invoked when AI generates product data from image
@@ -25,14 +24,12 @@ final class AddProductFromImageCoordinator: Coordinator {
          source: AddProductCoordinator.Source,
          productName: String?,
          sourceNavigationController: UINavigationController,
-         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
          onAIGenerationCompleted: @escaping (AddProductFromImageData?) -> Void) {
         self.siteID = siteID
         self.source = source
         self.productName = productName
         self.navigationController = sourceNavigationController
-        self.productImageUploader = productImageUploader
         self.productImageLoader = productImageLoader
         self.onAIGenerationCompleted = onAIGenerationCompleted
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageView.swift
@@ -96,11 +96,15 @@ struct AddProductFromImageView: View {
         .navigationTitle(Localization.title)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button(Localization.continueButtonTitle) {
-                    viewModel.trackContinueButtonTapped()
-                    completion(.init(name: viewModel.name, description: viewModel.description, image: viewModel.image))
+                if viewModel.isGeneratingDetails {
+                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                } else {
+                    Button(Localization.continueButtonTitle) {
+                        viewModel.trackContinueButtonTapped()
+                        completion(.init(name: viewModel.name, description: viewModel.description, image: viewModel.image))
+                    }
+                    .buttonStyle(LinkButtonStyle())
                 }
-                .buttonStyle(LinkButtonStyle())
             }
             ToolbarItem(placement: .cancellationAction) {
                 Button(Localization.cancelButtonTitle) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -80,8 +80,7 @@ struct AddProductWithAIContainerView: View {
                 ProductDetailPreviewView(viewModel: .init(siteID: viewModel.siteID,
                                                           productName: viewModel.productName,
                                                           productDescription: viewModel.productDescription,
-                                                          productFeatures: viewModel.productFeatures,
-                                                          packagingImage: viewModel.packagingImage) { product in
+                                                          productFeatures: viewModel.productFeatures) { product in
                     viewModel.didCreateProduct(product)
                 })
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -81,7 +81,9 @@ struct AddProductWithAIContainerView: View {
                                                           productName: viewModel.productName,
                                                           productDescription: viewModel.productDescription,
                                                           productFeatures: viewModel.productFeatures,
-                                                          packagingImage: viewModel.packagingImage))
+                                                          packagingImage: viewModel.packagingImage) { product in
+                    viewModel.didCreateProduct(product)
+                })
             }
         }
         .onAppear() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -60,10 +60,17 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         currentStep = .preview
     }
 
+    func didCreateProduct(_ product: Product) {
+        completionHandler(product)
+    }
+
     func didGenerateDataFromPackage(_ data: AddProductFromImageData?) {
-        productName = data?.name ?? ""
-        productDescription = data?.description
-        packagingImage = data?.image
+        guard let data else {
+            return
+        }
+        productName = data.name
+        productDescription = data.description
+        packagingImage = data.image
         currentStep = .preview
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -30,7 +30,6 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private(set) var productName: String = ""
     private(set) var productFeatures: String = ""
     private(set) var productDescription: String?
-    private(set) var packagingImage: MediaPickerImage?
 
     @Published private(set) var currentStep: AddProductWithAIStep = .productName
 
@@ -70,7 +69,6 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         }
         productName = data.name
         productDescription = data.description
-        packagingImage = data.image
         currentStep = .preview
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -128,9 +128,6 @@ struct ProductDetailPreviewView: View {
                     await viewModel.generateProductDetails()
                 }
             }
-            .onDisappear {
-                viewModel.onDisappear()
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -215,7 +215,7 @@ fileprivate extension ProductDetailPreviewView {
             comment: "Title on the add product with AI Preview screen."
         )
         static let subtitle = NSLocalizedString(
-            "Don't worry. You can always change below details later.",
+            "You can always change the below details later.",
             comment: "Subtitle on the add product with AI Preview screen."
         )
         static let feedbackQuestion = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -112,11 +112,13 @@ struct ProductDetailPreviewView: View {
             .padding(insets: Layout.insets)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
-                    if viewModel.isGeneratingDetails {
+                    if viewModel.isGeneratingDetails || viewModel.isSavingProduct {
                         ActivityIndicator(isAnimating: .constant(true), style: .medium)
                     } else {
                         Button(Localization.saveAsDraft) {
-                            viewModel.saveProductAsDraft()
+                            Task {
+                                await viewModel.saveProductAsDraft()
+                            }
                         }
                     }
                 }
@@ -125,6 +127,9 @@ struct ProductDetailPreviewView: View {
                 Task {
                     await viewModel.generateProductDetails()
                 }
+            }
+            .onDisappear {
+                viewModel.onDisappear()
             }
         }
     }
@@ -270,6 +275,6 @@ struct ProductDetailPreviewView_Previews: PreviewProvider {
         ProductDetailPreviewView(viewModel: .init(siteID: 123,
                                                   productName: "iPhone 15",
                                                   productDescription: "New smart phone",
-                                                  productFeatures: nil))
+                                                  productFeatures: nil) { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -21,7 +21,6 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     @Published private(set) var productShippingDetails: String?
 
     private let productFeatures: String?
-    private let packagingImage: MediaPickerImage?
 
     private let siteID: Int64
     private let stores: StoresManager
@@ -46,7 +45,6 @@ final class ProductDetailPreviewViewModel: ObservableObject {
          productName: String,
          productDescription: String?,
          productFeatures: String?,
-         packagingImage: MediaPickerImage? = nil,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          weightUnit: String? = ServiceLocator.shippingSettingsService.weightUnit,
@@ -71,7 +69,6 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         self.productName = productName
         self.productDescription = productDescription
         self.productFeatures = productFeatures
-        self.packagingImage = packagingImage
         self.productImageUploader = productImageUploader
 
         observeGeneratedProduct()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -90,7 +90,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         isGeneratingDetails = true
         try? await Task.sleep(nanoseconds: 1_000_000_000)
         #if canImport(SwiftUI) && DEBUG
-        generatedProduct = Product.swiftUIPreviewSample().copy(siteID: siteID)
+        generatedProduct = Product.swiftUIPreviewSample().copy(siteID: siteID, productID: 0)
         #endif
         isGeneratingDetails = false
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10766
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the product creation AI flow with the implementation for saving product and uploading packaging images. Detailed changes include:
- `ProductDetailPreviewViewModel`: 
  - ~~Handled background image uploads with local product ID immediately when "Save as draft" is tapped. I'm using 0 as the ID as this seems to be the default ID used for the product form too, but I'm not sure if I understand correctly. Let me know what you think.~~ (removed because we don't upload images anymore).
  - Integrated product creation to save the new product remotely.
  - Updated the product when all images are uploaded.
  - ~~Canceled background image upload when the view is dismissed.~~
  - Updated the UI to show an activity indicator when the upload is in progress.
- `AddProductWithAIContainerViewModel`:
  - Added callback handling from the preview view to trigger the completion closure.
  - Prevented showing the preview screen when the packaging image flow is dismissed.
- Updated `AddProductCoordinator` to dismiss the form and present the created product upon completion.
- Updated `AddProductFromImageView` to show an activity indicator when product details are being generated.

Since the product generation step is still mocked, a fake product is currently used for testing. Unit tests will be added after the product generation is implemented.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select add product with AI.
- Enter any product name and features to get to the preview screen.
- Notice that the UI displays sample data from [swiftUIPreviewSample](https://github.com/woocommerce/woocommerce-ios/blob/bdba4f3fc7003931e2347bb7125336f1af53089e/WooCommerce/Classes/Extensions/Product%2BSwiftUIPreviewHelpers.swift#L7).
- Tap Save as draft, after the product is created, the form should be dismissed and the new product form is displayed with the sample data.
- ~~Try again with the package image flow, notice that the package image is uploaded and displayed in the created product form.~~

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/959a84f5-4dc5-4f8c-874d-f01bacafbb37



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
