### PR TITLE
Product Creation AI: Error handling for preview screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -7,7 +7,7 @@ final class AddProductFeaturesViewModel: ObservableObject {
     let siteID: Int64
     let productName: String
 
-    @Published var productFeatures: String = ""
+    @Published var productFeatures: String
 
     private let stores: StoresManager
     private let analytics: Analytics
@@ -16,11 +16,13 @@ final class AddProductFeaturesViewModel: ObservableObject {
 
     init(siteID: Int64,
          productName: String,
+         productFeatures: String? = nil,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping (String) -> Void) {
         self.siteID = siteID
         self.productName = productName
+        self.productFeatures = productFeatures ?? ""
         self.stores = stores
         self.analytics = analytics
         self.onCompletion = onCompletion

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -3,7 +3,7 @@ import Foundation
 /// View model for `AddProductNameWithAIView`.
 ///
 final class AddProductNameWithAIViewModel: ObservableObject {
-    @Published var productNameContent: String = ""
+    @Published var productNameContent: String
 
     let siteID: Int64
     private let onUsePackagePhoto: (String?) -> Void
@@ -17,11 +17,13 @@ final class AddProductNameWithAIViewModel: ObservableObject {
     }
 
     init(siteID: Int64,
+         initialName: String = "",
          onUsePackagePhoto: @escaping (String?) -> Void,
          onContinueWithProductName: @escaping (String) -> Void) {
         self.siteID = siteID
         self.onUsePackagePhoto = onUsePackagePhoto
         self.onContinueWithProductName = onContinueWithProductName
+        self.productNameContent = initialName
     }
 
     func didTapUsePackagePhoto() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -63,6 +63,7 @@ struct AddProductWithAIContainerView: View {
             switch viewModel.currentStep {
             case .productName:
                 AddProductNameWithAIView(viewModel: .init(siteID: viewModel.siteID,
+                                                          initialName: viewModel.productName,
                                                           onUsePackagePhoto: onUsePackagePhoto,
                                                           onContinueWithProductName: { name in
                     withAnimation {
@@ -71,7 +72,8 @@ struct AddProductWithAIContainerView: View {
                 }))
             case .aboutProduct:
                 AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
-                                                        productName: viewModel.productName) { features in
+                                                        productName: viewModel.productName,
+                                                        productFeatures: viewModel.productFeatures) { features in
                     withAnimation {
                         viewModel.onProductFeaturesAdded(features: features)
                     }
@@ -82,6 +84,8 @@ struct AddProductWithAIContainerView: View {
                                                           productDescription: viewModel.productDescription,
                                                           productFeatures: viewModel.productFeatures) { product in
                     viewModel.didCreateProduct(product)
+                }, onDismiss: {
+                    viewModel.backtrackOrDismiss()
                 })
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -80,9 +80,3 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         }
     }
 }
-
-private extension AddProductWithAIContainerViewModel {
-    func handleCompletion() {
-        // TODO: Fire completion handler with created product
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -101,7 +101,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
             isGeneratingDetails = false
         } catch {
             DDLogError("⛔️ Error generating product with AI: \(error)")
-            errorState = .generatingProduct(errorMessage: Localization.errorGenerating)
+            errorState = .generatingProduct
         }
     }
 
@@ -117,7 +117,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
             onProductCreated(newProduct)
         } catch {
             DDLogError("⛔️ Error saving product with AI: \(error)")
-            errorState = .savingProduct(errorMessage: Localization.errorSaving)
+            errorState = .savingProduct
         }
         isSavingProduct = false
     }
@@ -273,16 +273,17 @@ private extension ProductDetailPreviewViewModel {
 extension ProductDetailPreviewViewModel {
     enum ErrorState: Equatable {
         case none
-        case generatingProduct(errorMessage: String)
-        case savingProduct(errorMessage: String)
+        case generatingProduct
+        case savingProduct
 
         var errorMessage: String {
             switch self {
             case .none:
                 return ""
-            case .generatingProduct(let errorMessage),
-                    .savingProduct(let errorMessage):
-                return errorMessage
+            case .generatingProduct:
+                return Localization.errorGenerating
+            case .savingProduct:
+                return Localization.errorSaving
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -19,7 +19,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     @Published private(set) var productCategories: String?
     @Published private(set) var productTags: String?
     @Published private(set) var productShippingDetails: String?
-    @Published private(set) var errorMessage: String?
+    @Published private(set) var errorState: ErrorState = .none
 
     private let productFeatures: String?
 
@@ -91,18 +91,18 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     @MainActor
     func generateProductDetails() async {
         isGeneratingDetails = true
-        errorMessage = nil
+        errorState = .none
         do {
             let language = try await identifyLanguage()
             let aiTone = userDefaults.aiTone(for: siteID)
             let product = try await generateProduct(language: language,
                                                     tone: aiTone)
             generatedProduct = product
+            isGeneratingDetails = false
         } catch {
-            errorMessage = error.localizedDescription
-            // TODO: Error handling
+            DDLogError("⛔️ Error generating product with AI: \(error)")
+            errorState = .generatingProduct(errorMessage: Localization.errorGenerating)
         }
-        isGeneratingDetails = false
     }
 
     @MainActor
@@ -110,13 +110,14 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         guard let generatedProduct else {
             return
         }
+        errorState = .none
         isSavingProduct = true
         do {
             let newProduct = try await saveProductRemotely(product: generatedProduct)
             onProductCreated(newProduct)
         } catch {
-            // TODO: error handling
             DDLogError("⛔️ Error saving product with AI: \(error)")
+            errorState = .savingProduct(errorMessage: Localization.errorSaving)
         }
         isSavingProduct = false
     }
@@ -267,6 +268,26 @@ private extension ProductDetailPreviewViewModel {
     }
 }
 
+// MARK: - Subtypes
+//
+extension ProductDetailPreviewViewModel {
+    enum ErrorState: Equatable {
+        case none
+        case generatingProduct(errorMessage: String)
+        case savingProduct(errorMessage: String)
+
+        var errorMessage: String {
+            switch self {
+            case .none:
+                return ""
+            case .generatingProduct(let errorMessage),
+                    .savingProduct(let errorMessage):
+                return errorMessage
+            }
+        }
+    }
+}
+
 private extension ProductDetailPreviewViewModel {
     enum Localization {
         static let virtualProductType = NSLocalizedString("Virtual", comment: "Display label for simple virtual product type.")
@@ -282,6 +303,15 @@ private extension ProductDetailPreviewViewModel {
                                                            comment: "Format of 2 dimensions on the Shipping Settings row - dimension x dimension[unit]")
         static let fullDimensionsFormat = NSLocalizedString("Dimensions: %1$@ x %2$@ x %3$@ %4$@",
                                                             comment: "Format of all 3 dimensions on the Shipping Settings row - L x W x H[unit]")
+        // Error messages
+        static let errorGenerating = NSLocalizedString(
+            "There was an error generating product details. Please try again.",
+            comment: "Error message when generating product details fails on the add product with AI Preview screen."
+        )
+        static let errorSaving = NSLocalizedString(
+            "There was an error saving product details. Please try again.",
+            comment: "Error message when saving product as draft on the add product with AI Preview screen."
+        )
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2143,6 +2143,7 @@
 		DE50295728BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */; };
+		DE5C19C72AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */; };
 		DE5FBB912A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */; };
 		DE5FBB932A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */; };
 		DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */; };
@@ -4656,6 +4657,7 @@
 		DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentialsAuthenticatorTests.swift; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModelTests.swift; sourceTree = "<group>"; };
+		DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModelTests.swift; sourceTree = "<group>"; };
 		DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Authenticated.swift"; sourceTree = "<group>"; };
@@ -11000,6 +11002,7 @@
 				DE8BEB8D2ABAC96700F5E56C /* ProductNameGenerationViewModelTests.swift */,
 				EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */,
 				DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */,
+				DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */,
 			);
 			path = AddProductWithAI;
 			sourceTree = "<group>";
@@ -13948,6 +13951,7 @@
 				5767E940256D9A4A00CFA652 /* OrderListViewModelTests.swift in Sources */,
 				26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */,
 				09EA565227C8235200407D40 /* ProductPriceSettingsValidatorTests.swift in Sources */,
+				DE5C19C72AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift in Sources */,
 				02490D1C284EEFC2002096EF /* ProductImageUploaderTests.swift in Sources */,
 				D8F01DD325DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift in Sources */,
 				020BE76F23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2142,6 +2142,7 @@
 		DE50295328BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295228BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift */; };
 		DE50295728BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
+		DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */; };
 		DE5FBB912A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */; };
 		DE5FBB932A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */; };
 		DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */; };
@@ -4654,6 +4655,7 @@
 		DE50295228BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentialsAuthenticatorTests.swift; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
+		DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModelTests.swift; sourceTree = "<group>"; };
 		DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Authenticated.swift"; sourceTree = "<group>"; };
@@ -10997,6 +10999,7 @@
 				EE5B5BB52AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift */,
 				DE8BEB8D2ABAC96700F5E56C /* ProductNameGenerationViewModelTests.swift */,
 				EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */,
+				DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */,
 			);
 			path = AddProductWithAI;
 			sourceTree = "<group>";
@@ -13567,6 +13570,7 @@
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				035BA3A8291000E90056F0AD /* JustInTimeMessageViewModelTests.swift in Sources */,
+				DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */,
 				023EC2E624DAB1270021DA91 /* EditableProductVariationModelTests.swift in Sources */,
 				09BE3A9127C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift in Sources */,
 				095A077E27CF486C007A61D2 /* ValueOneTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeaturesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeaturesViewModelTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import WooCommerce
+
+final class AddProductFeaturesViewModelTests: XCTestCase {
+
+    func test_productFeatures_is_updated_with_initial_features() {
+        // Given
+        let expectedFeatures = "Fancy new smart phone"
+        let viewModel = AddProductFeaturesViewModel(siteID: 123,
+                                                    productName: "iPhone 15",
+                                                    productFeatures: expectedFeatures,
+                                                    onCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.productFeatures, expectedFeatures)
+    }
+
+    func test_proceedToPreview_triggers_onCompletion() {
+        // Given
+        var triggeredFeatures: String?
+        let expectedFeatures = "Fancy new smart phone"
+        let viewModel = AddProductFeaturesViewModel(siteID: 123,
+                                                    productName: "iPhone 15",
+                                                    onCompletion: { triggeredFeatures = $0 })
+
+        // When
+        viewModel.productFeatures = expectedFeatures
+        viewModel.proceedToPreview()
+
+        // Then
+        XCTAssertEqual(triggeredFeatures, expectedFeatures)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class AddProductNameWithAIViewModelTests: XCTestCase {
+
+    func test_productNameContent_is_updated_correctly_with_initialName() {
+        // Given
+        let expectedName = "iPhone 15"
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123, initialName: expectedName, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.productNameContent, expectedName)
+    }
+
+    func test_onUsePackagePhoto_is_triggered_when_tapping_package_photo() {
+        // Given
+        var triggeredName: String?
+        let expectedName = "iPhone 15"
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123,
+                                                      initialName: expectedName,
+                                                      onUsePackagePhoto: { triggeredName = $0 },
+                                                      onContinueWithProductName: { _ in })
+
+        // When
+        viewModel.didTapUsePackagePhoto()
+
+        // Then
+        XCTAssertEqual(triggeredName, expectedName)
+    }
+
+    func test_onContinueWithProductName_is_triggered_when_tapping_continue() {
+        // Given
+        var triggeredName: String?
+        let expectedName = "iPhone 15"
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123,
+                                                      initialName: expectedName,
+                                                      onUsePackagePhoto: { _ in },
+                                                      onContinueWithProductName: { triggeredName = $0 })
+
+        // When
+        viewModel.didTapContinue()
+
+        // Then
+        XCTAssertEqual(triggeredName, expectedName)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -167,7 +167,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isGeneratingDetails)
     }
 
-    func test_errorMessage_is_updated_when_generateProductDetails_fails() async throws {
+    func test_errorState_is_updated_when_generateProductDetails_fails() async throws {
         // Given
         let siteID: Int64 = 123
 
@@ -188,15 +188,16 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
+        XCTAssertEqual(viewModel.errorState, .none)
 
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                XCTAssertNil(viewModel.errorMessage)
+                XCTAssertEqual(viewModel.errorState, .none)
                 completion(.failure(expectedError))
             case let .identifyLanguage(_, _, _, completion):
-                XCTAssertNil(viewModel.errorMessage)
+                XCTAssertEqual(viewModel.errorState, .none)
                 completion(.success("en"))
             default:
                 break
@@ -205,7 +206,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         await viewModel.generateProductDetails()
 
         // Then
-        XCTAssertEqual(viewModel.errorMessage, expectedError.localizedDescription)
+        XCTAssertEqual(viewModel.errorState, .generatingProduct)
     }
 
     func test_generateProductDetails_updates_generatedProduct_correctly() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10782 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds error handling for generating product details and saving product as draft on the preview screen of the product creation AI flow. 

Also, initial values have also been added to the product name and features screens to make sure the values are there when navigating back. There's an issue (#10784) that the packaging photo screen is not displayed when dismissing the preview screen - we'll need to handle that in a future PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select add product with AI.
- Enter any product name and features to get to the preview screen.
- Turn off the Internet connection and tap Continue. After loading for a while, an alert should be displayed with the message about generating product. Notice that the skeleton view is still displayed.
- Tap Cancel to navigate back to the previous screen. Enable the connection and tap Continue.
- After product details are generated successfully, disable the connection again and tap Save as draft.
- An alert should be displayed after a while with a message about saving product. The loading view should be hidden in this case.
- Enable the connection again and tap Retry. This time the request should succeed and you should be navigated to the product form with the correct product details.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="348" alt="Screenshot 2023-09-27 at 11 37 21" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/ff63373d-b552-4c7a-bb26-8627c87548a7">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
