### PR TITLE
Product Creation AI: Update mock data for UI test to make mock store ineligible for the feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -96,7 +96,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .manualTaxesInOrderM3:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productCreationAI:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .giftCardInOrderForm:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         default:

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_sites.json
@@ -63,7 +63,7 @@
                         "blog_public": 1,
                         "admin_url": "http:\/\/yourwoosite.com/wp-admin/",
                         "login_url": "http:\/\/yourwoosite.com/wp-login.php",
-                        "is_wpcom_store": true,
+                        "is_wpcom_store": false,
                         "woocommerce_is_active": true,
                         "can_blaze": false,
                         "jetpack_version": "8.1.1",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10688 
Closes: #10788
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The new product creation sheet with the AI option breaks some UI tests for product creation, so this PR fixes that by simply making the mock store ineligible for product creation AI. This was done by making the store non-wpcom and since it doesn't contain the AI assistant feature, the product creation with AI action sheet will not be displayed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
UI tests should all pass.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
