### PR TITLE
Product creation AI: Track events for the product name generation flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
@@ -2,6 +2,10 @@ import Foundation
 
 extension WooAnalyticsEvent {
     enum ProductNameAI {
+        enum EntryPointSource: String {
+            case productCreationAI = "product_creation_ai"
+        }
+
         private enum Key: String {
             case source = "source"
             case isRetry = "is_retry"
@@ -9,9 +13,12 @@ extension WooAnalyticsEvent {
             case language = "language"
         }
 
-        static func entryPointTapped(hasInputName: Bool) -> WooAnalyticsEvent {
+        static func entryPointTapped(hasInputName: Bool, source: EntryPointSource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productNameAIEntryPointTapped,
-                              properties: [Key.hasInputName.rawValue: hasInputName])
+                              properties: [
+                                Key.hasInputName.rawValue: hasInputName,
+                                Key.source.rawValue: source.rawValue
+                              ])
         }
 
         static func generateButtonTapped(isRetry: Bool) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
@@ -5,13 +5,13 @@ extension WooAnalyticsEvent {
         private enum Key: String {
             case source = "source"
             case isRetry = "is_retry"
-            case withMessage = "with_message"
+            case hasInputName = "has_input_name"
             case language = "language"
         }
 
-        static func entryPointTapped() -> WooAnalyticsEvent {
+        static func entryPointTapped(hasInputName: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productNameAIEntryPointTapped,
-                              properties: [:])
+                              properties: [Key.hasInputName.rawValue: hasInputName])
         }
 
         static func generateButtonTapped(isRetry: Bool) -> WooAnalyticsEvent {
@@ -21,7 +21,7 @@ extension WooAnalyticsEvent {
 
         static func copyButtonTapped(withMessage: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productNameAICopyButtonTapped,
-                              properties: [Key.withMessage.rawValue: withMessage])
+                              properties: [:])
         }
 
         static func applyButtonTapped() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
@@ -32,7 +32,7 @@ extension WooAnalyticsEvent {
         }
 
         static func applyButtonTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productNameAICopyButtonTapped,
+            WooAnalyticsEvent(statName: .productNameAIApplyButtonTapped,
                               properties: [:])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum ProductNameAI {
+        private enum Key: String {
+            case source = "source"
+            case isRetry = "is_retry"
+            case withMessage = "with_message"
+            case language = "language"
+        }
+
+        static func entryPointTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productNameAIEntryPointTapped,
+                              properties: [:])
+        }
+
+        static func generateButtonTapped(isRetry: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productNameAIGenerateButtonTapped,
+                              properties: [Key.isRetry.rawValue: isRetry])
+        }
+
+        static func copyButtonTapped(withMessage: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productNameAICopyButtonTapped,
+                              properties: [Key.withMessage.rawValue: withMessage])
+        }
+
+        static func applyButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productNameAICopyButtonTapped,
+                              properties: [:])
+        }
+
+        static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .identifyLanguageSuccess,
+                              properties: [Key.language.rawValue: identifiedLanguage,
+                                           Key.source.rawValue: Constants.productNameSource])
+        }
+
+        static func identifyLanguageFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .identifyLanguageFailed,
+                              properties: [Key.source.rawValue: Constants.productNameSource],
+                              error: error)
+        }
+
+        static func nameGenerated() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productNameAIGenerationSuccess,
+                              properties: [:])
+        }
+
+        static func nameGenerationFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productNameAIGenerationFailed,
+                              properties: [:],
+                              error: error)
+        }
+    }
+}
+
+private extension WooAnalyticsEvent.ProductNameAI {
+    enum Constants {
+        static let productNameSource = "product_name"
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductNameAI.swift
@@ -26,7 +26,7 @@ extension WooAnalyticsEvent {
                               properties: [Key.isRetry.rawValue: isRetry])
         }
 
-        static func copyButtonTapped(withMessage: Bool) -> WooAnalyticsEvent {
+        static func copyButtonTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productNameAICopyButtonTapped,
                               properties: [:])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -801,6 +801,15 @@ public enum WooAnalyticsStat: String {
     //
     case productAIFeedback = "product_ai_feedback"
 
+    // MARK: Product name AI
+    //
+    case productNameAIEntryPointTapped = "product_name_ai_entry_point_tapped"
+    case productNameAIGenerateButtonTapped = "product_name_ai_generate_button_tapped"
+    case productNameAICopyButtonTapped = "product_name_ai_copy_button_tapped"
+    case productNameAIApplyButtonTapped = "product_name_ai_apply_button_tapped"
+    case productNameAIGenerationSuccess = "product_name_ai_generation_success"
+    case productNameAIGenerationFailed = "product_name_ai_generation_failed"
+
     // MARK: Remote Request Events
     //
     case jetpackTunnelTimeout = "jetpack_tunnel_timeout"

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -88,6 +88,7 @@ private extension AddProductNameWithAIView {
         HStack {
             // Suggest a name
             Button {
+                viewModel.didTapSuggestName()
                 showingNameGeneratingView = true
             } label: {
                 HStack(alignment: .top) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -6,6 +6,7 @@ final class AddProductNameWithAIViewModel: ObservableObject {
     @Published var productNameContent: String
 
     let siteID: Int64
+    private let analytics: Analytics
     private let onUsePackagePhoto: (String?) -> Void
     private let onContinueWithProductName: (String) -> Void
 
@@ -18,16 +19,19 @@ final class AddProductNameWithAIViewModel: ObservableObject {
 
     init(siteID: Int64,
          initialName: String = "",
+         analytics: Analytics = ServiceLocator.analytics,
          onUsePackagePhoto: @escaping (String?) -> Void,
          onContinueWithProductName: @escaping (String) -> Void) {
         self.siteID = siteID
         self.onUsePackagePhoto = onUsePackagePhoto
         self.onContinueWithProductName = onContinueWithProductName
         self.productNameContent = initialName
+        self.analytics = analytics
     }
 
     func didTapUsePackagePhoto() {
         onUsePackagePhoto(productName)
+        analytics.track(event: .ProductNameAI.entryPointTapped(hasInputName: productNameContent.isNotEmpty, source: .productCreationAI))
     }
 
     func didTapContinue() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -33,8 +33,11 @@ final class AddProductNameWithAIViewModel: ObservableObject {
         onUsePackagePhoto(productName)
     }
 
+    func didTapSuggestName() {
+        analytics.track(event: .ProductNameAI.entryPointTapped(hasInputName: productNameContent.isNotEmpty, source: .productCreationAI))
+    }
+
     func didTapContinue() {
         onContinueWithProductName(productNameContent)
-        analytics.track(event: .ProductNameAI.entryPointTapped(hasInputName: productNameContent.isNotEmpty, source: .productCreationAI))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -31,10 +31,10 @@ final class AddProductNameWithAIViewModel: ObservableObject {
 
     func didTapUsePackagePhoto() {
         onUsePackagePhoto(productName)
-        analytics.track(event: .ProductNameAI.entryPointTapped(hasInputName: productNameContent.isNotEmpty, source: .productCreationAI))
     }
 
     func didTapContinue() {
         onContinueWithProductName(productNameContent)
+        analytics.track(event: .ProductNameAI.entryPointTapped(hasInputName: productNameContent.isNotEmpty, source: .productCreationAI))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGeneration/ProductNameGenerationView.swift
@@ -73,6 +73,7 @@ struct ProductNameGenerationView: View {
                         Spacer()
                         // CTA to copy the generated text.
                         Button {
+                            viewModel.didTapCopy()
                             UIPasteboard.general.string = suggestedText
                             copyTextNotice = .init(title: Localization.textCopiedNotice)
                         } label: {
@@ -125,6 +126,7 @@ struct ProductNameGenerationView: View {
 
                     // Action button to apply product name
                     Button(Localization.apply) {
+                        viewModel.didTapApply()
                         onCompletion(suggestedText)
                     }
                     .buttonStyle(PrimaryButtonStyle())

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2144,6 +2144,7 @@
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */; };
 		DE5C19C72AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */; };
+		DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */; };
 		DE5FBB912A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */; };
 		DE5FBB932A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */; };
 		DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */; };
@@ -4658,6 +4659,7 @@
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModelTests.swift; sourceTree = "<group>"; };
+		DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductNameAI.swift"; sourceTree = "<group>"; };
 		DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Authenticated.swift"; sourceTree = "<group>"; };
@@ -8027,6 +8029,7 @@
 				EE486DD12A70270C0079F7B8 /* WooAnalyticsEvent+FreeTrialSurvey.swift */,
 				DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */,
 				0210D8682A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift */,
+				DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -12258,6 +12261,7 @@
 				DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
 				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
+				DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */,
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
 				025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */,
 				456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -4,6 +4,22 @@ import Yosemite
 
 final class AddProductNameWithAIViewModelTests: XCTestCase {
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
     func test_productNameContent_is_updated_correctly_with_initialName() {
         // Given
         let expectedName = "iPhone 15"
@@ -43,5 +59,38 @@ final class AddProductNameWithAIViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(triggeredName, expectedName)
+    }
+
+    func test_didTapContinue_tracks_entry_point_event_for_product_name_ai_with_correct_empty_input() throws {
+        //  Given
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
+
+        // When
+        viewModel.didTapContinue()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_name_ai_entry_point_tapped"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_name_ai_entry_point_tapped"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["has_input_name"] as? Bool, false)
+        XCTAssertEqual(eventProperties["source"] as? String, "product_creation_ai")
+    }
+
+    func test_didTapContinue_tracks_entry_point_event_for_product_name_ai_with_correct_non_empty_input() throws {
+        //  Given
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
+
+        // When
+        viewModel.productNameContent = "iPhone 15"
+        viewModel.didTapContinue()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_name_ai_entry_point_tapped"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_name_ai_entry_point_tapped"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["has_input_name"] as? Bool, true)
+        XCTAssertEqual(eventProperties["source"] as? String, "product_creation_ai")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -77,13 +77,13 @@ final class AddProductNameWithAIViewModelTests: XCTestCase {
         XCTAssertEqual(eventProperties["source"] as? String, "product_creation_ai")
     }
 
-    func test_didTapContinue_tracks_entry_point_event_for_product_name_ai_with_correct_non_empty_input() throws {
+    func test_didTapSuggestName_tracks_entry_point_event_for_product_name_ai_with_correct_non_empty_input() throws {
         //  Given
         let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
 
         // When
         viewModel.productNameContent = "iPhone 15"
-        viewModel.didTapContinue()
+        viewModel.didTapSuggestName()
 
         // Then
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_name_ai_entry_point_tapped"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -61,12 +61,12 @@ final class AddProductNameWithAIViewModelTests: XCTestCase {
         XCTAssertEqual(triggeredName, expectedName)
     }
 
-    func test_didTapContinue_tracks_entry_point_event_for_product_name_ai_with_correct_empty_input() throws {
+    func test_didTapSuggestName_tracks_entry_point_event_for_product_name_ai_with_correct_empty_input() throws {
         //  Given
         let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
 
         // When
-        viewModel.didTapContinue()
+        viewModel.didTapSuggestName()
 
         // Then
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_name_ai_entry_point_tapped"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductNameGenerationViewModelTests.swift
@@ -5,6 +5,22 @@ import Yosemite
 @MainActor
 final class ProductNameGenerationViewModelTests: XCTestCase {
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
     func test_generateProductName_updates_generationInProgress_correctly() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -111,5 +127,140 @@ final class ProductNameGenerationViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.generateButtonTitle, ProductNameGenerationViewModel.Localization.regenerate)
         XCTAssertEqual(viewModel.generateButtonImage, try XCTUnwrap(UIImage(systemName: "arrow.counterclockwise")))
         XCTAssertTrue(viewModel.hasGeneratedMessage)
+    }
+
+    func test_generateProductName_tracks_correct_events_upon_success() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductNameGenerationViewModel(siteID: 123, keywords: "", stores: stores, analytics: analytics)
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateProductName(_, _, _, completion):
+                completion(.success("iPhone 15 Smart Phone"))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
+                break
+            }
+        }
+        await viewModel.generateProductName()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["product_name_ai_generate_button_tapped",
+                                                          "ai_identify_language_success",
+                                                          "product_name_ai_generation_success"])
+    }
+
+    func test_generateProductName_tracks_correct_events_upon_failure() async throws {
+        // Given
+        let expectedError = NSError(domain: "test", code: 503)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductNameGenerationViewModel(siteID: 123, keywords: "", stores: stores, analytics: analytics)
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateProductName(_, _, _, completion):
+                completion(.failure(expectedError))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
+                break
+            }
+        }
+        await viewModel.generateProductName()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["product_name_ai_generate_button_tapped",
+                                                          "ai_identify_language_success",
+                                                          "product_name_ai_generation_failed"])
+
+        let errorEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_name_ai_generation_failed"}))
+        let errorEventProperties = analyticsProvider.receivedProperties[errorEventIndex]
+        XCTAssertEqual(errorEventProperties["error_code"] as? String, "503")
+        XCTAssertEqual(errorEventProperties["error_domain"] as? String, "test")
+    }
+
+    func test_generateProductName_tracks_identified_language() async throws {
+        // Given
+        let expectedError = NSError(domain: "test", code: 503)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductNameGenerationViewModel(siteID: 123, keywords: "", stores: stores, analytics: analytics)
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateProductName(_, _, _, completion):
+                completion(.failure(expectedError))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
+                break
+            }
+        }
+        await viewModel.generateProductName()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("ai_identify_language_success"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "ai_identify_language_success"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["source"] as? String, "product_name")
+        XCTAssertEqual(eventProperties["language"] as? String, "en")
+    }
+
+    func test_generateProductName_tracks_correct_events_upon_language_identification_failure() async throws {
+        // Given
+        let expectedError = NSError(domain: "test", code: 503)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ProductNameGenerationViewModel(siteID: 123, keywords: "", stores: stores, analytics: analytics)
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.failure(expectedError))
+            default:
+                break
+            }
+        }
+        await viewModel.generateProductName()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, [
+            "product_name_ai_generate_button_tapped",
+            "ai_identify_language_failed",
+            "product_name_ai_generation_failed"
+        ])
+
+        let errorEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "ai_identify_language_failed"}))
+        let errorEventProperties = analyticsProvider.receivedProperties[errorEventIndex]
+        XCTAssertEqual(errorEventProperties["error_code"] as? String, "503")
+        XCTAssertEqual(errorEventProperties["error_domain"] as? String, "test")
+        XCTAssertEqual(errorEventProperties["source"] as? String, "product_name")
+    }
+
+    func test_didTapCopy_tracks_copy_event() {
+        // Given
+        let viewModel = ProductNameGenerationViewModel(siteID: 123, keywords: "", analytics: analytics)
+
+        // When
+        viewModel.didTapCopy()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["product_name_ai_copy_button_tapped"])
+    }
+
+    func test_didTapApply_tracks_apply_event() {
+        // Given
+        let viewModel = ProductNameGenerationViewModel(siteID: 123, keywords: "", analytics: analytics)
+
+        // When
+        viewModel.didTapApply()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["product_name_ai_apply_button_tapped"])
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10787 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking events for the product name flow:

Event name | Trigger | Properties
-- | -- | --
*_product_name_ai_entry_point_tapped | When the entry point to create product name with AI is tapped. | has_input_name: true \| falsesource: product_creation_ai
*_product_name_ai_generate_button_tapped | When the button to generate product name with AI is tapped. | is_retry: true \| false
*_product_name_ai_copy_button_tapped | When the button to copy the generated product name is tapped. |  
*_product_name_ai_apply_button_tapped | When the button to apply the generated product name is tapped. |  
*_product_name_ai_generation_success | When generating a product name with AI succeeds. |  
*_product_name_ai_generation_failed | When generating a product name with AI fails. | Error detail properties

 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select add product with AI.
- Tap on the entry point to product name AI. Notice in Xcode console: `🔵 Tracked product_name_ai_entry_point_tapped, properties: [AnyHashable("has_input_name"): false, AnyHashable("source"): "product_creation_ai"...]`
- Navigate back, type something in the name field and tap Suggest a name again. The same event should be tracked with property `has_input_name` being true.
- Tap on the Generate button, Xcode should log: `🔵 Tracked product_name_ai_generate_button_tapped, properties: [AnyHashable("is_retry"): false, ...]`.
- When the generation succeeds, you should see the following in the console: `🔵 Tracked ai_identify_language_success, properties: [AnyHashable("language"): "en", AnyHashable("source"): "product_name", ...]` and `🔵 Tracked product_name_ai_generation_success`.
- If the request fails, the correct failed event should be tracked.
- Tap the Regenerate button, `product_name_ai_generate_button_tapped` should be tracked with `is_retry`  being true.
- Tap the Copy button, `product_name_ai_copy_button_tapped` should be tracked.
- Tap the Apply button, `product_name_ai_apply_button_tapped` should be tracked.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
