### PR TITLE
Product Creation AI: Set product description from package flow as features

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -69,6 +69,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         }
         productName = data.name
         productDescription = data.description
+        productFeatures = data.description
         currentStep = .preview
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2358,6 +2358,7 @@
 		EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */; };
 		EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */; };
 		EEA1E2042AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */; };
+		EEA1E20C2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA1E20B2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift */; };
 		EEA537532A853B9500A39D3D /* StoreCreationProfilerUploadAnswersUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA537522A853B9500A39D3D /* StoreCreationProfilerUploadAnswersUseCaseTests.swift */; };
 		EEAA45FD293073FE0047D125 /* JetpackInstallStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */; };
 		EEAB47662A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAB47652A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift */; };
@@ -4871,6 +4872,7 @@
 		EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthentication.swift; sourceTree = "<group>"; };
 		EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModelTests.swift; sourceTree = "<group>"; };
 		EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailPreviewViewModelTests.swift; sourceTree = "<group>"; };
+		EEA1E20B2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIContainerViewModelTests.swift; sourceTree = "<group>"; };
 		EEA537522A853B9500A39D3D /* StoreCreationProfilerUploadAnswersUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerUploadAnswersUseCaseTests.swift; sourceTree = "<group>"; };
 		EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepTests.swift; sourceTree = "<group>"; };
 		EEAB47652A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerUploadAnswersUseCase.swift; sourceTree = "<group>"; };
@@ -11003,6 +11005,7 @@
 				EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */,
 				DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */,
 				DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */,
+				EEA1E20B2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift */,
 			);
 			path = AddProductWithAI;
 			sourceTree = "<group>";
@@ -13736,6 +13739,7 @@
 				5750BEE82764006F00388BE6 /* RefundFeesDetailsViewModelTests.swift in Sources */,
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				0331A7002A334982001D2C2C /* MockInAppPurchasesForWPComPlansManager.swift in Sources */,
+				EEA1E20C2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift in Sources */,
 				02DF174B2A4A134B008FD33B /* ProductFormActionsFactory+ProductCreationTests.swift in Sources */,
 				02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import WooCommerce
+
+final class AddProductWithAIContainerViewModelTests: XCTestCase {
+    // MARK: `didGenerateDataFromPackage`
+
+    func test_didGenerateDataFromPackage_sets_values_from_package_flow() {
+        // Given
+        let expectedName = "Fancy new smart phone"
+        let expectedDescription = "Phone, White color"
+        let expectedFeatures = expectedDescription
+
+        let viewModel = AddProductWithAIContainerViewModel(siteID: 123,
+                                                           source: .productDescriptionAIAnnouncementModal,
+                                                           onCancel: { },
+                                                           onCompletion: { _ in })
+
+        // When
+        viewModel.didGenerateDataFromPackage(.init(name: expectedName,
+                                                   description: expectedDescription,
+                                                   image: nil))
+
+        // Then
+        XCTAssertEqual(viewModel.productName, expectedName)
+        XCTAssertEqual(viewModel.productDescription, expectedDescription)
+        XCTAssertEqual(viewModel.productFeatures, expectedFeatures)
+    }
+}


### PR DESCRIPTION
Closes: #10784 

## Description

When coming to the preview screen from package flow, tapping the back button from the "Preview" screen does not take the user back to the package flow. 

Upon investigating, navigating back to package flow from the Preview screen requires many changes. To properly fix this we have to make the package flow part of the AI flow and include the package image screen as a step in `AddProductWithAIStep`

Instead, we decided to set the product description from the package flow as product features value. This will show the product description as features value in the "About your product" screen.


## Testing instructions
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select add product with AI.
- Select packaging photo CTA and select any packaging image.
- After product details are generated, tap Continue.
- The Preview screen should be displayed. Tap back to navigate back.
- The "About your product" screen's textfield should have the product description from the package flow.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/d4961750-d7e3-4f7e-a118-d51812ee1917



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
