### PR TITLE
Gift card support in order form: design updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
@@ -11,11 +11,15 @@ struct GiftCardInputView: View {
 
     var body: some View {
         NavigationView {
-            Form {
-                Section {
+            ScrollView {
+                VStack(alignment: .leading) {
+                    Text(Localization.header)
+                        .foregroundColor(.init(uiColor: .text))
+                        .subheadlineStyle()
                     HStack {
                         TextField(Localization.placeholder, text: $viewModel.code)
                             .focused()
+                            .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
                         Spacer()
                         Button {
                             showsScanner = true
@@ -38,20 +42,19 @@ struct GiftCardInputView: View {
                             .font(.footnote)
                             .foregroundColor(Color(.error))
                     }
-
-                    Button {
-                        viewModel.apply()
-                    } label: {
-                        Text(Localization.apply)
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .disabled(!viewModel.isValid)
                 }
             }
+            .padding(Constants.insets)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.cancel, action: {
                         viewModel.cancel()
+                    })
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.apply, action: {
+                        viewModel.apply()
                     })
                 }
             }
@@ -65,9 +68,14 @@ struct GiftCardInputView: View {
 private extension GiftCardInputView {
     enum Localization {
         static let title = NSLocalizedString("Add Gift Card", comment: "Title of the add gift card screen in the order form.")
-        static let placeholder = NSLocalizedString("Enter code", comment: "Placeholder of the gift card code text field in the order form.")
+        static let header = NSLocalizedString("Gift card code", comment: "Header of the gift card code text field in the order form.")
+        static let placeholder = NSLocalizedString("XXXX-XXXX-XXXX-XXXX", comment: "Placeholder of the gift card code text field in the order form.")
         static let apply = NSLocalizedString("Apply", comment: "Button to apply the gift card code to the order form.")
         static let cancel = NSLocalizedString("Cancel", comment: "Button to cancel entering the gift card code from the order form.")
+    }
+
+    enum Constants {
+        static let insets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
@@ -12,39 +12,56 @@ struct GiftCardInputView: View {
     var body: some View {
         NavigationView {
             ScrollView {
-                VStack(alignment: .leading) {
-                    Text(Localization.header)
-                        .foregroundColor(.init(uiColor: .text))
-                        .subheadlineStyle()
-                    HStack {
-                        TextField(Localization.placeholder, text: $viewModel.code)
-                            .focused()
-                            .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
-                        Spacer()
-                        Button {
-                            showsScanner = true
-                        } label: {
-                            Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
-                                .foregroundColor(Color(.accent))
+                VStack(alignment: .leading, spacing: .zero) {
+                    VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                        Text(Localization.header)
+                            .foregroundColor(.init(uiColor: .text))
+                            .subheadlineStyle()
+                        HStack {
+                            TextField(Localization.placeholder, text: $viewModel.code)
+                                .focused()
+                                .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                            Spacer()
+                            Button {
+                                showsScanner = true
+                            } label: {
+                                Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                                    .foregroundColor(Color(.accent))
+                            }
+                            .sheet(isPresented: $showsScanner) {
+                                GiftCardCodeScannerNavigationView(onCodeScanned: { code in
+                                    viewModel.code = code
+                                    showsScanner = false
+                                }, onClose: {
+                                    showsScanner = false
+                                })
+                            }
                         }
-                        .sheet(isPresented: $showsScanner) {
-                            GiftCardCodeScannerNavigationView(onCodeScanned: { code in
-                                viewModel.code = code
-                                showsScanner = false
-                            }, onClose: {
-                                showsScanner = false
-                            })
-                        }
-                    }
 
-                    if let errorMessage = viewModel.errorMessage {
-                        Text(errorMessage)
-                            .font(.footnote)
-                            .foregroundColor(Color(.error))
+                        if let errorMessage = viewModel.errorMessage {
+                            Text(errorMessage)
+                                .font(.footnote)
+                                .foregroundColor(Color(uiColor: .error))
+                        }
                     }
+                    .padding(Constants.insets)
+
+                    VStack(alignment: .leading, spacing: .zero) {
+                        Divider()
+
+                        Button {
+                            viewModel.remove()
+                        } label: {
+                            Text(Localization.remove)
+                                .foregroundColor(.init(uiColor: .error))
+                        }
+                        .foregroundColor(.init(uiColor: .error))
+                        .buttonStyle(RoundedBorderedStyle(borderColor: .init(uiColor: .error)))
+                        .padding(Constants.insets)
+                    }
+                    .renderedIf(viewModel.isValid)
                 }
             }
-            .padding(Constants.insets)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.cancel, action: {
@@ -56,6 +73,7 @@ struct GiftCardInputView: View {
                     Button(Localization.apply, action: {
                         viewModel.apply()
                     })
+                    .disabled(!viewModel.isValid)
                 }
             }
             .navigationTitle(Localization.title)
@@ -72,15 +90,18 @@ private extension GiftCardInputView {
         static let placeholder = NSLocalizedString("XXXX-XXXX-XXXX-XXXX", comment: "Placeholder of the gift card code text field in the order form.")
         static let apply = NSLocalizedString("Apply", comment: "Button to apply the gift card code to the order form.")
         static let cancel = NSLocalizedString("Cancel", comment: "Button to cancel entering the gift card code from the order form.")
+        static let remove = NSLocalizedString("Remove Gift Card", comment: "Button to remove the gift card code from the order form.")
     }
 
     enum Constants {
         static let insets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let verticalSpacing: CGFloat = 8
     }
 }
 
 struct GiftCardInputView_Previews: PreviewProvider {
     static var previews: some View {
-        GiftCardInputView(viewModel: .init(code: "", addGiftCard: { _ in }, dismiss: {}))
+        GiftCardInputView(viewModel: .init(code: "UU35-T3RE-BSWK-36J4", setGiftCard: { _ in }, dismiss: {}))
+        GiftCardInputView(viewModel: .init(code: "", setGiftCard: { _ in }, dismiss: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputViewModel.swift
@@ -7,19 +7,24 @@ final class GiftCardInputViewModel: ObservableObject {
     @Published private(set) var isValid: Bool = false
     @Published private(set) var errorMessage: String?
 
-    private let addGiftCard: (_ code: String) -> Void
+    private let setGiftCard: (_ code: String?) -> Void
     private let dismiss: () -> Void
 
-    init(code: String, addGiftCard: @escaping (_ code: String) -> Void, dismiss: @escaping () -> Void) {
+    init(code: String, setGiftCard: @escaping (_ code: String?) -> Void, dismiss: @escaping () -> Void) {
         self.code = code
-        self.addGiftCard = addGiftCard
+        self.setGiftCard = setGiftCard
         self.dismiss = dismiss
         observeCodeForValidCheck()
     }
 
     /// Applies the gift card code to the order.
     func apply() {
-        addGiftCard(code)
+        setGiftCard(code)
+    }
+
+    /// Removes the gift card code from the order.
+    func remove() {
+        setGiftCard(nil)
     }
 
     /// Cancels the gift card input form.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Gift card entered by the user in the order form.
+struct OrderFormGiftCardRow: View {
+    let code: String
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack(spacing: Constants.horizontalSpacing) {
+                Text(Localization.giftCard)
+                    .bodyStyle()
+                Image(systemName: "pencil")
+            }
+            .foregroundColor(.init(uiColor: .accent))
+
+            Text(code)
+                .footnoteStyle()
+        }
+    }
+}
+
+private extension OrderFormGiftCardRow {
+    enum Localization {
+        static let giftCard = NSLocalizedString("Gift Card", comment: "Label for the the row showing the gift card to apply to the order")
+    }
+
+    enum Constants {
+        static let horizontalSpacing: CGFloat = 8
+    }
+}
+
+struct OrderFormGiftCardRow_Previews: PreviewProvider {
+    static var previews: some View {
+        OrderFormGiftCardRow(code: "UU35-T3RE-BSWK-36J4")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
@@ -8,6 +8,7 @@ struct OrderFormGiftCardRow: View {
         VStack(alignment: .leading) {
             HStack(spacing: Constants.horizontalSpacing) {
                 Text(Localization.giftCard)
+                    .foregroundColor(.init(uiColor: .accent))
                     .bodyStyle()
                 Image(systemName: "pencil")
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
@@ -10,7 +10,7 @@ struct OrderFormGiftCardRow: View {
                 Text(Localization.giftCard)
                     .foregroundColor(.init(uiColor: .accent))
                     .bodyStyle()
-                Image(systemName: "pencil")
+                Image(uiImage: .pencilImage)
             }
             .foregroundColor(.init(uiColor: .accent))
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -25,7 +25,7 @@ struct OrderPaymentSection: View {
 
     /// Indicates if the gift card code input sheet should be shown or not.
     ///
-    @State private var shouldShowAddGiftCard: Bool = false
+    @State private var shouldShowGiftCardForm: Bool = false
 
     /// Indicates if the tax educational dialog should be shown or not.
     ///
@@ -189,43 +189,38 @@ struct OrderPaymentSection: View {
 
     @ViewBuilder private var addGiftCardRow: some View {
         Button(Localization.addGiftCard) {
-            shouldShowAddGiftCard = true
+            shouldShowGiftCardForm = true
         }
         .buttonStyle(PlusButtonStyle())
         .padding()
         .accessibilityIdentifier("add-gift-card-button")
         .disabled(!viewModel.isAddGiftCardActionEnabled)
-        .sheet(isPresented: $shouldShowAddGiftCard) {
+        .sheet(isPresented: $shouldShowGiftCardForm) {
             giftCardInput
         }
     }
 
     @ViewBuilder private func editGiftCardRow(giftCard: String) -> some View {
         HStack {
-            TitleAndValueRow(title: Localization.giftCard, value: .content(giftCard))
-                .onTapGesture {
-                    shouldShowAddGiftCard = true
-                }
-                .sheet(isPresented: $shouldShowAddGiftCard) {
-                    giftCardInput
-                }
-
             Button {
-                viewModel.setGiftCardClosure(nil)
+                shouldShowGiftCardForm = true
             } label: {
-                Image(uiImage: .closeButton)
+                OrderFormGiftCardRow(code: giftCard)
             }
             .padding()
+            .sheet(isPresented: $shouldShowGiftCardForm) {
+                giftCardInput
+            }
         }
     }
 
     @ViewBuilder private var giftCardInput: some View {
         GiftCardInputView(viewModel: .init(code: viewModel.giftCardToApply ?? "",
-                                           addGiftCard: { code in
+                                           setGiftCard: { code in
             viewModel.setGiftCardClosure(code)
-            shouldShowAddGiftCard = false
+            shouldShowGiftCardForm = false
         }, dismiss: {
-            shouldShowAddGiftCard = false
+            shouldShowGiftCardForm = false
         }))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -319,7 +319,6 @@ private extension OrderPaymentSection {
         static let addShipping = NSLocalizedString("Add Shipping", comment: "Title text of the button that adds shipping line when creating a new order")
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
         static let addGiftCard = NSLocalizedString("Add Gift Card", comment: "Title text of the button that adds shipping line when creating a new order")
-        static let giftCard = NSLocalizedString("Gift Card", comment: "Label for the the row showing the gift card to apply to the order")
         static let addFee = NSLocalizedString("Add Fee", comment: "Title text of the button that adds a fee when creating a new order")
         static let feesTotal = NSLocalizedString("Fees", comment: "Label for the row showing the cost of fees in the order")
         static let taxes = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -99,6 +99,15 @@ struct PlusButtonStyle: ButtonStyle {
     }
 }
 
+/// Button with a rounded border with default corner radius and a configurable color.
+struct RoundedBorderedStyle: ButtonStyle {
+    let borderColor: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        return RoundedBorderedButton(configuration: configuration, borderColor: borderColor)
+    }
+}
+
 /// Adds a primary button style while showing a progress view on top of the button when required.
 ///
 struct PrimaryLoadingButtonStyle: PrimitiveButtonStyle {
@@ -386,6 +395,22 @@ private struct PlusButton: View {
     }
 }
 
+private struct RoundedBorderedButton: View {
+    let configuration: ButtonStyleConfiguration
+    let borderColor: Color
+
+    var body: some View {
+        BaseButton(configuration: configuration)
+            .background(
+                RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
+                    .strokeBorder(
+                        borderColor,
+                        lineWidth: Style.defaultBorderWidth
+                    )
+            )
+    }
+}
+
 private enum Style {
     static let defaultCornerRadius = CGFloat(8.0)
     static let defaultBorderWidth = CGFloat(1.0)
@@ -396,39 +421,55 @@ private enum Style {
 struct PrimaryButton_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 20) {
-            Button("Primary button") {}
-                .buttonStyle(PrimaryButtonStyle())
+            Group {
+                Button("Primary button") {}
+                    .buttonStyle(PrimaryButtonStyle())
 
-            Button("Primary button (disabled)") {}
-                .buttonStyle(PrimaryButtonStyle())
-                .disabled(true)
+                Button("Primary button (disabled)") {}
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(true)
+            }
 
-            Button("Secondary button") {}
-                .buttonStyle(SecondaryButtonStyle())
+            Group {
+                Button("Secondary button") {}
+                    .buttonStyle(SecondaryButtonStyle())
+                
+                Button("Secondary button (disabled)") {}
+                    .buttonStyle(SecondaryButtonStyle())
+                    .disabled(true)
+            }
 
-            Button("Secondary button (disabled)") {}
-                .buttonStyle(SecondaryButtonStyle())
-                .disabled(true)
+            Group {
+                Button("Selectable secondary button (selected)") {}
+                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: true))
 
-            Button("Selectable secondary button (selected)") {}
-                .buttonStyle(SelectableSecondaryButtonStyle(isSelected: true))
+                Button("Selectable secondary button") {}
+                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: false))
+            }
 
-            Button("Selectable secondary button") {}
-                .buttonStyle(SelectableSecondaryButtonStyle(isSelected: false))
+            Group {
+                Button("Link button") {}
+                    .buttonStyle(LinkButtonStyle())
 
-            Button("Link button") {}
-                .buttonStyle(LinkButtonStyle())
+                Button("Link button (Disabled)") {}
+                    .buttonStyle(LinkButtonStyle())
+                    .disabled(true)
+            }
 
-            Button("Link button (Disabled)") {}
-            .buttonStyle(LinkButtonStyle())
-            .disabled(true)
+            Group {
+                Button("Plus button") {}
+                    .buttonStyle(PlusButtonStyle())
 
-            Button("Plus button") {}
-                .buttonStyle(PlusButtonStyle())
+                Button("Plus button (disabled)") {}
+                    .buttonStyle(PlusButtonStyle())
+                    .disabled(true)
+            }
 
-            Button("Plus button (disabled)") {}
-            .buttonStyle(PlusButtonStyle())
-            .disabled(true)
+            Group {
+                Button("Rounded bordered button") {}
+                    .foregroundColor(.init(uiColor: .error))
+                    .buttonStyle(RoundedBorderedStyle(borderColor: .init(uiColor: .error)))
+            }
         }
         .preferredColorScheme(.light)
         .padding()
@@ -485,6 +526,12 @@ struct PrimaryButton_Previews: PreviewProvider {
                 Button("Plus button (disabled)") {}
                     .buttonStyle(PlusButtonStyle())
                     .disabled(true)
+            }
+
+            Group {
+                Button("Rounded bordered button") {}
+                    .foregroundColor(.init(uiColor: .error))
+                    .buttonStyle(RoundedBorderedStyle(borderColor: .init(uiColor: .error)))
             }
         }
         .preferredColorScheme(.dark)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -433,7 +433,7 @@ struct PrimaryButton_Previews: PreviewProvider {
             Group {
                 Button("Secondary button") {}
                     .buttonStyle(SecondaryButtonStyle())
-                
+
                 Button("Secondary button (disabled)") {}
                     .buttonStyle(SecondaryButtonStyle())
                     .disabled(true)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024EFA6823FCC10B00F36918 /* Product+Media.swift */; };
 		024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024F1451250B65A40003030A /* AddProductCoordinatorTests.swift */; };
 		02503C632538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02503C622538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift */; };
+		0250BE8C2AC425F9006D067A /* OrderFormGiftCardRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0250BE8B2AC425F9006D067A /* OrderFormGiftCardRow.swift */; };
 		02521E11243DC3C400DC7810 /* CancellableMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02521E10243DC3C400DC7810 /* CancellableMedia.swift */; };
 		0252273529A89B0F0074EBFC /* StoreOnboardingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0252273429A89B0F0074EBFC /* StoreOnboardingCoordinatorTests.swift */; };
 		02524A5D252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02524A5C252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift */; };
@@ -2712,6 +2713,7 @@
 		024EFA6823FCC10B00F36918 /* Product+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+Media.swift"; sourceTree = "<group>"; };
 		024F1451250B65A40003030A /* AddProductCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductCoordinatorTests.swift; sourceTree = "<group>"; };
 		02503C622538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormActionsFactory+ReadonlyVariationTests.swift"; sourceTree = "<group>"; };
+		0250BE8B2AC425F9006D067A /* OrderFormGiftCardRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderFormGiftCardRow.swift; sourceTree = "<group>"; };
 		02521E10243DC3C400DC7810 /* CancellableMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellableMedia.swift; sourceTree = "<group>"; };
 		0252273429A89B0F0074EBFC /* StoreOnboardingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingCoordinatorTests.swift; sourceTree = "<group>"; };
 		02524A5C252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationLoadUseCaseTests.swift; sourceTree = "<group>"; };
@@ -9240,6 +9242,7 @@
 				02A723252AB2E1A6003AEC7E /* GiftCardInputView.swift */,
 				02A723272AB2E1C2003AEC7E /* GiftCardInputViewModel.swift */,
 				02667A1B2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift */,
+				0250BE8B2AC425F9006D067A /* OrderFormGiftCardRow.swift */,
 			);
 			path = PaymentSection;
 			sourceTree = "<group>";
@@ -12901,6 +12904,7 @@
 				03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */,
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,
 				CE2409F1215D12D30091F887 /* WooNavigationController.swift in Sources */,
+				0250BE8C2AC425F9006D067A /* OrderFormGiftCardRow.swift in Sources */,
 				0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */,
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
 				31FC8CE927B476BA004B9456 /* CardReaderSettingsResultsControllers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/GiftCards/GiftCardInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/PaymentSection/GiftCards/GiftCardInputViewModelTests.swift
@@ -7,7 +7,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_isValid_is_false_when_initial_code_is_empty() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "", setGiftCard: { _ in }, dismiss: {})
 
         // Then
         XCTAssertFalse(viewModel.isValid)
@@ -15,7 +15,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_isValid_is_true_when_initial_code_is_valid() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC-Z5F6", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC-Z5F6", setGiftCard: { _ in }, dismiss: {})
 
         // Then
         XCTAssertTrue(viewModel.isValid)
@@ -23,7 +23,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_isValid_is_false_when_initial_code_is_invalid() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", setGiftCard: { _ in }, dismiss: {})
 
         // Then
         XCTAssertFalse(viewModel.isValid)
@@ -31,7 +31,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_isValid_becomes_true_when_code_is_valid() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "", setGiftCard: { _ in }, dismiss: {})
 
         // When
         viewModel.code = "a7WP-MYVG-KNDC-Z5F6"
@@ -44,7 +44,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_errorMessage_is_nil_when_initial_code_is_empty() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "", setGiftCard: { _ in }, dismiss: {})
 
         // Then
         XCTAssertNil(viewModel.errorMessage)
@@ -52,7 +52,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_errorMessage_is_nil_when_initial_code_is_valid() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC-Z5F6", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC-Z5F6", setGiftCard: { _ in }, dismiss: {})
 
         // Then
         XCTAssertNil(viewModel.errorMessage)
@@ -60,7 +60,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_errorMessage_is_not_nil_when_initial_code_is_invalid() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", setGiftCard: { _ in }, dismiss: {})
 
         // Then
         XCTAssertNotNil(viewModel.errorMessage)
@@ -68,7 +68,7 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     func test_errorMessage_becomes_nil_when_code_is_valid() throws {
         // Given
-        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", addGiftCard: { _ in }, dismiss: {})
+        let viewModel = GiftCardInputViewModel(code: "a7WP-MYVG-KNDC", setGiftCard: { _ in }, dismiss: {})
 
         // When
         viewModel.code = "a7WP-MYVG-KNDC-Z5F6"
@@ -79,10 +79,10 @@ final class GiftCardInputViewModelTests: XCTestCase {
 
     // MARK: - `apply`
 
-    func test_apply_invokes_addGiftCard_with_code() throws {
+    func test_apply_invokes_setGiftCard_with_code() throws {
         let code = waitFor { promise in
             // Given
-            let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { code in
+            let viewModel = GiftCardInputViewModel(code: "", setGiftCard: { code in
                 promise(code)
             }, dismiss: {})
 
@@ -95,12 +95,30 @@ final class GiftCardInputViewModelTests: XCTestCase {
         XCTAssertEqual(code, "a7WP")
     }
 
+    // MARK: - `remove`
+
+    func test_remove_invokes_setGiftCard_with_nil_value() throws {
+        let code = waitFor { promise in
+            // Given
+            let viewModel = GiftCardInputViewModel(code: "AADI", setGiftCard: { code in
+                promise(code)
+            }, dismiss: {})
+
+            // When
+            viewModel.code = "a7WP"
+            viewModel.remove()
+        }
+
+        // Then
+        XCTAssertNil(code)
+    }
+
     // MARK: - `cancel`
 
     func test_cancel_invokes_dismiss() throws {
         waitFor { promise in
             // Given
-            let viewModel = GiftCardInputViewModel(code: "", addGiftCard: { _ in }, dismiss: {
+            let viewModel = GiftCardInputViewModel(code: "", setGiftCard: { _ in }, dismiss: {
                 // Then
                 promise(())
             })


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10518 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Joe provided some design guidance in w3JBReW1UJesCf02sj43kR-fi-513_7930. While not all of the suggestions can be applied like we don't have a way to get the gift card's remaining balance and know the amount we can apply, the gift card input form & the gift card row in the order form are updated based on the design.

## How

- The gift card removal CTA was moved from the order form to the gift card input form
- The gift card application CTA was moved to the navigation bar
- A rounded border button style was added for the remove gift card CTA
- The gift card input form has the major design updates
- `OrderFormGiftCardRow` view was created for the gift card in the order form after the user entered one

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Create order

- Switch to a store that has the Gift Cards plugin active if needed
- Go to the Orders tab
- Tap `+`
- Add a fee or product with a price so that the order total is non-zero
- Tap `Add Gift Card` --> the input form should look like in the design w3JBReW1UJesCf02sj43kR-fi-513_7930
- Enter some random text --> an error should appear, and `Apply` CTA is disabled
- Enter a valid code --> a Remove CTA should appear, and `Apply` CTA becomes enabled
- Tap `Apply` --> the entered code should appear below the coupon row following the design
- Tap on the gift card row --> the input form should be shown with the code and a Remove CTA
- Tap on `Remove Gift Card` --> the gift card should be removed
- Tap `Add Gift Card` and enter a valid gift card code, then tap `Apply`
- Tap `Create` --> the gift card should be applied to the new order successfully

### Update order

- Go to the Orders tab
- Tap on an editable order with a positive order total
- Tap `Edit`
- Tap `Add Gift Card`
- Enter a valid code and tap `Apply` --> the gift card should be applied to the order

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

gift card input form | gift card input - valid code | order form - gift card row
-- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/9c656631-aeca-4f3d-af60-51ac44ff1de1" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/ee3edae7-c3bf-46f8-9ac4-dd3ad58f9beb" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/652152e3-a1f6-41f6-a8c4-53eb5a10810f" width="300" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
