### PR TITLE
Product creation AI: Track publishing products with AI-generated details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -286,7 +286,7 @@ private extension AddProductCoordinator {
                                                                                          onCompletion: { [weak self] product in
             self?.onProductCreated(product)
             self?.navigationController.dismiss(animated: true) {
-                self?.presentProduct(product, formType: .edit)
+                self?.presentProduct(product, formType: .edit, isAIContent: true)
             }
         }))
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
@@ -294,7 +294,7 @@ private extension AddProductCoordinator {
 
     /// Presents a product onto the current navigation stack.
     ///
-    func presentProduct(_ product: Product, formType: ProductFormType = .add) {
+    func presentProduct(_ product: Product, formType: ProductFormType = .add, isAIContent: Bool = false) {
         let model = EditableProductModel(product: product)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
@@ -317,6 +317,7 @@ private extension AddProductCoordinator {
             }
         }
         let viewController = ProductFormViewController(viewModel: viewModel,
+                                                       isAIContent: isAIContent,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -84,13 +84,19 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     ///
     private var shareProductCoordinator: ShareProductCoordinator?
 
+    /// Whether the product details were generated with AI.
+    ///
+    private let isAIContent: Bool
+
     init(viewModel: ViewModel,
+         isAIContent: Bool = false,
          eventLogger: ProductFormEventLoggerProtocol,
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
          presentationStyle: ProductFormPresentationStyle,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.viewModel = viewModel
+        self.isAIContent = isAIContent
         self.eventLogger = eventLogger
         self.currency = currency
         self.presentationStyle = presentationStyle
@@ -210,6 +216,11 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     @objc func publishProduct() {
         if viewModel.formType == .add {
             ServiceLocator.analytics.track(.addProductPublishTapped, withProperties: ["product_type": product.productType.rawValue])
+        } else if viewModel.formType == .edit && isAIContent {
+            ServiceLocator.analytics.track(.addProductPublishTapped, withProperties: [
+                "product_type": product.productType.rawValue,
+                "is_ai_content": isAIContent
+            ])
         }
         saveProduct(status: .published)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10796 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to track how many merchants proceed to publish products with details generated with AI.
This PR adds a new property to track `add_product_publish_tapped` with `is_ai_content` to check the rate of publishing products with AI-generated details. 

**Note**: this solution means `is_ai_content` is only tracked when the user taps `Publish` immediately after generating a product. There's no reliable way to track AI content for draft products that gets published later as this information would need to be sent to the remote and synced in the local storage. Let me know if this is acceptable.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select add product with AI.
- Follow the steps to add product name, features and generate details.
- Tap Save as draft - after saving completes you should be navigated to a product form for the new product.
- Tap Publish. Notice in Xcode console: `🔵 Tracked add_product_publish_tapped, properties: [AnyHashable("is_ai_content"): true, ...]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
