### PR TITLE
Product creation AI: Show confirm alert when trying to dismiss by dragging

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -129,7 +129,6 @@ private extension AddProductNameWithAIView {
         HStack {
             // Use package photo
             Button {
-                viewModel.didTapUsePackagePhoto()
                 onUsePackagePhoto(viewModel.productName)
             } label: {
                 HStack(alignment: .top, spacing: Layout.UsePackagePhoto.spacing) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIView.swift
@@ -9,8 +9,15 @@ struct AddProductNameWithAIView: View {
 
     @State private var showingNameGeneratingView: Bool = false
 
-    init(viewModel: AddProductNameWithAIViewModel) {
+    private let onUsePackagePhoto: (String?) -> Void
+    private let onContinueWithProductName: (String) -> Void
+
+    init(viewModel: AddProductNameWithAIViewModel,
+         onUsePackagePhoto: @escaping (String?) -> Void,
+         onContinueWithProductName: @escaping (String) -> Void) {
         self.viewModel = viewModel
+        self.onUsePackagePhoto = onUsePackagePhoto
+        self.onContinueWithProductName = onContinueWithProductName
     }
 
     var body: some View {
@@ -122,6 +129,7 @@ private extension AddProductNameWithAIView {
             // Use package photo
             Button {
                 viewModel.didTapUsePackagePhoto()
+                onUsePackagePhoto(viewModel.productName)
             } label: {
                 HStack(alignment: .top, spacing: Layout.UsePackagePhoto.spacing) {
                     Image(systemName: Layout.UsePackagePhoto.cameraSFSymbol)
@@ -141,6 +149,7 @@ private extension AddProductNameWithAIView {
             // continue
             editorIsFocused = false
             viewModel.didTapContinue()
+            onContinueWithProductName(viewModel.productNameContent)
         } label: {
             Text(Localization.continueText)
         }
@@ -212,6 +221,6 @@ private extension AddProductNameWithAIView {
 
 struct AddProductNameWithAIView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductNameWithAIView(viewModel: .init(siteID: 123, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in }))
+        AddProductNameWithAIView(viewModel: .init(siteID: 123), onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -15,14 +15,10 @@ final class AddProductNameWithAIViewModel: ObservableObject {
         return productNameContent
     }
 
-    init(siteID: Int64, analytics: Analytics = ServiceLocator.analytics,) {
+    init(siteID: Int64, analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.productNameContent = ""
         self.analytics = analytics
-    }
-
-    func didTapUsePackagePhoto() {
-        // Analytics
     }
 
     func didTapSuggestName() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -6,31 +6,24 @@ final class AddProductNameWithAIViewModel: ObservableObject {
     @Published var productNameContent: String
 
     let siteID: Int64
-    private let onUsePackagePhoto: (String?) -> Void
-    private let onContinueWithProductName: (String) -> Void
 
-    private var productName: String? {
+    var productName: String? {
         guard productNameContent.isNotEmpty else {
             return nil
         }
         return productNameContent
     }
 
-    init(siteID: Int64,
-         initialName: String = "",
-         onUsePackagePhoto: @escaping (String?) -> Void,
-         onContinueWithProductName: @escaping (String) -> Void) {
+    init(siteID: Int64) {
         self.siteID = siteID
-        self.onUsePackagePhoto = onUsePackagePhoto
-        self.onContinueWithProductName = onContinueWithProductName
-        self.productNameContent = initialName
+        self.productNameContent = ""
     }
 
     func didTapUsePackagePhoto() {
-        onUsePackagePhoto(productName)
+        // Analytics
     }
 
     func didTapContinue() {
-        onContinueWithProductName(productNameContent)
+        // Analytics
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -77,14 +77,13 @@ struct AddProductWithAIContainerView: View {
 
             switch viewModel.currentStep {
             case .productName:
-                AddProductNameWithAIView(viewModel: .init(siteID: viewModel.siteID,
-                                                          initialName: viewModel.productName,
-                                                          onUsePackagePhoto: onUsePackagePhoto,
-                                                          onContinueWithProductName: { name in
+                AddProductNameWithAIView(viewModel: viewModel.addProductNameViewModel,
+                                         onUsePackagePhoto: onUsePackagePhoto,
+                                         onContinueWithProductName: { name in
                     withAnimation {
                         viewModel.onContinueWithProductName(name: name)
                     }
-                }))
+                })
             case .aboutProduct:
                 AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
                                                         productName: viewModel.productName,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -22,6 +22,21 @@ final class AddProductWithAIContainerHostingController: UIHostingController<AddP
         super.viewDidLoad()
 
         configureTransparentNavigationBar()
+        navigationController?.presentationController?.delegate = self
+    }
+}
+
+/// Intercepts to the dismiss drag gesture.
+///
+extension AddProductWithAIContainerHostingController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        return viewModel.canBeDismissed
+    }
+
+    func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            self?.dismiss(animated: true)
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -75,6 +75,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         guard let data else {
             return
         }
+        addProductNameViewModel.productNameContent = data.name
         productName = data.name
         productDescription = data.description
         productFeatures = data.description

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -24,7 +24,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     let source: AddProductCoordinator.Source
 
     var canBeDismissed: Bool {
-        productName.isEmpty && productFeatures.isEmpty && productDescription == nil
+        currentStep == .productName && addProductNameViewModel.productName == nil
     }
 
     private let analytics: Analytics
@@ -34,6 +34,10 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private(set) var productName: String = ""
     private(set) var productFeatures: String = ""
     private(set) var productDescription: String?
+
+    private(set) lazy var addProductNameViewModel: AddProductNameWithAIViewModel = {
+        .init(siteID: siteID)
+    }()
 
     @Published private(set) var currentStep: AddProductWithAIStep = .productName
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -23,6 +23,10 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     let siteID: Int64
     let source: AddProductCoordinator.Source
 
+    var canBeDismissed: Bool {
+        productName.isEmpty && productFeatures.isEmpty && productDescription == nil
+    }
+
     private let analytics: Analytics
     private let onCancel: () -> Void
     private let completionHandler: (Product) -> Void

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -55,7 +55,7 @@ final class AddProductNameWithAIViewModelTests: XCTestCase {
 
     func test_didTapContinue_tracks_continue_tapped_event() throws {
         //  Given
-        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics)
 
         // When
         viewModel.didTapContinue()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -3,45 +3,5 @@ import Yosemite
 @testable import WooCommerce
 
 final class AddProductNameWithAIViewModelTests: XCTestCase {
-
-    func test_productNameContent_is_updated_correctly_with_initialName() {
-        // Given
-        let expectedName = "iPhone 15"
-        let viewModel = AddProductNameWithAIViewModel(siteID: 123, initialName: expectedName, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
-
-        // Then
-        XCTAssertEqual(viewModel.productNameContent, expectedName)
-    }
-
-    func test_onUsePackagePhoto_is_triggered_when_tapping_package_photo() {
-        // Given
-        var triggeredName: String?
-        let expectedName = "iPhone 15"
-        let viewModel = AddProductNameWithAIViewModel(siteID: 123,
-                                                      initialName: expectedName,
-                                                      onUsePackagePhoto: { triggeredName = $0 },
-                                                      onContinueWithProductName: { _ in })
-
-        // When
-        viewModel.didTapUsePackagePhoto()
-
-        // Then
-        XCTAssertEqual(triggeredName, expectedName)
-    }
-
-    func test_onContinueWithProductName_is_triggered_when_tapping_continue() {
-        // Given
-        var triggeredName: String?
-        let expectedName = "iPhone 15"
-        let viewModel = AddProductNameWithAIViewModel(siteID: 123,
-                                                      initialName: expectedName,
-                                                      onUsePackagePhoto: { _ in },
-                                                      onContinueWithProductName: { triggeredName = $0 })
-
-        // When
-        viewModel.didTapContinue()
-
-        // Then
-        XCTAssertEqual(triggeredName, expectedName)
-    }
+    // TODO: add tests for analytics
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -22,7 +22,7 @@ final class AddProductNameWithAIViewModelTests: XCTestCase {
 
     func test_didTapSuggestName_tracks_entry_point_event_for_product_name_ai_with_correct_empty_input() throws {
         //  Given
-        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics)
 
         // When
         viewModel.didTapSuggestName()
@@ -38,7 +38,7 @@ final class AddProductNameWithAIViewModelTests: XCTestCase {
 
     func test_didTapSuggestName_tracks_entry_point_event_for_product_name_ai_with_correct_non_empty_input() throws {
         //  Given
-        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics)
 
         // When
         viewModel.productNameContent = "iPhone 15"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
@@ -2,6 +2,45 @@ import XCTest
 @testable import WooCommerce
 
 final class AddProductWithAIContainerViewModelTests: XCTestCase {
+
+    // MARK: - `canBeDismissed`
+
+    func test_canBeDismissed_returns_true_if_current_step_is_productName_and_the_name_field_is_empty() {
+        // Given
+        let viewModel = AddProductWithAIContainerViewModel(siteID: 123, source: .productsTab, onCancel: {}, onCompletion: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.canBeDismissed)
+    }
+
+    func test_canBeDismissed_returns_False_if_current_step_is_productName_and_the_name_field_is_not_empty() {
+        // Given
+        let viewModel = AddProductWithAIContainerViewModel(siteID: 123, source: .productsTab, onCancel: {}, onCompletion: { _ in })
+
+        // When
+        viewModel.addProductNameViewModel.productNameContent = "iPhone 15"
+
+        // Then
+        XCTAssertFalse(viewModel.canBeDismissed)
+    }
+
+    func test_canBeDismissed_returns_False_if_current_step_is_not_product_name() {
+        // Given
+        let viewModel = AddProductWithAIContainerViewModel(siteID: 123, source: .productsTab, onCancel: {}, onCompletion: { _ in })
+
+        // When
+        viewModel.onContinueWithProductName(name: "iPhone 15")
+
+        // Then
+        XCTAssertFalse(viewModel.canBeDismissed)
+
+        // When
+        viewModel.onProductFeaturesAdded(features: "No lightning jack")
+
+        // Then
+        XCTAssertFalse(viewModel.canBeDismissed)
+    }
+
     // MARK: `didGenerateDataFromPackage`
 
     func test_didGenerateDataFromPackage_sets_values_from_package_flow() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
@@ -63,5 +63,6 @@ final class AddProductWithAIContainerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productName, expectedName)
         XCTAssertEqual(viewModel.productDescription, expectedDescription)
         XCTAssertEqual(viewModel.productFeatures, expectedFeatures)
+        XCTAssertEqual(viewModel.addProductNameViewModel.productName, expectedName)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
@@ -13,7 +13,7 @@ final class AddProductWithAIContainerViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.canBeDismissed)
     }
 
-    func test_canBeDismissed_returns_False_if_current_step_is_productName_and_the_name_field_is_not_empty() {
+    func test_canBeDismissed_returns_false_if_current_step_is_productName_and_the_name_field_is_not_empty() {
         // Given
         let viewModel = AddProductWithAIContainerViewModel(siteID: 123, source: .productsTab, onCancel: {}, onCompletion: { _ in })
 
@@ -24,7 +24,7 @@ final class AddProductWithAIContainerViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canBeDismissed)
     }
 
-    func test_canBeDismissed_returns_False_if_current_step_is_not_product_name() {
+    func test_canBeDismissed_returns_false_if_current_step_is_not_product_name() {
         // Given
         let viewModel = AddProductWithAIContainerViewModel(siteID: 123, source: .productsTab, onCancel: {}, onCompletion: { _ in })
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10799 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR intercepts the swipe-to-dismiss gesture on the product creation AI sheet. A confirm action sheet is displayed if there are any changes to product name or description.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select add product with AI.
- Follow the steps to add product name, features and generate details.
- Try swiping-to-dismiss the sheet, an action sheet should be displayed asking to confirm the dismissal.
- Navigate back to previous screen, the same sheet should be displayed when attempting to swipe to dismiss.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/fe66f6c3-08f3-43f6-baba-130f02473200



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
