### PR TITLE
[Manual Taxes M3] Improvements

### DIFF
--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -95,6 +95,16 @@ extension Address {
              country: "")
     }
 
+    /// Changes the location components (city, state, postcode, country) to those of the passed tax rate. The other components remain unmodified.
+    /// 
+    func applyingTaxRate(taxRate: TaxRate) -> Address {
+        resettingTaxRateComponents().copy(city: taxRate.cities.first ?? taxRate.city,
+                                          state: taxRate.state,
+                                          postcode: taxRate.postcodes.first ?? taxRate.postcode,
+                                          country: taxRate.country)
+
+    }
+
     /// Generates an Address object from a TaxRate object data
     ///
     static func from(taxRate: TaxRate) -> Address {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1332,7 +1332,7 @@ private extension EditableOrderViewModel {
 
     func configureTaxRates() {
         // Tax rates are not configurable if the order is not editable.
-        // Even in creation flow we get right at the beginning that the order is not editable, that's why we have to check the flow here as well
+        // In the creation flow orders are initially (incorrectly) reported as not editable, so we have to check the flow here as well
         if case let .editing(order) = flow,
            !order.isEditable {
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1336,7 +1336,10 @@ private extension EditableOrderViewModel {
                 (setting == .customerBillingAddress || setting == .customerShippingAddress)
                 if canApplyTaxRates {
                     Task { @MainActor in
-                        await self.applySelectedStoredTaxRateIfAny()
+                        if self.flow == .creation {
+                            await self.applySelectedStoredTaxRateIfAny()
+                        }
+
                         // Show the tax rate section once we know if any stored tax rate applies, as it can change the text
                         self.shouldShowNewTaxRateSection = true
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1324,6 +1324,13 @@ private extension EditableOrderViewModel {
     }
 
     func configureTaxRates() {
+        // Tax rates are not configurable if the order is not editable.
+        // Even in creation flow we get right at the beginning that the order is not editable, that's why we have to check the flow here as well
+        if case let .editing(order) = flow,
+           !order.isEditable {
+            return
+        }
+
         stores.dispatch(SettingAction.retrieveTaxBasedOnSetting(siteID: siteID,
                                                                 onCompletion: { [weak self] result in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -595,13 +595,16 @@ final class EditableOrderViewModel: ObservableObject {
             storedTaxRate = nil
         }
 
-        let address = Address.from(taxRate: taxRate)
         let input: OrderSyncAddressesInput
         switch taxBasedOnSetting {
         case .customerBillingAddress:
-            input = OrderSyncAddressesInput(billing: address, shipping: nil)
+            input = OrderSyncAddressesInput(billing: orderSynchronizer.order.billingAddress?.applyingTaxRate(taxRate: taxRate) ??
+                                            Address.from(taxRate: taxRate),
+                                            shipping: orderSynchronizer.order.shippingAddress)
         case .customerShippingAddress:
-            input = OrderSyncAddressesInput(billing: nil, shipping: address)
+            input = OrderSyncAddressesInput(billing: orderSynchronizer.order.billingAddress,
+                                            shipping: orderSynchronizer.order.shippingAddress?.applyingTaxRate(taxRate: taxRate) ??
+                                            Address.from(taxRate: taxRate))
         default:
             // Do not add address if the taxes are not based on the customer's addresses
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -813,6 +813,7 @@ extension EditableOrderViewModel {
         let taxLineViewModels: [TaxLineViewModel]
         let taxEducationalDialogViewModel: TaxEducationalDialogViewModel
         let taxBasedOnSetting: TaxBasedOnSetting?
+        let shouldShowTaxesInfoButton: Bool
         let shouldShowStoredTaxRateAddedAutomatically: Bool
         let couponCode: String
         var discountTotal: String
@@ -863,6 +864,7 @@ extension EditableOrderViewModel {
              giftCardToApply: String? = nil,
              appliedGiftCards: [AppliedGiftCard] = [],
              taxBasedOnSetting: TaxBasedOnSetting? = nil,
+             shouldShowTaxesInfoButton: Bool = false,
              shouldShowStoredTaxRateAddedAutomatically: Bool = false,
              taxLineViewModels: [TaxLineViewModel] = [],
              taxEducationalDialogViewModel: TaxEducationalDialogViewModel = TaxEducationalDialogViewModel(orderTaxLines: [], taxBasedOnSetting: nil),
@@ -901,6 +903,7 @@ extension EditableOrderViewModel {
             self.giftCardToApply = giftCardToApply
             self.appliedGiftCards = appliedGiftCards
             self.taxBasedOnSetting = taxBasedOnSetting
+            self.shouldShowTaxesInfoButton = shouldShowTaxesInfoButton
             self.shouldShowStoredTaxRateAddedAutomatically = shouldShowStoredTaxRateAddedAutomatically
             self.taxLineViewModels = taxLineViewModels
             self.taxEducationalDialogViewModel = taxEducationalDialogViewModel
@@ -1255,6 +1258,7 @@ private extension EditableOrderViewModel {
                                             giftCardToApply: giftCardToApply,
                                             appliedGiftCards: appliedGiftCards,
                                             taxBasedOnSetting: taxBasedOnSetting,
+                                            shouldShowTaxesInfoButton: order.isEditable,
                                             shouldShowStoredTaxRateAddedAutomatically: self.storedTaxRate != nil,
                                             taxLineViewModels: self.taxLineViewModels(from: order.taxes),
                                             taxEducationalDialogViewModel: TaxEducationalDialogViewModel(orderTaxLines: order.taxes,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -260,6 +260,7 @@ struct OrderPaymentSection: View {
                 Image(systemName: "questionmark.circle")
                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
             }
+            .renderedIf(viewModel.shouldShowTaxesInfoButton)
 
             Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
@@ -15,79 +15,87 @@ struct TaxEducationalDialogView: View {
     var body: some View {
         ZStack {
             Color.black.opacity(Layout.backgroundOpacity).edgesIgnoringSafeArea(.all)
-            VStack {
-                VStack(alignment: .center, spacing: Layout.verticalSpacing) {
-                    Text(Localization.title)
-                        .headlineStyle()
-                    Text(Localization.bodyFirstParagraph)
-                        .bodyStyle()
-                    Text(Localization.bodySecondParagraph)
-                        .bodyStyle()
+
+                VStack {
+                    GeometryReader { geometry in
+                        ScrollView {
+                            VStack(alignment: .center, spacing: Layout.verticalSpacing) {
+                                Text(Localization.title)
+                                    .headlineStyle()
+                                Text(Localization.bodyFirstParagraph)
+                                    .bodyStyle()
+                                    .fixedSize(horizontal: false, vertical: true)
+                                Text(Localization.bodySecondParagraph)
+                                    .bodyStyle()
 
 
-                    VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
-                        Divider()
-                            .frame(height: Layout.dividerHeight)
-                            .foregroundColor(Color(.opaqueSeparator))
-                        if let taxBasedOnSettingExplanatoryText = viewModel.taxBasedOnSettingExplanatoryText {
-                            Text(taxBasedOnSettingExplanatoryText)
-                                .bodyStyle()
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
+                                VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                                    Divider()
+                                        .frame(height: Layout.dividerHeight)
+                                        .foregroundColor(Color(.opaqueSeparator))
+                                    if let taxBasedOnSettingExplanatoryText = viewModel.taxBasedOnSettingExplanatoryText {
+                                        Text(taxBasedOnSettingExplanatoryText)
+                                            .bodyStyle()
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
 
-                        ForEach(viewModel.taxLines, id: \.title) { taxLine in
-                            HStack {
-                                AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.taxLinesInnerSpacing) {
-                                    Text(taxLine.title)
-                                        .font(.body)
-                                        .fontWeight(.semibold)
-                                        .multilineTextAlignment(.leading)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                    ForEach(viewModel.taxLines, id: \.title) { taxLine in
+                                        HStack {
+                                            AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.taxLinesInnerSpacing) {
+                                                Text(taxLine.title)
+                                                    .font(.body)
+                                                    .fontWeight(.semibold)
+                                                    .multilineTextAlignment(.leading)
+                                                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                                    Text(taxLine.value)
-                                        .font(.body)
-                                        .fontWeight(.semibold)
-                                        .multilineTextAlignment(.trailing)
-                                        .frame(width: nil, alignment: .trailing)
+                                                Text(taxLine.value)
+                                                    .font(.body)
+                                                    .fontWeight(.semibold)
+                                                    .multilineTextAlignment(.trailing)
+                                                    .frame(width: nil, alignment: .trailing)
+                                            }
+                                        }
+                                    }
+                                    Divider()
+                                        .frame(height: Layout.dividerHeight)
+                                        .foregroundColor(Color(.opaqueSeparator))
+                                }.renderedIf(viewModel.taxLines.isNotEmpty)
+
+                                Button {
+                                    viewModel.onGoToWpAdminButtonTapped()
+                                    showingWPAdminWebview = true
+                                } label: {
+                                    Label {
+                                        Text(Localization.editTaxRatesInAdminButtonTitle)
+                                            .font(.body)
+                                            .fontWeight(.bold)
+                                    } icon: {
+                                        Image(systemName: "arrow.up.forward.square")
+                                            .resizable()
+                                            .frame(width: Layout.externalLinkImageSize * scale, height: Layout.externalLinkImageSize * scale)
+                                    }
                                 }
+                                .buttonStyle(PrimaryButtonStyle())
+                                .safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminTaxSettingsURL, onDismiss: {
+                                    onDismissWpAdminWebView()
+                                    showingWPAdminWebview = false
+                                })
+
+                                Button {
+                                    dismiss()
+                                } label: {
+                                    Text(Localization.doneButtonTitle)
+                                }
+                                .buttonStyle(SecondaryButtonStyle())
                             }
+                            .padding(Layout.outterPadding)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .background(Color(.systemBackground))
+                            .cornerRadius(Layout.cornerRadius)
+                            .frame(width: geometry.size.width)      // Make the scroll view full-width
+                            .frame(minHeight: geometry.size.height)
                         }
-                        Divider()
-                            .frame(height: Layout.dividerHeight)
-                            .foregroundColor(Color(.opaqueSeparator))
-                    }.renderedIf(viewModel.taxLines.isNotEmpty)
-
-                    Button {
-                        viewModel.onGoToWpAdminButtonTapped()
-                        showingWPAdminWebview = true
-                    } label: {
-                        Label {
-                            Text(Localization.editTaxRatesInAdminButtonTitle)
-                                .font(.body)
-                                .fontWeight(.bold)
-                        } icon: {
-                            Image(systemName: "arrow.up.forward.square")
-                                .resizable()
-                                .frame(width: Layout.externalLinkImageSize * scale, height: Layout.externalLinkImageSize * scale)
-                        }
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminTaxSettingsURL, onDismiss: {
-                        onDismissWpAdminWebView()
-                        showingWPAdminWebview = false
-                    })
-
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text(Localization.doneButtonTitle)
-                    }
-                    .buttonStyle(SecondaryButtonStyle())
                 }
-                .padding(Layout.outterPadding)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .background(Color(.systemBackground))
-                .cornerRadius(Layout.cornerRadius)
             }
             .padding(Layout.outterPadding)
             .frame(maxWidth: .infinity, alignment: .center)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1487,6 +1487,30 @@ final class EditableOrderViewModelTests: XCTestCase {
             XCTAssertFalse(viewModel.shouldShowNewTaxRateSection)
         }
 
+    func test_shouldShowTaxesInfoButton_when_order_is_not_editable_then_returns_false() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
+        let order = Order.fake().copy(isEditable: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: order),
+                                               stores: stores, featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertFalse(viewModel.paymentDataViewModel.shouldShowTaxesInfoButton)
+    }
+
+    func test_shouldShowTaxesInfoButton_when_order_is_editable_then_returns_true() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
+        let order = Order.fake().copy(isEditable: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: order),
+                                               stores: stores, featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowTaxesInfoButton)
+    }
+
     func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerBillingAddress_then_resets_addressFormViewModel_fields_with_new_data() {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1511,7 +1511,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowTaxesInfoButton)
     }
 
-    func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerBillingAddress_then_resets_addressFormViewModel_fields_with_new_data() {
+    func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerBillingAddress_then_updates_only_addressFormViewModel_location_fields_with_new_data() {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
             switch action {
@@ -1522,19 +1522,30 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
         })
 
+        let customer = Customer.fake().copy(
+            email: "scrambled@scrambled.com",
+            firstName: "Johnny",
+            lastName: "Appleseed",
+            billing: sampleAddress1(),
+            shipping: sampleAddress2()
+        )
+
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
         let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
-
+        viewModel.addCustomerAddressToOrder(customer: customer)
         viewModel.onTaxRateSelected(taxRate)
 
         // Then
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.firstName, customer.firstName)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.lastName, customer.lastName)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.email, customer.email)
         XCTAssertEqual(viewModel.addressFormViewModel.fields.state, taxRate.state)
         XCTAssertEqual(viewModel.addressFormViewModel.fields.country, taxRate.country)
         XCTAssertEqual(viewModel.addressFormViewModel.fields.postcode, taxRate.postcodes.first)
         XCTAssertEqual(viewModel.addressFormViewModel.fields.city, taxRate.cities.first)
     }
 
-    func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerShippingAddress_then_resets_addressFormViewModel_secondaryFields_with_new_data() {
+    func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerShippingAddress_then_updates_only_addressFormViewModel_location_fields_with_new_data() {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
             switch action {
@@ -1545,12 +1556,24 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
         })
 
+        let customer = Customer.fake().copy(
+            email: "scrambled@scrambled.com",
+            firstName: "Johnny",
+            lastName: "Appleseed",
+            billing: sampleAddress1(),
+            shipping: sampleAddress2()
+        )
+
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
         let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
 
+        viewModel.addCustomerAddressToOrder(customer: customer)
         viewModel.onTaxRateSelected(taxRate)
 
         // Then
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.firstName, customer.firstName)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.lastName, customer.lastName)
+        XCTAssertEqual(viewModel.addressFormViewModel.fields.email, customer.email)
         XCTAssertEqual(viewModel.addressFormViewModel.secondaryFields.state, taxRate.state)
         XCTAssertEqual(viewModel.addressFormViewModel.secondaryFields.country, taxRate.country)
         XCTAssertEqual(viewModel.addressFormViewModel.secondaryFields.postcode, taxRate.postcodes.first)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1448,7 +1448,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
-    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_shopBaseAddress_then_returns_true() {
+    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_shopBaseAddress_then_returns_false() {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
             switch action {
@@ -1465,6 +1465,27 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.shouldShowNewTaxRateSection)
     }
+
+    func test_shouldShowNewTaxRateSection_when_order_is_not_editable_and_flow_is_editing_then_returns_false() {
+            // Given
+            stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
+                switch action {
+                case .retrieveTaxBasedOnSetting(_, let onCompletion):
+                    onCompletion(.success(.customerShippingAddress))
+                default:
+                    break
+                }
+            })
+
+            let featureFlagService = MockFeatureFlagService(manualTaxesInOrderM2: true)
+            let order = Order.fake().copy(isEditable: false)
+            let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                                   flow: .editing(initialOrder: order),
+                                                   stores: stores, featureFlagService: featureFlagService)
+
+            // Then
+            XCTAssertFalse(viewModel.shouldShowNewTaxRateSection)
+        }
 
     func test_onTaxRateSelected_when_taxBasedOnSetting_is_customerBillingAddress_then_resets_addressFormViewModel_fields_with_new_data() {
         // Given


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add a few improvements to the Manual Taxes following the suggestions from PRs and testing. These are:

- Only change the location fields (city, state, postcode, country) of the Address relevant to the tax rate. Leave other fields (e.g. first name, second name, email...) unmodified. Likewise, change only the relevant address (shipping/billing).
- Do not apply automatically the stored tax rate when editing an order, only when creating it.
- Hide the "Set new tax rate button" when editing completed orders
- Add the educational dialog into a Scroll View so all its content can be visualized on landscape.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Only change the location fields (city, state, postcode, country) of the Address relevant to the tax rate

1. Go to Orders
2. Tap on + to create a new order
3. Check your tax based on setting. Add customer first name to both addresses (billing/shipping)
4. Set a tax rate.
5. Verify that the customer first name is still there:


https://github.com/woocommerce/woocommerce-ios/assets/1864060/b716e179-54a9-4367-86c5-0a1de166b2a8

### Do not apply automatically the stored tax rate when editing an order, only when creating it.

With a stored tax rate.

1. Go to Orders
2. Tap on a pending order
3. Check that the tax rate is not applied automatically


https://github.com/woocommerce/woocommerce-ios/assets/1864060/6f72e8e8-47bb-40bc-a94e-3929ec6b3ca2


### Hide the "Set new tax rate button" when editing completed orders

1. Go to Orders
2. Tap on a completed (paid) order
3. Tap on edit
4. Check that the "Set new tax rate" button is not there

https://github.com/woocommerce/woocommerce-ios/assets/1864060/2590bf4b-920b-4016-a7e3-b7ca5463c48f

### Add the educational dialog into a Scroll View so all its content can be visualized.

1. Go to Orders
2. Tap on + to create a new order
3. Add taxable products.
4. Set a tax rate.
5. Tap on the ? button close to Total Taxes
6. Turn to landscape.
7. See that you can scroll to see all the content.

https://github.com/woocommerce/woocommerce-ios/assets/1864060/df4bf117-be85-4543-bd29-d3084a649e49

Note: Unfortunately in the case showed in the video, with one tax rate, it's not clear to the user that view is scrollable and there's more content below. I tried the `scrollIndicators(.visible)`, but it only shows when scrolling. On iOS 17 we have `scrollIndicatorsFlash`, but it's not available for us yet.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
