### PR TITLE
[Manual Taxes M3] Enable feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -94,7 +94,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .refreshOrderBeforeInPersonPayment:
             return true
         case .manualTaxesInOrderM3:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .productCreationAI:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .giftCardInOrderForm:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 15.6
 -----
-
+- [**] Taxes in orders: Users can now store the tax rate's location to add it automatically to a new order customer's address. [https://github.com/woocommerce/woocommerce-ios/pull/10802]
 
 15.5
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10668
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we enable the Manual Taxes 3 feature flag so it can run in Release. As the feature could still be improved, we leave the flag implementation to remove it in the future.
## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run the app with the Release build configuration and ensure the feature is visible. You can set the Release build configuration by editing the WooCommerce schema (see screenshot).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="928" alt="Screenshot 2023-07-17 at 10 44 14" src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/676ff06d-352c-431d-b8e5-9545eaee0753">