### PR TITLE
Product Creation AI: Tracking for main creation flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+AIFeedback.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+AIFeedback.swift
@@ -12,6 +12,7 @@ extension WooAnalyticsEvent {
         enum Source: String {
             case productDescription = "product_description"
             case productSharingMessage = "product_sharing_message"
+            case productCreation = "product_creation"
         }
 
         /// Tracked when feedback for AI-generated content in sent.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -4,6 +4,7 @@ extension WooAnalyticsEvent {
     enum ProductCreationAI {
         private enum Key: String {
             case value = "value"
+            case isFirstAttempt = "is_first_attempt"
         }
 
         static func entryPointDisplayed() -> WooAnalyticsEvent {
@@ -24,6 +25,11 @@ extension WooAnalyticsEvent {
         static func aiToneSelected(_ tone: AIToneVoice) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIToneSelected,
                               properties: [Key.value.rawValue: tone.rawValue])
+        }
+
+        static func generateDetailsTapped(isFirstAttempt: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIGenerateDetailsTapped,
+                              properties: [Key.isFirstAttempt.rawValue: isFirstAttempt])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -24,7 +24,7 @@ extension WooAnalyticsEvent {
 
         static func aiToneSelected(_ tone: AIToneVoice) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIToneSelected,
-                              properties: [Key.value.rawValue: tone.rawValue])
+                              properties: [Key.value.rawValue: tone.rawValue.lowercased()])
         }
 
         static func generateDetailsTapped(isFirstAttempt: Bool) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -8,7 +8,12 @@ extension WooAnalyticsEvent {
         }
 
         static func entryPointTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productNameAIEntryPointTapped,
+            WooAnalyticsEvent(statName: .productCreationAIEntryPointTapped,
+                              properties: [:])
+        }
+
+        static func productNameContinueTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIProductNameContinueTapped,
                               properties: [:])
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum ProductCreationAI {
+        static func entryPointDisplayed() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIEntryPointDisplayed,
+                              properties: [:])
+        }
+
+        static func entryPointTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productNameAIEntryPointTapped,
+                              properties: [:])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -2,6 +2,10 @@ import Foundation
 
 extension WooAnalyticsEvent {
     enum ProductCreationAI {
+        private enum Key: String {
+            case value = "value"
+        }
+
         static func entryPointDisplayed() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIEntryPointDisplayed,
                               properties: [:])
@@ -15,6 +19,11 @@ extension WooAnalyticsEvent {
         static func productNameContinueTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIProductNameContinueTapped,
                               properties: [:])
+        }
+
+        static func aiToneSelected(_ tone: AIToneVoice) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIToneSelected,
+                              properties: [Key.value.rawValue: tone.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -31,5 +31,16 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIGenerateDetailsTapped,
                               properties: [Key.isFirstAttempt.rawValue: isFirstAttempt])
         }
+
+        static func generateProductDetailsSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIGenerateProductDetailsSuccess,
+                              properties: [:])
+        }
+
+        static func generateProductDetailsFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIGenerateProductDetailsFailed,
+                              properties: [:],
+                              error: error)
+        }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -42,5 +42,21 @@ extension WooAnalyticsEvent {
                               properties: [:],
                               error: error)
         }
+
+        static func saveAsDraftButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAISaveAsDraftButtonTapped,
+                              properties: [:])
+        }
+
+        static func saveAsDraftSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAISaveAsDraftSuccess,
+                              properties: [:])
+        }
+
+        static func saveAsDraftFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAISaveAsDraftFailed,
+                              properties: [:],
+                              error: error)
+        }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -817,6 +817,7 @@ public enum WooAnalyticsStat: String {
     //
     case productCreationAIEntryPointDisplayed = "product_creation_ai_entry_point_displayed"
     case productCreationAIEntryPointTapped = "product_creation_ai_entry_point_tapped"
+    case productCreationAIProductNameContinueTapped = "product_creation_ai_product_name_continue_button_tapped"
 
     // MARK: Remote Request Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -818,6 +818,7 @@ public enum WooAnalyticsStat: String {
     case productCreationAIEntryPointDisplayed = "product_creation_ai_entry_point_displayed"
     case productCreationAIEntryPointTapped = "product_creation_ai_entry_point_tapped"
     case productCreationAIProductNameContinueTapped = "product_creation_ai_product_name_continue_button_tapped"
+    case productCreationAIToneSelected = "product_creation_ai_tone_selected"
 
     // MARK: Remote Request Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -822,6 +822,9 @@ public enum WooAnalyticsStat: String {
     case productCreationAIGenerateDetailsTapped = "product_creation_ai_generate_details_tapped"
     case productCreationAIGenerateProductDetailsSuccess = "product_creation_ai_generate_product_details_success"
     case productCreationAIGenerateProductDetailsFailed = "product_creation_ai_generate_product_details_failed"
+    case productCreationAISaveAsDraftButtonTapped = "product_creation_ai_save_as_draft_button_tapped"
+    case productCreationAISaveAsDraftSuccess = "product_creation_ai_save_as_draft_success"
+    case productCreationAISaveAsDraftFailed = "product_creation_ai_save_as_draft_failed"
 
     // MARK: Remote Request Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -813,6 +813,11 @@ public enum WooAnalyticsStat: String {
     case productNameAIGenerationSuccess = "product_name_ai_generation_success"
     case productNameAIGenerationFailed = "product_name_ai_generation_failed"
 
+    // MARK: Product creation AI
+    //
+    case productCreationAIEntryPointDisplayed = "product_creation_ai_entry_point_displayed"
+    case productCreationAIEntryPointTapped = "product_creation_ai_entry_point_tapped"
+
     // MARK: Remote Request Events
     //
     case jetpackTunnelTimeout = "jetpack_tunnel_timeout"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -820,6 +820,8 @@ public enum WooAnalyticsStat: String {
     case productCreationAIProductNameContinueTapped = "product_creation_ai_product_name_continue_button_tapped"
     case productCreationAIToneSelected = "product_creation_ai_tone_selected"
     case productCreationAIGenerateDetailsTapped = "product_creation_ai_generate_details_tapped"
+    case productCreationAIGenerateProductDetailsSuccess = "product_creation_ai_generate_product_details_success"
+    case productCreationAIGenerateProductDetailsFailed = "product_creation_ai_generate_product_details_failed"
 
     // MARK: Remote Request Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -819,6 +819,7 @@ public enum WooAnalyticsStat: String {
     case productCreationAIEntryPointTapped = "product_creation_ai_entry_point_tapped"
     case productCreationAIProductNameContinueTapped = "product_creation_ai_product_name_continue_button_tapped"
     case productCreationAIToneSelected = "product_creation_ai_tone_selected"
+    case productCreationAIGenerateDetailsTapped = "product_creation_ai_generate_details_tapped"
 
     // MARK: Remote Request Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -269,6 +269,7 @@ private extension AddProductCoordinator {
     func presentActionSheetWithAI() {
         let controller = AddProductWithAIActionSheetHostingController(onAIOption: { [weak self] in
             self?.addProductWithAIBottomSheetPresenter?.dismiss {
+                self?.analytics.track(event: .ProductCreationAI.entryPointTapped())
                 self?.addProductWithAIBottomSheetPresenter = nil
                 self?.startProductCreationWithAI()
             }
@@ -281,6 +282,7 @@ private extension AddProductCoordinator {
 
         addProductWithAIBottomSheetPresenter = buildBottomSheetPresenter(height: navigationController.view.frame.height * 0.3)
         addProductWithAIBottomSheetPresenter?.present(controller, from: navigationController)
+        analytics.track(event: .ProductCreationAI.entryPointDisplayed())
     }
 
     func startProductCreationWithAI() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModel.swift
@@ -30,6 +30,7 @@ final class AIToneVoiceViewModel: ObservableObject {
     func onSelectTone(_ aiPromptTone: AIToneVoice) {
         self.selectedTone = aiPromptTone
         userDefaults.setAITone(aiPromptTone, for: siteID)
+        analytics.track(event: .ProductCreationAI.aiToneSelected(aiPromptTone))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -142,6 +142,9 @@ private extension AddProductFeaturesView {
 
 struct AddProductDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        AddProductFeaturesView(viewModel: .init(siteID: 123, productName: "iPhone 15", onCompletion: { _ in }))
+        AddProductFeaturesView(viewModel: .init(siteID: 123,
+                                                isFirstAttemptGeneratingDetails: .constant(true),
+                                                productName: "iPhone 15",
+                                                onCompletion: { _ in }))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesView.swift
@@ -143,7 +143,6 @@ private extension AddProductFeaturesView {
 struct AddProductDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         AddProductFeaturesView(viewModel: .init(siteID: 123,
-                                                isFirstAttemptGeneratingDetails: .constant(true),
                                                 productName: "iPhone 15",
                                                 onCompletion: { _ in }))
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -13,10 +13,8 @@ final class AddProductFeaturesViewModel: ObservableObject {
     private let analytics: Analytics
     // TODO: add new type for product details and return it here.
     private let onCompletion: (String) -> Void
-    @Binding private var isFirstAttemptGeneratingDetails: Bool
 
     init(siteID: Int64,
-         isFirstAttemptGeneratingDetails: Binding<Bool>,
          productName: String,
          productFeatures: String? = nil,
          stores: StoresManager = ServiceLocator.stores,
@@ -28,11 +26,9 @@ final class AddProductFeaturesViewModel: ObservableObject {
         self.stores = stores
         self.analytics = analytics
         self.onCompletion = onCompletion
-        self._isFirstAttemptGeneratingDetails = isFirstAttemptGeneratingDetails
     }
 
     func proceedToPreview() {
-        analytics.track(event: .ProductCreationAI.generateDetailsTapped(isFirstAttempt: isFirstAttemptGeneratingDetails))
         onCompletion(productFeatures)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeatures/AddProductFeaturesViewModel.swift
@@ -13,8 +13,10 @@ final class AddProductFeaturesViewModel: ObservableObject {
     private let analytics: Analytics
     // TODO: add new type for product details and return it here.
     private let onCompletion: (String) -> Void
+    @Binding private var isFirstAttemptGeneratingDetails: Bool
 
     init(siteID: Int64,
+         isFirstAttemptGeneratingDetails: Binding<Bool>,
          productName: String,
          productFeatures: String? = nil,
          stores: StoresManager = ServiceLocator.stores,
@@ -26,10 +28,11 @@ final class AddProductFeaturesViewModel: ObservableObject {
         self.stores = stores
         self.analytics = analytics
         self.onCompletion = onCompletion
+        self._isFirstAttemptGeneratingDetails = isFirstAttemptGeneratingDetails
     }
 
     func proceedToPreview() {
-        // TODO: analytics
+        analytics.track(event: .ProductCreationAI.generateDetailsTapped(isFirstAttempt: isFirstAttemptGeneratingDetails))
         onCompletion(productFeatures)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AddProductName/AddProductNameWithAIViewModel.swift
@@ -38,6 +38,7 @@ final class AddProductNameWithAIViewModel: ObservableObject {
     }
 
     func didTapContinue() {
+        analytics.track(event: .ProductCreationAI.productNameContinueTapped())
         onContinueWithProductName(productNameContent)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -72,6 +72,7 @@ struct AddProductWithAIContainerView: View {
                 }))
             case .aboutProduct:
                 AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
+                                                        isFirstAttemptGeneratingDetails: $viewModel.isFirstAttemptGeneratingDetails,
                                                         productName: viewModel.productName,
                                                         productFeatures: viewModel.productFeatures) { features in
                     withAnimation {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -72,7 +72,6 @@ struct AddProductWithAIContainerView: View {
                 }))
             case .aboutProduct:
                 AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
-                                                        isFirstAttemptGeneratingDetails: $viewModel.isFirstAttemptGeneratingDetails,
                                                         productName: viewModel.productName,
                                                         productFeatures: viewModel.productFeatures) { features in
                     withAnimation {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -30,6 +30,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private(set) var productName: String = ""
     private(set) var productFeatures: String = ""
     private(set) var productDescription: String?
+    @Published var isFirstAttemptGeneratingDetails: Bool
 
     @Published private(set) var currentStep: AddProductWithAIStep = .productName
 
@@ -43,6 +44,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
         self.analytics = analytics
         self.onCancel = onCancel
         self.completionHandler = onCompletion
+        isFirstAttemptGeneratingDetails = true
     }
 
     func onAppear() {
@@ -57,6 +59,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     func onProductFeaturesAdded(features: String) {
         productFeatures = features
         currentStep = .preview
+        isFirstAttemptGeneratingDetails = false
     }
 
     func didCreateProduct(_ product: Product) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -30,7 +30,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private(set) var productName: String = ""
     private(set) var productFeatures: String = ""
     private(set) var productDescription: String?
-    @Published var isFirstAttemptGeneratingDetails: Bool
+    private var isFirstAttemptGeneratingDetails: Bool
 
     @Published private(set) var currentStep: AddProductWithAIStep = .productName
 
@@ -57,6 +57,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     }
 
     func onProductFeaturesAdded(features: String) {
+        analytics.track(event: .ProductCreationAI.generateDetailsTapped(isFirstAttempt: isFirstAttemptGeneratingDetails))
         productFeatures = features
         currentStep = .preview
         isFirstAttemptGeneratingDetails = false

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -109,7 +109,9 @@ struct ProductDetailPreviewView: View {
                              backgroundColor: .init(uiColor: .init(light: .withColorStudio(.wooCommercePurple, shade: .shade0),
                                                                    dark: .tertiarySystemBackground)),
                              onVote: { vote in
-                    viewModel.handleFeedback(vote)
+                    withAnimation {
+                        viewModel.handleFeedback(vote)
+                    }
                 })
                 .renderedIf(viewModel.shouldShowFeedbackView)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -111,7 +111,7 @@ struct ProductDetailPreviewView: View {
                              onVote: { vote in
                     viewModel.handleFeedback(vote)
                 })
-                .renderedIf(viewModel.isGeneratingDetails == false)
+                .renderedIf(viewModel.shouldShowFeedbackView)
             }
             .padding(insets: Layout.insets)
             .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -54,8 +54,6 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         return ResultsController<StorageProductTag>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
 
-    private let delayBeforeDismissingFeedbackBanner: TimeInterval
-
     init(siteID: Int64,
          productName: String,
          productDescription: String?,
@@ -69,7 +67,6 @@ final class ProductDetailPreviewViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
          userDefaults: UserDefaults = .standard,
-         delayBeforeDismissingFeedbackBanner: TimeInterval = 0.5,
          onProductCreated: @escaping (Product) -> Void) {
         self.siteID = siteID
         self.stores = stores
@@ -88,7 +85,6 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         self.productName = productName
         self.productDescription = productDescription
         self.productFeatures = productFeatures
-        self.delayBeforeDismissingFeedbackBanner = delayBeforeDismissingFeedbackBanner
 
         try? categoryResultController.performFetch()
         try? tagResultController.performFetch()
@@ -140,10 +136,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         analytics.track(event: .AIFeedback.feedbackSent(source: .productCreation,
                                                         isUseful: vote == .up))
 
-        // Delay the disappearance of the banner for a better UX.
-        DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeDismissingFeedbackBanner) { [weak self] in
-            self?.shouldShowFeedbackView = false
-        }
+        shouldShowFeedbackView = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -99,7 +99,9 @@ final class ProductDetailPreviewViewModel: ObservableObject {
                                                     tone: aiTone)
             generatedProduct = product
             isGeneratingDetails = false
+            analytics.track(event: .ProductCreationAI.generateProductDetailsSuccess())
         } catch {
+            analytics.track(event: .ProductCreationAI.generateProductDetailsFailed(error: error))
             DDLogError("⛔️ Error generating product with AI: \(error)")
             errorState = .generatingProduct
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -109,6 +109,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
 
     @MainActor
     func saveProductAsDraft() async {
+        analytics.track(event: .ProductCreationAI.saveAsDraftButtonTapped())
         guard let generatedProduct else {
             return
         }
@@ -116,9 +117,11 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         isSavingProduct = true
         do {
             let newProduct = try await saveProductRemotely(product: generatedProduct)
+            analytics.track(event: .ProductCreationAI.saveAsDraftSuccess())
             onProductCreated(newProduct)
         } catch {
             DDLogError("⛔️ Error saving product with AI: \(error)")
+            analytics.track(event: .ProductCreationAI.saveAsDraftFailed(error: error))
             errorState = .savingProduct
         }
         isSavingProduct = false

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -128,7 +128,8 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     }
 
     func handleFeedback(_ vote: FeedbackView.Vote) {
-        // TODO
+        analytics.track(event: .AIFeedback.feedbackSent(source: .productCreation,
+                                                        isUseful: vote == .up))
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2360,6 +2360,7 @@
 		EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */; };
 		EEA1E2042AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */; };
 		EEA1E20C2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA1E20B2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift */; };
+		EEA1E20E2AC55F2200A37ADD /* WooAnalyticsEvent+ProductCreationAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA1E20D2AC55F2200A37ADD /* WooAnalyticsEvent+ProductCreationAI.swift */; };
 		EEA537532A853B9500A39D3D /* StoreCreationProfilerUploadAnswersUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA537522A853B9500A39D3D /* StoreCreationProfilerUploadAnswersUseCaseTests.swift */; };
 		EEAA45FD293073FE0047D125 /* JetpackInstallStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */; };
 		EEAB47662A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAB47652A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift */; };
@@ -4875,6 +4876,7 @@
 		EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModelTests.swift; sourceTree = "<group>"; };
 		EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailPreviewViewModelTests.swift; sourceTree = "<group>"; };
 		EEA1E20B2AC4639400A37ADD /* AddProductWithAIContainerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIContainerViewModelTests.swift; sourceTree = "<group>"; };
+		EEA1E20D2AC55F2200A37ADD /* WooAnalyticsEvent+ProductCreationAI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductCreationAI.swift"; sourceTree = "<group>"; };
 		EEA537522A853B9500A39D3D /* StoreCreationProfilerUploadAnswersUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerUploadAnswersUseCaseTests.swift; sourceTree = "<group>"; };
 		EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepTests.swift; sourceTree = "<group>"; };
 		EEAB47652A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProfilerUploadAnswersUseCase.swift; sourceTree = "<group>"; };
@@ -8031,6 +8033,7 @@
 				DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */,
 				0210D8682A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift */,
 				DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */,
+				EEA1E20D2AC55F2200A37ADD /* WooAnalyticsEvent+ProductCreationAI.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -13012,6 +13015,7 @@
 				45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */,
 				45C8B2582313FA570002FA77 /* CustomerNoteTableViewCell.swift in Sources */,
 				02B21C5329C830EB00C5623B /* WPAdminWebViewModel.swift in Sources */,
+				EEA1E20E2AC55F2200A37ADD /* WooAnalyticsEvent+ProductCreationAI.swift in Sources */,
 				DE0134172A30364B000A6F54 /* ProductSharingMessageGenerationViewModel.swift in Sources */,
 				02C3FACE282A93020095440A /* WooAnalyticsEvent+Dashboard.swift in Sources */,
 				DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
@@ -5,6 +5,21 @@ import XCTest
 
 final class AIToneVoiceViewModelTests: XCTestCase {
     private let siteID: Int64 = 123
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
 
     func test_casual_is_the_default_tone() throws {
         // Given
@@ -77,5 +92,22 @@ final class AIToneVoiceViewModelTests: XCTestCase {
         // Then
         let dictionary = try XCTUnwrap(defaults[.aiPromptTone] as? [String: String])
         XCTAssertEqual(dictionary["\(siteID)"], AIToneVoice.convincing.rawValue)
+    }
+
+    // MARK: Analytics
+
+    func test_onSelectTone_tracks_tone_selected_event() throws {
+        //  Given
+        let viewModel = AIToneVoiceViewModel(siteID: siteID, analytics: analytics)
+
+        // When
+        viewModel.onSelectTone(.flowery)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_tone_selected"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_creation_ai_tone_selected"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["value"] as? String, "Flowery")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModelTests.swift
@@ -108,6 +108,6 @@ final class AIToneVoiceViewModelTests: XCTestCase {
 
         let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_creation_ai_tone_selected"}))
         let eventProperties = analyticsProvider.receivedProperties[eventIndex]
-        XCTAssertEqual(eventProperties["value"] as? String, "Flowery")
+        XCTAssertEqual(eventProperties["value"] as? String, "flowery")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeaturesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeaturesViewModelTests.swift
@@ -2,27 +2,10 @@ import XCTest
 @testable import WooCommerce
 
 final class AddProductFeaturesViewModelTests: XCTestCase {
-    private var analyticsProvider: MockAnalyticsProvider!
-    private var analytics: WooAnalytics!
-
-    override func setUp() {
-        super.setUp()
-
-        analyticsProvider = MockAnalyticsProvider()
-        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-    }
-
-    override func tearDown() {
-        analytics = nil
-        analyticsProvider = nil
-        super.tearDown()
-    }
-
     func test_productFeatures_is_updated_with_initial_features() {
         // Given
         let expectedFeatures = "Fancy new smart phone"
         let viewModel = AddProductFeaturesViewModel(siteID: 123,
-                                                    isFirstAttemptGeneratingDetails: .constant(true),
                                                     productName: "iPhone 15",
                                                     productFeatures: expectedFeatures,
                                                     onCompletion: { _ in })
@@ -36,7 +19,6 @@ final class AddProductFeaturesViewModelTests: XCTestCase {
         var triggeredFeatures: String?
         let expectedFeatures = "Fancy new smart phone"
         let viewModel = AddProductFeaturesViewModel(siteID: 123,
-                                                    isFirstAttemptGeneratingDetails: .constant(true),
                                                     productName: "iPhone 15",
                                                     onCompletion: { triggeredFeatures = $0 })
 
@@ -46,46 +28,5 @@ final class AddProductFeaturesViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(triggeredFeatures, expectedFeatures)
-    }
-
-    // MARK: Analytics
-
-    func test_proceedToPreview_tracks_generate_details_event_with_is_first_attempt_as_true_for_first_time_generation() throws {
-        //  Given
-        let viewModel = AddProductFeaturesViewModel(siteID: 123,
-                                                    isFirstAttemptGeneratingDetails: .constant(true),
-                                                    productName: "iPhone 15",
-                                                    analytics: analytics,
-                                                    onCompletion: { _ in })
-        // When
-        viewModel.proceedToPreview()
-
-        // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_generate_details_tapped"))
-
-        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_creation_ai_generate_details_tapped"}))
-        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
-        XCTAssertEqual(eventProperties["is_first_attempt"] as? Bool, true)
-    }
-
-    func test_proceedToPreview_tracks_generate_details_event_with_is_first_attempt_as_false_for_second_time_generation() throws {
-        //  Given
-        let viewModel = AddProductFeaturesViewModel(siteID: 123,
-                                                    isFirstAttemptGeneratingDetails: .constant(false),
-                                                    productName: "iPhone 15",
-                                                    analytics: analytics,
-                                                    onCompletion: { _ in })
-        // When
-
-        // Two generation attempts
-        viewModel.proceedToPreview()
-        viewModel.proceedToPreview()
-
-        // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_generate_details_tapped"))
-
-        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "product_creation_ai_generate_details_tapped"}))
-        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
-        XCTAssertEqual(eventProperties["is_first_attempt"] as? Bool, false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeaturesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductFeaturesViewModelTests.swift
@@ -2,11 +2,27 @@ import XCTest
 @testable import WooCommerce
 
 final class AddProductFeaturesViewModelTests: XCTestCase {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
 
     func test_productFeatures_is_updated_with_initial_features() {
         // Given
         let expectedFeatures = "Fancy new smart phone"
         let viewModel = AddProductFeaturesViewModel(siteID: 123,
+                                                    isFirstAttemptGeneratingDetails: .constant(true),
                                                     productName: "iPhone 15",
                                                     productFeatures: expectedFeatures,
                                                     onCompletion: { _ in })
@@ -20,6 +36,7 @@ final class AddProductFeaturesViewModelTests: XCTestCase {
         var triggeredFeatures: String?
         let expectedFeatures = "Fancy new smart phone"
         let viewModel = AddProductFeaturesViewModel(siteID: 123,
+                                                    isFirstAttemptGeneratingDetails: .constant(true),
                                                     productName: "iPhone 15",
                                                     onCompletion: { triggeredFeatures = $0 })
 
@@ -31,4 +48,44 @@ final class AddProductFeaturesViewModelTests: XCTestCase {
         XCTAssertEqual(triggeredFeatures, expectedFeatures)
     }
 
+    // MARK: Analytics
+
+    func test_proceedToPreview_tracks_generate_details_event_with_is_first_attempt_as_true_for_first_time_generation() throws {
+        //  Given
+        let viewModel = AddProductFeaturesViewModel(siteID: 123,
+                                                    isFirstAttemptGeneratingDetails: .constant(true),
+                                                    productName: "iPhone 15",
+                                                    analytics: analytics,
+                                                    onCompletion: { _ in })
+        // When
+        viewModel.proceedToPreview()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_generate_details_tapped"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_creation_ai_generate_details_tapped"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["is_first_attempt"] as? Bool, true)
+    }
+
+    func test_proceedToPreview_tracks_generate_details_event_with_is_first_attempt_as_false_for_second_time_generation() throws {
+        //  Given
+        let viewModel = AddProductFeaturesViewModel(siteID: 123,
+                                                    isFirstAttemptGeneratingDetails: .constant(false),
+                                                    productName: "iPhone 15",
+                                                    analytics: analytics,
+                                                    onCompletion: { _ in })
+        // When
+
+        // Two generation attempts
+        viewModel.proceedToPreview()
+        viewModel.proceedToPreview()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_generate_details_tapped"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "product_creation_ai_generate_details_tapped"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["is_first_attempt"] as? Bool, false)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductNameWithAIViewModelTests.swift
@@ -93,4 +93,15 @@ final class AddProductNameWithAIViewModelTests: XCTestCase {
         XCTAssertEqual(eventProperties["has_input_name"] as? Bool, true)
         XCTAssertEqual(eventProperties["source"] as? String, "product_creation_ai")
     }
+
+    func test_didTapContinue_tracks_continue_tapped_event() throws {
+        //  Given
+        let viewModel = AddProductNameWithAIViewModel(siteID: 123, analytics: analytics, onUsePackagePhoto: { _ in }, onContinueWithProductName: { _ in })
+
+        // When
+        viewModel.didTapContinue()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_product_name_continue_button_tapped"))
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
@@ -2,6 +2,22 @@ import XCTest
 @testable import WooCommerce
 
 final class AddProductWithAIContainerViewModelTests: XCTestCase {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
     // MARK: `didGenerateDataFromPackage`
 
     func test_didGenerateDataFromPackage_sets_values_from_package_flow() {
@@ -28,19 +44,42 @@ final class AddProductWithAIContainerViewModelTests: XCTestCase {
 
     // MARK: `onProductFeaturesAdded`
 
-    func test_onProductFeaturesAdded_sets_isFirstAttemptGeneratingDetails_as_false() {
-        // Given
+    func test_onProductFeaturesAdded_tracks_generate_details_event_with_is_first_attempt_as_true_for_first_time_generation() throws {
+        //  Given
         let viewModel = AddProductWithAIContainerViewModel(siteID: 123,
                                                            source: .productDescriptionAIAnnouncementModal,
+                                                           analytics: analytics,
                                                            onCancel: { },
                                                            onCompletion: { _ in })
-
-        XCTAssertTrue(viewModel.isFirstAttemptGeneratingDetails)
-
         // When
         viewModel.onProductFeaturesAdded(features: "")
 
         // Then
-        XCTAssertFalse(viewModel.isFirstAttemptGeneratingDetails)
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_generate_details_tapped"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_creation_ai_generate_details_tapped"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["is_first_attempt"] as? Bool, true)
+    }
+
+    func test_onProductFeaturesAdded_tracks_generate_details_event_with_is_first_attempt_as_false_for_second_time_generation() throws {
+        //  Given
+        let viewModel = AddProductWithAIContainerViewModel(siteID: 123,
+                                                           source: .productDescriptionAIAnnouncementModal,
+                                                           analytics: analytics,
+                                                           onCancel: { },
+                                                           onCompletion: { _ in })
+        // When
+
+        // Two generation attempts
+        viewModel.onProductFeaturesAdded(features: "")
+        viewModel.onProductFeaturesAdded(features: "")
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_generate_details_tapped"))
+
+        let eventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "product_creation_ai_generate_details_tapped"}))
+        let eventProperties = analyticsProvider.receivedProperties[eventIndex]
+        XCTAssertEqual(eventProperties["is_first_attempt"] as? Bool, false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
@@ -25,4 +25,22 @@ final class AddProductWithAIContainerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productDescription, expectedDescription)
         XCTAssertEqual(viewModel.productFeatures, expectedFeatures)
     }
+
+    // MARK: `onProductFeaturesAdded`
+
+    func test_onProductFeaturesAdded_sets_isFirstAttemptGeneratingDetails_as_false() {
+        // Given
+        let viewModel = AddProductWithAIContainerViewModel(siteID: 123,
+                                                           source: .productDescriptionAIAnnouncementModal,
+                                                           onCancel: { },
+                                                           onCompletion: { _ in })
+
+        XCTAssertTrue(viewModel.isFirstAttemptGeneratingDetails)
+
+        // When
+        viewModel.onProductFeaturesAdded(features: "")
+
+        // Then
+        XCTAssertFalse(viewModel.isFirstAttemptGeneratingDetails)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Yosemite
 @testable import WooCommerce
+@testable import Yosemite
 
 @MainActor
 final class ProductDetailPreviewViewModelTests: XCTestCase {
@@ -487,5 +488,121 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         let errorEventProperties = analyticsProvider.receivedProperties[errorEventIndex]
         XCTAssertEqual(errorEventProperties["error_code"] as? String, "503")
         XCTAssertEqual(errorEventProperties["error_domain"] as? String, "test")
+    }
+
+    func test_saveProductAsDraft_tracks_tapped_event() async throws {
+        // Given
+        let siteID: Int64 = 123
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+                                                      productName: "Pen",
+                                                      productDescription: nil,
+                                                      productFeatures: "Ballpoint, Blue ink, ABS plastic",
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      analytics: analytics,
+                                                      onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateProduct(_, _, _, _, _, _, _, _, _, _, completion):
+                completion(.success(Product.fake()))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.saveProductAsDraft()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_save_as_draft_button_tapped"))
+    }
+
+    func test_saveProductAsDraft_tracks_event_on_success() async throws {
+        // Given
+        let siteID: Int64 = 123
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+                                                      productName: "Pen",
+                                                      productDescription: nil,
+                                                      productFeatures: "Ballpoint, Blue ink, ABS plastic",
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      analytics: analytics,
+                                                      onProductCreated: { _ in })
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateProduct(_, _, _, _, _, _, _, _, _, _, completion):
+                completion(.success(Product.fake()))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            case let .addProduct(product, completion):
+                completion(.success(product))
+            default:
+                break
+            }
+        }
+        await viewModel.generateProductDetails()
+
+        // When
+        await viewModel.saveProductAsDraft()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_save_as_draft_success"))
+    }
+
+    func test_saveProductAsDraft_tracks_event_on_failure() async throws {
+        // Given
+        let siteID: Int64 = 123
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
+
+        let expectedError = ProductUpdateError(error: NSError(domain: "test", code: 503))
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+                                                      productName: "Pen",
+                                                      productDescription: nil,
+                                                      productFeatures: "Ballpoint, Blue ink, ABS plastic",
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      analytics: analytics,
+                                                      onProductCreated: { _ in })
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateProduct(_, _, _, _, _, _, _, _, _, _, completion):
+                completion(.success(Product.fake()))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            case let .addProduct(_, completion):
+                completion(.failure(expectedError))
+            default:
+                break
+            }
+        }
+        await viewModel.generateProductDetails()
+
+        // When
+        await viewModel.saveProductAsDraft()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("product_creation_ai_save_as_draft_failed"))
+
+        let errorEventIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "product_creation_ai_save_as_draft_failed"}))
+        let errorEventProperties = analyticsProvider.receivedProperties[errorEventIndex]
+        XCTAssertEqual(errorEventProperties["error_code"] as? String, "0")
+        XCTAssertEqual(errorEventProperties["error_domain"] as? String, "Yosemite.ProductUpdateError")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -405,6 +405,34 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.errorState, .savingProduct)
     }
 
+    func test_handleFeedback_sets_shouldShowFeedbackView_to_false() {
+        // Given
+        let siteID: Int64 = 123
+        let delay: TimeInterval = 0
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+                                                      productName: "Pen",
+                                                      productDescription: nil,
+                                                      productFeatures: "Ballpoint, Blue ink, ABS plastic",
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      analytics: analytics,
+                                                      delayBeforeDismissingFeedbackBanner: delay,
+                                                      onProductCreated: { _ in })
+
+        // When
+        viewModel.handleFeedback(.up)
+
+        // Then
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            XCTAssertFalse(viewModel.shouldShowFeedbackView)
+        }
+    }
+
     // MARK: Analytics
 
     func test_generateProductDetails_tracks_event_on_success() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -408,7 +408,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
     func test_handleFeedback_sets_shouldShowFeedbackView_to_false() {
         // Given
         let siteID: Int64 = 123
-        let delay: TimeInterval = 0
 
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let storage = MockStorageManager()
@@ -421,16 +420,13 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       storageManager: storage,
                                                       analytics: analytics,
-                                                      delayBeforeDismissingFeedbackBanner: delay,
                                                       onProductCreated: { _ in })
 
         // When
         viewModel.handleFeedback(.up)
 
         // Then
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            XCTAssertFalse(viewModel.shouldShowFeedbackView)
-        }
+        XCTAssertFalse(viewModel.shouldShowFeedbackView)
     }
 
     // MARK: Analytics

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -415,11 +415,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         let storage = MockStorageManager()
         storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
 
-        let uuid = UUID().uuidString
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        userDefaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.casual.rawValue]
-
-        let viewModel = ProductDetailPreviewViewModel(siteID: 123,
+        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -427,8 +423,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
-
-        // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateProduct(_, _, _, _, _, _, _, _, _, _, completion):
@@ -439,6 +433,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 break
             }
         }
+
+        // When
         await viewModel.generateProductDetails()
 
         // Then
@@ -453,13 +449,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         let storage = MockStorageManager()
         storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
 
-        let uuid = UUID().uuidString
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        userDefaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.casual.rawValue]
-
         let expectedError = NSError(domain: "test", code: 503)
 
-        let viewModel = ProductDetailPreviewViewModel(siteID: 123,
+        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -467,8 +459,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
-
-        // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateProduct(_, _, _, _, _, _, _, _, _, _, completion):
@@ -479,6 +469,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 break
             }
         }
+
+        // When
         await viewModel.generateProductDetails()
 
         // Then


### PR DESCRIPTION
Closes: #10795 Closes: #10809

## Description

- Adds tracking events for the main product creation AI flow. 
- Hides the feedback control after user provides feedback. 

## Testing instructions
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Validate the following event is present in Xcode console
```
Tracked product_creation_ai_entry_point_displayed, properties: [AnyHashable("site_url"): <site_url>, AnyHashable("plan"): "jetpack_free", AnyHashable("blog_id"): <site_id>, AnyHashable("was_ecommerce_trial"): false, AnyHashable("is_wpcom_store"): false]
```
- Select add product with AI.
- Validate the following event is present in Xcode console
```
Tracked product_creation_ai_entry_point_tapped, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("blog_id"): <site_id>, AnyHashable("plan"): "jetpack_free", AnyHashable("site_url"): <site_url>, AnyHashable("is_wpcom_store"): false]
```
- Enter a product name -> Tap "Continue"
- Validate the following event is present in Xcode console
```
Tracked product_creation_ai_product_name_continue_button_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("plan"): "jetpack_free", AnyHashable("blog_id"): <site_id>, AnyHashable("was_ecommerce_trial"): false, AnyHashable("site_url"): <site_url>]
```
- Tap "Set tone and voice"
- Select a tone
- Validate the following event is present in Xcode console
```
Tracked product_creation_ai_tone_selected, properties: [AnyHashable("site_url"): <site_url>, AnyHashable("value"): "Formal", AnyHashable("is_wpcom_store"): false, AnyHashable("blog_id"): <site_id>, AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "jetpack_free"]
```
- Enter product features -> Tap "Create Product Details" button
- Validate the following event is present in Xcode console
```
Tracked product_creation_ai_generate_details_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("plan"): "jetpack_free", AnyHashable("blog_id"): <site_id>, AnyHashable("was_ecommerce_trial"): false, AnyHashable("site_url"): <site_url>, AnyHashable("is_first_attempt"): true]
```
- The `is_first_attempt` property should be false when trying the generation next time. (Navigate back from the preview screen and try again)
- Once product details are generated, you will see the product details in the Preview screen.
- Validate the following event is present in Xcode console
```
Tracked product_creation_ai_generate_product_details_success, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("site_url"): <site_url>, AnyHashable("was_ecommerce_trial"): false, AnyHashable("blog_id"): <site_id>, AnyHashable("plan"): "jetpack_free"]
```
- Go back to the features screen. 
- Turn off wifi ->  -> Tap "Create Product Details" button
- When the generation fails, you will see the following event in Xcode console
```
Tracked product_creation_ai_generate_product_details_failed, properties: [AnyHashable("site_url"):  <site_url>, AnyHashable("is_wpcom_store"): false, AnyHashable("error_domain"): "WooCommerce.IdentifyLanguageError", AnyHashable("was_ecommerce_trial"): false, AnyHashable("error_description"): "<error_details>", AnyHashable("blog_id"): <site_id>, AnyHashable("plan"): "jetpack_free", AnyHashable("error_code"): "0"]
```
- Enable wifi and generate details again
- Give feedback by tapping thumbs up or down and validate that the following event is tracked
```
Tracked product_ai_feedback, properties: [AnyHashable("is_useful"): true, AnyHashable("source"): "product_creation", AnyHashable("plan"): "ecommerce-trial-bundle-monthly", AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): <site_id>, AnyHashable("was_ecommerce_trial"): true, AnyHashable("site_url"): <site_url>]
```
- Tap "Save as draft" button
- Validate the following event in Xcode console
```
Tracked product_creation_ai_save_as_draft_button_tapped, properties: [AnyHashable("site_url"): <site_url>, AnyHashable("blog_id"): <site_id>, AnyHashable("was_ecommerce_trial"): false, AnyHashable("is_wpcom_store"): false, AnyHashable("plan"): "jetpack_free"]
```
- Once the product is saved successfully you should see the following event in console
```
Tracked product_creation_ai_save_as_draft_success, properties: [AnyHashable("site_url"): <site_url>, AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "jetpack_free", AnyHashable("blog_id"): <site_id>, AnyHashable("is_wpcom_store"): false]
```
- When saving the product fails, you should see the following event in Xcode console
```
Tracked product_creation_ai_save_as_draft_failed, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("plan"): "jetpack_free", AnyHashable("blog_id"): 224075732, AnyHashable("error_code"): "0", AnyHashable("site_url"): <site_url>, AnyHashable("error_domain"): "Yosemite.ProductUpdateError", AnyHashable("was_ecommerce_trial"): false, AnyHashable("error_description"): "<error_details>"]
```


## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/86fbe8c1-3a1b-41e1-9253-b44c527d0fc9



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
