### PR TITLE
[Hazmat Shipping] Make hazmat parameter absent when no declaration happens

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -12,7 +12,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
     public let height: Double
     public let weight: Double
     public let isLetter: Bool
-    public let hazmatCategory: String
+    public let hazmatCategory: String?
     public let customsForm: ShippingLabelCustomsForm?
 
     public init(id: String,
@@ -22,7 +22,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
                 height: Double,
                 weight: Double,
                 isLetter: Bool,
-                hazmatCategory: String,
+                hazmatCategory: String?,
                 customsForm: ShippingLabelCustomsForm?) {
         self.id = id
         self.boxID = boxID
@@ -49,9 +49,7 @@ extension ShippingLabelPackageSelected: Encodable {
         try container.encode(height, forKey: .height)
         try container.encode(weight, forKey: .weight)
         try container.encode(isLetter, forKey: .isLetter)
-        if !hazmatCategory.isEmpty {
-            try container.encode(hazmatCategory, forKey: .hazmatCategory)
-        }
+        try container.encodeIfPresent(hazmatCategory, forKey: .hazmatCategory)
         if let form = customsForm {
             try container.encode(form.contentsType.rawValue, forKey: .contentsType)
             try container.encode(form.contentExplanation, forKey: .contentsExplanation)

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -12,7 +12,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
     public let height: Double
     public let weight: Double
     public let isLetter: Bool
-    public let hazmatCategory: String?
+    public let hazmatCategory: String
     public let customsForm: ShippingLabelCustomsForm?
 
     public init(id: String,
@@ -31,7 +31,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
         self.height = height
         self.weight = weight
         self.isLetter = isLetter
-        self.hazmatCategory = hazmatCategory.isEmpty ? nil : hazmatCategory
+        self.hazmatCategory = hazmatCategory
         self.customsForm = customsForm
     }
 }
@@ -49,7 +49,9 @@ extension ShippingLabelPackageSelected: Encodable {
         try container.encode(height, forKey: .height)
         try container.encode(weight, forKey: .weight)
         try container.encode(isLetter, forKey: .isLetter)
-        try container.encode(hazmatCategory, forKey: .hazmatCategory)
+        if !hazmatCategory.isEmpty {
+            try container.encode(hazmatCategory, forKey: .hazmatCategory)
+        }
         if let form = customsForm {
             try container.encode(form.contentsType.rawValue, forKey: .contentsType)
             try container.encode(form.contentExplanation, forKey: .contentsExplanation)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -63,6 +63,7 @@ final class ShippingLabelFormViewModel {
         return selectedPackagesDetails.compactMap { package -> ShippingLabelPackageSelected? in
             let weight = NumberFormatter.double(from: package.totalWeight) ?? .zero
             let customsForm = customsForms.first(where: { $0.packageID == package.id })
+            let hazmatCategory = package.selectedHazmatCategory != .none ? package.selectedHazmatCategory.rawValue : ""
 
             if let customPackage = packagesResponse.customPackages.first(where: { $0.title == package.packageID }) {
                 let boxID = customPackage.title
@@ -73,7 +74,7 @@ final class ShippingLabelFormViewModel {
                                                     height: customPackage.getHeight(),
                                                     weight: weight,
                                                     isLetter: customPackage.isLetter,
-                                                    hazmatCategory: package.selectedHazmatCategory.rawValue,
+                                                    hazmatCategory: hazmatCategory,
                                                     customsForm: customsForm)
             }
 
@@ -87,7 +88,7 @@ final class ShippingLabelFormViewModel {
                                                         height: predefinedPackage.getHeight(),
                                                         weight: weight,
                                                         isLetter: predefinedPackage.isLetter,
-                                                        hazmatCategory: package.selectedHazmatCategory.rawValue,
+                                                        hazmatCategory: hazmatCategory,
                                                         customsForm: customsForm)
                 }
             }
@@ -100,7 +101,7 @@ final class ShippingLabelFormViewModel {
                                                     height: Double(item.dimensions.height) ?? 0,
                                                     weight: item.weight,
                                                     isLetter: false,
-                                                    hazmatCategory: package.selectedHazmatCategory.rawValue,
+                                                    hazmatCategory: hazmatCategory,
                                                     customsForm: customsForm)
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -63,7 +63,7 @@ final class ShippingLabelFormViewModel {
         return selectedPackagesDetails.compactMap { package -> ShippingLabelPackageSelected? in
             let weight = NumberFormatter.double(from: package.totalWeight) ?? .zero
             let customsForm = customsForms.first(where: { $0.packageID == package.id })
-            let hazmatCategory = package.selectedHazmatCategory != .none ? package.selectedHazmatCategory.rawValue : ""
+            let hazmatCategory = package.selectedHazmatCategory != .none ? package.selectedHazmatCategory.rawValue : nil
 
             if let customPackage = packagesResponse.customPackages.first(where: { $0.title == package.packageID }) {
                 let boxID = customPackage.title

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -251,6 +251,38 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(shippingLabelFormViewModel.selectedPackagesDetails, [selectedPackage])
     }
 
+    func test_handlePackageDetailsValueChanges_returns_empty_hazmat_string_when_category_is_none() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
+        let expectedPackageID = ShippingLabelPackageAttributes.originalPackagingBoxID
+        let expectedPackageWeight = "55"
+        let givenPackageItem = ShippingLabelPackageItem()
+        let givenPackageAttributes = ShippingLabelPackageAttributes(packageID: expectedPackageID,
+                                                             totalWeight: expectedPackageWeight,
+                                                             items: [givenPackageItem],
+                                                             selectedHazmatCategory: .none)
+        let givenPackageResponse = ShippingLabelPackagesResponse.fake()
+        let expectedSelectedPackage = ShippingLabelPackageSelected(id: expectedPackageID,
+                                                           boxID: expectedPackageID,
+                                                           length: 0,
+                                                           width: 0,
+                                                           height: 0,
+                                                           weight: 0,
+                                                           isLetter: false,
+                                                           hazmatCategory: "",
+                                                           customsForm: nil)
+
+        // When
+        shippingLabelFormViewModel.handleNewPackagesResponse(packagesResponse: givenPackageResponse)
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [givenPackageAttributes])
+
+        // Then
+        XCTAssertEqual(shippingLabelFormViewModel.selectedPackages, [expectedSelectedPackage])
+    }
+
     func test_handlePackageDetailsValueChanges_reset_carrier_and_rates_selection() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -251,32 +251,41 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(shippingLabelFormViewModel.selectedPackagesDetails, [selectedPackage])
     }
 
-    func test_handlePackageDetailsValueChanges_returns_empty_hazmat_string_when_category_is_none() {
+    func test_selectedPackages_returns_package_with_empty_hazmat_string_when_category_is_none() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
                                                                     destinationAddress: nil,
                                                                     userDefaults: userDefaults)
         let expectedPackageID = ShippingLabelPackageAttributes.originalPackagingBoxID
-        let expectedPackageWeight = "55"
-        let givenPackageItem = ShippingLabelPackageItem()
+        let expectedPackageWeight = "10"
+        let expectedDimensions = ProductDimensions(length: "10", width: "10", height: "10")
+        let packageName = "package-name"
+        let givenPackageItem = ShippingLabelPackageItem(productOrVariationID: 0,
+                                                        name: packageName,
+                                                        weight: 10.0,
+                                                        quantity: 1,
+                                                        value: 10.0,
+                                                        dimensions: expectedDimensions,
+                                                        attributes: [])
+
         let givenPackageAttributes = ShippingLabelPackageAttributes(packageID: expectedPackageID,
-                                                             totalWeight: expectedPackageWeight,
-                                                             items: [givenPackageItem],
-                                                             selectedHazmatCategory: .none)
-        let givenPackageResponse = ShippingLabelPackagesResponse.fake()
-        let expectedSelectedPackage = ShippingLabelPackageSelected(id: expectedPackageID,
-                                                           boxID: expectedPackageID,
-                                                           length: 0,
-                                                           width: 0,
-                                                           height: 0,
-                                                           weight: 0,
-                                                           isLetter: false,
-                                                           hazmatCategory: "",
-                                                           customsForm: nil)
+                                                                    totalWeight: expectedPackageWeight,
+                                                                    items: [givenPackageItem],
+                                                                    selectedHazmatCategory: .none)
+
+        let expectedSelectedPackage = ShippingLabelPackageSelected(id: givenPackageAttributes.id,
+                                                                   boxID: expectedPackageID,
+                                                                   length: 10.0,
+                                                                   width: 10.0,
+                                                                   height: 10.0,
+                                                                   weight: 10.0,
+                                                                   isLetter: false,
+                                                                   hazmatCategory: "",
+                                                                   customsForm: nil)
 
         // When
-        shippingLabelFormViewModel.handleNewPackagesResponse(packagesResponse: givenPackageResponse)
+        shippingLabelFormViewModel.handleNewPackagesResponse(packagesResponse: ShippingLabelPackagesResponse.fake())
         shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [givenPackageAttributes])
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -281,7 +281,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                    height: 10.0,
                                                                    weight: 10.0,
                                                                    isLetter: false,
-                                                                   hazmatCategory: "",
+                                                                   hazmatCategory: nil,
                                                                    customsForm: nil)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -292,6 +292,47 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(shippingLabelFormViewModel.selectedPackages, [expectedSelectedPackage])
     }
 
+    func test_selectedPackages_returns_package_with_valid_hazmat_string_when_category_is_NOT_none() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
+        let expectedPackageID = ShippingLabelPackageAttributes.originalPackagingBoxID
+        let expectedPackageWeight = "10"
+        let expectedDimensions = ProductDimensions(length: "10", width: "10", height: "10")
+        let packageName = "package-name"
+        let givenPackageItem = ShippingLabelPackageItem(productOrVariationID: 0,
+                                                        name: packageName,
+                                                        weight: 10.0,
+                                                        quantity: 1,
+                                                        value: 10.0,
+                                                        dimensions: expectedDimensions,
+                                                        attributes: [])
+
+        let givenPackageAttributes = ShippingLabelPackageAttributes(packageID: expectedPackageID,
+                                                                    totalWeight: expectedPackageWeight,
+                                                                    items: [givenPackageItem],
+                                                                    selectedHazmatCategory: .class7)
+
+        let expectedSelectedPackage = ShippingLabelPackageSelected(id: givenPackageAttributes.id,
+                                                                   boxID: expectedPackageID,
+                                                                   length: 10.0,
+                                                                   width: 10.0,
+                                                                   height: 10.0,
+                                                                   weight: 10.0,
+                                                                   isLetter: false,
+                                                                   hazmatCategory: "CLASS_7",
+                                                                   customsForm: nil)
+
+        // When
+        shippingLabelFormViewModel.handleNewPackagesResponse(packagesResponse: ShippingLabelPackagesResponse.fake())
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [givenPackageAttributes])
+
+        // Then
+        XCTAssertEqual(shippingLabelFormViewModel.selectedPackages, [expectedSelectedPackage])
+    }
+
     func test_handlePackageDetailsValueChanges_reset_carrier_and_rates_selection() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),


### PR DESCRIPTION
Closes #10804 

Why
==========
After some user reports, we found out that the shipping label feature is failing to acquire rates when the packages doesn't contain any hazmat declaration. This is because when we submit a `nil` or empty hazmat, the Shipping Label API will consider that the parameter is incorrect instead of ignoring it.

How
==========
Introduces a simple adjustment to allow us to remove the `hazmat` parameter from the package request data when no hazmat category is selected.

Screen Capture
==========
### Before fix -- no shipping rates response
https://github.com/woocommerce/woocommerce-ios/assets/5920403/b2579ba0-1d1a-4fdd-84b1-cbd323d36572

### After fix
https://github.com/woocommerce/woocommerce-ios/assets/5920403/e53143f2-e85f-4d24-8b19-e61634bb895b

| Package without hazmat (no hazmat parameter declared)  | Package with hazmat |
| ------------- | ------------- |
| <img width="474" alt="Screenshot 2023-09-28 at 11 24 20" src="https://github.com/woocommerce/woocommerce-ios/assets/5920403/94447c9c-eedc-4cfa-b8b8-f4df1d66103f"> | <img width="327" alt="Screenshot 2023-09-28 at 11 23 19" src="https://github.com/woocommerce/woocommerce-ios/assets/5920403/875e5b0f-a706-4f96-b741-9676ca740111"> |

How to Test
==========
### Scenario 1
Go through the Shipping Label creation scenario without declaring any Hazmat package. Verify that the shipping rates are calculated correctly and that generating the shipping label is possible just fine.

### Scenario 2
Go through the Shipping Label creation scenario and DECLARE at least one package with Hazmat content. Verify that the shipping rates are calculated correctly and that generating the shipping label is possible just fine.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.










