### PR TITLE
Product Creation AI: Workaround to show separators on Preview screen only when needed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -62,38 +62,30 @@ struct ProductDetailPreviewView: View {
                                            cornerRadius: Layout.cornerRadius)
                     .padding(.bottom, Layout.contentPadding)
 
-                    VStack(spacing: 0) {
+                    VStack(spacing: Constants.separatorHeight) {
                         // Price
                         TitleAndValueDetailRow(title: Localization.price,
                                                value: viewModel.productPrice,
                                                image: UIImage.priceImage,
                                                isLoading: viewModel.isGeneratingDetails)
-                        Divider()
-                            .background(Color(.separator))
 
                         // Inventory
                         TitleAndValueDetailRow(title: Localization.inventory,
                                                value: Localization.inStock,
                                                image: UIImage.inventoryImage,
                                                isLoading: viewModel.isGeneratingDetails)
-                        Divider()
-                            .background(Color(.separator))
 
                         // Categories
                         TitleAndValueDetailRow(title: Localization.categories,
                                                value: viewModel.productCategories,
                                                image: UIImage.categoriesIcon,
                                                isLoading: viewModel.isGeneratingDetails)
-                        Divider()
-                            .background(Color(.separator))
 
                         // Tags
                         TitleAndValueDetailRow(title: Localization.tags,
                                                value: viewModel.productTags,
                                                image: UIImage.tagsIcon,
                                                isLoading: viewModel.isGeneratingDetails)
-                        Divider()
-                            .background(Color(.separator))
 
                         // Shipping details
                         TitleAndValueDetailRow(title: Localization.shipping,
@@ -101,6 +93,7 @@ struct ProductDetailPreviewView: View {
                                                image: UIImage.shippingImage,
                                                isLoading: viewModel.isGeneratingDetails)
                     }
+                    .background(Color(.separator))
                     .cornerRadius(Layout.cornerRadius)
                 }
 
@@ -223,6 +216,7 @@ fileprivate extension ProductDetailPreviewView {
         static let contentPadding: CGFloat = 16
         static let cornerRadius: CGFloat = 8
         static let detailVerticalSpacing: CGFloat = 4
+        static let separatorHeight: CGFloat = 0.5
     }
     enum Constants {
         static let dummyText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -62,7 +62,7 @@ struct ProductDetailPreviewView: View {
                                            cornerRadius: Layout.cornerRadius)
                     .padding(.bottom, Layout.contentPadding)
 
-                    VStack(spacing: Constants.separatorHeight) {
+                    VStack(spacing: Layout.separatorHeight) {
                         // Price
                         TitleAndValueDetailRow(title: Localization.price,
                                                value: viewModel.productPrice,
@@ -93,7 +93,7 @@ struct ProductDetailPreviewView: View {
                                                image: UIImage.shippingImage,
                                                isLoading: viewModel.isGeneratingDetails)
                     }
-                    .background(Color(.separator))
+                    .background(viewModel.isGeneratingDetails ? Color.clear : Color(.separator))
                     .cornerRadius(Layout.cornerRadius)
                 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10774 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a workaround for the separators in the Preview screen. Since we don't know when a detail is available, it's not easy to determine when to show a divider. My solution is to not use dividers and instead use the combination of spacing and background color.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select add product with AI.
- Follow the steps to add product name, features and generate details.
- On the Preview screen, notice that there are only dividers between detail rows, not at the top or bottom.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Light mode | Dark mode |
| --- | --- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/ed2808f0-d61b-404d-97bb-c01a4f2f014a" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/82a3c200-6657-4b27-b45b-277e4c441549" width=320 /> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
