### PR TITLE
Release Product Creation AI

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -96,7 +96,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .manualTaxesInOrderM3:
             return true
         case .productCreationAI:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .giftCardInOrderForm:
             return true
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 15.6
 -----
 - [**] Taxes in orders: Users can now store the tax rate's location to add it automatically to a new order customer's address. [https://github.com/woocommerce/woocommerce-ios/pull/10802]
+- [**] WPCOM stores and self-hosted stores with Jetpack AI plugin can now create products using AI. [https://github.com/woocommerce/woocommerce-ios/pull/10812]
 
 15.5
 -----


### PR DESCRIPTION
Closes: #10811 

## Description

Releases the Product Creation using AI feature by enabling the feature flag. The release notes is also updated. 

## Testing instructions
- Log in to a WPCom or self-hosted store with Jetpack AI installed.
- Switch to the Products tab and select "+" to add a new product.
- Select "Create a product with AI".
- Enter a product name or tap "Suggest a name" to generate a name using AI. 
- Optionally, you can tap on "Use package photo" to create details from a package photo
- After entering the product name, tap "Continue" to navigate to the "About your product" screen
- Enter a few keywords to represent the product.
- Experiment with setting the AI tone by tapping on "Set tone and voice."
- Tap "Create Product Details" to navigate to the Preview screen 
- Once the details are generated, you can save the AI-generated product as a draft by tapping on "Save as draft"

## Screenshots
https://github.com/woocommerce/woocommerce-ios/assets/524475/86fbe8c1-3a1b-41e1-9253-b44c527d0fc9

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
