### PR TITLE
iOS 17: Disable the splitViewInOrdersTab feature flag to bypass a crash when opening orders

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -16,7 +16,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInOrdersTab:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            // We have a crash with this feature flag enabled. See https://github.com/woocommerce/woocommerce-ios/issues/10815
+            return false
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -76,10 +76,7 @@ public final class SingleOrderScreen: ScreenObject {
     }
 
     public func goBackToOrdersScreen() throws -> OrdersScreen {
-        // Only needed for iPhone because iPad shows both Orders and Single Order screens on the same view
-        if XCUIDevice.isPhone {
-            pop()
-        }
+        pop()
         return try OrdersScreen()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before this PR the feature flag `splitViewInOrdersTab`was enabled for localDeveloper and alpha build configuration. When upgrading to iOS 17 we experienced a crash due to its implementation: it crashes after trying to open an order from the order list. 

Because of that, I disable it totally with this PR so we can keep working without it affecting our development. Together with that, I opened an https://github.com/woocommerce/woocommerce-ios/issues/10815 to tackle the crash in the future.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With iOS 17 iPhone 15 Pro simulator, Xcode 15, and the `splitViewInOrdersTab` feature flag enabled

1. Go to Orders
2. Tap on any order from the list
3. Crash

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.