### PR TITLE
Bundle products in order form: Networking & Yosemite layer changes

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -586,6 +586,20 @@ extension Networking.OrderItemAttribute {
         )
     }
 }
+extension Networking.OrderItemBundleItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.OrderItemBundleItem {
+        .init(
+            bundledItemID: .fake(),
+            productID: .fake(),
+            quantity: .fake(),
+            isOptionalAndSelected: .fake(),
+            variationID: .fake(),
+            variationAttributes: .fake()
+        )
+    }
+}
 extension Networking.OrderItemProductAddOn {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -570,7 +570,8 @@ extension Networking.OrderItem {
             totalTax: .fake(),
             attributes: .fake(),
             addOns: .fake(),
-            parent: .fake()
+            parent: .fake(),
+            bundleConfiguration: .fake()
         )
     }
 }
@@ -954,7 +955,15 @@ extension Networking.ProductBundleItem {
             productID: .fake(),
             menuOrder: .fake(),
             title: .fake(),
-            stockStatus: .fake()
+            stockStatus: .fake(),
+            minQuantity: .fake(),
+            maxQuantity: .fake(),
+            defaultQuantity: .fake(),
+            isOptional: .fake(),
+            overridesVariations: .fake(),
+            allowedVariations: .fake(),
+            overridesDefaultVariationAttributes: .fake(),
+            defaultVariationAttributes: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		023930632918FF5400B2632F /* DomainRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023930622918FF5400B2632F /* DomainRemote.swift */; };
 		0239306B291A96F800B2632F /* DomainRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0239306A291A96F800B2632F /* DomainRemoteTests.swift */; };
 		0239306D291A973F00B2632F /* domain-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = 0239306C291A973F00B2632F /* domain-suggestions.json */; };
+		024124862AC93E470035A247 /* OrderItemBundleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024124852AC93E470035A247 /* OrderItemBundleItem.swift */; };
 		025CA2C0238EB8CB00B05C81 /* ProductShippingClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2BF238EB8CB00B05C81 /* ProductShippingClass.swift */; };
 		025CA2C2238EBBAA00B05C81 /* ProductShippingClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2C1238EBBAA00B05C81 /* ProductShippingClassListMapper.swift */; };
 		025CA2C4238EBC4300B05C81 /* ProductShippingClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */; };
@@ -1016,6 +1017,7 @@
 		023930622918FF5400B2632F /* DomainRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRemote.swift; sourceTree = "<group>"; };
 		0239306A291A96F800B2632F /* DomainRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRemoteTests.swift; sourceTree = "<group>"; };
 		0239306C291A973F00B2632F /* domain-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "domain-suggestions.json"; sourceTree = "<group>"; };
+		024124852AC93E470035A247 /* OrderItemBundleItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemBundleItem.swift; sourceTree = "<group>"; };
 		025CA2BF238EB8CB00B05C81 /* ProductShippingClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClass.swift; sourceTree = "<group>"; };
 		025CA2C1238EBBAA00B05C81 /* ProductShippingClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassListMapper.swift; sourceTree = "<group>"; };
 		025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassRemote.swift; sourceTree = "<group>"; };
@@ -2433,6 +2435,7 @@
 				CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */,
 				B5C6FCCE20A3592900A4F8E4 /* OrderItem.swift */,
 				021EAA5525493B3600AA8CCD /* OrderItemAttribute.swift */,
+				024124852AC93E470035A247 /* OrderItemBundleItem.swift */,
 				02EBCB3D2AA03D520019085B /* OrderItemProductAddOn.swift */,
 				CE430671234B9EB20073CBFF /* OrderItemTax.swift */,
 				CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */,
@@ -4049,6 +4052,7 @@
 				EE57C1152979371B00BC31E7 /* ApplicationPassword.swift in Sources */,
 				B554FA8F2180BC7000C54DFF /* NoteHashListMapper.swift in Sources */,
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
+				024124862AC93E470035A247 /* OrderItemBundleItem.swift in Sources */,
 				CE71E22B2A4C363E00DB5376 /* ProductsReportsRemote.swift in Sources */,
 				45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */,
 				B557DA0D20975DB1005962F4 /* WordPressAPIVersion.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -720,7 +720,8 @@ extension Networking.OrderItem {
         totalTax: CopiableProp<String> = .copy,
         attributes: CopiableProp<[OrderItemAttribute]> = .copy,
         addOns: CopiableProp<[OrderItemProductAddOn]> = .copy,
-        parent: NullableCopiableProp<Int64> = .copy
+        parent: NullableCopiableProp<Int64> = .copy,
+        bundleConfiguration: CopiableProp<[OrderItemBundleItem]> = .copy
     ) -> Networking.OrderItem {
         let itemID = itemID ?? self.itemID
         let name = name ?? self.name
@@ -738,6 +739,7 @@ extension Networking.OrderItem {
         let attributes = attributes ?? self.attributes
         let addOns = addOns ?? self.addOns
         let parent = parent ?? self.parent
+        let bundleConfiguration = bundleConfiguration ?? self.bundleConfiguration
 
         return Networking.OrderItem(
             itemID: itemID,
@@ -755,7 +757,8 @@ extension Networking.OrderItem {
             totalTax: totalTax,
             attributes: attributes,
             addOns: addOns,
-            parent: parent
+            parent: parent,
+            bundleConfiguration: bundleConfiguration
         )
     }
 }
@@ -1405,20 +1408,44 @@ extension Networking.ProductBundleItem {
         productID: CopiableProp<Int64> = .copy,
         menuOrder: CopiableProp<Int64> = .copy,
         title: CopiableProp<String> = .copy,
-        stockStatus: CopiableProp<ProductBundleItemStockStatus> = .copy
+        stockStatus: CopiableProp<ProductBundleItemStockStatus> = .copy,
+        minQuantity: CopiableProp<Decimal> = .copy,
+        maxQuantity: NullableCopiableProp<Decimal> = .copy,
+        defaultQuantity: CopiableProp<Decimal> = .copy,
+        isOptional: CopiableProp<Bool> = .copy,
+        overridesVariations: CopiableProp<Bool> = .copy,
+        allowedVariations: CopiableProp<[Int64]> = .copy,
+        overridesDefaultVariationAttributes: CopiableProp<Bool> = .copy,
+        defaultVariationAttributes: CopiableProp<[ProductVariationAttribute]> = .copy
     ) -> Networking.ProductBundleItem {
         let bundledItemID = bundledItemID ?? self.bundledItemID
         let productID = productID ?? self.productID
         let menuOrder = menuOrder ?? self.menuOrder
         let title = title ?? self.title
         let stockStatus = stockStatus ?? self.stockStatus
+        let minQuantity = minQuantity ?? self.minQuantity
+        let maxQuantity = maxQuantity ?? self.maxQuantity
+        let defaultQuantity = defaultQuantity ?? self.defaultQuantity
+        let isOptional = isOptional ?? self.isOptional
+        let overridesVariations = overridesVariations ?? self.overridesVariations
+        let allowedVariations = allowedVariations ?? self.allowedVariations
+        let overridesDefaultVariationAttributes = overridesDefaultVariationAttributes ?? self.overridesDefaultVariationAttributes
+        let defaultVariationAttributes = defaultVariationAttributes ?? self.defaultVariationAttributes
 
         return Networking.ProductBundleItem(
             bundledItemID: bundledItemID,
             productID: productID,
             menuOrder: menuOrder,
             title: title,
-            stockStatus: stockStatus
+            stockStatus: stockStatus,
+            minQuantity: minQuantity,
+            maxQuantity: maxQuantity,
+            defaultQuantity: defaultQuantity,
+            isOptional: isOptional,
+            overridesVariations: overridesVariations,
+            allowedVariations: allowedVariations,
+            overridesDefaultVariationAttributes: overridesDefaultVariationAttributes,
+            defaultVariationAttributes: defaultVariationAttributes
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -781,6 +781,33 @@ extension Networking.OrderItemAttribute {
     }
 }
 
+extension Networking.OrderItemBundleItem {
+    public func copy(
+        bundledItemID: CopiableProp<Int64> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        quantity: CopiableProp<Decimal> = .copy,
+        isOptionalAndSelected: NullableCopiableProp<Bool> = .copy,
+        variationID: NullableCopiableProp<Int64> = .copy,
+        variationAttributes: NullableCopiableProp<[ProductVariationAttribute]> = .copy
+    ) -> Networking.OrderItemBundleItem {
+        let bundledItemID = bundledItemID ?? self.bundledItemID
+        let productID = productID ?? self.productID
+        let quantity = quantity ?? self.quantity
+        let isOptionalAndSelected = isOptionalAndSelected ?? self.isOptionalAndSelected
+        let variationID = variationID ?? self.variationID
+        let variationAttributes = variationAttributes ?? self.variationAttributes
+
+        return Networking.OrderItemBundleItem(
+            bundledItemID: bundledItemID,
+            productID: productID,
+            quantity: quantity,
+            isOptionalAndSelected: isOptionalAndSelected,
+            variationID: variationID,
+            variationAttributes: variationAttributes
+        )
+    }
+}
+
 extension Networking.OrderItemProductAddOn {
     public func copy(
         addOnID: NullableCopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -34,6 +34,10 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
     ///
     public let parent: Int64?
 
+    /// Networking layer only, used when Product Bundles extension/plugin is active.
+    /// The property is non-empty when the order item is a bundle product with configuration for each bundled item.
+    public let bundleConfiguration: [OrderItemBundleItem]
+
     /// OrderItem struct initializer.
     ///
     public init(itemID: Int64,
@@ -51,7 +55,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
                 totalTax: String,
                 attributes: [OrderItemAttribute],
                 addOns: [OrderItemProductAddOn],
-                parent: Int64?) {
+                parent: Int64?,
+                bundleConfiguration: [OrderItemBundleItem]) {
         self.itemID = itemID
         self.name = name
         self.productID = productID
@@ -68,6 +73,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         self.attributes = attributes
         self.addOns = addOns
         self.parent = parent
+        self.bundleConfiguration = bundleConfiguration
     }
 
     /// The public initializer for OrderItem.
@@ -139,7 +145,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
                   totalTax: totalTax,
                   attributes: attributes,
                   addOns: productAddOns,
-                  parent: bundledBy ?? compositeParent)
+                  parent: bundledBy ?? compositeParent,
+                  bundleConfiguration: [])
     }
 
     /// Encodes an order item.
@@ -161,6 +168,10 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
 
         if !total.isEmpty {
             try container.encode(total, forKey: .total)
+        }
+
+        if !bundleConfiguration.isEmpty {
+            try container.encode(bundleConfiguration, forKey: .bundleConfiguration)
         }
     }
 }
@@ -188,6 +199,7 @@ extension OrderItem {
         case totalTax       = "total_tax"
         case bundledBy      = "bundled_by"
         case compositeParent = "composite_parent"
+        case bundleConfiguration = "bundle_configuration"
     }
 }
 

--- a/Networking/Networking/Model/OrderItemBundleItem.swift
+++ b/Networking/Networking/Model/OrderItemBundleItem.swift
@@ -22,7 +22,12 @@ public struct OrderItemBundleItem: Encodable, Equatable, Hashable {
     /// Bundle item's variation attributes if the item is a variable product. All attributes need to be specified ("Any" is not supported).
     public let variationAttributes: [ProductVariationAttribute]?
 
-    public init(bundledItemID: Int64, productID: Int64, quantity: Decimal, isOptionalAndSelected: Bool?, variationID: Int64?, variationAttributes: [ProductVariationAttribute]?) {
+    public init(bundledItemID: Int64,
+                productID: Int64,
+                quantity: Decimal,
+                isOptionalAndSelected: Bool?,
+                variationID: Int64?,
+                variationAttributes: [ProductVariationAttribute]?) {
         self.bundledItemID = bundledItemID
         self.productID = productID
         self.quantity = quantity

--- a/Networking/Networking/Model/OrderItemBundleItem.swift
+++ b/Networking/Networking/Model/OrderItemBundleItem.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Networking layer and encodable only, when creating/updating an `OrderItem`.
 /// Contains configurable properties of a bundle item when an order item is a bundle product.
-public struct OrderItemBundleItem: Encodable, Equatable, Hashable {
+public struct OrderItemBundleItem: Encodable, Equatable, Hashable, GeneratedFakeable, GeneratedCopiable {
     /// Bundle item ID.
     public let bundledItemID: Int64
 

--- a/Networking/Networking/Model/OrderItemBundleItem.swift
+++ b/Networking/Networking/Model/OrderItemBundleItem.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Codegen
+
+/// Networking layer and encodable only, when creating/updating an `OrderItem`.
+/// Contains configurable properties of a bundle item when an order item is a bundle product.
+public struct OrderItemBundleItem: Encodable, Equatable, Hashable {
+    /// Bundle item ID.
+    public let bundledItemID: Int64
+
+    /// Bundle item's product ID.
+    public let productID: Int64
+
+    /// Quantity of the bundle item.
+    public let quantity: Decimal
+
+    /// Only `true` if the bundle item is optional and selected. If the bundle item is not optional, the value is `nil`.
+    public let isOptionalAndSelected: Bool?
+
+    /// Bundle item's variation ID if the item is a variable product.
+    public let variationID: Int64?
+
+    /// Bundle item's variation attributes if the item is a variable product. All attributes need to be specified ("Any" is not supported).
+    public let variationAttributes: [ProductVariationAttribute]?
+
+    public init(bundledItemID: Int64, productID: Int64, quantity: Decimal, isOptionalAndSelected: Bool?, variationID: Int64?, variationAttributes: [ProductVariationAttribute]?) {
+        self.bundledItemID = bundledItemID
+        self.productID = productID
+        self.quantity = quantity
+        self.isOptionalAndSelected = isOptionalAndSelected
+        self.variationID = variationID
+        self.variationAttributes = variationAttributes
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(bundledItemID, forKey: .bundledItemID)
+        try container.encode(productID, forKey: .productID)
+        try container.encode(quantity, forKey: .quantity)
+
+        if let isOptionalAndSelected, isOptionalAndSelected {
+            try container.encode(isOptionalAndSelected, forKey: .isOptionalAndSelected)
+        }
+
+        if let variationID, let variationAttributes {
+            try container.encode(variationID, forKey: .variationID)
+            try container.encode(variationAttributes, forKey: .variationAttributes)
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bundledItemID = "bundled_item_id"
+        case productID = "product_id"
+        case quantity
+        case isOptionalAndSelected = "optional_selected"
+        case variationID = "variation_id"
+        case variationAttributes = "attributes"
+    }
+}

--- a/Networking/Networking/Model/Product/ProductBundleItem.swift
+++ b/Networking/Networking/Model/Product/ProductBundleItem.swift
@@ -84,7 +84,7 @@ public struct ProductBundleItem: Codable, Equatable, GeneratedCopiable, Generate
         let title = try container.decode(String.self, forKey: .title)
         let stockStatus = try container.decode(ProductBundleItemStockStatus.self, forKey: .stockStatus)
         let minQuantity = try container.decode(Decimal.self, forKey: .minQuantity)
-        // When there is no max quantity, an empty string is returned null.
+        // When there is no max quantity, an empty string is returned.
         let maxQuantity = container.failsafeDecodeIfPresent(decimalForKey: .maxQuantity)
         let defaultQuantity = try container.decode(Decimal.self, forKey: .defaultQuantity)
         let isOptional = try container.decode(Bool.self, forKey: .isOptional)

--- a/Networking/Networking/Model/Product/ProductBundleItem.swift
+++ b/Networking/Networking/Model/Product/ProductBundleItem.swift
@@ -19,18 +19,58 @@ public struct ProductBundleItem: Codable, Equatable, GeneratedCopiable, Generate
     /// Stock status of the bundled item, taking minimum quantity into account.
     public let stockStatus: ProductBundleItemStockStatus
 
+    /// Minimum quantity of the item in a bundle product.
+    public let minQuantity: Decimal
+
+    /// Maximum quantity of the item in a bundle product.
+    public let maxQuantity: Decimal?
+
+    /// Default quantity of the item in a bundle product.
+    public let defaultQuantity: Decimal
+
+    /// Whether the bundle item is optional.
+    public let isOptional: Bool
+
+    /// Whether variations filtering is active, applicable for variable bundled products only.
+    public let overridesVariations: Bool
+
+    /// List of enabled variation IDs of the bundle item, applicable when variations filtering is active.
+    public let allowedVariations: [Int64]
+
+    /// Whether the default variation attribute values are overridden, applicable for variable bundled products only.
+    public let overridesDefaultVariationAttributes: Bool
+
+    /// Overridden default variation attribute values, if applicable.
+    public let defaultVariationAttributes: [ProductVariationAttribute]
+
     /// ProductBundleItem struct initializer
     ///
     public init(bundledItemID: Int64,
                 productID: Int64,
                 menuOrder: Int64,
                 title: String,
-                stockStatus: ProductBundleItemStockStatus) {
+                stockStatus: ProductBundleItemStockStatus,
+                minQuantity: Decimal,
+                maxQuantity: Decimal?,
+                defaultQuantity: Decimal,
+                isOptional: Bool,
+                overridesVariations: Bool,
+                allowedVariations: [Int64],
+                overridesDefaultVariationAttributes: Bool,
+                defaultVariationAttributes: [ProductVariationAttribute]) {
         self.bundledItemID = bundledItemID
         self.productID = productID
         self.menuOrder = menuOrder
         self.title = title
         self.stockStatus = stockStatus
+        self.minQuantity = minQuantity
+        self.maxQuantity = maxQuantity
+        self.defaultQuantity = defaultQuantity
+        self.isOptional = isOptional
+        self.overridesVariations = overridesVariations
+        self.allowedVariations = allowedVariations
+        self.overridesDefaultVariationAttributes = overridesDefaultVariationAttributes
+        self.defaultVariationAttributes = defaultVariationAttributes
     }
 
     /// The public initializer for ProductBundleItem.
@@ -43,12 +83,29 @@ public struct ProductBundleItem: Codable, Equatable, GeneratedCopiable, Generate
         let menuOrder = try container.decode(Int64.self, forKey: .menuOrder)
         let title = try container.decode(String.self, forKey: .title)
         let stockStatus = try container.decode(ProductBundleItemStockStatus.self, forKey: .stockStatus)
+        let minQuantity = try container.decode(Decimal.self, forKey: .minQuantity)
+        // When there is no max quantity, an empty string is returned null.
+        let maxQuantity = container.failsafeDecodeIfPresent(decimalForKey: .maxQuantity)
+        let defaultQuantity = try container.decode(Decimal.self, forKey: .defaultQuantity)
+        let isOptional = try container.decode(Bool.self, forKey: .isOptional)
+        let overridesVariations = try container.decode(Bool.self, forKey: .overridesVariations)
+        let allowedVariations = try container.decode([Int64].self, forKey: .allowedVariations)
+        let overridesDefaultVariationAttributes = try container.decode(Bool.self, forKey: .overridesDefaultVariationAttributes)
+        let defaultVariationAttributes = try container.decode([ProductVariationAttribute].self, forKey: .defaultVariationAttributes)
 
         self.init(bundledItemID: bundledItemID,
                   productID: productID,
                   menuOrder: menuOrder,
                   title: title,
-                  stockStatus: stockStatus)
+                  stockStatus: stockStatus,
+                  minQuantity: minQuantity,
+                  maxQuantity: maxQuantity,
+                  defaultQuantity: defaultQuantity,
+                  isOptional: isOptional,
+                  overridesVariations: overridesVariations,
+                  allowedVariations: allowedVariations,
+                  overridesDefaultVariationAttributes: overridesDefaultVariationAttributes,
+                  defaultVariationAttributes: defaultVariationAttributes)
     }
 }
 
@@ -62,6 +119,14 @@ private extension ProductBundleItem {
         case menuOrder                          = "menu_order"
         case title
         case stockStatus                        = "stock_status"
+        case minQuantity = "quantity_min"
+        case maxQuantity = "quantity_max"
+        case defaultQuantity = "quantity_default"
+        case isOptional = "optional"
+        case overridesVariations = "override_variations"
+        case allowedVariations = "allowed_variations"
+        case overridesDefaultVariationAttributes = "override_default_variation_attributes"
+        case defaultVariationAttributes = "default_variation_attributes"
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductVariationAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductVariationAttribute.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Product Variation Attribute Entity.
 ///
-public struct ProductVariationAttribute: Codable, Equatable, GeneratedFakeable {
+public struct ProductVariationAttribute: Codable, Equatable, GeneratedFakeable, Hashable {
     public let id: Int64
     public let name: String
     public let option: String

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -328,6 +328,17 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(bundledItem.menuOrder, 0)
         XCTAssertEqual(bundledItem.title, "Beanie with Logo")
         XCTAssertEqual(bundledItem.stockStatus, .inStock)
+        XCTAssertEqual(bundledItem.minQuantity, 1)
+        XCTAssertEqual(bundledItem.maxQuantity, nil)
+        XCTAssertEqual(bundledItem.defaultQuantity, 1)
+        XCTAssertEqual(bundledItem.isOptional, true)
+        XCTAssertEqual(bundledItem.overridesVariations, false)
+        XCTAssertEqual(bundledItem.allowedVariations, [39, 32, 33])
+        XCTAssertEqual(bundledItem.overridesDefaultVariationAttributes, false)
+        XCTAssertEqual(bundledItem.defaultVariationAttributes, [
+            .init(id: 1, name: "Color", option: "blue"),
+            .init(id: 0, name: "Logo", option: "Yes")
+        ])
     }
 
     /// Test that products with the `composite` product type are properly parsed.

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -336,6 +336,53 @@ final class OrdersRemoteTests: XCTestCase {
         assertEqual(received, expected)
     }
 
+    func test_update_order_properly_encodes_order_item_bundle_configuration() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let orderItem = OrderItem.fake().copy(itemID: 123, productID: 5, quantity: 2, bundleConfiguration: [
+            // Non-variable bundle item
+            .init(bundledItemID: 20, productID: 51, quantity: 3, isOptionalAndSelected: true, variationID: nil, variationAttributes: nil),
+            // Variable bundle item
+            .init(bundledItemID: 21,
+                  productID: 52,
+                  quantity: 5,
+                  isOptionalAndSelected: nil,
+                  variationID: 77,
+                  variationAttributes: [.init(id: 2, name: "Color", option: "Coral")])
+        ])
+        let order = Order.fake().copy(items: [orderItem])
+
+        // When
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.items]) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let lineItem = try XCTUnwrap((request.parameters["line_items"] as? [[String: AnyHashable]])?.first)
+        let received = try XCTUnwrap(lineItem["bundle_configuration"] as? [[String: AnyHashable]])
+        let expected: [[String: AnyHashable]] = [
+            [
+                "bundled_item_id": 20,
+                "product_id": 51,
+                "quantity": 3,
+                "optional_selected": true
+            ],
+            [
+                "bundled_item_id": 21,
+                "product_id": 52,
+                "quantity": 5,
+                "variation_id": 77,
+                "attributes": [
+                    [
+                        "id": 2,
+                        "name": "Color",
+                        "option": "Coral"
+                    ] as [String: AnyHashable]
+                ] as [AnyHashable]
+            ]
+        ]
+        assertEqual(expected, received)
+    }
+
     func test_update_order_properly_encodes_coupon_lines() throws {
         // Given
         let remote = OrdersRemote(network: network)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -157,6 +157,7 @@ private extension ProductInputTransformer {
                          totalTax: "",
                          attributes: [],
                          addOns: [],
-                         parent: nil)
+                         parent: nil,
+                         bundleConfiguration: [])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -538,7 +538,8 @@ extension ShippingLabelPackagesFormViewModel {
                               totalTax: "1.20",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle",
@@ -555,7 +556,8 @@ extension ShippingLabelPackagesFormViewModel {
                               totalTax: "0.00",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         return [item1, item2]
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -104,7 +104,8 @@ private extension ShippingLabelSampleData {
                               totalTax: "1.20",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle",
@@ -121,7 +122,8 @@ private extension ShippingLabelSampleData {
                               totalTax: "0.00",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         return [item1, item2]
     }

--- a/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
@@ -34,6 +34,7 @@ public struct MockOrderItem {
                          totalTax: totalTax,
                          attributes: attributes,
                          addOns: [],
-                         parent: parent)
+                         parent: parent,
+                         bundleConfiguration: [])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -647,7 +647,8 @@ private extension OrderDetailsDataSourceTests {
                   totalTax: "1",
                   attributes: [],
                   addOns: [],
-                  parent: nil)
+                  parent: nil,
+                  bundleConfiguration: [])
     }
 
     func makeRefund(refundID: Int64, orderID: Int64, siteID: Int64) -> Refund {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -270,7 +270,8 @@ private extension ProductDetailsCellViewModelTests {
                   totalTax: "",
                   attributes: attributes,
                   addOns: [],
-                  parent: nil)
+                  parent: nil,
+                  bundleConfiguration: [])
     }
 
     func makeAggregateOrderItem(quantity: Decimal,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
@@ -106,7 +106,8 @@ private extension ProductLoaderViewControllerModelTests {
                   totalTax: "",
                   attributes: [],
                   addOns: [],
-                  parent: nil)
+                  parent: nil,
+                  bundleConfiguration: [])
     }
 
     func makeOrderItemRefund(productID: Int64, variationID: Int64) -> OrderItemRefund {

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -217,7 +217,8 @@ extension MockObjectGraph {
             totalTax: "0",
             attributes: [],
             addOns: [],
-            parent: nil
+            parent: nil,
+            bundleConfiguration: []
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -55,6 +55,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
                          totalTax: totalTax ?? "",
                          attributes: attributes,
                          addOns: addOns,
-                         parent: parent?.int64Value)
+                         parent: parent?.int64Value,
+                         bundleConfiguration: [])
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ProductBundleItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductBundleItem+ReadOnlyConvertible.swift
@@ -14,15 +14,38 @@ extension Storage.ProductBundleItem: ReadOnlyConvertible {
         menuOrder = bundleItem.menuOrder
         title = bundleItem.title
         stockStatus = bundleItem.stockStatus.rawValue
+        minQuantity = NSDecimalNumber(decimal: bundleItem.minQuantity)
+        maxQuantity = bundleItem.maxQuantity.map { NSDecimalNumber(decimal: $0) }
+        defaultQuantity = NSDecimalNumber(decimal: bundleItem.defaultQuantity)
+        isOptional = bundleItem.isOptional
+        overridesVariations = bundleItem.overridesVariations
+        allowedVariations = bundleItem.allowedVariations
+        overridesDefaultVariationAttributes = bundleItem.overridesDefaultVariationAttributes
     }
 
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductBundleItem {
+        let defaultVariationAttributes = defaultVariationAttributesArray
+            .map { ProductVariationAttribute(id: $0.id, name: $0.key, option: $0.value) }
         return ProductBundleItem(bundledItemID: bundledItemID,
                                  productID: productID,
                                  menuOrder: menuOrder,
                                  title: title ?? "",
-                                 stockStatus: ProductBundleItemStockStatus(rawValue: stockStatus ?? "in_stock") ?? .inStock)
+                                 stockStatus: ProductBundleItemStockStatus(rawValue: stockStatus ?? "in_stock") ?? .inStock,
+                                 minQuantity: minQuantity.decimalValue,
+                                 maxQuantity: maxQuantity?.decimalValue,
+                                 defaultQuantity: defaultQuantity.decimalValue,
+                                 isOptional: isOptional,
+                                 overridesVariations: overridesVariations,
+                                 allowedVariations: allowedVariations ?? [],
+                                 overridesDefaultVariationAttributes: overridesDefaultVariationAttributes,
+                                 defaultVariationAttributes: defaultVariationAttributes)
+    }
+}
+
+private extension Storage.ProductBundleItem {
+    var defaultVariationAttributesArray: [Storage.GenericAttribute] {
+        return defaultVariationAttributes?.toArray() ?? []
     }
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1004,6 +1004,19 @@ extension ProductStore {
         let storageBundledItems = readOnlyProduct.bundledItems.map { readOnlyBundleItem -> StorageProductBundleItem in
             let storageBundledItem = storage.insertNewObject(ofType: StorageProductBundleItem.self)
             storageBundledItem.update(with: readOnlyBundleItem)
+
+            // Removes all default variation attributes and adds new ones from the readonly version.
+            if let defaultVariationAttributes = storageBundledItem.defaultVariationAttributes {
+                storageBundledItem.removeFromDefaultVariationAttributes(defaultVariationAttributes)
+            }
+
+            let storageDefaultVariationAttributes = readOnlyBundleItem.defaultVariationAttributes.map {
+                let storageVariationAttribute = storage.insertNewObject(ofType: Storage.GenericAttribute.self)
+                storageVariationAttribute.update(with: $0)
+                return storageVariationAttribute
+            }
+            storageBundledItem.addToDefaultVariationAttributes(NSOrderedSet(array: storageDefaultVariationAttributes))
+
             return storageBundledItem
         }
         storageProduct.addToBundledItems(NSOrderedSet(array: storageBundledItems))

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -412,17 +412,6 @@ private extension ProductStore {
         })
     }
 
-    func retrieveProducts(from productIDs: [Int64]) -> [Product] {
-        productIDs
-            .compactMap {
-                let predicate = NSPredicate(format: "productID == %lld", $0)
-                let product = sharedDerivedStorage.allObjects(ofType: StorageProduct.self,
-                                                          matching: predicate,
-                                                          sortedBy: nil).first
-                return product
-            }.map { $0.toReadOnly() }
-    }
-
     /// Adds a product.
     ///
     func addProduct(product: Product, onCompletion: @escaping (Result<Product, ProductUpdateError>) -> Void) {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -39,6 +39,8 @@ final class MockProductsRemote {
     /// The results to return based on the given site ID in `loadNumberOfProducts`.
     private var loadNumberOfProductsResultsBySiteID = [Int64: Result<Int64, Error>]()
 
+    private var searchProductsResultsByQuery = [String: Result<[Product], Error>]()
+
     /// The number of times that `loadProduct()` was invoked.
     private(set) var invocationCountOfLoadProduct: Int = 0
 
@@ -85,6 +87,12 @@ final class MockProductsRemote {
     ///
     func whenLoadingNumberOfProducts(siteID: Int64, thenReturn result: Result<Int64, Error>) {
         loadNumberOfProductsResultsBySiteID[siteID] = result
+    }
+
+    /// Set the value passed to the `completion` block if `searchProducts()` is called.
+    ///
+    func whenSearchingProducts(query: String, thenReturn result: Result<[Product], Error>) {
+        searchProductsResultsByQuery[query] = result
     }
 }
 
@@ -187,6 +195,9 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         searchProductWithProductType = productType
         searchProductWithProductStatus = productStatus
         searchProductWithProductCategory = productCategory
+        if let result = searchProductsResultsByQuery[keyword] {
+            completion(result)
+        }
     }
 
     func searchProductsBySKU(for siteID: Int64,

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -347,7 +347,8 @@ private extension OrdersUpsertUseCaseTests {
                   totalTax: "",
                   attributes: [],
                   addOns: [],
-                  parent: nil)
+                  parent: nil,
+                  bundleConfiguration: [])
     }
 
     func makeOrder() -> Networking.Order {
@@ -370,6 +371,7 @@ private extension OrdersUpsertUseCaseTests {
               totalTax: "0.00",
               attributes: attributes,
               addOns: [],
-              parent: nil)
+              parent: nil,
+              bundleConfiguration: [])
     }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1654,7 +1654,8 @@ private extension OrderStoreTests {
                               totalTax: "1.20",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle",
@@ -1671,7 +1672,8 @@ private extension OrderStoreTests {
                               totalTax: "0.00",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         return [item1, item2]
     }
@@ -1692,7 +1694,8 @@ private extension OrderStoreTests {
                               totalTax: "4.00",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         let item2 = OrderItem(itemID: 891,
                               name: "Fruits Bundle 2",
@@ -1709,7 +1712,8 @@ private extension OrderStoreTests {
                               totalTax: "0.40",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         let item3 = OrderItem(itemID: 23,
                               name: "Some new product",
@@ -1726,7 +1730,8 @@ private extension OrderStoreTests {
                               totalTax: "10.40",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         return [item1, item2, item3]
     }
@@ -1747,7 +1752,8 @@ private extension OrderStoreTests {
                               totalTax: "4.00",
                               attributes: [],
                               addOns: [],
-                              parent: nil)
+                              parent: nil,
+                              bundleConfiguration: [])
 
         return [item1]
     }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -1095,6 +1095,7 @@ private extension ProductVariationStoreTests {
               totalTax: "1.20",
               attributes: [],
               addOns: [],
-              parent: nil)
+              parent: nil,
+              bundleConfiguration: [])
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -529,7 +529,8 @@ private extension ReceiptStoreTests {
                            totalTax: "",
                            attributes: [],
                            addOns: [],
-                           parent: nil)
+                           parent: nil,
+                           bundleConfiguration: [])
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10428 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please make sure https://github.com/woocommerce/woocommerce-ios/pull/10826 is approved before reviewing this PR

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In https://github.com/woocommerce/woocommerce-ios/pull/10826, the new attributes/relationship were added to `ProductBundleItem` in storage. This PR adds the equivalent properties to `ProductBundleItem` in the Networking layer (readonly version) with the storage <--> readonly conversion, plus the logic on how bundle configuration is encoded when creating/updating `OrderItem` whe the order item is a bundle product.

## How

### Order item's bundle configuration

In order to configure a bundle product in an order item remotely, a `bundle_configuration` field is passed to the order line item with properties in the [API doc](https://woocommerce.com/document/bundles-rest-api-reference/#bundle-configuration-properties). This field is only passed when creating/updating an order, and does not exist in the API response. To represent each configuration item (bundled item in a bundle order item), `OrderItemBundleItem` struct was created that conforms only to `Encodable`. This `bundle_configuration` field is only encoded in an order line item when the array is non-empty.

### Variable product's bundle items

On the other hand, to display the form for configuring an order item variable product's bundled item, the new properties were added to the pre-existing `ProductBundleItem` that corresponds to the schema updates in https://github.com/woocommerce/woocommerce-ios/pull/10826.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

A confidence check would be great on the order form to ensure the PR changes do not affect the current app behavior:

- Go to the Orders tab
- Tap on the `+` to create an order
- In the order creation form, add at least a product as an order item
- Tap `Create` to create the order remotely --> the order should be created successfully with the selected product(s)
- Go back to the Orders tab
- Tap on the previously created order
- Tap on `Edit` to edit the order
- Add at least another product as an order item --> the order should be updated successfully with the selected product(s)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
