### PR TITLE
Support WCiOS app login links

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -84,7 +84,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 7.0'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'fd76b20c129fe428351d0104190645f0e68a9fa8'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '77ad0121dff27f4126647b5372632e914dbdf1f9'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -83,8 +83,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 7.0'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  # pod 'WordPressAuthenticator', '~> 7.0'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'fd76b20c129fe428351d0104190645f0e68a9fa8'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -83,8 +83,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 7.0'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '76fb48381b8e415eb6c3c8b3f22025cc74bc3077'
+  pod 'WordPressAuthenticator', '~> 7.1.0'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -84,7 +84,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 7.0'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '77ad0121dff27f4126647b5372632e914dbdf1f9'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '76fb48381b8e415eb6c3c8b3f22025cc74bc3077'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `77ad0121dff27f4126647b5372632e914dbdf1f9`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `76fb48381b8e415eb6c3c8b3f22025cc74bc3077`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -114,12 +114,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: 77ad0121dff27f4126647b5372632e914dbdf1f9
+    :commit: 76fb48381b8e415eb6c3c8b3f22025cc74bc3077
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 77ad0121dff27f4126647b5372632e914dbdf1f9
+    :commit: 76fb48381b8e415eb6c3c8b3f22025cc74bc3077
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -155,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: d0b3581cdc3ffff67203ca18d4f281fba0d624ab
+PODFILE CHECKSUM: 20b9e599e324a33d705b49a14cbee51040df96a1
 
 COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `76fb48381b8e415eb6c3c8b3f22025cc74bc3077`)
+  - WordPressAuthenticator (~> 7.1.0)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -80,6 +80,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
     - WordPressKit
   trunk:
     - Alamofire
@@ -112,16 +113,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: 76fb48381b8e415eb6c3c8b3f22025cc74bc3077
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 76fb48381b8e415eb6c3c8b3f22025cc74bc3077
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   Automattic-Tracks-iOS: eb06b138cd65453dc565ab047f55fbb759aca133
@@ -140,7 +131,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: f73ba530531bb14eedd2f2b69c9b2d387004026c
+  WordPressAuthenticator: c12572a8500f1eaf1e8b0d71c8655cc3455a0682
   WordPressKit: 5969d12c5339e6a8b25707048ca3548b83bd37a6
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
@@ -155,6 +146,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 20b9e599e324a33d705b49a14cbee51040df96a1
+PODFILE CHECKSUM: 1abd2cf268791d238da7013fda241d544b36c896
 
 COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
     - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.5.2):
+  - WordPressKit (8.6.0-beta.1):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fd76b20c129fe428351d0104190645f0e68a9fa8`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `77ad0121dff27f4126647b5372632e914dbdf1f9`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -114,12 +114,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: fd76b20c129fe428351d0104190645f0e68a9fa8
+    :commit: 77ad0121dff27f4126647b5372632e914dbdf1f9
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: fd76b20c129fe428351d0104190645f0e68a9fa8
+    :commit: 77ad0121dff27f4126647b5372632e914dbdf1f9
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -141,7 +141,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: f73ba530531bb14eedd2f2b69c9b2d387004026c
-  WordPressKit: d2846c24373b2341e363e38530235ac59641f6c9
+  WordPressKit: 5969d12c5339e6a8b25707048ca3548b83bd37a6
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
@@ -155,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 7c175c2a65c11b98f8422745a0c9e45b4b3ebb70
+PODFILE CHECKSUM: d0b3581cdc3ffff67203ca18d4f281fba0d624ab
 
 COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,14 +28,14 @@ PODS:
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
     - WordPress-Aztec-iOS (= 1.19.9)
-  - WordPressAuthenticator (7.0.0):
+  - WordPressAuthenticator (7.1.0):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
     - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.5.1):
+  - WordPressKit (8.5.2):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (~> 7.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fd76b20c129fe428351d0104190645f0e68a9fa8`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -80,7 +80,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
     - WordPressKit
   trunk:
     - Alamofire
@@ -113,6 +112,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: fd76b20c129fe428351d0104190645f0e68a9fa8
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: fd76b20c129fe428351d0104190645f0e68a9fa8
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   Automattic-Tracks-iOS: eb06b138cd65453dc565ab047f55fbb759aca133
@@ -131,8 +140,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: 132ccf00a41443e0ebd792d9a36ff5697a8f5414
-  WordPressKit: f4c39ae3a5949846d2d7c51843690d078711ab36
+  WordPressAuthenticator: f73ba530531bb14eedd2f2b69c9b2d387004026c
+  WordPressKit: d2846c24373b2341e363e38530235ac59641f6c9
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
@@ -146,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: f507cf8b9766555bc21c274d1f6d37b4488692fb
+PODFILE CHECKSUM: 7c175c2a65c11b98f8422745a0c9e45b4b3ebb70
 
 COCOAPODS: 1.13.0

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -125,4 +125,10 @@ struct AuthenticationConstants {
         "Enter the password for your account.",
         comment: "Instructional text shown when requesting the user's password for WPCom login."
     )
+
+    /// Error message when an app deep link login fails
+    ///
+    static let appLinkLoginFailureMessage = NSLocalizedString(
+        "We couldn't process your app login request",
+        comment: "A message displayed through a bottom notice letting the user know that the login from the app link failed")
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -116,7 +116,47 @@ class AuthenticationManager: Authentication {
                                                                         rootViewController: rootViewController)
         }
 
+        if isAppLoginUrl(url) {
+            guard let queryDictionary = url.query?.dictionaryFromQueryString(),
+            let siteURL = queryDictionary.string(forKey: "siteUrl") else {
+                print("App login link error: we couldn't retrieve the query dictionary from the sign-in URL.")
+                return false
+            }
+
+            if let wpcomEmail = queryDictionary.string(forKey: "wpcomEmail") {
+                showWPCOMLogin(siteURL: siteURL, email: wpcomEmail, rootViewController: rootViewController)
+                return true
+            }
+
+            if let wporgUsername = queryDictionary.string(forKey: "username") {
+                showWPOrgLogin(siteURL: siteURL, username: wporgUsername, rootViewController: rootViewController)
+                return true
+            }
+        }
+
         return false
+    }
+
+    private func showWPCOMLogin(siteURL: String, email: String, rootViewController: UIViewController) {
+        let loginFields = LoginFields()
+        loginFields.siteAddress = siteURL
+        loginFields.restrictToWPCom = true
+        loginFields.username = email
+        NavigateToEnterWPCOMPassword(loginFields: loginFields).execute(from: rootViewController)
+    }
+
+    private func showWPOrgLogin(siteURL: String, username: String, rootViewController: UIViewController) {
+        let loginFields = LoginFields()
+        loginFields.siteAddress = siteURL
+        loginFields.restrictToWPCom = false
+        loginFields.username = username
+        NavigateToEnterSiteCredentials(loginFields: loginFields).execute(from: rootViewController)
+    }
+
+    private func isAppLoginUrl(_ url: URL) -> Bool {
+        // TODO-jc: move to constants
+        let expectedPrefix = "\(ApiCredentials.dotcomAuthScheme)://app-login"
+        return url.absoluteString.hasPrefix(expectedPrefix)
     }
 
     /// Injects `loggedOutAppSettings`

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -146,10 +146,7 @@ class AuthenticationManager: Authentication {
         loginFields.siteAddress = siteURL
         loginFields.restrictToWPCom = true
         loginFields.username = email
-        NavigateToEnterWPCOMPassword(loginFields: loginFields, onDismiss: {
-            NavigateToRoot().execute(from: rootViewController)
-        })
-        .execute(from: rootViewController)
+        NavigateToEnterWPCOMPassword(loginFields: loginFields).execute(from: rootViewController)
     }
 
     private func showWPOrgLogin(siteURL: String, username: String, rootViewController: UIViewController) {
@@ -157,9 +154,7 @@ class AuthenticationManager: Authentication {
         loginFields.siteAddress = siteURL
         loginFields.restrictToWPCom = false
         loginFields.username = username
-        NavigateToEnterSiteCredentials(loginFields: loginFields, onDismiss: {
-            NavigateToRoot().execute(from: rootViewController)
-        }).execute(from: rootViewController)
+        NavigateToEnterSiteCredentials(loginFields: loginFields).execute(from: rootViewController)
     }
 
     private func showLoginURLFailure(rootViewController: UIViewController) {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -118,17 +118,20 @@ class AuthenticationManager: Authentication {
 
         if isAppLoginUrl(url) {
             guard let queryDictionary = url.query?.dictionaryFromQueryString(),
-            let siteURL = queryDictionary.string(forKey: "siteUrl") else {
+                  let siteURL = queryDictionary.string(forKey: "siteUrl"),
+                  siteURL.isNotEmpty else {
                 print("App login link error: we couldn't retrieve the query dictionary from the sign-in URL.")
                 return false
             }
 
-            if let wpcomEmail = queryDictionary.string(forKey: "wpcomEmail") {
+            if let wpcomEmail = queryDictionary.string(forKey: "wpcomEmail"),
+               wpcomEmail.isNotEmpty {
                 showWPCOMLogin(siteURL: siteURL, email: wpcomEmail, rootViewController: rootViewController)
                 return true
             }
 
-            if let wporgUsername = queryDictionary.string(forKey: "username") {
+            if let wporgUsername = queryDictionary.string(forKey: "username"),
+               wporgUsername.isNotEmpty {
                 showWPOrgLogin(siteURL: siteURL, username: wporgUsername, rootViewController: rootViewController)
                 return true
             }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -164,7 +164,7 @@ class AuthenticationManager: Authentication {
             noticePresenter.presentingViewController = rootViewController
             return noticePresenter
         }()
-        contextNoticePresenter.enqueue(notice: .init(title: "Deu ruim"))
+        contextNoticePresenter.enqueue(notice: .init(title: AuthenticationConstants.appLinkLoginFailureMessage))
     }
 
     private func isAppLoginUrl(_ url: URL) -> Bool {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -121,6 +121,7 @@ class AuthenticationManager: Authentication {
                   let siteURL = queryDictionary.string(forKey: "siteUrl"),
                   siteURL.isNotEmpty else {
                 print("App login link error: we couldn't retrieve the query dictionary from the sign-in URL.")
+                showLoginURLFailure(rootViewController: rootViewController)
                 return false
             }
 
@@ -137,6 +138,7 @@ class AuthenticationManager: Authentication {
             }
         }
 
+        showLoginURLFailure(rootViewController: rootViewController)
         return false
     }
 
@@ -154,6 +156,15 @@ class AuthenticationManager: Authentication {
         loginFields.restrictToWPCom = false
         loginFields.username = username
         NavigateToEnterSiteCredentials(loginFields: loginFields).execute(from: rootViewController)
+    }
+
+    private func showLoginURLFailure(rootViewController: UIViewController) {
+        let contextNoticePresenter: NoticePresenter = {
+            let noticePresenter = DefaultNoticePresenter()
+            noticePresenter.presentingViewController = rootViewController
+            return noticePresenter
+        }()
+        contextNoticePresenter.enqueue(notice: .init(title: "Deu ruim"))
     }
 
     private func isAppLoginUrl(_ url: URL) -> Bool {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -124,7 +124,6 @@ class AuthenticationManager: Authentication {
                 showLoginURLFailure(rootViewController: rootViewController)
                 return false
             }
-
             if let wpcomEmail = queryDictionary.string(forKey: "wpcomEmail"),
                wpcomEmail.isNotEmpty {
                 showWPCOMLogin(siteURL: siteURL, email: wpcomEmail, rootViewController: rootViewController)
@@ -147,7 +146,10 @@ class AuthenticationManager: Authentication {
         loginFields.siteAddress = siteURL
         loginFields.restrictToWPCom = true
         loginFields.username = email
-        NavigateToEnterWPCOMPassword(loginFields: loginFields).execute(from: rootViewController)
+        NavigateToEnterWPCOMPassword(loginFields: loginFields, onDismiss: {
+            NavigateToRoot().execute(from: rootViewController)
+        })
+        .execute(from: rootViewController)
     }
 
     private func showWPOrgLogin(siteURL: String, username: String, rootViewController: UIViewController) {
@@ -155,7 +157,9 @@ class AuthenticationManager: Authentication {
         loginFields.siteAddress = siteURL
         loginFields.restrictToWPCom = false
         loginFields.username = username
-        NavigateToEnterSiteCredentials(loginFields: loginFields).execute(from: rootViewController)
+        NavigateToEnterSiteCredentials(loginFields: loginFields, onDismiss: {
+            NavigateToRoot().execute(from: rootViewController)
+        }).execute(from: rootViewController)
     }
 
     private func showLoginURLFailure(rootViewController: UIViewController) {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -120,7 +120,7 @@ class AuthenticationManager: Authentication {
             guard let queryDictionary = url.query?.dictionaryFromQueryString(),
                   let siteURL = queryDictionary.string(forKey: "siteUrl"),
                   siteURL.isNotEmpty else {
-                print("App login link error: we couldn't retrieve the query dictionary from the sign-in URL.")
+                DDLogWarn("App login link error: we couldn't retrieve the query dictionary from the sign-in URL.")
                 showLoginURLFailure(rootViewController: rootViewController)
                 return false
             }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -168,8 +168,7 @@ class AuthenticationManager: Authentication {
     }
 
     private func isAppLoginUrl(_ url: URL) -> Bool {
-        // TODO-jc: move to constants
-        let expectedPrefix = "\(ApiCredentials.dotcomAuthScheme)://app-login"
+        let expectedPrefix = "\(ApiCredentials.dotcomAuthScheme)\(WooConstants.appLoginURLPrefix)"
         return url.absoluteString.hasPrefix(expectedPrefix)
     }
 

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -73,6 +73,10 @@ enum WooConstants {
     /// Default store name when creating a site with free trial
     ///
     static let defaultStoreName = "Store Name"
+
+    /// App login deep link prefix
+    ///
+    static let appLoginURLPrefix = "://app-login"
 }
 
 // MARK: URLs


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10843
<!-- Id number of the GitHub issue this PR addresses. -->

Depends on WPAuthenticator changes: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/784

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

More details about the app login link support is in pe5pgL-3MC-p2. Overall, we want to make it easier to log in to the app from the web onboarding task after they install the Woo mobile app. As in pe5pgL-3MC-p2#comment-3051, the link should pre-fill as many details as we can so that the merchant just needs to enter the password for either WPCOM or wp-admin site credentials.

## How
Add to the `AuthenticationManager` proper handling of deep link calls containing the `app-login` prefix. Whenever the deep link is called with valid data, the WordPressAuthenticator navigation events will be called according to the expected scenario.

- NavigateToEnterWPCOMPassword for WordPress.com accounts
- NavigateToEnterSiteCredentials for non-Jetpack stores credentials

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Similar to how magic links work, when the app receives a URL from the URL scheme, it first checks if the URL is an app login link that we're implementing. Then, it extracts the query parameters to see if contains a WPCOM email - if yes, it navigates to the WPCOM password flow. Otherwise, it checks if the parameters contain a username - if yes, it navigates to the site credentials flow.

In order to easily trigger deep link interaction, I recommend typing the following commands:

### WPCOM account scenario
```
xcrun simctl openurl booted 'woocommerce://app-login?siteUrl=<Replace with your store URL>&wpcomEmail=<Replace with WPCOM account email>'
```

### Non-jetpack store scenario
```
xcrun simctl openurl booted 'woocommerce://app-login?siteUrl=<Replace with your store URL>&username=<Replace with the store credentials user name>'
```

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### WordPress.com deep link
https://github.com/woocommerce/woocommerce-ios/assets/5920403/ae9e445d-3992-4622-814e-3081e8468ea1

### Non-jetpack store deep link
https://github.com/woocommerce/woocommerce-ios/assets/5920403/683bae82-9893-46ea-9837-58b8f28f0262



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.