### PR TITLE
[Orders with Coupons M6] Adds `ordersWithCouponsM6` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -83,6 +83,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .ordersWithCouponsM4:
             return true
+        case .ordersWithCouponsM6:
+            return false
         case .betterCustomerSelectionInOrder:
             return true
         case .manualTaxesInOrderM2:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -178,6 +178,10 @@ public enum FeatureFlag: Int {
     /// Enables the Milestone 4 of the Orders with Coupons project: Adding discounts to products
     case ordersWithCouponsM4
 
+    /// Enables the Milestone 6 of the Orders with Coupons project: UX improvements
+    ///
+    case ordersWithCouponsM6
+
     /// Enables the improvements in the customer selection logic when creating an order
     /// 
     case betterCustomerSelectionInOrder


### PR DESCRIPTION
Closes: #10832

## Description
This PR adds a `ordersWithCouponsM6` feature flag for the Orders with Coupons UX improvements project.

I opted to leave it as `false` in trunk because since we're modifying one of the main flows of order creation it could be troublesome for development to leave it enabled in dev builds. 

## Testing instructions
There are no changes to test at the moment. CI must pass.
