### PR TITLE
Product Creation AI: Networking and Yosemite for bulk add categories

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -886,6 +886,9 @@
 		EE2C09C629AF60BA009396F9 /* store-onboarding-tasks-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE2C09C529AF60BA009396F9 /* store-onboarding-tasks-without-data.json */; };
 		EE2C09C829AF6357009396F9 /* StoreOnboardingTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2C09C729AF6357009396F9 /* StoreOnboardingTask.swift */; };
 		EE338A0E294AF9BD00183934 /* ApplicationPasswordMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE338A0D294AF9BD00183934 /* ApplicationPasswordMapperTests.swift */; };
+		EE4D51B22ACC6F1E00783D77 /* ProductCategoryFromBatchCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4D51B12ACC6F1E00783D77 /* ProductCategoryFromBatchCreation.swift */; };
+		EE4D51B52ACD331300783D77 /* product-categories-created.json in Resources */ = {isa = PBXBuildFile; fileRef = EE4D51B32ACD331300783D77 /* product-categories-created.json */; };
+		EE4D51B62ACD331300783D77 /* product-categories-created-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE4D51B42ACD331300783D77 /* product-categories-created-without-data.json */; };
 		EE54C89F2947782E00A9BF61 /* ApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */; };
 		EE54C8A729486B6800A9BF61 /* ApplicationPasswordMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */; };
 		EE57C10E2979277300BC31E7 /* ApplicationPasswordNameAndUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C10D2979277300BC31E7 /* ApplicationPasswordNameAndUUID.swift */; };
@@ -1873,6 +1876,9 @@
 		EE2C09C529AF60BA009396F9 /* store-onboarding-tasks-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "store-onboarding-tasks-without-data.json"; sourceTree = "<group>"; };
 		EE2C09C729AF6357009396F9 /* StoreOnboardingTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTask.swift; sourceTree = "<group>"; };
 		EE338A0D294AF9BD00183934 /* ApplicationPasswordMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapperTests.swift; sourceTree = "<group>"; };
+		EE4D51B12ACC6F1E00783D77 /* ProductCategoryFromBatchCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryFromBatchCreation.swift; sourceTree = "<group>"; };
+		EE4D51B32ACD331300783D77 /* product-categories-created.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-categories-created.json"; sourceTree = "<group>"; };
+		EE4D51B42ACD331300783D77 /* product-categories-created-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-categories-created-without-data.json"; sourceTree = "<group>"; };
 		EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
 		EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapper.swift; sourceTree = "<group>"; };
 		EE57C10D2979277300BC31E7 /* ApplicationPasswordNameAndUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordNameAndUUID.swift; sourceTree = "<group>"; };
@@ -2750,6 +2756,8 @@
 				45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */,
 				EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */,
 				45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */,
+				EE4D51B42ACD331300783D77 /* product-categories-created-without-data.json */,
+				EE4D51B32ACD331300783D77 /* product-categories-created.json */,
 				020EF5EC2A8C8F4F009D2169 /* products-total.json */,
 				CEC4BF90234E40B5008D9195 /* refund-single.json */,
 				CEC4BF92234E7EE0008D9195 /* refunds-all.json */,
@@ -3209,6 +3217,7 @@
 				45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */,
 				45CDAFAA2434CA9300F83C22 /* ProductCatalogVisibility.swift */,
 				458C6DE325AC72A1009B300D /* StoredProductSettings.swift */,
+				EE4D51B12ACC6F1E00783D77 /* ProductCategoryFromBatchCreation.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";
@@ -3561,6 +3570,7 @@
 				31A451D827863A2E00FE81AA /* stripe-account-restricted-overdue.json in Resources */,
 				D865CE69278CA245002C8520 /* stripe-payment-intent-unknown-status.json in Resources */,
 				DE66C5572976913C00DAA978 /* wcpay-charge-card-present-without-data.json in Resources */,
+				EE4D51B62ACD331300783D77 /* product-categories-created-without-data.json in Resources */,
 				DE42F9652967F34400D514C2 /* refund-single-without-data.json in Resources */,
 				0205021C27C86B9700FB1C6B /* inbox-note-without-isRead.json in Resources */,
 				24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */,
@@ -3653,6 +3663,7 @@
 				D8FBFF1822D4DDB9006E3336 /* order-stats-v4-hour.json in Resources */,
 				CCA1D6082943804C00B40560 /* site-summary-stats.json in Resources */,
 				EE28C7DC2AC17961004A69F4 /* generate-product-success.json in Resources */,
+				EE4D51B52ACD331300783D77 /* product-categories-created.json in Resources */,
 				B554FA8D2180B59700C54DFF /* notifications-load-hashes.json in Resources */,
 				022902D622E2436400059692 /* no_stats_permission_error.json in Resources */,
 				FE28F6E826842D57004465C7 /* user-complete.json in Resources */,
@@ -4103,6 +4114,7 @@
 				0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */,
 				7452387321124B7700A973CD /* AnyCodable.swift in Sources */,
 				03DCB72626244B9B00C8953D /* Coupon.swift in Sources */,
+				EE4D51B22ACC6F1E00783D77 /* ProductCategoryFromBatchCreation.swift in Sources */,
 				31054706262E278100C5C02B /* RemotePaymentIntent.swift in Sources */,
 				026CF61E237D6985009563D4 /* ProductVariationListMapper.swift in Sources */,
 				CE43066E2347CBA70073CBFF /* OrderItemTaxRefund.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductCategoryListMapper.swift
+++ b/Networking/Networking/Mapper/ProductCategoryListMapper.swift
@@ -9,6 +9,8 @@ struct ProductCategoryListMapper: Mapper {
     ///
     let siteID: Int64
 
+    let responseType: ResponseType
+
     /// (Attempts) to convert a dictionary into [ProductCategory].
     ///
     func map(response: Data) throws -> [ProductCategory] {
@@ -17,11 +19,41 @@ struct ProductCategoryListMapper: Mapper {
             .siteID: siteID
         ]
 
-        if hasDataEnvelope(in: response) {
-            return try decoder.decode(ProductCategoryListEnvelope.self, from: response).productCategories
-        } else {
-            return try decoder.decode([ProductCategory].self, from: response)
+        let hasDataEnvelope = hasDataEnvelope(in: response)
+
+        switch responseType {
+        case .load:
+            if hasDataEnvelope {
+                return try decoder.decode(ProductCategoryListEnvelope.self, from: response).productCategories
+            } else {
+                return try decoder.decode([ProductCategory].self, from: response)
+            }
+        case .create:
+            let categories: [ProductCategoryFromBatchCreation] = try {
+                if hasDataEnvelope {
+                    return try decoder.decode(ProductCategoryListBatchCreateEnvelope.self, from: response).data.categories
+                } else {
+                    return try decoder.decode(ProductCategoryListBatchCreateContainer.self, from: response).categories
+                }
+            }()
+            return categories
+                .filter { $0.error == nil }
+                .compactMap { (categoryCreated) -> ProductCategory? in
+                    if let name = categoryCreated.name, let slug = categoryCreated.slug {
+                        return ProductCategory(categoryID: categoryCreated.categoryID,
+                                               siteID: categoryCreated.siteID,
+                                               parentID: categoryCreated.parentID,
+                                               name: name,
+                                               slug: slug)
+                    }
+                    return nil
+                }
         }
+    }
+
+    enum ResponseType {
+      case load
+      case create
     }
 }
 
@@ -35,5 +67,25 @@ private struct ProductCategoryListEnvelope: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case productCategories = "data"
+    }
+}
+
+/// ProductCategoryListBatchCreateEnvelope Disposable Entity:
+/// `Batch Create Products Categories` endpoint returns the products tags under the `data` key, nested under `create`  key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductCategoryListBatchCreateEnvelope: Decodable {
+    let data: ProductCategoryListBatchCreateContainer
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}
+
+private struct ProductCategoryListBatchCreateContainer: Decodable {
+    let categories: [ProductCategoryFromBatchCreation]
+
+    private enum CodingKeys: String, CodingKey {
+        case categories = "create"
     }
 }

--- a/Networking/Networking/Model/Product/ProductCategoryFromBatchCreation.swift
+++ b/Networking/Networking/Model/Product/ProductCategoryFromBatchCreation.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Represents a ProductCategory entity, used during categories batch creation.
+///
+struct ProductCategoryFromBatchCreation: Decodable {
+    let categoryID: Int64
+    let siteID: Int64
+    let parentID: Int64
+    let error: CreateError?
+    let name, slug: String?
+
+    /// ProductCategoryFromBatchCreation initializer.
+    ///
+    init(categoryID: Int64,
+         siteID: Int64,
+         parentID: Int64,
+         error: CreateError?,
+         name: String?,
+         slug: String?) {
+        self.categoryID = categoryID
+        self.siteID = siteID
+        self.parentID = parentID
+        self.error = error
+        self.name = name
+        self.slug = slug
+    }
+
+    /// Initializer for ProductCategoryFromBatchCreation.
+    ///
+    init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw ProductCategoryCreateDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let categoryID = try container.decode(Int64.self, forKey: .categoryID)
+        let error = try container.decodeIfPresent(CreateError.self, forKey: .error)
+        let parentID = container.failsafeDecodeIfPresent(Int64.self, forKey: .parentID) ?? 0
+        let name = try container.decodeIfPresent(String.self, forKey: .name)
+        let slug = try container.decodeIfPresent(String.self, forKey: .slug)
+
+        self.init(categoryID: categoryID,
+                  siteID: siteID,
+                  parentID: parentID,
+                  error: error,
+                  name: name,
+                  slug: slug)
+    }
+}
+
+/// Defines all of the ProductCategoryFromBatchCreation CodingKeys
+///
+private extension ProductCategoryFromBatchCreation {
+    enum CodingKeys: String, CodingKey {
+        case siteID     = "siteID"
+        case categoryID = "id"
+        case name       = "name"
+        case slug       = "slug"
+        case parentID   = "parent"
+        case error      = "error"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum ProductCategoryCreateDecodingError: Error {
+    case missingSiteID
+}

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -129,7 +129,7 @@ public final class ProductCategoriesRemote: Remote, ProductCategoriesRemoteProto
                                         completion: @escaping (Result<[ProductCategory], Error>) -> Void) {
 
         let parameters = [
-            ParameterKey.create: names.compactMap { name in
+            ParameterKey.create: names.map { name in
                 var json = [ParameterKey.name: name]
                 if let parentID {
                     json[ParameterKey.parent] = String(parentID)

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -56,7 +56,7 @@ public final class ProductCategoriesRemote: Remote, ProductCategoriesRemoteProto
                                      path: path,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        let mapper = ProductCategoryListMapper(siteID: siteID)
+        let mapper = ProductCategoryListMapper(siteID: siteID, responseType: .load)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -1,8 +1,33 @@
 import Foundation
 
+public protocol ProductCategoriesRemoteProtocol {
+    func loadAllProductCategories(for siteID: Int64,
+                                  pageNumber: Int,
+                                  pageSize: Int,
+                                  completion: @escaping ([ProductCategory]?, Error?) -> Void)
+
+    func loadProductCategory(with categoryID: Int64,
+                             siteID: Int64,
+                             completion: @escaping (Result<ProductCategory, Error>) -> Void) -> Void
+
+    func createProductCategory(for siteID: Int64,
+                               name: String,
+                               parentID: Int64?,
+                               completion: @escaping (Result<ProductCategory, Error>) -> Void)
+
+    func createProductCategories(for siteID: Int64,
+                                 names: [String],
+                                 parentID: Int64?,
+                                 completion: @escaping (Result<[ProductCategory], Error>) -> Void)
+
+    func updateProductCategory(_ category: ProductCategory) async throws -> ProductCategory
+
+    func deleteProductCategory(for siteID: Int64, categoryID: Int64) async throws
+}
+
 /// Product Categories: Remote Endpoints
 ///
-public final class ProductCategoriesRemote: Remote {
+public final class ProductCategoriesRemote: Remote, ProductCategoriesRemoteProtocol {
 
     // MARK: - Product Categories
 

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -114,6 +114,42 @@ public final class ProductCategoriesRemote: Remote, ProductCategoriesRemoteProto
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+
+    /// Create new multiple `ProductCategory` entities.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll add new product categories.
+    ///     - names: Array of category names.
+    ///     - parentID: The ID for the parent of the categories.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createProductCategories(for siteID: Int64,
+                                        names: [String],
+                                        parentID: Int64?,
+                                        completion: @escaping (Result<[ProductCategory], Error>) -> Void) {
+
+        let parameters = [
+            ParameterKey.create: names.compactMap { name in
+                var json = [ParameterKey.name: name]
+                if let parentID {
+                    json[ParameterKey.parent] = String(parentID)
+                }
+                return json
+            }
+        ]
+
+        let path = Path.categoriesBatch
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+        let mapper = ProductCategoryListMapper(siteID: siteID, responseType: .create)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Updates an existing `ProductCategory`.
     ///
     /// - Parameter category: Details to be updated for a category.
@@ -165,6 +201,7 @@ public extension ProductCategoriesRemote {
 
     private enum Path {
         static let categories = "products/categories"
+        static let categoriesBatch = "products/categories/batch"
     }
 
     private enum ParameterKey {
@@ -172,5 +209,6 @@ public extension ProductCategoriesRemote {
         static let perPage: String = "per_page"
         static let name: String = "name"
         static let parent: String = "parent"
+        static let create: String = "create"
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductCategoyListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoyListMapperTests.swift
@@ -33,6 +33,34 @@ final class ProductCategoryListMapperTests: XCTestCase {
         XCTAssertEqual(secondProductCategory.name, "American")
         XCTAssertEqual(secondProductCategory.slug, "american")
     }
+
+    /// Verifies that all of the ProductCategory Fields under `create` field are parsed correctly.
+    ///
+    func test_ProductCategory_fields_when_created_are_properly_parsed() throws {
+        let categories = try mapLoadProductCategoriesCreatedResponse()
+        XCTAssertEqual(categories.count, 1)
+
+        let first = categories[0]
+        XCTAssertEqual(first.categoryID, 21)
+        XCTAssertEqual(first.parentID, 3)
+        XCTAssertEqual(first.siteID, dummySiteID)
+        XCTAssertEqual(first.name, "Headphone")
+        XCTAssertEqual(first.slug, "headphone")
+    }
+
+    /// Verifies that all of the ProductCategory Fields under `create` field are parsed correctly without data enveloper.
+    ///
+    func test_ProductCategory_fields_when_created_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let categories = try mapLoadProductCategoriesCreatedResponseWithoutDataEnvelope()
+        XCTAssertEqual(categories.count, 1)
+
+        let first = categories[0]
+        XCTAssertEqual(first.categoryID, 21)
+        XCTAssertEqual(first.parentID, 3)
+        XCTAssertEqual(first.siteID, dummySiteID)
+        XCTAssertEqual(first.name, "Headphone")
+        XCTAssertEqual(first.slug, "headphone")
+    }
 }
 
 
@@ -42,23 +70,35 @@ private extension ProductCategoryListMapperTests {
 
     /// Returns the ProducCategoryListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductCategories(from filename: String) throws -> [ProductCategory] {
+    func mapProductCategories(from filename: String, responseType: ProductCategoryListMapper.ResponseType) throws -> [ProductCategory] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try ProductCategoryListMapper(siteID: dummySiteID).map(response: response)
+        return try ProductCategoryListMapper(siteID: dummySiteID, responseType: responseType).map(response: response)
     }
 
-    /// Returns the ProductListMapper output upon receiving `categories-all`
+    /// Returns the ProductCategoryListMapper output upon receiving `categories-all`
     ///
     func mapLoadAllProductCategoriesResponse() throws -> [ProductCategory] {
-        return try mapProductCategories(from: "categories-all")
+        return try mapProductCategories(from: "categories-all", responseType: .load)
     }
 
-    /// Returns the ProductListMapper output upon receiving `categories-all-without-data`
+    /// Returns the ProductCategoryListMapper output upon receiving `categories-all-without-data`
     ///
     func mapLoadAllProductCategoriesResponseWithoutDataEnvelope() throws -> [ProductCategory] {
-        return try mapProductCategories(from: "categories-all-without-data")
+        return try mapProductCategories(from: "categories-all-without-data", responseType: .load)
+    }
+
+    /// Returns the ProductCategoryListMapper output upon receiving `product-categories-created`
+    ///
+    func mapLoadProductCategoriesCreatedResponse() throws -> [ProductCategory] {
+        return try mapProductCategories(from: "product-categories-created", responseType: .create)
+    }
+
+    /// Returns the ProductCategoryListMapper output upon receiving `product-categories-created-without-data`
+    ///
+    func mapLoadProductCategoriesCreatedResponseWithoutDataEnvelope() throws -> [ProductCategory] {
+        return try mapProductCategories(from: "product-categories-created-without-data", responseType: .create)
     }
 }

--- a/Networking/NetworkingTests/Responses/product-categories-created-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-categories-created-without-data.json
@@ -1,0 +1,38 @@
+{
+  "create": [
+    {
+      "id": 21,
+      "name": "Headphone",
+      "slug": "headphone",
+      "parent": 3,
+      "description": "",
+      "display": "default",
+      "image": null,
+      "menu_order": 0,
+      "count": 0,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories/21"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/categories"
+          }
+        ]
+      }
+    },
+    {
+      "id": 0,
+      "error": {
+        "code": "term_exists",
+        "message": "A term with the name provided already exists with this parent.",
+        "data": {
+          "status": 400,
+          "resource_id": 18
+        }
+      }
+    }
+  ]
+}

--- a/Networking/NetworkingTests/Responses/product-categories-created.json
+++ b/Networking/NetworkingTests/Responses/product-categories-created.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "create": [
+      {
+        "id": 21,
+        "name": "Headphone",
+        "slug": "headphone",
+        "parent": 3,
+        "description": "",
+        "display": "default",
+        "image": null,
+        "menu_order": 0,
+        "count": 0,
+        "_links": {
+          "self": [
+            {
+              "href": "https://example.com/wp-json/wc/v3/products/categories/21"
+            }
+          ],
+          "collection": [
+            {
+              "href": "https://example.com/wp-json/wc/v3/products/categories"
+            }
+          ]
+        }
+      },
+      {
+        "id": 0,
+        "error": {
+          "code": "term_exists",
+          "message": "A term with the name provided already exists with this parent.",
+          "data": {
+            "status": 400,
+            "resource_id": 18
+          }
+        }
+      }
+    ]
+  }
+}

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -428,6 +428,7 @@
 		E18FDB0128F98376008519BA /* AppAccountTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18FDB0028F98376008519BA /* AppAccountTokenTests.swift */; };
 		E1BD4D0027ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */; };
 		E1F54D0427AD4DAF00012983 /* CardPresentConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F54D0327AD4DAF00012983 /* CardPresentConfigurationTests.swift */; };
+		EE4D51B82ACD3C9800783D77 /* MockProductCategoriesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4D51B72ACD3C9800783D77 /* MockProductCategoriesRemote.swift */; };
 		EEB4E2C929B0489800371C3C /* StoreOnboardingTasksStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2C829B0489800371C3C /* StoreOnboardingTasksStore.swift */; };
 		EEB4E2CB29B04A1200371C3C /* StoreOnboardingTasksAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2CA29B04A1200371C3C /* StoreOnboardingTasksAction.swift */; };
 		EEB4E2CD29B04CE900371C3C /* MockStoreOnboardingTasksRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2CC29B04CE900371C3C /* MockStoreOnboardingTasksRemote.swift */; };
@@ -890,6 +891,7 @@
 		E18FDB0028F98376008519BA /* AppAccountTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAccountTokenTests.swift; sourceTree = "<group>"; };
 		E1BD4CFF27ABF84D006416D9 /* CardPresentPaymentsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsConfiguration.swift; sourceTree = "<group>"; };
 		E1F54D0327AD4DAF00012983 /* CardPresentConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationTests.swift; sourceTree = "<group>"; };
+		EE4D51B72ACD3C9800783D77 /* MockProductCategoriesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductCategoriesRemote.swift; sourceTree = "<group>"; };
 		EEB4E2C829B0489800371C3C /* StoreOnboardingTasksStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTasksStore.swift; sourceTree = "<group>"; };
 		EEB4E2CA29B04A1200371C3C /* StoreOnboardingTasksAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTasksAction.swift; sourceTree = "<group>"; };
 		EEB4E2CC29B04CE900371C3C /* MockStoreOnboardingTasksRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreOnboardingTasksRemote.swift; sourceTree = "<group>"; };
@@ -1269,6 +1271,7 @@
 				027CC11029F7AAEA00614B6E /* MockGenerativeContentRemote.swift */,
 				0286A1BD2A0CC4810099EF94 /* MockFeatureFlagRemote.swift */,
 				02DF98082A136BFB0009E2EA /* MockSitePluginsRemote.swift */,
+				EE4D51B72ACD3C9800783D77 /* MockProductCategoriesRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -2354,6 +2357,7 @@
 				03EB99922907EBB300F06A39 /* JustInTimeMessageStoreTests.swift in Sources */,
 				026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */,
 				7492FAE1217FB87100ED2C69 /* SettingStoreTests.swift in Sources */,
+				EE4D51B82ACD3C9800783D77 /* MockProductCategoriesRemote.swift in Sources */,
 				45ED4F16239E939A004F1BE3 /* TaxStoreTests.swift in Sources */,
 				57264572250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift in Sources */,
 				0286A1BE2A0CC4810099EF94 /* MockFeatureFlagRemote.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
@@ -15,8 +15,8 @@ public enum ProductCategoryAction: Action {
     ///
     case addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: (Result<ProductCategory, Error>) -> Void)
 
-    /// Creates new product categories associated with a given Site ID.
-    /// `onCompletion` will be invoked when the add operation finishes. `error` will be nil if the operation succeed.
+    /// Creates new product categories associated with a given Site ID, category names, and an optional parent ID
+    /// `onCompletion` will be invoked when the add operation finishes.
     ///
     case addProductCategories(siteID: Int64, names: [String], parentID: Int64?, onCompletion: (Result<[ProductCategory], Error>) -> Void)
 

--- a/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
@@ -15,6 +15,11 @@ public enum ProductCategoryAction: Action {
     ///
     case addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: (Result<ProductCategory, Error>) -> Void)
 
+    /// Creates new product categories associated with a given Site ID.
+    /// `onCompletion` will be invoked when the add operation finishes. `error` will be nil if the operation succeed.
+    ///
+    case addProductCategories(siteID: Int64, names: [String], parentID: Int64?, onCompletion: (Result<[ProductCategory], Error>) -> Void)
+
     /// Synchronizes the ProductCategory matching the specified categoryID.
     /// `onCompletion` will be invoked when the sync operation finishes. `error` will be nil if the operation succeed.
     ///

--- a/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
@@ -43,6 +43,8 @@ public final class ProductCategoryStore: Store {
             synchronizeAllProductCategories(siteID: siteID, fromPageNumber: fromPageNumber, onCompletion: onCompletion)
         case .addProductCategory(siteID: let siteID, name: let name, parentID: let parentID, onCompletion: let onCompletion):
             addProductCategory(siteID: siteID, name: name, parentID: parentID, onCompletion: onCompletion)
+        case .addProductCategories(siteID: let siteID, names: let names, parentID: let parentID, onCompletion: let onCompletion):
+            addProductCategories(siteID: siteID, names: names, parentID: parentID, onCompletion: onCompletion)
         case .synchronizeProductCategory(siteID: let siteID, categoryID: let CategoryID, onCompletion: let onCompletion):
             synchronizeProductCategory(siteID: siteID, categoryID: CategoryID, onCompletion: onCompletion)
         case let .updateProductCategory(category, onCompletion):
@@ -117,6 +119,24 @@ private extension ProductCategoryStore {
             case .success(let productCategory):
                 self?.upsertStoredProductCategoriesInBackground([productCategory], siteID: siteID) {
                     onCompletion(.success(productCategory))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Create new product categories associated with a given Site ID.
+    ///
+    func addProductCategories(siteID: Int64,
+                              names: [String],
+                              parentID: Int64?,
+                              onCompletion: @escaping (Result<[ProductCategory], Error>) -> Void) {
+        remote.createProductCategories(for: siteID, names: names, parentID: parentID) { [weak self] result in
+            switch result {
+            case .success(let productCategories):
+                self?.upsertStoredProductCategoriesInBackground(productCategories, siteID: siteID) {
+                    onCompletion(.success(productCategories))
                 }
             case .failure(let error):
                 onCompletion(.failure(error))

--- a/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
@@ -5,7 +5,7 @@ import Storage
 // MARK: - ProductCategoryStore
 //
 public final class ProductCategoryStore: Store {
-    private let remote: ProductCategoriesRemote
+    private let remote: ProductCategoriesRemoteProtocol
 
     private lazy var sharedDerivedStorage: StorageType = {
         return storageManager.writerDerivedStorage
@@ -13,6 +13,14 @@ public final class ProductCategoryStore: Store {
 
     public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         self.remote = ProductCategoriesRemote(network: network)
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    init(dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         network: Network,
+         remote: ProductCategoriesRemoteProtocol) {
+        self.remote = remote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductCategoriesRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductCategoriesRemote.swift
@@ -1,0 +1,50 @@
+import Combine
+import Foundation
+import Networking
+
+import XCTest
+
+/// Mock for `ProductCategoriesRemote`.
+///
+final class MockProductCategoriesRemote {
+    /// The results to return based on the given site ID in `createProductCategoriesResult`.
+    private var createProductCategoriesResult: Result<[ProductCategory], Error>?
+
+    /// Returns the value when `createProductCategories` is called.
+    func whenCreatingProductCategories(thenReturn result: Result<[ProductCategory], Error>) {
+        createProductCategoriesResult = result
+    }
+}
+
+extension MockProductCategoriesRemote: ProductCategoriesRemoteProtocol {
+    func loadAllProductCategories(for siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping ([Networking.ProductCategory]?, Error?) -> Void) {
+        // no-op
+    }
+
+    func loadProductCategory(with categoryID: Int64, siteID: Int64, completion: @escaping (Result<Networking.ProductCategory, Error>) -> Void) {
+        // no-op
+    }
+
+    func createProductCategory(for siteID: Int64, name: String, parentID: Int64?, completion: @escaping (Result<Networking.ProductCategory, Error>) -> Void) {
+        // no-op
+    }
+
+    func updateProductCategory(_ category: Networking.ProductCategory) async throws -> Networking.ProductCategory {
+        .fake()
+    }
+
+    func deleteProductCategory(for siteID: Int64, categoryID: Int64) async throws {
+        // no-op
+    }
+
+    func createProductCategories(for siteID: Int64,
+                                 names: [String],
+                                 parentID: Int64?,
+                                 completion: @escaping (Result<[ProductCategory], Error>) -> Void) {
+        guard let result = createProductCategoriesResult else {
+            XCTFail("Could not find result for creating product categories.")
+            return
+        }
+        completion(result)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -7,6 +7,10 @@ import XCTest
 /// ProductCategoryStore Unit Tests
 ///
 final class ProductCategoryStoreTests: XCTestCase {
+    /// Mock Dispatcher!
+    ///
+    private var dispatcher: Dispatcher!
+
     /// Mock Network: Allows us to inject predefined responses!
     ///
     private var network: MockNetwork!
@@ -43,6 +47,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        dispatcher = Dispatcher()
         network = MockNetwork(useResponseQueue: true)
         storageManager = MockStorageManager()
         store = ProductCategoryStore(dispatcher: Dispatcher(),
@@ -54,6 +59,7 @@ final class ProductCategoryStoreTests: XCTestCase {
         store = nil
         network = nil
         storageManager = nil
+        dispatcher = nil
 
         super.tearDown()
     }

--- a/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -481,6 +481,29 @@ final class ProductCategoryStoreTests: XCTestCase {
         XCTAssertEqual(categories[1].name, "Sample 2")
     }
 
+    func test_createProductCategories_updates_stored_categories_on_success() throws {
+        // Given
+        let network = MockNetwork()
+        let remote = MockProductCategoriesRemote()
+        remote.whenCreatingProductCategories(thenReturn: .success([.fake().copy(name: "Sample 1"),
+                                                                   .fake().copy(name: "Sample 2")]))
+        let store = ProductCategoryStore(dispatcher: dispatcher,
+                                         storageManager: storageManager,
+                                         network: network,
+                                         remote: remote)
+        XCTAssertEqual(storedProductCategoriesCount, 0)
+
+        // When
+        _ = waitFor { promise in
+            store.onAction(ProductCategoryAction.addProductCategories(siteID: self.sampleSiteID, names: [], parentID: nil) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertEqual(storedProductCategoriesCount, 2)
+    }
+
     func test_createProductCategories_returns_error_on_failure() throws {
         // Given
         let network = MockNetwork()


### PR DESCRIPTION
Part of: #10841 

## Description

As an improvement to Product creation with AI, we plan to create the categories and tags suggested by AI. 

This PR handles the Networking and Yosemite layer changes to add the ability to bulk create categories. 

#### Changes
- Add new action to `ProductCategoryStore` to bulk add categories.
- Add method to `ProductCategoriesRemote` to handle network request.
- Update mapper to handle bulk creation response.
- Unit tests and mock files.  

🗒️  The existing batch creation implementation of tags helped. 

## Testing instructions
CI passing is sufficient. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
