### PR TITLE
[UI Tests] - Add swipeUp() to get addCustomerDetailsButton in view

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -26,7 +26,7 @@ public final class UnifiedOrderScreen: ScreenObject {
     }
 
     private let addCustomerDetailsButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.staticTexts["Add Customer Details"]
+        $0.buttons["Add Customer Details"]
     }
 
     private let addShippingButtonGetter: (XCUIApplication) -> XCUIElement = {
@@ -117,6 +117,10 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Opens the Customer Details screen.
     /// - Returns: Customer Details screen object.
     public func openCustomerDetailsScreen() throws -> CustomerDetailsScreen {
+        // Swipe up to get the addCustomerDetailsButton in view.
+        // There's no condition for this because somehow button.exists, button.isHittable and button.isEnabled
+        // all returns true even when the button is not fully in view
+        app.swipeUp()
         addCustomerDetailsButton.tap()
         return try CustomerDetailsScreen()
     }


### PR DESCRIPTION
### Description
This PR adds a `swipeUp()` action before tapping on `addCustomerDetailsButton` as it is now pushed down on the screen after the Taxes field is added. 

Initially, I wanted to add a condition to check before the test would decide if the swipe should happen or not but I found that all the following returned true even when the button is not visible on screen:
![Screenshot 2023-10-04 at 5 03 04 PM](https://github.com/woocommerce/woocommerce-ios/assets/17252150/be517c80-4571-4949-9753-ae31fbb7a6a3)

Simulator view when running the above:
<img src="https://github.com/woocommerce/woocommerce-ios/assets/17252150/8555c8ed-f91c-4e67-ba65-cbf3cba0cfa5" width="50%" height="50%" />

Since the test adds each field in the order that they appear on the screen, I think adding a `swipeUp` should be fine for this particular test. But let me know if there are better alternatives! 

### Testing
CI should be 🟢 