### PR TITLE
Product Creation AI: New tags/categories

### DIFF
--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -202,7 +202,7 @@ private extension GenerativeContentRemote {
 
         let tagsAsString = {
             guard !tags.isEmpty else {
-                return ""
+                return ", tags: suggest an array of the best matching tags for this product."
             }
 
             return
@@ -212,7 +212,7 @@ private extension GenerativeContentRemote {
 
         let categoriesAsString = {
             guard !categories.isEmpty else {
-                return ""
+                return ", categories: suggest an array of the best matching categories for this product."
             }
 
             return

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -207,8 +207,7 @@ private extension GenerativeContentRemote {
 
             return
                 ", tags: Given the list of available tags ```\(tags.map { $0.name }.joined(separator: ", "))```, " +
-                "suggest an array of the best matching tags for this product, if no matches are found return an empty array, " +
-                "don’t suggest any value other than the available ones."
+                "suggest an array of the best matching tags for this product. You can suggest new tags as well."
         }()
 
         let categoriesAsString = {
@@ -218,8 +217,7 @@ private extension GenerativeContentRemote {
 
             return
                 ", categories: Given the list of available categories ```\(categories.map { $0.name }.joined(separator: ", "))```, " +
-                "suggest an array of the best matching categories for this product, if no matches are found return an empty array, " +
-                "don’t suggest any value other than the available ones."
+                "suggest an array of the best matching categories for this product. You can suggest new categories as well."
         }()
 
         let shippingJson = {

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -300,8 +300,8 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
         let prompt = try XCTUnwrap(request.parameters?["prompt"] as? String)
-        XCTAssertTrue(prompt.contains("categories:"))
-        XCTAssertTrue(prompt.contains("Snacks, Makeup, Clothes"))
+        XCTAssertTrue(prompt.contains("categories: Given the list of available categories ```Snacks, Makeup, Clothes```, "
+                                      + "suggest an array of the best matching categories for this product. You can suggest new categories as well."))
     }
 
     func test_generateAIProduct_prompt_asks_for_new_categories_if_no_categories_available() async throws {
@@ -351,8 +351,8 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
         let prompt = try XCTUnwrap(request.parameters?["prompt"] as? String)
-        XCTAssertTrue(prompt.contains("tags:"))
-        XCTAssertTrue(prompt.contains("Food, Grocery"))
+        XCTAssertTrue(prompt.contains("tags: Given the list of available tags ```Food, Grocery```, "
+                                      + "suggest an array of the best matching tags for this product. You can suggest new tags as well."))
     }
 
     func test_generateAIProduct_prompt_asks_for_new_tags_if_no_tags_available() async throws {

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -304,7 +304,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         XCTAssertTrue(prompt.contains("Snacks, Makeup, Clothes"))
     }
 
-    func test_generateAIProduct_prompt_does_not_have_categories_if_no_categories_available() async throws {
+    func test_generateAIProduct_prompt_asks_for_new_categories_if_no_categories_available() async throws {
         // Given
         let remote = GenerativeContentRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-openai-query/jwt", filename: "jwt-token-success")
@@ -326,8 +326,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
         let prompt = try XCTUnwrap(request.parameters?["prompt"] as? String)
-        XCTAssertFalse(prompt.contains("categories:"))
-        XCTAssertFalse(prompt.contains("Snacks, Makeup, Clothes"))
+        XCTAssertTrue(prompt.contains("categories: suggest an array of the best matching categories for this product."))
     }
 
     func test_generateAIProduct_prompt_has_existing_tags() async throws {
@@ -356,7 +355,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         XCTAssertTrue(prompt.contains("Food, Grocery"))
     }
 
-    func test_generateAIProduct_prompt_does_not_have_tags_if_no_tags_available() async throws {
+    func test_generateAIProduct_prompt_asks_for_new_tags_if_no_tags_available() async throws {
         // Given
         let remote = GenerativeContentRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-openai-query/jwt", filename: "jwt-token-success")
@@ -377,8 +376,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
         let prompt = try XCTUnwrap(request.parameters?["prompt"] as? String)
-        XCTAssertFalse(prompt.contains("tags:"))
-        XCTAssertFalse(prompt.contains("Food, Grocery"))
+        XCTAssertTrue(prompt.contains("tags: suggest an array of the best matching tags for this product."))
     }
 
     func test_generateAIProduct_with_success_returns_AIProduct() async throws {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 15.7
 -----
-
+- [*] Generate new tags/categories while creating product using AI. [https://github.com/woocommerce/woocommerce-ios/pull/10864]
 
 15.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -394,6 +394,28 @@ private extension ProductDetailPreviewViewModel {
 // MARK: - Saving product
 //
 private extension ProductDetailPreviewViewModel {
+    @MainActor
+    func saveLocalCategoriesAndTags(_ product: Product) async throws -> Product {
+        async let categories: [ProductCategory] = try await {
+            let categoriesToBeAdded = product.categories.filter { $0.categoryID == 0 }
+            let newCategories = try await addCategories(categoriesToBeAdded.map { $0.name })
+
+            let existingCategories = product.categories.filter { $0.categoryID != 0 }
+            return existingCategories + newCategories
+        }()
+
+        async let tags: [ProductTag] = try await {
+            let tagsToBeAdded = product.tags.filter { $0.tagID == 0 }
+            let newTags = try await addTags(tagsToBeAdded.map { $0.name })
+
+            let existingTags = product.tags.filter { $0.tagID != 0 }
+            return existingTags + newTags
+        }()
+
+        return product.copy(categories: try await categories,
+                            tags: try await tags)
+    }
+
     /// Saves the provided product remotely.
     ///
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -122,9 +122,10 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         errorState = .none
         isSavingProduct = true
         do {
-            let newProduct = try await saveProductRemotely(product: generatedProduct)
+            let productUpdatedWithRemoteCategoriesAndTags = try await saveLocalCategoriesAndTags(generatedProduct)
+            let remoteProduct = try await saveProductRemotely(product: productUpdatedWithRemoteCategoriesAndTags)
             analytics.track(event: .ProductCreationAI.saveAsDraftSuccess())
-            onProductCreated(newProduct)
+            onProductCreated(remoteProduct)
         } catch {
             DDLogError("⛔️ Error saving product with AI: \(error)")
             analytics.track(event: .ProductCreationAI.saveAsDraftFailed(error: error))

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -459,3 +459,11 @@ private extension ProductDetailPreviewViewModel {
         )
     }
 }
+
+// MARK: - Constants
+//
+private extension ProductDetailPreviewViewModel {
+    enum Default {
+        public static let firstPageNumber = 1
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -316,7 +316,15 @@ private extension ProductDetailPreviewViewModel {
                                                     existingCategories: existingCategories,
                                                     existingTags: existingTags)
 
-        let categories = existingCategories.filter({ aiProduct.categories.contains($0.name) })
+        var categories = [ProductCategory]()
+
+        aiProduct.categories.forEach { aiCategory in
+            if let match = existingCategories.first(where: { $0.name == aiCategory }) {
+                categories.append(match)
+            } else {
+                categories.append(ProductCategory(categoryID: 0, siteID: siteID, parentID: 0, name: aiCategory, slug: ""))
+            }
+        }
         let tags = existingTags.filter({ aiProduct.tags.contains($0.name) })
 
         return Product(siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -427,20 +427,26 @@ private extension ProductDetailPreviewViewModel {
 // MARK: - Saving product
 //
 private extension ProductDetailPreviewViewModel {
+    /// Saves the local categories and tags to remote
+    ///
     @MainActor
     func saveLocalCategoriesAndTags(_ product: Product) async throws -> Product {
         async let categories: [ProductCategory] = try await {
+            // Find the categories with ID as 0 (local items) and add those to remote
             let categoriesToBeAdded = product.categories.filter { $0.categoryID == 0 }
             let newCategories = try await addCategories(categoriesToBeAdded.map { $0.name })
 
+            // Combine the existing categories with the new remote categories
             let existingCategories = product.categories.filter { $0.categoryID != 0 }
             return existingCategories + newCategories
         }()
 
         async let tags: [ProductTag] = try await {
+            // Find the tags with ID as 0 (local items) and add those to remote
             let tagsToBeAdded = product.tags.filter { $0.tagID == 0 }
             let newTags = try await addTags(tagsToBeAdded.map { $0.name })
 
+            // Combine the existing tags with the new remote tags
             let existingTags = product.tags.filter { $0.tagID != 0 }
             return existingTags + newTags
         }()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -333,6 +333,36 @@ private extension ProductDetailPreviewViewModel {
     }
 }
 
+// MARK: - Categories
+//
+private extension ProductDetailPreviewViewModel {
+    @MainActor
+    func synchronizeAllCategories() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(ProductCategoryAction.synchronizeProductCategories(siteID: siteID,
+                                                                               fromPageNumber: Default.firstPageNumber,
+                                                                               onCompletion: { result in
+                continuation.resume()
+            }))
+        }
+    }
+
+    @MainActor
+    func addCategories(_ names: [String]) async throws -> [ProductCategory] {
+        guard names.isNotEmpty else {
+            return []
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(ProductCategoryAction.addProductCategories(siteID: siteID,
+                                                                       names: names,
+                                                                       parentID: nil,
+                                                                       onCompletion: { result in
+                continuation.resume(with: result)
+            }))
+        }
+    }
+}
+
 // MARK: - Saving product
 //
 private extension ProductDetailPreviewViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -325,7 +325,16 @@ private extension ProductDetailPreviewViewModel {
                 categories.append(ProductCategory(categoryID: 0, siteID: siteID, parentID: 0, name: aiCategory, slug: ""))
             }
         }
-        let tags = existingTags.filter({ aiProduct.tags.contains($0.name) })
+
+        var tags = [ProductTag]()
+
+        aiProduct.tags.forEach { aiTag in
+            if let match = existingTags.first(where: { $0.name == aiTag }) {
+                tags.append(match)
+            } else {
+                tags.append(ProductTag(siteID: siteID, tagID: 0, name: aiTag, slug: ""))
+            }
+        }
 
         return Product(siteID: siteID,
                        aiProduct: aiProduct,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -318,21 +318,29 @@ private extension ProductDetailPreviewViewModel {
                                                     existingTags: existingTags)
 
         var categories = [ProductCategory]()
-
         aiProduct.categories.forEach { aiCategory in
+            // If there exists a `ProductCategory` matching the AI suggestion
             if let match = existingCategories.first(where: { $0.name == aiCategory }) {
                 categories.append(match)
             } else {
+                /// Create a local `ProductCategory` with categoryID as 0, as there is no existing category matching the AI suggestion
+                ///
+                /// We will later upload the local category using `saveLocalCategoriesAndTags` method
+                ///
                 categories.append(ProductCategory(categoryID: 0, siteID: siteID, parentID: 0, name: aiCategory, slug: ""))
             }
         }
 
         var tags = [ProductTag]()
-
         aiProduct.tags.forEach { aiTag in
+            // If there exists a `ProductTag` matching the AI suggestion
             if let match = existingTags.first(where: { $0.name == aiTag }) {
                 tags.append(match)
             } else {
+                /// Create a local `ProductTag` with tagID as 0, as there is no existing tag matching the AI suggestion
+                ///
+                /// We will later upload the local tag using `saveLocalCategoriesAndTags` method
+                ///
                 tags.append(ProductTag(siteID: siteID, tagID: 0, name: aiTag, slug: ""))
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -363,6 +363,34 @@ private extension ProductDetailPreviewViewModel {
     }
 }
 
+// MARK: - Tags
+//
+private extension ProductDetailPreviewViewModel {
+    @MainActor
+    func synchronizeAllTags() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(ProductTagAction.synchronizeAllProductTags(siteID: siteID,
+                                                                       onCompletion: { result in
+                continuation.resume()
+            }))
+        }
+    }
+
+    @MainActor
+    func addTags(_ names: [String]) async throws -> [ProductTag] {
+        guard names.isNotEmpty else {
+            return []
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(ProductTagAction.addProductTags(siteID: siteID,
+                                                            tags: names,
+                                                            onCompletion: { result in
+                continuation.resume(with: result)
+            }))
+        }
+    }
+}
+
 // MARK: - Saving product
 //
 private extension ProductDetailPreviewViewModel {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -159,6 +159,138 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         await viewModel.generateProductDetails()
     }
 
+    func test_generateProductDetails_synchronizes_categories() async throws {
+        // Given
+        let sampleSiteID: Int64 = 123
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
+
+        let productName = "Pen"
+        let productFeatures = "Ballpoint, Blue ink, ABS plastic"
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
+                                                      productName: productName,
+                                                      productDescription: nil,
+                                                      productFeatures: productFeatures,
+                                                      weightUnit: nil,
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .synchronizeGeneralSiteSettings(_, completion):
+                completion(nil)
+            case let .synchronizeProductSiteSettings(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(siteID, _, completion):
+                // Then
+                XCTAssertEqual(siteID, sampleSiteID)
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.generateProductDetails()
+    }
+
+    func test_generateProductDetails_synchronizes_tags() async throws {
+        // Given
+        let sampleSiteID: Int64 = 123
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
+
+        let productName = "Pen"
+        let productFeatures = "Ballpoint, Blue ink, ABS plastic"
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
+                                                      productName: productName,
+                                                      productDescription: nil,
+                                                      productFeatures: productFeatures,
+                                                      weightUnit: nil,
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .synchronizeGeneralSiteSettings(_, completion):
+                completion(nil)
+            case let .synchronizeProductSiteSettings(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(siteID, completion):
+                // Then
+                XCTAssertEqual(siteID, sampleSiteID)
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.generateProductDetails()
+    }
+
     func test_generateProductDetails_sends_name_and_features_to_identify_language() async throws {
         // Given
         let siteID: Int64 = 123

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -652,7 +652,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(generatedProduct.categories, [biscuit])
     }
 
-    func test_generateProduct_generates_product_with_matching_existing_tags() async throws {
+    func test_generateProductDetails_generates_product_with_matching_existing_tags() async throws {
         // Given
         let sampleSiteID: Int64 = 123
         let food: ProductTag = .fake().copy(siteID: sampleSiteID, name: "Food")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -905,6 +905,61 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(generatedProduct.tags, [food])
     }
 
+    func test_generateProductDetails_generates_product_with_new_tags_suggested_by_AI() async throws {
+        // Given
+        let sampleSiteID: Int64 = 123
+        let product = AIProduct.fake().copy(tags: ["Food", "Grocery"])
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
+                                                      productName: "Pen",
+                                                      productDescription: nil,
+                                                      productFeatures: "Ballpoint, Blue ink, ABS plastic",
+                                                      weightUnit: "kg",
+                                                      dimensionUnit: "m",
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+                completion(.success(product))
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
+                break
+            }
+        }
+        await viewModel.generateProductDetails()
+
+        // Then
+        let generatedProduct = try XCTUnwrap(viewModel.generatedProduct)
+        XCTAssertEqual(generatedProduct.tags.map { $0.name }, ["Food", "Grocery"])
+        XCTAssertEqual(generatedProduct.tags.map { $0.tagID }, [0, 0])
+    }
+
     // MARK: - Save product
 
     func test_saveProductAsDraft_updates_isSavingProduct_properly() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -69,6 +69,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             }
         }
 
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         // When
         await viewModel.generateProductDetails()
     }
@@ -119,6 +137,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             }
         }
 
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         // When
         await viewModel.generateProductDetails()
     }
@@ -157,6 +193,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 // Then
                 XCTAssertEqual(string, productName + " " + productFeatures)
                 completion(.success("en"))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
             default:
                 break
             }
@@ -242,6 +296,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             }
         }
 
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         // When
         await viewModel.generateProductDetails()
     }
@@ -281,6 +353,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 completion(.success(.fake()))
             case let .identifyLanguage(_, _, _, completion):
                 completion(.success("en"))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
             default:
                 break
             }
@@ -326,6 +416,25 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 break
             }
         }
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         await viewModel.generateProductDetails()
 
         // Then
@@ -356,6 +465,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
         XCTAssertEqual(viewModel.errorState, .none)
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
 
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -415,6 +542,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
@@ -471,6 +616,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
@@ -518,6 +681,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
@@ -535,7 +716,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         let generatedProduct = try XCTUnwrap(viewModel.generatedProduct)
         XCTAssertEqual(generatedProduct.tags, [food])
     }
-
 
     // MARK: - Save product
 
@@ -555,6 +735,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       dimensionUnit: "m",
                                                       stores: stores,
                                                       onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
 
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -597,6 +795,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       onProductCreated: { createdProduct = $0 })
 
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
@@ -630,6 +846,24 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       onProductCreated: { _ in })
         XCTAssertEqual(viewModel.errorState, .none)
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
 
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -697,6 +931,25 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
@@ -735,6 +988,25 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
@@ -825,6 +1097,25 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 break
             }
         }
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         await viewModel.generateProductDetails()
 
         // When
@@ -866,6 +1157,25 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 break
             }
         }
+
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+
         await viewModel.generateProductDetails()
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -885,6 +885,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.errorState, .savingProduct)
     }
 
+    // MARK: - Handle feedback
+
     func test_handleFeedback_sets_shouldShowFeedbackView_to_false() {
         // Given
         let siteID: Int64 = 123


### PR DESCRIPTION
Closes: #10841 

## Description

We have only been asking AI to match existing tags/categories. Starting from this PR
- Ask AI to suggest new tags/categories if existing items don't match.
    - We also load tags/categories before generating a product.
- Save the new AI-suggested tags/categories before saving a product.

Internal discussion about the flow - p1696499410470729/1696499095.943969-slack-C03L1NF1EA3

## Testing instructions
- Create a JN site with the Jetpack AI plugin. (Checkbox available on JN home page to install this plugin)
- Login into the app using the JN site
- Switch to the Products tab and select the "+" button to add a new product. 
- Tap "Create a product with AI" option
- Enter a product name and tap "Continue"
- Enter product features in the next screen and tap "Create Product Details"
- Optionally tap on "Set tone and voice" and select a tone.
- The product details should be displayed on the next screen after the loading animation.
- Scroll down and validate the categories/tags are available.
- Save the product as a draft, and the new categories/tags should be saved along with the Product. 

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/c74c72da-d4cc-4005-9ff8-68e806ea3551



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.