### PR TITLE
Fix order item variation attributes missing with product addons

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 15.7
 -----
 - [*] Generate new tags/categories while creating product using AI. [https://github.com/woocommerce/woocommerce-ios/pull/10864]
+- [*] Fix: in order details where an order item is a variable product with attributes and has add-ons, the variation attributes are shown now. [https://github.com/woocommerce/woocommerce-ios/pull/10877]
 
 15.6
 -----

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -214,9 +214,15 @@ private extension ProductDetailsCellViewModel {
                                 + " The %1$@ is the list of attributes (e.g. from variation)."
                                 + " The %2$@ is the quantity. The %3$@ is the formatted price with currency (e.g. $400.00).")
         static func subtitle(quantity: String, price: String, attributes: [VariationAttributeViewModel], addOns: AddOnsViewModel) -> String {
-            let attributesText = attributes.map { $0.nameOrValue }.joined(separator: ", ")
-            // The attributes are only shown when add-ons are not available.
-            if attributes.isEmpty || addOns.addOns.isNotEmpty {
+            // Only the attributes that are not in the order item add-ons are shown since add-ons are displayed separately.
+            let nonAddOnAttributes: [VariationAttributeViewModel] = {
+                let addOns = addOns.addOns
+                return attributes.filter { attribute in
+                    !addOns.contains(where: { $0.key == attribute.name && $0.value == attribute.value })
+                }
+            }()
+            let attributesText = nonAddOnAttributes.map { $0.nameOrValue }.joined(separator: ", ")
+            if nonAddOnAttributes.isEmpty {
                 return String.localizedStringWithFormat(subtitleFormat, quantity, price)
             } else {
                 return String.localizedStringWithFormat(subtitleWithAttributesFormat, attributesText, quantity, price)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -223,7 +223,7 @@ final class ProductDetailsCellViewModelTests: XCTestCase {
         ], viewModel.addOns)
     }
 
-    func test_subtitle_does_not_include_attributes_when_addOns_are_available() {
+    func test_subtitle_includes_non_addOn_attributes_when_addOns_are_available() {
         // Given
         let item = makeAggregateOrderItem(quantity: 2,
                                           price: 3.5,
@@ -231,7 +231,8 @@ final class ProductDetailsCellViewModelTests: XCTestCase {
                                           sku: "",
                                           attributes: [
                                             .init(metaID: 2, name: "Woo", value: "Wao"),
-                                            .init(metaID: 25, name: "Wooo", value: "Waoo")
+                                            .init(metaID: 25, name: "Wooo", value: "Waoo"),
+                                            .init(metaID: 2, name: "Sugar level", value: "25%")
                                           ])
             .copy(addOns: [.init(addOnID: 1, key: "Sugar level", value: "25%")])
 
@@ -243,7 +244,7 @@ final class ProductDetailsCellViewModelTests: XCTestCase {
                                                     isChildWithParent: true)
 
         // Then
-        let subtitle = String.localizedStringWithFormat(Localization.subtitleFormat, "2", "$3.50")
+        let subtitle = String.localizedStringWithFormat(Localization.subtitleWithAttributesFormat, "Wao, Waoo", "2", "$3.50")
         XCTAssertEqual(viewModel.subtitle, subtitle)
         XCTAssertTrue(viewModel.addOns.addOns.isNotEmpty)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes issue for #10419 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From p1696492979816859-slack-C02KUCFCSFP, we received a report where the variation attributes in an order item aren't shown when the order item also has product add-ons. I was able to reproduce this, and this PR aims to fix the issue.

## How

In the previous PR diff https://github.com/woocommerce/woocommerce-ios/pull/10661/files#diff-c2589eff8e87a318ca249908b00935197e9f7a1de545e581d5bb8371ef2f55a0R219, the variation attributes are not shown in the order item subtitle when the item also has add-ons. This is a scenario that I didn't consider, I only tested the case for variable product order items without add-ons. Because an order item's attributes can also contain the ones generated by product add-ons, the attributes are filtered so that only non-add-on attributes are shown in the subtitle.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has the Product Add-ons plugin, and one order with a variable product with attributes **and** add-ons

- Go to the Orders tab
- Tap on an order in the prerequisite --> the variation attributes should be shown in the subtitle (they aren't shown in `trunk`), and the add-ons are displayed below in separate lines

---
- [x] @jaclync tests that the attributes are shown for order items with a variable product without add-ons
- [x] @jaclync tests that the attributes are not shown for order items with a non-variable product with add-ons

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/e35416fd-4099-4b97-88d9-adf87ea256f7" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/9cd64c37-5962-4864-8cf5-687922233cd5" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.