### PR TITLE
[TTPUK] TTPUK feature flags

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -44,8 +44,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             // It is not possible to get the TTPoI entitlement for an enterprise certificate,
             // so we should not enable this for alpha builds.
             return buildConfig == .localDeveloper || buildConfig == .appStore
-        case .tapToPayOnIPhoneMilestone2:
-            return true
         case .domainSettings:
             return true
         case .jetpackSetupWithApplicationPassword:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -98,6 +98,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .wooPaymentsDepositsOverviewInPaymentsMenu:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+        case .tapToPayOnIPhoneInUK:
+            return buildConfig == .localDeveloper
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -46,8 +46,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .appStore
         case .tapToPayOnIPhoneMilestone2:
             return true
-        case .tapToPayBadge:
-            return true
         case .domainSettings:
             return true
         case .jetpackSetupWithApplicationPassword:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -52,10 +52,6 @@ public enum FeatureFlag: Int {
     ///
     case tapToPayOnIPhone
 
-    /// Enables Tap to Pay on iPhone Milestone 2 (Tap to Pay deeplinks, JITM deeplink handling, JITM customisation) on eligible devices.
-    ///
-    case tapToPayOnIPhoneMilestone2
-
     /// Just In Time Messages on Dashboard
     ///
     case justInTimeMessagesOnDashboard

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -205,4 +205,8 @@ public enum FeatureFlag: Int {
     /// Enables the Woo Payments Deposits item in the Payments menu
     ///
     case wooPaymentsDepositsOverviewInPaymentsMenu
+
+    /// Enables Tap to Pay for UK Woo Payments stores
+    /// 
+    case tapToPayOnIPhoneInUK
 }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -56,10 +56,6 @@ public enum FeatureFlag: Int {
     ///
     case tapToPayOnIPhoneMilestone2
 
-    /// Enables badging the route to Set up Tap to Pay on iPhone on eligible devices
-    ///
-    case tapToPayBadge
-
     /// Just In Time Messages on Dashboard
     ///
     case justInTimeMessagesOnDashboard

--- a/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
@@ -1,23 +1,20 @@
 import Foundation
-import Experiments /// Remove when `.tapToPayOnIPhoneMilestone2` is removed
 
 /// Links supported URLs with a /payments root path to various destinations in the Payments Hub Menu
 /// 
 struct PaymentsRoute: Route {
     private let deepLinkForwarder: DeepLinkForwarder
-    private let featureFlagService: FeatureFlagService // Temporary for testing with `tapToPayOnIPhoneMilestone2` enabled
 
-    init(deepLinkForwarder: DeepLinkForwarder, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(deepLinkForwarder: DeepLinkForwarder) {
         self.deepLinkForwarder = deepLinkForwarder
-        self.featureFlagService = featureFlagService
     }
 
     func canHandle(subPath: String) -> Bool {
-        return HubMenuCoordinator.DeepLinkDestination(paymentsDeepLinkSubPath: subPath, featureFlagService: featureFlagService) != nil
+        return HubMenuCoordinator.DeepLinkDestination(paymentsDeepLinkSubPath: subPath) != nil
     }
 
     func perform(for subPath: String, with parameters: [String: String]) -> Bool {
-        guard let destination = HubMenuCoordinator.DeepLinkDestination(paymentsDeepLinkSubPath: subPath, featureFlagService: featureFlagService) else {
+        guard let destination = HubMenuCoordinator.DeepLinkDestination(paymentsDeepLinkSubPath: subPath) else {
             return false
         }
 
@@ -28,7 +25,7 @@ struct PaymentsRoute: Route {
 }
 
 private extension HubMenuCoordinator.DeepLinkDestination {
-    init?(paymentsDeepLinkSubPath: String, featureFlagService: FeatureFlagService) {
+    init?(paymentsDeepLinkSubPath: String) {
         guard paymentsDeepLinkSubPath.hasPrefix(Constants.paymentsRoot) else {
             return nil
         }
@@ -36,16 +33,6 @@ private extension HubMenuCoordinator.DeepLinkDestination {
         let destinationSubPath = paymentsDeepLinkSubPath
             .removingPrefix(Constants.paymentsRoot)
             .removingPrefix("/")
-
-        /// Before Tap to Pay Milestone 2, we only support deeplinks directly to the Payments menu root
-        guard featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneMilestone2) else {
-            if destinationSubPath == "" {
-                self = .paymentsMenu
-                return
-            } else {
-                return nil
-            }
-        }
 
         switch destinationSubPath {
         case "":

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -44,16 +44,14 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
         /// priority, so viewmodels related to starting set up should come before viewmodels
         /// that expect set up to be completed, etc.
         ///
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneMilestone2) {
-            viewModelsAndViews.append(PaymentSettingsFlowViewModelAndView(
+        viewModelsAndViews.append(contentsOf: [
+            PaymentSettingsFlowViewModelAndView(
                 viewModel: InPersonPaymentsViewModel(useCase: onboardingUseCase,
                                                      didChangeShouldShow: { [weak self] state in
                                                          self?.onDidChangeShouldShow(state)
                                                      }),
-                viewPresenter: SetUpTapToPayOnboardingViewController.self))
-        }
+                viewPresenter: SetUpTapToPayOnboardingViewController.self),
 
-        viewModelsAndViews.append(contentsOf: [
             PaymentSettingsFlowViewModelAndView(
                 viewModel: SetUpTapToPayInformationViewModel(
                     siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -34,8 +34,6 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         cardPresentPaymentsOnboardingUseCase.state.isCompleted
     }
 
-    private let setUpFlowOnlyEnabledAfterOnboardingComplete: Bool
-
     /// Main TableView
     ///
     private lazy var tableView: UITableView = {
@@ -75,7 +73,6 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         self.viewModel = InPersonPaymentsMenuViewModel(dependencies: .init(tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker))
         self.cardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase()
         self.cashOnDeliveryToggleRowViewModel = InPersonPaymentsCashOnDeliveryToggleRowViewModel()
-        self.setUpFlowOnlyEnabledAfterOnboardingComplete = !featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneMilestone2)
         self.viewDidLoadAction = viewDidLoadAction
 
         super.init(nibName: nil, bundle: nil)
@@ -388,12 +385,6 @@ private extension InPersonPaymentsMenuViewController {
         cell.configure(image: .tapToPayOnIPhoneIcon,
                        text: Localization.tapToPayOnIPhone,
                        showBadge: viewModel.shouldBadgeTapToPayOnIPhone)
-
-        if setUpFlowOnlyEnabledAfterOnboardingComplete {
-            cell.accessoryType = enableSetUpTapToPayOnIPhoneCell ? .disclosureIndicator : .none
-            cell.selectionStyle = enableSetUpTapToPayOnIPhoneCell ? .default : .none
-            updateEnabledState(in: cell, shouldBeEnabled: enableSetUpTapToPayOnIPhoneCell)
-        }
     }
 
     func configureTapToPayOnIPhoneFeedback(cell: LeftImageTableViewCell) {
@@ -519,15 +510,7 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func presentSetUpTapToPayOnIPhoneViewController() {
-        if setUpFlowOnlyEnabledAfterOnboardingComplete {
-            guard enableSetUpTapToPayOnIPhoneCell else {
-                return
-            }
-
-            presentSetUpTapToPayOnIPhoneWithoutOnboarding()
-        } else {
-            presentSetUpTapToPayOnIPhoneWithOnboarding()
-        }
+        presentSetUpTapToPayOnIPhoneWithOnboarding()
     }
 
     private func presentSetUpTapToPayOnIPhoneWithoutOnboarding() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
@@ -4,16 +4,13 @@ import Experiments
 import Combine
 
 final class TapToPayBadgePromotionChecker {
-    private let featureFlagService: FeatureFlagService
     private let stores: StoresManager
 
     @Published private(set) var shouldShowTapToPayBadges: Bool = false
 
     private var cancellables: Set<AnyCancellable> = []
 
-    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         stores: StoresManager = ServiceLocator.stores) {
-        self.featureFlagService = featureFlagService
+    init(stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
 
         listenToTapToPayBadgeReloadRequired()
@@ -51,7 +48,7 @@ final class TapToPayBadgePromotionChecker {
                 }
                 self?.stores.dispatch(action)
             })
-            shouldShowTapToPayBadges = visible && featureFlagService.isFeatureFlagEnabled(.tapToPayBadge)
+            shouldShowTapToPayBadges = visible
         } catch {
             DDLogError("Could not fetch feature announcement visibility \(error)")
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -10,7 +10,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
     private let jetpackSetupWithApplicationPassword: Bool
-    private let isTapToPayOnIPhoneMilestone2On: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
     private let isProductDescriptionAIEnabled: Bool
     private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
@@ -32,7 +31,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
-         isTapToPayOnIPhoneMilestone2On: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
          isProductDescriptionAIEnabled: Bool = false,
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
@@ -53,7 +51,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
-        self.isTapToPayOnIPhoneMilestone2On = isTapToPayOnIPhoneMilestone2On
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
         self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
@@ -86,8 +83,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isDashboardStoreOnboardingEnabled
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
-        case .tapToPayOnIPhoneMilestone2:
-            return isTapToPayOnIPhoneMilestone2On
         case .readOnlySubscriptions:
             return isReadOnlySubscriptionsEnabled
         case .productDescriptionAI:

--- a/WooCommerce/WooCommerceTests/Universal Links/Routes/PaymentsRouteTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/Routes/PaymentsRouteTests.swift
@@ -5,13 +5,11 @@ import XCTest
 final class PaymentsRouteTests: XCTestCase {
 
     private var deepLinkForwarder: MockDeepLinkForwarder!
-    private var featureFlagService: MockFeatureFlagService!
     private var sut: PaymentsRoute!
 
     override func setUp() {
         deepLinkForwarder = MockDeepLinkForwarder()
-        featureFlagService = MockFeatureFlagService(isTapToPayOnIPhoneMilestone2On: true)
-        sut = PaymentsRoute(deepLinkForwarder: deepLinkForwarder, featureFlagService: featureFlagService)
+        sut = PaymentsRoute(deepLinkForwarder: deepLinkForwarder)
     }
 
     func test_canHandle_returns_true_for_set_up_tap_to_pay_deep_link_path() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10873 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We'll add Tap to Pay on iPhone support for UK WooPayments merchants. This PR cleans up some unused TTP related feature flags, and adds a feature flag for TTP in the UK.

TTP can't work with an enterprise certificate, i.e. on our CI builds, so I've only included `localDeveloper` builds initially, as `alpha` builds won't be able to use it anyway.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check unit tests pass.

TTPM2 – Check that the Set Up Tap to Pay on iPhone flow still checks IPP onboarding before continuing with the flow:

1. Using a US-based WooPayments store, disable the WooPayments plugin
2. Launch the app and go to `Menu > Payments > Set up Tap to Pay on iPhone`
3. Confirm that you see the expected "You need to activate WooPayments" message
4. Re-activate the WooPayments plugin
5. Observe that the set up flow continues as expected

Badge – Check that the Payment menu badging still works:

1. Delete the app from your phone
2. Run it again 
3. Log in and select a WooPayments US/CA store
4. Observe that the Menu tab has a small badge
5. Open the Menu tab and observe that the Payments item has a small badge
6. Open the Payments menu and observe that Set up Tap to Pay on iPhone has a small badge
7. Tap Set up Tap to Pay on iPhone
8. Dismiss the flow (even without completing it)
9. Observe the badges are all gone


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
