### PR TITLE
Product Creation AI: Check JWT expiry date to reduce network requests

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -877,6 +877,10 @@
 		E1BAB2C32913FA6400C3982B /* ResponseDataValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C22913FA6400C3982B /* ResponseDataValidator.swift */; };
 		E1BAB2C52913FB1800C3982B /* WordPressApiValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C42913FB1800C3982B /* WordPressApiValidator.swift */; };
 		E1BAB2C72913FB5800C3982B /* WordPressApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C62913FB5800C3982B /* WordPressApiError.swift */; };
+		EE078D8F2AD2E65400C1199E /* JWToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE078D8E2AD2E65400C1199E /* JWToken.swift */; };
+		EE078D912AD2EFBA00C1199E /* JWTokenMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE078D902AD2EFBA00C1199E /* JWTokenMapper.swift */; };
+		EE078D932AD2F1E500C1199E /* JWTokenMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE078D922AD2F1E500C1199E /* JWTokenMapperTests.swift */; };
+		EE078D952AD2FCFA00C1199E /* jwt-token-expired-token.json in Resources */ = {isa = PBXBuildFile; fileRef = EE078D942AD2FCFA00C1199E /* jwt-token-expired-token.json */; };
 		EE1D9A9F2ACD6BA60020D817 /* AIProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1D9A9E2ACD6BA60020D817 /* AIProduct.swift */; };
 		EE28C7DA2AC17961004A69F4 /* generate-product-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = EE28C7D72AC17960004A69F4 /* generate-product-failure.json */; };
 		EE28C7DB2AC17961004A69F4 /* generate-product-invalid-token.json in Resources */ = {isa = PBXBuildFile; fileRef = EE28C7D82AC17961004A69F4 /* generate-product-invalid-token.json */; };
@@ -1870,6 +1874,10 @@
 		E1BAB2C22913FA6400C3982B /* ResponseDataValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseDataValidator.swift; sourceTree = "<group>"; };
 		E1BAB2C42913FB1800C3982B /* WordPressApiValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiValidator.swift; sourceTree = "<group>"; };
 		E1BAB2C62913FB5800C3982B /* WordPressApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiError.swift; sourceTree = "<group>"; };
+		EE078D8E2AD2E65400C1199E /* JWToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWToken.swift; sourceTree = "<group>"; };
+		EE078D902AD2EFBA00C1199E /* JWTokenMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTokenMapper.swift; sourceTree = "<group>"; };
+		EE078D922AD2F1E500C1199E /* JWTokenMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTokenMapperTests.swift; sourceTree = "<group>"; };
+		EE078D942AD2FCFA00C1199E /* jwt-token-expired-token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "jwt-token-expired-token.json"; sourceTree = "<group>"; };
 		EE1D9A9E2ACD6BA60020D817 /* AIProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProduct.swift; sourceTree = "<group>"; };
 		EE28C7D72AC17960004A69F4 /* generate-product-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-product-failure.json"; sourceTree = "<group>"; };
 		EE28C7D82AC17961004A69F4 /* generate-product-invalid-token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-product-invalid-token.json"; sourceTree = "<group>"; };
@@ -2506,6 +2514,7 @@
 				02AAFCD12A132C1D00F05E60 /* DotcomSitePlugin.swift */,
 				CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */,
 				B990FA912AA1EBC600496375 /* TaxRate.swift */,
+				EE078D8E2AD2E65400C1199E /* JWToken.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2523,6 +2532,7 @@
 				DEA662A12A84DD5100731D36 /* site-settings-success.json */,
 				EEFC4C942A5E996C004C5A83 /* jwt-token-failure.json */,
 				EEFC4C952A5E996C004C5A83 /* jwt-token-success.json */,
+				EE078D942AD2FCFA00C1199E /* jwt-token-expired-token.json */,
 				EEE846A12A54745F005239B6 /* identify-language-failure.json */,
 				EEE846A02A54745F005239B6 /* identify-language-success.json */,
 				EEFC4C9A2A5ED1F6004C5A83 /* identify-language-invalid-token.json */,
@@ -3016,6 +3026,7 @@
 				B9DFE4BD2AA2057B00174004 /* TaxRateListMapper.swift */,
 				B9CFF6512AB2118900C2F616 /* TaxRateMapper.swift */,
 				EE839C252ABEF9C900049545 /* AIProductMapper.swift */,
+				EE078D902AD2EFBA00C1199E /* JWTokenMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -3174,6 +3185,7 @@
 				EE2C09C329AF5274009396F9 /* StoreOnboardingTaskListMapperTests.swift */,
 				6812FC002A6B27E100D7C625 /* InAppPurchasesTransactionMapperTests.swift */,
 				EEA1E2012AC18CD700A37ADD /* AIProductMapperTests.swift */,
+				EE078D922AD2F1E500C1199E /* JWTokenMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -3805,6 +3817,7 @@
 				2676F4D0290B0EC800C7A15B /* product-id-only.json in Resources */,
 				31D27C8F2602B553002EDB1D /* plugins.json in Resources */,
 				DE66C55D2977C35A00DAA978 /* shipping-label-packages-success-without-data.json in Resources */,
+				EE078D952AD2FCFA00C1199E /* jwt-token-expired-token.json in Resources */,
 				027EB57529C07524003CE551 /* site-launch-success.json in Resources */,
 				261CF1B4255AD6B30090D8D3 /* payment-gateway-list.json in Resources */,
 				0359EA2527AAF7D60048DE2D /* wcpay-charge-card.json in Resources */,
@@ -4077,6 +4090,7 @@
 				EE57C1152979371B00BC31E7 /* ApplicationPassword.swift in Sources */,
 				B554FA8F2180BC7000C54DFF /* NoteHashListMapper.swift in Sources */,
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
+				EE078D912AD2EFBA00C1199E /* JWTokenMapper.swift in Sources */,
 				024124862AC93E470035A247 /* OrderItemBundleItem.swift in Sources */,
 				CE71E22B2A4C363E00DB5376 /* ProductsReportsRemote.swift in Sources */,
 				45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */,
@@ -4201,6 +4215,7 @@
 				021EAA5625493B3600AA8CCD /* OrderItemAttribute.swift in Sources */,
 				77CE40602514CB3E003FF69D /* ProductDownloadDragAndDrop.swift in Sources */,
 				2685C0FE263B5D8900D9EE97 /* AddOnGroupRemote.swift in Sources */,
+				EE078D8F2AD2E65400C1199E /* JWToken.swift in Sources */,
 				AE1950F3296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift in Sources */,
 				450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */,
 				B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */,
@@ -4415,6 +4430,7 @@
 				CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */,
 				2670C3FC270F4E06002FE931 /* SiteListMapperTests.swift in Sources */,
 				025CA2C6238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift in Sources */,
+				EE078D932AD2F1E500C1199E /* JWTokenMapperTests.swift in Sources */,
 				D800DA0A25EFEB9C001E13CE /* WCPayRemoteTests.swift in Sources */,
 				EE57C13A297F9EBE00BC31E7 /* ProductVariationsBulkCreateMapperTests.swift in Sources */,
 				E13BAD5328F8625600217769 /* InAppPurchasesRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/JWTokenMapper.swift
+++ b/Networking/Networking/Mapper/JWTokenMapper.swift
@@ -34,7 +34,7 @@ struct JWTokenMapper: Mapper {
 
         let siteID =  try {
             guard let payload,
-                  let siteID = payload[PayloadKey.blodID] as? Int64 else {
+                  let siteID = payload[PayloadKey.blogID] as? Int64 else {
                 throw JWTokenMapperError.blogIDNotFound
             }
 
@@ -52,7 +52,7 @@ struct JWTokenMapper: Mapper {
 private extension JWTokenMapper {
     enum PayloadKey {
         static let expiryDate = "exp"
-        static let blodID = "blog_id"
+        static let blogID = "blog_id"
     }
 }
 

--- a/Networking/Networking/Mapper/JWTokenMapper.swift
+++ b/Networking/Networking/Mapper/JWTokenMapper.swift
@@ -1,0 +1,90 @@
+
+import Foundation
+
+/// Mapper to parse the JWToken
+///
+struct JWTokenMapper: Mapper {
+    func map(response: Data) throws -> JWToken {
+        let decoder = JSONDecoder()
+        let jwt = try decoder.decode(JWTokenResponse.self, from: response).token
+
+        let payload: [String: Any]? = {
+            let parts = jwt.components(separatedBy: ".")
+            guard parts.count == 3 else {
+                return nil
+            }
+
+            let midPart = parts[1]
+
+            guard let bodyData = Data(base64URLEncoded: midPart) else {
+                return nil
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: bodyData, options: []),
+                  let payload = json as? [String: Any] else {
+                return nil
+            }
+            return payload
+        }()
+
+        let expiryDate = try {
+            guard let payload,
+                  let expiry = payload[PayloadKey.expiryDate] as? Double else {
+                throw JWTokenMapperError.expiryDateNotFound
+            }
+
+            return Date(timeIntervalSince1970: expiry)
+        }()
+
+        let siteID =  try {
+            guard let payload,
+                  let siteID = payload[PayloadKey.blodID] as? Int64 else {
+                throw JWTokenMapperError.blogIDNotFound
+            }
+
+            return siteID
+        }()
+
+        return JWToken(token: jwt, expiryDate: expiryDate, siteID: siteID)
+    }
+
+    struct JWTokenResponse: Decodable {
+        let token: String
+    }
+}
+
+private extension JWTokenMapper {
+    enum PayloadKey {
+        static let expiryDate = "exp"
+        static let blodID = "blog_id"
+    }
+}
+
+enum JWTokenMapperError: Error {
+    case expiryDateNotFound
+    case blogIDNotFound
+}
+
+private extension Data {
+    /// "base64url" is an encoding that is safe to use with URLs.
+    /// It is defined in RFC 4648, section 5.
+    ///
+    /// See:
+    /// - https://tools.ietf.org/html/rfc4648#section-5
+    /// - https://tools.ietf.org/html/rfc7515#appendix-C
+    init?(base64URLEncoded: String) {
+        let base64 = base64URLEncoded
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+        let requiredLength = 4 * ceil(length / 4.0)
+        let paddingLength = requiredLength - length
+        if paddingLength > 0 {
+            let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+            self.init(base64Encoded: base64 + padding, options: .ignoreUnknownCharacters)
+        } else {
+            self.init(base64Encoded: base64, options: .ignoreUnknownCharacters)
+        }
+    }
+}

--- a/Networking/Networking/Mapper/JWTokenMapper.swift
+++ b/Networking/Networking/Mapper/JWTokenMapper.swift
@@ -20,11 +20,7 @@ struct JWTokenMapper: Mapper {
                 return nil
             }
 
-            guard let json = try? JSONSerialization.jsonObject(with: bodyData, options: []),
-                  let payload = json as? [String: Any] else {
-                return nil
-            }
-            return payload
+            return try? JSONSerialization.jsonObject(with: bodyData, options: []) as? [String: Any]
         }()
 
         let expiryDate = try {

--- a/Networking/Networking/Model/JWToken.swift
+++ b/Networking/Networking/Model/JWToken.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Authentication token for WPCOM AI endpoint
+///
+struct JWToken {
+    /// JWT
+    ///
+    let token: String
+
+    /// Expiry date
+    ///
+    let expiryDate: Date
+
+    /// Site ID
+    ///
+    let siteID: Int64
+}

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -70,7 +70,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                              base: String,
                              feature: GenerativeContentRemoteFeature) async throws -> String {
         do {
-            guard let token else {
+            guard let token, token.isTokenValid(for: siteID) else {
                 throw GenerativeContentRemoteError.tokenNotFound
             }
             return try await generateText(siteID: siteID, base: base, feature: feature, token: token)
@@ -86,7 +86,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                  string: String,
                                  feature: GenerativeContentRemoteFeature) async throws -> String {
         do {
-            guard let token else {
+            guard let token, token.isTokenValid(for: siteID) else {
                 throw GenerativeContentRemoteError.tokenNotFound
             }
             return try await identifyLanguage(siteID: siteID, string: string, feature: feature, token: token)
@@ -110,7 +110,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                   tags: [ProductTag]) async throws -> AIProduct {
 
         do {
-            guard let token else {
+            guard let token, token.isTokenValid(for: siteID) else {
                 throw GenerativeContentRemoteError.tokenNotFound
             }
             return try await generateAIProduct(siteID: siteID,

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -334,3 +334,11 @@ private struct TextCompletionResponseMapper: Mapper {
         let completion: String
     }
 }
+
+// MARK: - Helper to check token validity
+//
+private extension JWToken {
+    func isTokenValid(for currentSelectedSiteID: Int64) -> Bool {
+        expiryDate > Date() && siteID == currentSelectedSiteID
+    }
+}

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -309,19 +309,6 @@ private extension GenerativeContentRemote {
     }
 }
 
-// MARK: - Mapper to parse the JWT token
-//
-private struct JWTTokenResponseMapper: Mapper {
-    func map(response: Data) throws -> String {
-        let decoder = JSONDecoder()
-        return try decoder.decode(JWTTokenResponse.self, from: response).token
-    }
-
-    struct JWTTokenResponse: Decodable {
-        let token: String
-    }
-}
-
 // MARK: - Mapper to parse the `text-completion` endpoint response
 //
 private struct TextCompletionResponseMapper: Mapper {

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -64,7 +64,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         case tokenNotFound
     }
 
-    private var token: String?
+    private var token: JWToken?
 
     public func generateText(siteID: Int64,
                              base: String,
@@ -144,18 +144,18 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 }
 
 private extension GenerativeContentRemote {
-    func fetchToken(siteID: Int64) async throws -> String {
+    func fetchToken(siteID: Int64) async throws -> JWToken {
         let path = "sites/\(siteID)/\(Path.jwtToken)"
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path)
-        let mapper = JWTTokenResponseMapper()
+        let mapper = JWTokenMapper()
         return try await enqueue(request, mapper: mapper)
     }
 
     func generateText(siteID: Int64,
                       base: String,
                       feature: GenerativeContentRemoteFeature,
-                      token: String) async throws -> String {
-        let parameters = [ParameterKey.token: token,
+                      token: JWToken) async throws -> String {
+        let parameters = [ParameterKey.token: token.token,
                           ParameterKey.prompt: base,
                           ParameterKey.feature: feature.rawValue,
                           ParameterKey.fields: ParameterValue.completion]
@@ -170,13 +170,13 @@ private extension GenerativeContentRemote {
     func identifyLanguage(siteID: Int64,
                           string: String,
                           feature: GenerativeContentRemoteFeature,
-                          token: String) async throws -> String {
+                          token: JWToken) async throws -> String {
         let prompt = [
             "What is the ISO language code of the language used in the below text?" +
             "Do not include any explanations and only provide the ISO language code in your response.",
             "Text: ```\(string)```"
         ].joined(separator: "\n")
-        let parameters = [ParameterKey.token: token,
+        let parameters = [ParameterKey.token: token.token,
                           ParameterKey.prompt: prompt,
                           ParameterKey.feature: feature.rawValue,
                           ParameterKey.fields: ParameterValue.completion]
@@ -198,7 +198,7 @@ private extension GenerativeContentRemote {
                            weightUnit: String?,
                            categories: [ProductCategory],
                            tags: [ProductTag],
-                           token: String) async throws -> AIProduct {
+                           token: JWToken) async throws -> AIProduct {
 
         let tagsAsString = {
             guard !tags.isEmpty else {
@@ -270,7 +270,7 @@ private extension GenerativeContentRemote {
 
         let prompt = input + "\n" + expectedJsonFormat
 
-        let parameters = [ParameterKey.token: token,
+        let parameters = [ParameterKey.token: token.token,
                           ParameterKey.prompt: prompt,
                           ParameterKey.feature: GenerativeContentRemoteFeature.productCreation.rawValue,
                           ParameterKey.fields: ParameterValue.completion]

--- a/Networking/NetworkingTests/Mapper/JWTokenMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/JWTokenMapperTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Networking
+
+final class JWTokenMapperTests: XCTestCase {
+    func test_it_maps_JWToken_correctly_from_token_response() throws {
+        // Given
+        let data = try retrieveJWTResponse()
+        let mapper = JWTokenMapper()
+
+        // When
+        let jwtoken = try mapper.map(response: data)
+
+        // Then
+        XCTAssertEqual(jwtoken.expiryDate.timeIntervalSince1970, 7282344061)
+        XCTAssertEqual(jwtoken.siteID, 1234)
+        XCTAssertEqual(jwtoken.token,
+                       "123abc." +
+                       // swiftlint:disable:next line_length
+                       "ew0KICAiaXNzIjogImpldHBhY2suY29tIiwNCiAgImlhdCI6IDEyMzEyMywNCiAgImJsb2dfaWQiOiAxMjM0LA0KICAidXNlcl9pZCI6IDEyMzEyMywNCiAgImF1dGgiOiAiamV0cGFja19vcGVuYWkiLA0KICAiYWNjZXNzIjogIm9wZW5haSIsDQogICJleHAiOiA3MjgyMzQ0MDYxLA0KICAiZXhwaXJlcyI6IDcyODIzNDQwNjENCn0" +
+                       ".abc123")
+    }
+}
+
+// MARK: - Test Helpers
+///
+private extension JWTokenMapperTests {
+    func retrieveJWTResponse() throws -> Data {
+        guard let response = Loader.contentsOf("jwt-token-success") else {
+            throw FileNotFoundError()
+        }
+
+        return response
+    }
+
+    struct FileNotFoundError: Error {}
+}

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -123,6 +123,31 @@ final class GenerativeContentRemoteTests: XCTestCase {
         XCTAssertEqual(numberOfTextCompletionRequests(in: network.requestsForResponseData), 4)
     }
 
+    func test_generateText_generates_token_if_token_expired() async throws {
+        // Given
+        let jwtRequestPath = "sites/\(sampleSiteID)/jetpack-openai-query/jwt"
+        let textCompletionPath = "text-completion"
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: jwtRequestPath, filename: "jwt-token-expired-token")
+        network.simulateResponse(requestUrlSuffix: textCompletionPath, filename: "generative-text-success")
+
+        // When
+        _ = try await remote.generateText(siteID: sampleSiteID,
+                                          base: "generate a product description for wapuu pencil",
+                                          feature: .productDescription)
+        // Then
+        XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 1)
+
+        // When
+        _ = try await remote.generateText(siteID: sampleSiteID,
+                                          base: "generate a product description for wapuu pencil",
+                                          feature: .productDescription)
+
+        // Then
+        // Ensures that token is requested again
+        XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 2)
+    }
+
     // MARK: - `identifyLanguage`
 
     func test_identifyLanguage_sends_correct_fields_value() async throws {
@@ -225,6 +250,31 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // Then
         XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 2)
         XCTAssertEqual(numberOfTextCompletionRequests(in: network.requestsForResponseData), 4)
+    }
+
+    func test_identifyLanguage_generates_token_if_token_expired() async throws {
+        // Given
+        let jwtRequestPath = "sites/\(sampleSiteID)/jetpack-openai-query/jwt"
+        let textCompletionPath = "text-completion"
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: jwtRequestPath, filename: "jwt-token-expired-token")
+        network.simulateResponse(requestUrlSuffix: textCompletionPath, filename: "identify-language-success")
+
+        // When
+        _ = try await remote.identifyLanguage(siteID: sampleSiteID,
+                                              string: "Woo is awesome.",
+                                              feature: .productDescription)
+        // Then
+        XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 1)
+
+        // When
+        _ = try await remote.identifyLanguage(siteID: sampleSiteID,
+                                              string: "Woo is awesome.",
+                                              feature: .productDescription)
+
+        // Then
+        // Ensures that token is requested again
+        XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 2)
     }
 
     // MARK: - `generateAIProduct`
@@ -515,6 +565,45 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // Then
         XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 2)
         XCTAssertEqual(numberOfTextCompletionRequests(in: network.requestsForResponseData), 4)
+    }
+
+    func test_generateAIProduct_generates_token_if_token_expired() async throws {
+        // Given
+        let jwtRequestPath = "sites/\(sampleSiteID)/jetpack-openai-query/jwt"
+        let textCompletionPath = "text-completion"
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: jwtRequestPath, filename: "jwt-token-expired-token")
+        network.simulateResponse(requestUrlSuffix: textCompletionPath, filename: "generate-product-success")
+
+        // When
+        _ = try await remote.generateAIProduct(siteID: sampleSiteID,
+                                               productName: "Cookie",
+                                               keywords: "Crunchy, Crispy",
+                                               language: "en",
+                                               tone: "Casual",
+                                               currencySymbol: "INR",
+                                               dimensionUnit: "cm",
+                                               weightUnit: "kg",
+                                               categories: [ProductCategory.fake(), ProductCategory.fake()],
+                                               tags: [ProductTag.fake(), ProductTag.fake()])
+        // Then
+        XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 1)
+
+        // When
+        _ = try await remote.generateAIProduct(siteID: sampleSiteID,
+                                               productName: "Cookie",
+                                               keywords: "Crunchy, Crispy",
+                                               language: "en",
+                                               tone: "Casual",
+                                               currencySymbol: "INR",
+                                               dimensionUnit: "cm",
+                                               weightUnit: "kg",
+                                               categories: [ProductCategory.fake(), ProductCategory.fake()],
+                                               tags: [ProductTag.fake(), ProductTag.fake()])
+
+        // Then
+        // Ensures that token is requested again
+        XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 2)
     }
 }
 

--- a/Networking/NetworkingTests/Responses/jwt-token-expired-token.json
+++ b/Networking/NetworkingTests/Responses/jwt-token-expired-token.json
@@ -1,0 +1,4 @@
+{
+  "success": true,
+  "token": "123abc.ew0KICAiaXNzIjogImpldHBhY2suY29tIiwNCiAgImlhdCI6IDEyMzEyMywNCiAgImJsb2dfaWQiOiAxMjM0LA0KICAidXNlcl9pZCI6IDEyMzEyMywNCiAgImF1dGgiOiAiamV0cGFja19vcGVuYWkiLA0KICAiYWNjZXNzIjogIm9wZW5haSIsDQogICJleHAiOiAxNjMzNjg0ODYxLA0KICAiZXhwaXJlcyI6IDE2MzM2ODQ4NjENCn0.abc123"
+}

--- a/Networking/NetworkingTests/Responses/jwt-token-success.json
+++ b/Networking/NetworkingTests/Responses/jwt-token-success.json
@@ -1,4 +1,4 @@
 {
   "success": true,
-  "token": "abc123456"
+  "token": "123abc.ew0KICAiaXNzIjogImpldHBhY2suY29tIiwNCiAgImlhdCI6IDEyMzEyMywNCiAgImJsb2dfaWQiOiAxMjM0LA0KICAidXNlcl9pZCI6IDEyMzEyMywNCiAgImF1dGgiOiAiamV0cGFja19vcGVuYWkiLA0KICAiYWNjZXNzIjogIm9wZW5haSIsDQogICJleHAiOiA3MjgyMzQ0MDYxLA0KICAiZXhwaXJlcyI6IDcyODIzNDQwNjENCn0.abc123"
 }


### PR DESCRIPTION
Closes: #10887 

## Description

To send requests to the AI endpoint, we are fetching a JWT token.

Right now, we are not checking the expiry date of the token. We store the token in memory and use it until we receive an expired error from the remote. Upon receiving an error, we fetch a new token again.

Instead, we can check the token's expiry date by reading the token's mid part as a JSON. This way, we can avoid hitting the endpoint with an expired token and instead fetch a new token before sending the request.

Changes
- Mapper for parsing JWT moved outside remote file.
- Model to hold the token, site ID and expiry date.
- Check token validity before sending a request to the AI endpoint.
- Unit tests and mock files. 

## Testing instructions

Testing this isn't straightforward. 
Please test that Product creation with AI works as before by following the instructions from #10812

## Screenshots

NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
