### PR TITLE
[Custom Amounts M1] Editable Order - Products section - Nothing added

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -85,6 +85,10 @@ final class EditableOrderViewModel: ObservableObject {
         featureFlagService.isFeatureFlagEnabled(.ordersWithCouponsM6)
     }
 
+    var shouldShowCustomAmountsWithProducts: Bool {
+        featureFlagService.isFeatureFlagEnabled(.orderCustomAmountsM1)
+    }
+
     /// Indicates the customer details screen to be shown. If there's no address added show the customer selector, otherwise the form so it can be edited
     ///
     var customerNavigationScreen: CustomerNavigationScreen {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -391,6 +391,7 @@ private struct ProductsSection: View {
                         .foregroundColor(Color(.brand))
                         .renderedIf(viewModel.shouldShowNonEditableIndicators)
                 }
+                .renderedIf(!viewModel.shouldShowCustomAmountsWithProducts)
 
                 ForEach(viewModel.productRows) { productRow in
                     CollapsibleProductRowCard(viewModel: productRow)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -474,6 +474,13 @@ private struct ProductsSection: View {
                     })
                     .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
                 }
+
+                HStack {
+                    Button(OrderForm.Localization.addCustomAmount) {}
+                    .accessibilityIdentifier(OrderForm.Accessibility.addCustomAmountIdentifier)
+                    .buttonStyle(PlusButtonStyle())
+                }
+                .renderedIf(viewModel.shouldShowCustomAmountsWithProducts)
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()
@@ -515,6 +522,8 @@ private extension OrderForm {
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating or editing an order")
         static let addProducts = NSLocalizedString("Add Products",
                                                    comment: "Title text of the button that allows to add multiple products when creating or editing an order")
+        static let addCustomAmount = NSLocalizedString("Add custom amount",
+                                                   comment: "Title text of the button that allows to add a custom amount when creating or editing an order")
         static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
                                                                    comment: "Accessibility hint for selecting a product in an order form")
         static let permissionsTitle =
@@ -537,6 +546,7 @@ private extension OrderForm {
         static let cancelButtonIdentifier = "new-order-cancel-button"
         static let doneButtonIdentifier = "edit-order-done-button"
         static let addProductButtonIdentifier = "new-order-add-product-button"
+        static let addCustomAmountIdentifier = "new-order-add-custom-amount-button"
         static let addProductViaSKUScannerButtonIdentifier = "new-order-add-product-via-sku-scanner-button"
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10878 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This short PR implements the new Products section design in the Editable Order screen when nothing is added. Basically, it adds two changes:

- Remove the Products Section title (It's merged with the Add Product button, but only shown when there are products added to the order.
- Add the + Add custom amount button

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Orders
2. Tap on + to create a new order
3. See that the Products title is gone, and we have now an + Add custom amount button row

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/eed288e4-0567-4832-8724-988a03e7e985" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
