### PR TITLE
[TTPUK] About Tap to Pay screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2062,6 +2062,7 @@ extension WooAnalyticsEvent {
             case paymentMethods
             case tapToPaySummary
             case manageCardReader
+            case aboutTapToPay
 
             var trackingValue: String {
                 switch self {
@@ -2073,6 +2074,8 @@ extension WooAnalyticsEvent {
                     return "tap_to_pay_summary"
                 case .manageCardReader:
                     return "manage_card_reader"
+                case .aboutTapToPay:
+                    return "about_tap_to_pay"
                 }
             }
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -321,6 +321,7 @@ public enum WooAnalyticsStat: String {
     case tapToPaySetupOnboardingCancelTapped = "tap_to_pay_set_up_onboarding_cancel_tapped"
     case tapToPaySetupSuccessDoneTapped = "tap_to_pay_set_up_success_done_tapped"
     case tapToPaySummaryShown = "tap_to_pay_summary_shown"
+    case aboutTapToPayOrderCardReaderTapped = "about_tap_to_pay_order_card_reader_tapped"
 
     // MARK: Cash on Delivery Enable events
     case enableCashOnDeliverySuccess = "enable_cash_on_delivery_success"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -988,6 +988,7 @@ public enum WooAnalyticsStat: String {
     case paymentsMenuPaymentProviderTapped = "settings_card_present_select_payment_gateway_tapped"
     case inPersonPaymentsLearnMoreTapped = "in_person_payments_learn_more_tapped"
     case setUpTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_tapped"
+    case aboutTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_about_tapped"
 
     // MARK: Payments Menu
     case pluginsNotSyncedYet = "plugins_not_synced_yet"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -66,11 +66,13 @@ struct AboutTapToPayView: View {
     }
 }
 
-#Preview {
-    NavigationView {
-        AboutTapToPayView(viewModel: AboutTapToPayViewModel(
-            configuration: .init(country: "GB"),
-            buttonAction: { }))
+struct AboutTapToPayView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            AboutTapToPayView(viewModel: AboutTapToPayViewModel(
+                configuration: .init(country: "GB"),
+                buttonAction: { }))
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -4,6 +4,7 @@ import WooFoundation
 
 struct AboutTapToPayView: View {
     @ObservedObject var viewModel: AboutTapToPayViewModel
+    @State private var showingWebView: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -43,14 +44,22 @@ struct AboutTapToPayView: View {
 
             VStack(alignment: .leading, spacing: Layout.spacing) {
                 Button(Localization.setUpTapToPayOnIPhoneButtonTitle) {
-                    // no-op
+                    viewModel.callToActionTapped()
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .renderedIf(viewModel.shouldShowButton)
 
-                InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel())
+                InPersonPaymentsLearnMore(viewModel: .tapToPay(source: .aboutTapToPay))
+                    .customOpenURL(action: { _ in
+                        showingWebView = true
+                    })
             }
             .padding()
+        }
+        .sheet(isPresented: $showingWebView) {
+            WebViewSheet(viewModel: viewModel.webViewModel) {
+                showingWebView = false
+            }
         }
         .navigationTitle(Localization.aboutTapToPayNavigationTitle)
         .navigationBarTitleDisplayMode(.inline)
@@ -125,6 +134,7 @@ private extension AboutTapToPayView {
 
 struct AboutTapToPayContactlessLimitView: View {
     let viewModel: AboutTapToPayContactlessLimitViewModel
+    @State private var showingWebView: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.spacing) {
@@ -136,7 +146,8 @@ struct AboutTapToPayContactlessLimitView: View {
             Text(viewModel.contactlessLimitDetails)
             Text(Localization.overLimitSuggestion)
             Button(Localization.limitButtonTitle) {
-                // no-op
+                viewModel.orderCardReaderPressed()
+                showingWebView = true
             }
             .buttonStyle(TextButtonStyle())
         }
@@ -146,6 +157,11 @@ struct AboutTapToPayContactlessLimitView: View {
             name: .wooCommercePurple,
             shade: .shade0))
         .cornerRadius(Layout.cornerRadius)
+        .sheet(isPresented: $showingWebView) {
+            WebViewSheet(viewModel: viewModel.webViewModel) {
+                showingWebView = false
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import Yosemite
 import WooFoundation
 
 struct AboutTapToPayView: View {
+    @ObservedObject var viewModel: AboutTapToPayViewModel
+
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             ScrollView(.vertical) {
                 VStack {
                     VStack(alignment: .leading, spacing: Layout.spacing) {
@@ -12,6 +15,10 @@ struct AboutTapToPayView: View {
                         Text(Localization.aboutTapToPayDescription)
                     }
                     .padding(.vertical)
+
+                    AboutTapToPayContactlessLimitView(
+                        viewModel: AboutTapToPayContactlessLimitViewModel(configuration: viewModel.configuration))
+                    .renderedIf(viewModel.shouldShowContactlessLimit)
 
                     VStack(alignment: .leading, spacing: Layout.spacing) {
                         Text(Localization.howItWorksHeading)
@@ -32,26 +39,29 @@ struct AboutTapToPayView: View {
 
             Spacer()
 
-            Divider()
+            Divider().renderedIf(viewModel.shouldShowButton)
 
             VStack(alignment: .leading, spacing: Layout.spacing) {
                 Button(Localization.setUpTapToPayOnIPhoneButtonTitle) {
                     // no-op
                 }
                 .buttonStyle(PrimaryButtonStyle())
+                .renderedIf(viewModel.shouldShowButton)
 
                 InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel())
             }
             .padding()
         }
-        .fixedSize(horizontal: false, vertical: true)
         .navigationTitle(Localization.aboutTapToPayNavigationTitle)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
 #Preview {
     NavigationView {
-        AboutTapToPayView()
+        AboutTapToPayView(viewModel: AboutTapToPayViewModel(
+            configuration: .init(country: "GB"),
+            buttonAction: { }))
     }
 }
 
@@ -62,7 +72,7 @@ private extension AboutTapToPayView {
             comment: "Main heading for the About Tap to Pay on iPhone screen")
 
         static let aboutTapToPayDescription = NSLocalizedString(
-            "Tap to Pay on iPhone lets you accept all types of contactless payments – from physical debit and credit " + 
+            "Tap to Pay on iPhone lets you accept all types of contactless payments – from physical debit and credit " +
             "cards, to Apple Pay and other digital wallets – without the need to purchase a physical card reader.",
             comment: "Description of Tap to Pay on iPhone shown on the About Tap to Pay on iPhone screen, as an intro.")
 
@@ -109,5 +119,55 @@ private extension AboutTapToPayView {
 
     enum Layout {
         static let spacing: CGFloat = 8
+    }
+}
+
+
+struct AboutTapToPayContactlessLimitView: View {
+    let viewModel: AboutTapToPayContactlessLimitViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.spacing) {
+            HStack {
+                Image(systemName: "info.circle")
+                Text(Localization.importantInformation)
+            }
+            .headlineStyle()
+            Text(viewModel.contactlessLimitDetails)
+            Text(Localization.overLimitSuggestion)
+            Button(Localization.limitButtonTitle) {
+                // no-op
+            }
+            .buttonStyle(TextButtonStyle())
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(Color.withColorStudio(
+            name: .wooCommercePurple,
+            shade: .shade0))
+        .cornerRadius(Layout.cornerRadius)
+    }
+}
+
+private extension AboutTapToPayContactlessLimitView {
+    enum Localization {
+        static let importantInformation = NSLocalizedString(
+            "Important information",
+            comment: "Heading for the details pane showing the contactless limit on About Tap to Pay")
+
+        static let overLimitSuggestion = NSLocalizedString(
+            "To accept payments above this limit, consider purchasing a card reader.",
+            comment: "A suggestion to buy a hardware card reader to handle transactions above the contactless limit, " +
+            "shown on the About Tap to Pay screen")
+
+        static let limitButtonTitle = NSLocalizedString(
+            "Learn more about card readers",
+            comment: "A button to view more about hardware card readers to handle transactions above the contactless " +
+            "limit, shown on the About Tap to Pay screen")
+    }
+
+    enum Layout {
+        static let spacing: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import WooFoundation
+
+struct AboutTapToPayView: View {
+    var body: some View {
+        VStack {
+            ScrollView(.vertical) {
+                VStack {
+                    VStack(alignment: .leading, spacing: Layout.spacing) {
+                        Text(Localization.aboutTapToPayHeading)
+                            .font(.title2.bold())
+                        Text(Localization.aboutTapToPayDescription)
+                    }
+                    .padding(.vertical)
+
+                    VStack(alignment: .leading, spacing: Layout.spacing) {
+                        Text(Localization.howItWorksHeading)
+                            .headlineStyle()
+                        Text(Localization.howItWorksStep1)
+                        Text(Localization.howItWorksStep2)
+                        Text(Localization.howItWorksStep3)
+                        Text(Localization.howItWorksStep4)
+                        Text(Localization.howItWorksStep5)
+                    }
+                    .padding(.vertical)
+
+                    Text(Localization.systemRequirementsDetails)
+                        .footnoteStyle(isError: false)
+                }
+                .padding()
+            }
+
+            Spacer()
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: Layout.spacing) {
+                Button(Localization.setUpTapToPayOnIPhoneButtonTitle) {
+                    // no-op
+                }
+                .buttonStyle(PrimaryButtonStyle())
+
+                InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel())
+            }
+            .padding()
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .navigationTitle(Localization.aboutTapToPayNavigationTitle)
+    }
+}
+
+#Preview {
+    NavigationView {
+        AboutTapToPayView()
+    }
+}
+
+private extension AboutTapToPayView {
+    enum Localization {
+        static let aboutTapToPayHeading = NSLocalizedString(
+            "What is Tap to Pay on iPhone?",
+            comment: "Main heading for the About Tap to Pay on iPhone screen")
+
+        static let aboutTapToPayDescription = NSLocalizedString(
+            "Tap to Pay on iPhone lets you accept all types of contactless payments – from physical debit and credit " + 
+            "cards, to Apple Pay and other digital wallets – without the need to purchase a physical card reader.",
+            comment: "Description of Tap to Pay on iPhone shown on the About Tap to Pay on iPhone screen, as an intro.")
+
+        static let howItWorksHeading = NSLocalizedString(
+            "How it works",
+            comment: "Headline for the 'How it works' section on the About Tap to Pay on iPhone screen, which " +
+            "describes the steps required to take a payment.")
+
+        static let howItWorksStep1 = NSLocalizedString(
+            "1. Create an order or collect a payment",
+            comment: "Step 1 of the 'How it works' list, instructing the merchant to prepare an order for payment")
+
+        static let howItWorksStep2 = NSLocalizedString(
+            "2. Tap “Collect Payment” and choose “Tap to Pay on iPhone”.",
+            comment: "Step 2 of the 'How it works' list, instructing the merchant to how to select Tap to Pay payments")
+
+        static let howItWorksStep3 = NSLocalizedString(
+            "3. Present your iPhone to the customer.",
+            comment: "Step 3 of the 'How it works' list, instructing the merchant to present the phone to the shopper")
+
+        static let howItWorksStep4 = NSLocalizedString(
+            "4. Your customer holds their card horizontally at the top of your iPhone, over the contactless symbol.",
+            comment: "Step 4 of the 'How it works' list, informing the merchant of how a shopper should present their card")
+
+        static let howItWorksStep5 = NSLocalizedString(
+            "5. After you see the “Done” checkmark, your store will process the payment, and the transaction will be complete.",
+            comment: "Step 5 of the 'How it works' list, instructing the merchant to wait until processing is complete.")
+
+        static let systemRequirementsDetails = NSLocalizedString(
+            "Requires iPhone XS or later with iOS 16 or later. The Contactless Symbol is a trademark owned by and " +
+            "used with permission of EMVCo, LLC.",
+            comment: "Requirements for Tap to Pay on iPhone, and other small print shown on the About Tap to Pay on " +
+            "iPhone screen.")
+
+        static let setUpTapToPayOnIPhoneButtonTitle = NSLocalizedString(
+            "Set Up Tap to Pay on iPhone",
+            comment: "Button title for the main CTA on the About Tap to Pay on iPhone screen. The button opens the " +
+            "Set Up Tap to Pay on iPhone flow.")
+
+        static let aboutTapToPayNavigationTitle = NSLocalizedString(
+            "About Tap to Pay on iPhone",
+            comment: "Navigation title for the About Tap to Pay on iPhone Screen.")
+    }
+
+    enum Layout {
+        static let spacing: CGFloat = 8
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Yosemite
+import WooFoundation
+
+class AboutTapToPayViewModel: ObservableObject {
+    @Published var configuration: CardPresentPaymentsConfiguration
+    private let buttonAction: (() -> Void)?
+
+    @Published var shouldShowContactlessLimit: Bool = false
+    @Published var shouldShowButton: Bool = false
+
+    init(configuration: CardPresentPaymentsConfiguration,
+         buttonAction: (() -> Void)?) {
+        self.configuration = configuration
+        self.buttonAction = buttonAction
+        shouldShowButton = buttonAction != nil
+        shouldShowContactlessLimit = configuration.contactlessLimitAmount != nil
+    }
+}
+
+class AboutTapToPayContactlessLimitViewModel: ObservableObject {
+    private let configuration: CardPresentPaymentsConfiguration
+
+    @Published private(set) var contactlessLimitDetails: String
+
+    init(configuration: CardPresentPaymentsConfiguration) {
+        self.configuration = configuration
+        self.contactlessLimitDetails = configuration.limitParagraph
+    }
+}
+
+private extension CardPresentPaymentsConfiguration {
+    var localizedCountryName: String {
+        guard let countryCode = SiteAddress.CountryCode(rawValue: countryCode) else {
+            return self.countryCode
+        }
+        return countryCode.readableCountry
+    }
+
+    var limitParagraph: String {
+        guard let amount = formattedContactlessLimitAmount else {
+            return String(format: Localization.contactlessLimitFallback, localizedCountryName)
+        }
+        // TODO: make it "In the United Kingdom..." not just "In United Kingdom..."
+        return String(format: Localization.contactlessLimitWithAmount, localizedCountryName, amount)
+    }
+
+    var formattedContactlessLimitAmount: String? {
+        guard let contactlessLimitAmount,
+              let currency = currencies.first?.rawValue else {
+            return nil
+        }
+        let decimalLimit = Decimal(contactlessLimitAmount)/stripeSmallestCurrencyUnitMultiplier
+        let formatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+        return formatter.formatAmount(decimalLimit, with: currency, numberOfDecimals: 0)
+    }
+
+    enum Localization {
+        static let contactlessLimitFallback = NSLocalizedString(
+            "In %1$@, cards may only be used with Tap to Pay for transactions up to the contactless limit.",
+            comment: "A fallback describing the contactless limit, shown on the About Tap to Pay screen. %1$@ will " +
+            "be replaced with the country name of the store.")
+
+        static let contactlessLimitWithAmount = NSLocalizedString(
+            "In %1$@, cards may only be used with Tap to Pay for transactions up to %2$@.",
+            comment: "A description of the contactless limit, shown on the About Tap to Pay screen. %1$@ will " +
+            "be replaced with the country name of the store, %2$@ with the limit amount in the local currency.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -37,10 +37,10 @@ private extension AboutTapToPayViewModel {
     }
 }
 
-class AboutTapToPayContactlessLimitViewModel: ObservableObject {
+class AboutTapToPayContactlessLimitViewModel {
     private let configuration: CardPresentPaymentsConfiguration
 
-    @Published private(set) var contactlessLimitDetails: String
+    let contactlessLimitDetails: String
 
     lazy var webViewModel: WebViewSheetViewModel = {
         WebViewSheetViewModel(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -88,11 +88,14 @@ private extension CardPresentPaymentsConfiguration {
     }
 
     var limitParagraph: String {
-        guard let amount = formattedContactlessLimitAmount else {
+        guard let amount = formattedContactlessLimitAmount,
+              countryCode == "GB" else {
+            // N.B. This is not ideal, because some countries have an article, e.g. 'the United States', and some don't.
+            // Since it's a fallback, this is a fair trade off, but for the ideal string, the country name should be embedded.
             return String(format: Localization.contactlessLimitFallback, localizedCountryName)
         }
-        // TODO: make it "In the United Kingdom..." not just "In United Kingdom..."
-        return String(format: Localization.contactlessLimitWithAmount, localizedCountryName, amount)
+
+        return String(format: Localization.contactlessLimitWithAmountGB, amount)
     }
 
     var formattedContactlessLimitAmount: String? {
@@ -109,11 +112,12 @@ private extension CardPresentPaymentsConfiguration {
         static let contactlessLimitFallback = NSLocalizedString(
             "In %1$@, cards may only be used with Tap to Pay for transactions up to the contactless limit.",
             comment: "A fallback describing the contactless limit, shown on the About Tap to Pay screen. %1$@ will " +
-            "be replaced with the country name of the store.")
+            "be replaced with the country name of the store, which is a trade off as it can't be contextually " +
+            "translated, however this string is only used when there's a problem decoding the limit, so it's acceptable.")
 
-        static let contactlessLimitWithAmount = NSLocalizedString(
-            "In %1$@, cards may only be used with Tap to Pay for transactions up to %2$@.",
-            comment: "A description of the contactless limit, shown on the About Tap to Pay screen. %1$@ will " +
-            "be replaced with the country name of the store, %2$@ with the limit amount in the local currency.")
+        static let contactlessLimitWithAmountGB = NSLocalizedString(
+            "In the United Kingdom, cards may only be used with Tap to Pay for transactions up to %1$@.",
+            comment: "A description of the contactless limit, shown on the About Tap to Pay screen. This string is for " +
+            "the UK specifically. %1$@ will be replaced with the limit amount in £ formatted correctly for the locale.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -510,26 +510,6 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func presentSetUpTapToPayOnIPhoneViewController() {
-        presentSetUpTapToPayOnIPhoneWithOnboarding()
-    }
-
-    private func presentSetUpTapToPayOnIPhoneWithoutOnboarding() {
-        guard let siteID = stores.sessionManager.defaultStoreID,
-              let _ = pluginState?.preferred else {
-            return
-        }
-
-        let viewModelsAndViews = SetUpTapToPayViewModelsOrderedList(siteID: siteID,
-                                                                    configuration: viewModel.cardPresentPaymentsConfiguration,
-                                                                    onboardingUseCase: cardPresentPaymentsOnboardingUseCase)
-        let setUpTapToPayViewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
-        let controller = WooNavigationController(rootViewController: setUpTapToPayViewController)
-        controller.navigationBar.isHidden = true
-
-        navigationController?.present(controller, animated: true)
-    }
-
-    private func presentSetUpTapToPayOnIPhoneWithOnboarding() {
         guard let siteID = stores.sessionManager.defaultStoreID else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -239,7 +239,7 @@ private extension InPersonPaymentsMenuViewController {
         guard featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) else {
             return nil
         }
-        var rows: [Row] = [.setUpTapToPayOnIPhone]
+        var rows: [Row] = [.setUpTapToPayOnIPhone, .aboutTapToPayOnIPhone]
 
         if shouldShowFeedbackRow {
             rows.append(.tapToPayOnIPhoneFeedback)
@@ -317,6 +317,8 @@ private extension InPersonPaymentsMenuViewController {
             configureToggleEnableCashOnDelivery(cell: cell)
         case let cell as BadgedLeftImageTableViewCell where row == .setUpTapToPayOnIPhone:
             configureSetUpTapToPayOnIPhone(cell: cell)
+        case let cell as LeftImageTableViewCell where row == .aboutTapToPayOnIPhone:
+            configureAboutTapToPayOnIPhone(cell: cell)
         case let cell as LeftImageTableViewCell where row == .tapToPayOnIPhoneFeedback:
             configureTapToPayOnIPhoneFeedback(cell: cell)
         case let cell as LeftImageTableViewCell where row == .depositOverview:
@@ -385,6 +387,13 @@ private extension InPersonPaymentsMenuViewController {
         cell.configure(image: .tapToPayOnIPhoneIcon,
                        text: Localization.tapToPayOnIPhone,
                        showBadge: viewModel.shouldBadgeTapToPayOnIPhone)
+    }
+
+    func configureAboutTapToPayOnIPhone(cell: LeftImageTableViewCell) {
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "about-tap-to-pay"
+        cell.configure(image: .infoOutlineImage,
+                       text: Localization.aboutTapToPayOnIPhone)
     }
 
     func configureTapToPayOnIPhoneFeedback(cell: LeftImageTableViewCell) {
@@ -524,6 +533,10 @@ extension InPersonPaymentsMenuViewController {
         navigationController?.present(controller, animated: true)
     }
 
+    func aboutTapToPayOnIPhoneWasPressed() {
+        // TODO: open the new screen
+    }
+
     func tapToPayOnIPhoneFeedbackWasPressed() {
         let surveyNavigation = SurveyCoordinatingController(survey: .tapToPayFirstPayment)
         navigationController?.present(surveyNavigation, animated: true)
@@ -626,6 +639,8 @@ extension InPersonPaymentsMenuViewController: UITableViewDelegate {
             break
         case .setUpTapToPayOnIPhone:
             setUpTapToPayOnIPhoneWasPressed()
+        case .aboutTapToPayOnIPhone:
+            aboutTapToPayOnIPhoneWasPressed()
         case .tapToPayOnIPhoneFeedback:
             tapToPayOnIPhoneFeedbackWasPressed()
         case .depositOverview:
@@ -713,6 +728,11 @@ private extension InPersonPaymentsMenuViewController {
             comment: "Navigates to the Tap to Pay on iPhone set up flow. The full name is expected by Apple. " +
             "The destination screen also allows for a test payment, after set up.")
 
+        static let aboutTapToPayOnIPhone = NSLocalizedString(
+            "About Tap to Pay on iPhone",
+            comment: "Navigates to the About Tap to Pay on iPhone screen, which explains the capabilities and limits " +
+            "of Tap to Pay on iPhone, relevant to the store territory.")
+
         static let tapToPayOnIPhoneFeedback = NSLocalizedString(
             "Share Tap to Pay on iPhone Feedback",
             comment: "Navigates to a screen to share feedback about Tap to Pay on iPhone.")
@@ -755,6 +775,7 @@ private enum Row: CaseIterable {
     case collectPayment
     case toggleEnableCashOnDelivery
     case setUpTapToPayOnIPhone
+    case aboutTapToPayOnIPhone
     case tapToPayOnIPhoneFeedback
     case depositOverview
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -534,6 +534,7 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func aboutTapToPayOnIPhoneWasPressed() {
+        ServiceLocator.analytics.track(.aboutTapToPayOnIPhoneTapped)
         // TODO: open the new screen
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -538,7 +538,7 @@ extension InPersonPaymentsMenuViewController {
         let hostingController = UIHostingController(
             rootView: AboutTapToPayView(viewModel: AboutTapToPayViewModel(
                     configuration: viewModel.cardPresentPaymentsConfiguration,
-                    buttonAction: { }))
+                    buttonAction: setUpTapToPayOnIPhoneWasPressed))
         )
         show(hostingController, sender: self)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -535,7 +535,13 @@ extension InPersonPaymentsMenuViewController {
 
     func aboutTapToPayOnIPhoneWasPressed() {
         ServiceLocator.analytics.track(.aboutTapToPayOnIPhoneTapped)
-        // TODO: open the new screen
+        let hostingController = UIHostingController(
+            rootView: AboutTapToPayView(viewModel: AboutTapToPayViewModel(
+                    configuration: viewModel.cardPresentPaymentsConfiguration,
+                    buttonAction: { }))
+        )
+        show(hostingController, sender: self)
+
     }
 
     func tapToPayOnIPhoneFeedbackWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
@@ -64,6 +64,15 @@ private enum Localization {
                  """
     )
 
+    static let tapToPayLearnMoreText = NSLocalizedString(
+        "tapToPay.learnMore.text",
+        value: "%1$@ about accepting payments with Tap to Pay on iPhone.",
+        comment: """
+                 A label prompting users to learn more about Tap to Pay on iPhone.
+                 %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                 which should be translated separately and considered part of this sentence.
+                 """)
+
     static let inPersonPaymentslearnMoreText = NSLocalizedString(
         "cardPresent.modalScanningForReader.learnMore.text",
         value: "%1$@ about In‑Person Payments",
@@ -82,6 +91,13 @@ extension LearnMoreViewModel {
         LearnMoreViewModel(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL(),
                            linkText: Localization.learnMoreLink,
                            formatText: Localization.inPersonPaymentslearnMoreText,
+                           tappedAnalyticEvent: .InPersonPayments.learnMoreTapped(source: source))
+    }
+
+    static func tapToPay(source: WooAnalyticsEvent.InPersonPayments.LearnMoreLinkSource) -> LearnMoreViewModel {
+        LearnMoreViewModel(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL(),
+                           linkText: Localization.learnMoreLink,
+                           formatText: Localization.tapToPayLearnMoreText,
                            tappedAnalyticEvent: .InPersonPayments.learnMoreTapped(source: source))
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -700,6 +700,7 @@
 		174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */ = {isa = PBXBuildFile; productRef = 174CA86927D90A6200126524 /* AutomatticAbout */; };
 		174CA86C27D90E8900126524 /* WooAboutScreenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA86B27D90E8900126524 /* WooAboutScreenConfiguration.swift */; };
 		174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */; };
+		201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */; };
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
@@ -3208,6 +3209,7 @@
 		09F5DE5C27CF948000E5A4D2 /* BulkUpdateOptionsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkUpdateOptionsModel.swift; sourceTree = "<group>"; };
 		174CA86B27D90E8900126524 /* WooAboutScreenConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAboutScreenConfiguration.swift; sourceTree = "<group>"; };
 		174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextItemActivitySource.swift; sourceTree = "<group>"; };
+		201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayViewModel.swift; sourceTree = "<group>"; };
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
@@ -10888,6 +10890,7 @@
 			children = (
 				E107FCDD26C1295600BAF51B /* Onboarding Errors */,
 				20E188832AD059A50053E945 /* AboutTapToPayView.swift */,
+				201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */,
 				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
@@ -13488,6 +13491,7 @@
 				B95864082A657D2F002C4C6E /* EnhancedCouponListViewController.swift in Sources */,
 				CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */,
 				023053492374528A00487A64 /* AztecBlockquoteFormatBarCommand.swift in Sources */,
+				201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */,
 				0282DD98233CA093006A5FDB /* OrderSearchUICommand.swift in Sources */,
 				B541B21A2189F3A2008FE7C1 /* StringFormatter.swift in Sources */,
 				0279F0DF252DC12D0098D7DE /* ProductLoaderViewControllerModel+Init.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -704,6 +704,7 @@
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
+		20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* AboutTapToPayView.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -3211,6 +3212,7 @@
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
+		20E188832AD059A50053E945 /* AboutTapToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayView.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
@@ -10885,6 +10887,7 @@
 			isa = PBXGroup;
 			children = (
 				E107FCDD26C1295600BAF51B /* Onboarding Errors */,
+				20E188832AD059A50053E945 /* AboutTapToPayView.swift */,
 				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
@@ -13289,6 +13292,7 @@
 				B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */,
 				029D444922F13F8A00DEFA8A /* DashboardUI.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
+				20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */,
 				026D4652295D763B0037F59A /* CountryCode+FlagEmoji.swift in Sources */,
 				B9F3DAAD29BB71B100DDD545 /* CollectPaymentAppIntent.swift in Sources */,
 				EEBDF7DF2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -705,6 +705,7 @@
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
+		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
 		20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* AboutTapToPayView.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
@@ -3214,6 +3215,7 @@
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
+		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* AboutTapToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayView.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
@@ -6433,6 +6435,7 @@
 				03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */,
 				03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */,
 				039B7E6629F2855B00E21EF4 /* InPersonPaymentsViewModelTests.swift */,
+				20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */,
 				03B9E52A2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift */,
 			);
 			path = "In-Person Payments";
@@ -14027,6 +14030,7 @@
 				02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */,
 				45E9A6EB24DAFC3E00A600E8 /* ProductReviewsViewModelTests.swift in Sources */,
 				268EC46426D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift in Sources */,
+				20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */,
 				453770D12431FF4700AC718D /* ProductSettingsViewModelTests.swift in Sources */,
 				2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */,
 				020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayContactlessLimitViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayContactlessLimitViewModelTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import WooCommerce
+
+final class AboutTapToPayContactlessLimitViewModelTests: XCTestCase {
+
+    func test_for_gb_configuration_a_formatted_limit_paragraph_is_provided() {
+        let sut = AboutTapToPayContactlessLimitViewModel(configuration: .init(country: "GB"))
+        assertEqual("In the United Kingdom, cards may only be used with Tap to Pay for transactions up to £100.", sut.contactlessLimitDetails)
+    }
+
+    func test_for_us_configuration_a_fallback_paragraph_is_provided_because_the_view_is_not_shown() {
+        let sut = AboutTapToPayContactlessLimitViewModel(configuration: .init(country: "US"))
+        assertEqual("In United States, cards may only be used with Tap to Pay for transactions up to the contactless limit.", sut.contactlessLimitDetails)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10870 
Merge after: #10888

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We'll add Tap to Pay on iPhone support for UK WooPayments merchants. This PR adds the About Tap to Pay screen, and a button to show it from the Payments menu on stores/devices which support Tap to Pay.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a build from Xcode, and a UK-based WooPayments store, on an iPhone XS or newer running iOS 16+:

1. Navigate to Menu > Payments
2. Observe that `About Tap to Pay on iPhone` is visible – tap it
3. Try the `Learn more about card readers` button – observe that it opens an authenticated web view to the correct card reader page for the UK.
4. Close the web view and tap `Learn more` at the bottom (related to Tap to Pay) – observe that it opens a webview to the documentation for Tap to Pay
5. Tap the `Set up Tap to Pay on iPhone` button and run through the set up flow, checking that it works.


Repeat the above test with a US WooPayments store. On step 3, observe that there is no button and the `Important information` section is not shown.

Repeat again with a CA WooPayments store. Observe that the `About Tap to Pay on iPhone` row is not available.

N.B. there's a known issue with the authenticated web views for accounts with 2FA on, particularly prevalent in a simulator at least for A11n accounts, where the Reader is opened after you enter a code – this is pre-existing and out of scope here.

N.B. 2 I've asked Joe for a better colour for the panel in dark mode.

N.B. 3 The list formatting is off, but non-trivial to fix. I've broken it out in #10903 


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/ad61281f-63cd-4d2a-8f59-ec7468bdb256



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
