### PR TITLE
Product Creation AI: Display short description on preview screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -39,6 +39,15 @@ struct ProductDetailPreviewView: View {
                                    isLoading: viewModel.isGeneratingDetails)
                 }
 
+                // Product short description
+                VStack(alignment: .leading, spacing: Layout.contentVerticalSpacing) {
+                    Text(Localization.productShortDescription)
+                        .foregroundColor(.primary)
+                        .subheadlineStyle()
+                    BasicDetailRow(content: viewModel.productShortDescription,
+                                   isLoading: viewModel.isGeneratingDetails)
+                }
+
                 // Product description
                 VStack(alignment: .leading, spacing: Layout.contentVerticalSpacing) {
                     Text(Localization.productDescription)
@@ -240,6 +249,10 @@ fileprivate extension ProductDetailPreviewView {
         static let productName = NSLocalizedString(
             "Product name",
             comment: "Title of the name field on the add product with AI Preview screen."
+        )
+        static let productShortDescription = NSLocalizedString(
+            "Product short description",
+            comment: "Title of the short description field on the add product with AI Preview screen."
         )
         static let productDescription = NSLocalizedString(
             "Product description",

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -14,6 +14,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
 
     @Published private(set) var productName: String
     @Published private(set) var productDescription: String?
+    @Published private(set) var productShortDescription: String?
     @Published private(set) var productType: String?
     @Published private(set) var productPrice: String?
     @Published private(set) var productCategories: String?
@@ -156,7 +157,8 @@ private extension ProductDetailPreviewViewModel {
 
     func updateProductDetails(with product: Product) {
         productName = product.name
-        productDescription = product.fullDescription ?? product.shortDescription
+        productShortDescription = product.shortDescription
+        productDescription = product.fullDescription
         productType = product.virtual ? Localization.virtualProductType : Localization.physicalProductType
 
         if let regularPrice = product.regularPrice, regularPrice.isNotEmpty {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10850 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When generating products with AI, we also ask for a short description but was not displaying it on the preview screen. This PR updates the UI to show the extra field for more clarity.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom site or a Jetpack site with Jetpack AI installed.
- Navigate to the Products tab and select "+".
- Select Add product with AI.
- Follow the steps to add product name and keywords or packaging image.
- Tap Continue to generate product details with AI.
- When the details are generated, notice on the preview screen that the product short description is displayed below the product name field.
- Tap Save as draft. Confirm that the short description field displays the matching content as the preview screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/5066cd7a-9bb1-44c5-968c-e40b2207adf0



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
