### PR TITLE
[TTPUK] Extract CountryCode to WooFoundation

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryButton.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryButton.swift
@@ -1,11 +1,12 @@
 import SwiftUI
+import WooFoundation
 
 /// A button for a country that the user can select for their store during the store creation profiler flow.
 struct StoreCreationCountryButton: View {
-    private let countryCode: SiteAddress.CountryCode
+    private let countryCode: CountryCode
     @ObservedObject private var viewModel: StoreCreationCountryQuestionViewModel
 
-    init(countryCode: SiteAddress.CountryCode, viewModel: StoreCreationCountryQuestionViewModel) {
+    init(countryCode: CountryCode, viewModel: StoreCreationCountryQuestionViewModel) {
         self.countryCode = countryCode
         self.viewModel = viewModel
     }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
@@ -1,10 +1,9 @@
 import Combine
 import Foundation
+import WooFoundation
 
 /// View model for `StoreCreationCountryQuestionView`, an optional profiler question about store country in the store creation flow.
 final class StoreCreationCountryQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
-    typealias CountryCode = SiteAddress.CountryCode
-
     let topHeader: String = Localization.header
 
     let title: String = Localization.title

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountrySectionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountrySectionView.swift
@@ -1,12 +1,13 @@
 import SwiftUI
+import WooFoundation
 
 /// Shows a header label and a list of countries for selection in the store creation profiler flow.
 struct StoreCreationCountrySectionView: View {
     private let header: String
-    private let countryCodes: [SiteAddress.CountryCode]
+    private let countryCodes: [CountryCode]
     @ObservedObject private var viewModel: StoreCreationCountryQuestionViewModel
 
-    init(header: String, countryCodes: [SiteAddress.CountryCode], viewModel: StoreCreationCountryQuestionViewModel) {
+    init(header: String, countryCodes: [CountryCode], viewModel: StoreCreationCountryQuestionViewModel) {
         self.header = header
         self.countryCodes = countryCodes
         self.viewModel = viewModel

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 enum StoreCreationProfilerQuestion: Int, CaseIterable {
     case sellingStatus = 1
@@ -36,7 +37,7 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
             storeAnswers()
         }
     }
-    private var storeCountry: SiteAddress.CountryCode? {
+    private var storeCountry: CountryCode? {
         didSet {
             storeAnswers()
         }
@@ -93,7 +94,7 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
         analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerCountryQuestion))
     }
 
-    func saveCountry(_ answer: SiteAddress.CountryCode) {
+    func saveCountry(_ answer: CountryCode) {
         storeCountry = answer
         currentQuestion = .challenges
         analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerChallengesQuestion))

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WooFoundation
 
 /// Hosting controller that wraps the `StoreCreationSummaryView`.
 final class StoreCreationSummaryHostingController: UIHostingController<StoreCreationSummaryView> {
@@ -42,7 +43,7 @@ struct StoreCreationSummaryViewModel {
     /// Optional category name from the previous profiler question.
     let categoryName: String?
     /// Country code for the store location.
-    let countryCode: SiteAddress.CountryCode
+    let countryCode: CountryCode
 }
 
 /// Displays a summary of the store creation flow with the store information (e.g. store name, store slug).

--- a/WooCommerce/Classes/Extensions/CountryCode+FlagEmoji.swift
+++ b/WooCommerce/Classes/Extensions/CountryCode+FlagEmoji.swift
@@ -1,6 +1,7 @@
 import Foundation
+import WooFoundation
 
-extension SiteAddress.CountryCode {
+extension CountryCode {
     /// Returns the flag emoji based on the country code if available.
     /// Reference: https://stackoverflow.com/a/30403199/9185596
     var flagEmoji: String? {

--- a/WooCommerce/Classes/Tools/SiteAddress.swift
+++ b/WooCommerce/Classes/Tools/SiteAddress.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Yosemite
-
+import WooFoundation
 
 /// Represent and parse the Address of the store, returned in the SiteSettings API `/settings/general/`
 ///
@@ -76,609 +76,307 @@ private extension SiteAddress {
 // in one of the following formats:
 // - `"COUNTRY_CODE": "READABALE_COUNTRY_NAME"
 // - `"COUNTRY_CODE:COUNTRY_REGION": "READABLE_COUNTRY_NAME - READABLE_COUNTRY_REGION"
-extension SiteAddress {
-    enum CountryCode: String, CaseIterable {
-        // A
-        case AX
-        case AF
-        case AL
-        case DZ
-        case AS
-        case AD
-        case AO
-        case AI
-        case AQ
-        case AG
-        case AR
-        case AM
-        case AW
-        case AU
-        case AT
-        case AZ
-
-        // B
-        case BS
-        case BH
-        case BD
-        case BB
-        case BY
-        case PW
-        case BE
-        case BZ
-        case BJ
-        case BM
-        case BT
-        case BO
-        case BQ
-        case BA
-        case BW
-        case BV
-        case BR
-        case IO
-        case VG
-        case BN
-        case BG
-        case BF
-        case BI
-
-        // C
-        case KH
-        case CM
-        case CA
-        case CV
-        case KY
-        case CF
-        case TD
-        case CL
-        case CN
-        case CX
-        case CC
-        case CO
-        case KM
-        case CG
-        case CD
-        case CK
-        case CR
-        case HR
-        case CU
-        case CW
-        case CY
-        case CZ
-
-        // D
-        case DK
-        case DJ
-        case DM
-        case DO
-
-        // E
-        case EC
-        case EG
-        case SV
-        case GQ
-        case ER
-        case EE
-        case ET
-
-        // F
-        case FK
-        case FO
-        case FJ
-        case FI
-        case FR
-        case GF
-        case PF
-        case TF
-
-        // G
-        case GA
-        case GM
-        case GE
-        case DE
-        case GH
-        case GI
-        case GR
-        case GL
-        case GD
-        case GP
-        case GU
-        case GT
-        case GG
-        case GN
-        case GW
-        case GY
-
-        // H
-        case HT
-        case HM
-        case HN
-        case HK
-        case HU
-
-        // I
-        case IS
-        case IN
-        case ID
-        case IR
-        case IQ
-        case IE
-        case IM
-        case IL
-        case IT
-        case CI
-
-        // J
-        case JM
-        case JP
-        case JE
-        case JO
-
-        // K
-        case KZ
-        case KE
-        case KI
-        case KW
-        case KG
-
-        // L
-        case LA
-        case LV
-        case LB
-        case LS
-        case LR
-        case LY
-        case LI
-        case LT
-        case LU
-
-        // M
-        case MO
-        case MK
-        case MG
-        case MW
-        case MY
-        case MV
-        case ML
-        case MT
-        case MH
-        case MQ
-        case MR
-        case MU
-        case YT
-        case MX
-        case FM
-        case MD
-        case MC
-        case MN
-        case ME
-        case MS
-        case MA
-        case MZ
-        case MM
-
-        // N
-        case NA
-        case NR
-        case NP
-        case NL
-        case NC
-        case NZ
-        case NI
-        case NE
-        case NG
-        case NU
-        case NF
-        case KP
-        case MP
-        case NO
-
-        // O
-        case OM
-
-        // P
-        case PK
-        case PS
-        case PA
-        case PG
-        case PY
-        case PE
-        case PH
-        case PN
-        case PL
-        case PT
-        case PR
-
-        // Q
-        case QA
-
-        // R
-        case RE
-        case RO
-        case RU
-        case RW
-
-        // S
-        case ST
-        case BL
-        case SH
-        case KN
-        case LC
-        case SX
-        case MF
-        case PM
-        case VC
-        case WS
-        case SM
-        case SA
-        case SN
-        case RS
-        case SC
-        case SL
-        case SG
-        case SK
-        case SI
-        case SB
-        case SO
-        case ZA
-        case GS
-        case KR
-        case SS
-        case ES
-        case LK
-        case SD
-        case SR
-        case SJ
-        case SZ
-        case SE
-        case CH
-        case SY
-
-        // T
-        case TW
-        case TJ
-        case TZ
-        case TH
-        case TL
-        case TG
-        case TK
-        case TO
-        case TT
-        case TN
-        case TR
-        case TM
-        case TC
-        case TV
-
-        // U
-        case UG
-        case UA
-        case AE
-        case GB
-        case US
-        case UM
-        case VI
-        case UY
-        case UZ
-
-        // V
-        case VU
-        case VA
-        case VE
-        case VN
-
-        // W
-        case WF
-        case EH
-
-        // Y
-        case YE
-
-        // Z
-        case ZM
-        case ZW
-
-
-        var readableCountry: String {
-            switch self {
+extension CountryCode {
+    var readableCountry: String {
+        switch self {
             // A
-            case .AX: return NSLocalizedString("Åland Islands", comment: "Country option for a site address.")
-            case .AF: return NSLocalizedString("Afghanistan", comment: "Country option for a site address.")
-            case .AL: return NSLocalizedString("Albania", comment: "Country option for a site address.")
-            case .DZ: return NSLocalizedString("Algeria", comment: "Country option for a site address.")
-            case .AS: return NSLocalizedString("American Samoa", comment: "Country option for a site address.")
-            case .AD: return NSLocalizedString("Andorra", comment: "Country option for a site address.")
-            case .AO: return NSLocalizedString("Angola", comment: "Country option for a site address.")
-            case .AI: return NSLocalizedString("Anguilla", comment: "Country option for a site address.")
-            case .AQ: return NSLocalizedString("Antarctica", comment: "Country option for a site address.")
-            case .AG: return NSLocalizedString("Antigua and Barbuda", comment: "Country option for a site address.")
-            case .AR: return NSLocalizedString("Argentina", comment: "Country option for a site address.")
-            case .AM: return NSLocalizedString("Armenia", comment: "Country option for a site address.")
-            case .AW: return NSLocalizedString("Aruba", comment: "Country option for a site address.")
-            case .AU: return NSLocalizedString("Australia", comment: "Country option for a site address.")
-            case .AT: return NSLocalizedString("Austria", comment: "Country option for a site address.")
-            case .AZ: return NSLocalizedString("Azerbaijan", comment: "Country option for a site address.")
+        case .AX: return NSLocalizedString("Åland Islands", comment: "Country option for a site address.")
+        case .AF: return NSLocalizedString("Afghanistan", comment: "Country option for a site address.")
+        case .AL: return NSLocalizedString("Albania", comment: "Country option for a site address.")
+        case .DZ: return NSLocalizedString("Algeria", comment: "Country option for a site address.")
+        case .AS: return NSLocalizedString("American Samoa", comment: "Country option for a site address.")
+        case .AD: return NSLocalizedString("Andorra", comment: "Country option for a site address.")
+        case .AO: return NSLocalizedString("Angola", comment: "Country option for a site address.")
+        case .AI: return NSLocalizedString("Anguilla", comment: "Country option for a site address.")
+        case .AQ: return NSLocalizedString("Antarctica", comment: "Country option for a site address.")
+        case .AG: return NSLocalizedString("Antigua and Barbuda", comment: "Country option for a site address.")
+        case .AR: return NSLocalizedString("Argentina", comment: "Country option for a site address.")
+        case .AM: return NSLocalizedString("Armenia", comment: "Country option for a site address.")
+        case .AW: return NSLocalizedString("Aruba", comment: "Country option for a site address.")
+        case .AU: return NSLocalizedString("Australia", comment: "Country option for a site address.")
+        case .AT: return NSLocalizedString("Austria", comment: "Country option for a site address.")
+        case .AZ: return NSLocalizedString("Azerbaijan", comment: "Country option for a site address.")
 
             // B
-            case .BS: return NSLocalizedString("Bahamas", comment: "Country option for a site address.")
-            case .BH: return NSLocalizedString("Bahrain", comment: "Country option for a site address.")
-            case .BD: return NSLocalizedString("Bangladesh", comment: "Country option for a site address.")
-            case .BB: return NSLocalizedString("Barbados", comment: "Country option for a site address.")
-            case .BY: return NSLocalizedString("Belarus", comment: "Country option for a site address.")
-            case .PW: return NSLocalizedString("Belau", comment: "Country option for a site address.")
-            case .BE: return NSLocalizedString("Belgium", comment: "Country option for a site address.")
-            case .BZ: return NSLocalizedString("Belize", comment: "Country option for a site address.")
-            case .BJ: return NSLocalizedString("Benin", comment: "Country option for a site address.")
-            case .BM: return NSLocalizedString("Bermuda", comment: "Country option for a site address.")
-            case .BT: return NSLocalizedString("Bhutan", comment: "Country option for a site address.")
-            case .BO: return NSLocalizedString("Bolivia", comment: "Country option for a site address.")
-            case .BQ: return NSLocalizedString("Bonaire, Saint Eustatius and Saba", comment: "Country option for a site address.")
-            case .BA: return NSLocalizedString("Bosnia and Herzegovina", comment: "Country option for a site address.")
-            case .BW: return NSLocalizedString("Botswana", comment: "Country option for a site address.")
-            case .BV: return NSLocalizedString("Bouvet Island", comment: "Country option for a site address.")
-            case .BR: return NSLocalizedString("Brazil", comment: "Country option for a site address.")
-            case .IO: return NSLocalizedString("British Indian Ocean Territory", comment: "Country option for a site address.")
-            case .VG: return NSLocalizedString("British Virgin Islands", comment: "Country option for a site address.")
-            case .BN: return NSLocalizedString("Brunei", comment: "Country option for a site address.")
-            case .BG: return NSLocalizedString("Bulgaria", comment: "Country option for a site address.")
-            case .BF: return NSLocalizedString("Burkina Faso", comment: "Country option for a site address.")
-            case .BI: return NSLocalizedString("Burundi", comment: "Country option for a site address.")
+        case .BS: return NSLocalizedString("Bahamas", comment: "Country option for a site address.")
+        case .BH: return NSLocalizedString("Bahrain", comment: "Country option for a site address.")
+        case .BD: return NSLocalizedString("Bangladesh", comment: "Country option for a site address.")
+        case .BB: return NSLocalizedString("Barbados", comment: "Country option for a site address.")
+        case .BY: return NSLocalizedString("Belarus", comment: "Country option for a site address.")
+        case .PW: return NSLocalizedString("Belau", comment: "Country option for a site address.")
+        case .BE: return NSLocalizedString("Belgium", comment: "Country option for a site address.")
+        case .BZ: return NSLocalizedString("Belize", comment: "Country option for a site address.")
+        case .BJ: return NSLocalizedString("Benin", comment: "Country option for a site address.")
+        case .BM: return NSLocalizedString("Bermuda", comment: "Country option for a site address.")
+        case .BT: return NSLocalizedString("Bhutan", comment: "Country option for a site address.")
+        case .BO: return NSLocalizedString("Bolivia", comment: "Country option for a site address.")
+        case .BQ: return NSLocalizedString("Bonaire, Saint Eustatius and Saba", comment: "Country option for a site address.")
+        case .BA: return NSLocalizedString("Bosnia and Herzegovina", comment: "Country option for a site address.")
+        case .BW: return NSLocalizedString("Botswana", comment: "Country option for a site address.")
+        case .BV: return NSLocalizedString("Bouvet Island", comment: "Country option for a site address.")
+        case .BR: return NSLocalizedString("Brazil", comment: "Country option for a site address.")
+        case .IO: return NSLocalizedString("British Indian Ocean Territory", comment: "Country option for a site address.")
+        case .VG: return NSLocalizedString("British Virgin Islands", comment: "Country option for a site address.")
+        case .BN: return NSLocalizedString("Brunei", comment: "Country option for a site address.")
+        case .BG: return NSLocalizedString("Bulgaria", comment: "Country option for a site address.")
+        case .BF: return NSLocalizedString("Burkina Faso", comment: "Country option for a site address.")
+        case .BI: return NSLocalizedString("Burundi", comment: "Country option for a site address.")
 
             // C
-            case .KH: return NSLocalizedString("Cambodia", comment: "Country option for a site address.")
-            case .CM: return NSLocalizedString("Cameroon", comment: "Country option for a site address.")
-            case .CA: return NSLocalizedString("Canada", comment: "Country option for a site address.")
-            case .CV: return NSLocalizedString("Cape Verde", comment: "Country option for a site address.")
-            case .KY: return NSLocalizedString("Cayman Islands", comment: "Country option for a site address.")
-            case .CF: return NSLocalizedString("Central African Republic", comment: "Country option for a site address.")
-            case .TD: return NSLocalizedString("Chad", comment: "Country option for a site address.")
-            case .CL: return NSLocalizedString("Chile", comment: "Country option for a site address.")
-            case .CN: return NSLocalizedString("China", comment: "Country option for a site address.")
-            case .CX: return NSLocalizedString("Christmas Island", comment: "Country option for a site address.")
-            case .CC: return NSLocalizedString("Cocos (Keeling) Islands", comment: "Country option for a site address.")
-            case .CO: return NSLocalizedString("Colombia", comment: "Country option for a site address.")
-            case .KM: return NSLocalizedString("Comoros", comment: "Country option for a site address.")
-            case .CG: return NSLocalizedString("Congo (Brazzaville)", comment: "Country option for a site address.")
-            case .CD: return NSLocalizedString("Congo (Kinshasa)", comment: "Country option for a site address.")
-            case .CK: return NSLocalizedString("Cook Islands", comment: "Country option for a site address.")
-            case .CR: return NSLocalizedString("Costa Rica", comment: "Country option for a site address.")
-            case .HR: return NSLocalizedString("Croatia", comment: "Country option for a site address.")
-            case .CU: return NSLocalizedString("Cuba", comment: "Country option for a site address.")
-            case .CW: return NSLocalizedString("Curacao", comment: "Country option for a site address.")
-            case .CY: return NSLocalizedString("Cyprus", comment: "Country option for a site address.")
-            case .CZ: return NSLocalizedString("Czech Republic", comment: "Country option for a site address.")
+        case .KH: return NSLocalizedString("Cambodia", comment: "Country option for a site address.")
+        case .CM: return NSLocalizedString("Cameroon", comment: "Country option for a site address.")
+        case .CA: return NSLocalizedString("Canada", comment: "Country option for a site address.")
+        case .CV: return NSLocalizedString("Cape Verde", comment: "Country option for a site address.")
+        case .KY: return NSLocalizedString("Cayman Islands", comment: "Country option for a site address.")
+        case .CF: return NSLocalizedString("Central African Republic", comment: "Country option for a site address.")
+        case .TD: return NSLocalizedString("Chad", comment: "Country option for a site address.")
+        case .CL: return NSLocalizedString("Chile", comment: "Country option for a site address.")
+        case .CN: return NSLocalizedString("China", comment: "Country option for a site address.")
+        case .CX: return NSLocalizedString("Christmas Island", comment: "Country option for a site address.")
+        case .CC: return NSLocalizedString("Cocos (Keeling) Islands", comment: "Country option for a site address.")
+        case .CO: return NSLocalizedString("Colombia", comment: "Country option for a site address.")
+        case .KM: return NSLocalizedString("Comoros", comment: "Country option for a site address.")
+        case .CG: return NSLocalizedString("Congo (Brazzaville)", comment: "Country option for a site address.")
+        case .CD: return NSLocalizedString("Congo (Kinshasa)", comment: "Country option for a site address.")
+        case .CK: return NSLocalizedString("Cook Islands", comment: "Country option for a site address.")
+        case .CR: return NSLocalizedString("Costa Rica", comment: "Country option for a site address.")
+        case .HR: return NSLocalizedString("Croatia", comment: "Country option for a site address.")
+        case .CU: return NSLocalizedString("Cuba", comment: "Country option for a site address.")
+        case .CW: return NSLocalizedString("Curacao", comment: "Country option for a site address.")
+        case .CY: return NSLocalizedString("Cyprus", comment: "Country option for a site address.")
+        case .CZ: return NSLocalizedString("Czech Republic", comment: "Country option for a site address.")
 
             // D
-            case .DK: return NSLocalizedString("Denmark", comment: "Country option for a site address.")
-            case .DJ: return NSLocalizedString("Djibouti", comment: "Country option for a site address.")
-            case .DM: return NSLocalizedString("Dominica", comment: "Country option for a site address.")
-            case .DO: return NSLocalizedString("Dominican Republic", comment: "Country option for a site address.")
+        case .DK: return NSLocalizedString("Denmark", comment: "Country option for a site address.")
+        case .DJ: return NSLocalizedString("Djibouti", comment: "Country option for a site address.")
+        case .DM: return NSLocalizedString("Dominica", comment: "Country option for a site address.")
+        case .DO: return NSLocalizedString("Dominican Republic", comment: "Country option for a site address.")
 
             // E
-            case .EC: return NSLocalizedString("Ecuador", comment: "Country option for a site address.")
-            case .EG: return NSLocalizedString("Egypt", comment: "Country option for a site address.")
-            case .SV: return NSLocalizedString("El Salvador", comment: "Country option for a site address.")
-            case .GQ: return NSLocalizedString("Equatorial Guinea", comment: "Country option for a site address.")
-            case .ER: return NSLocalizedString("Eritrea", comment: "Country option for a site address.")
-            case .EE: return NSLocalizedString("Estonia", comment: "Country option for a site address.")
-            case .ET: return NSLocalizedString("Ethiopia", comment: "Country option for a site address.")
+        case .EC: return NSLocalizedString("Ecuador", comment: "Country option for a site address.")
+        case .EG: return NSLocalizedString("Egypt", comment: "Country option for a site address.")
+        case .SV: return NSLocalizedString("El Salvador", comment: "Country option for a site address.")
+        case .GQ: return NSLocalizedString("Equatorial Guinea", comment: "Country option for a site address.")
+        case .ER: return NSLocalizedString("Eritrea", comment: "Country option for a site address.")
+        case .EE: return NSLocalizedString("Estonia", comment: "Country option for a site address.")
+        case .ET: return NSLocalizedString("Ethiopia", comment: "Country option for a site address.")
 
             // F
-            case .FK: return NSLocalizedString("Falkland Islands", comment: "Country option for a site address.")
-            case .FO: return NSLocalizedString("Faroe Islands", comment: "Country option for a site address.")
-            case .FJ: return NSLocalizedString("Fiji", comment: "Country option for a site address.")
-            case .FI: return NSLocalizedString("Finland", comment: "Country option for a site address.")
-            case .FR: return NSLocalizedString("France", comment: "Country option for a site address.")
-            case .GF: return NSLocalizedString("French Guiana", comment: "Country option for a site address.")
-            case .PF: return NSLocalizedString("French Polynesia", comment: "Country option for a site address.")
-            case .TF: return NSLocalizedString("French Southern Territories", comment: "Country option for a site address.")
+        case .FK: return NSLocalizedString("Falkland Islands", comment: "Country option for a site address.")
+        case .FO: return NSLocalizedString("Faroe Islands", comment: "Country option for a site address.")
+        case .FJ: return NSLocalizedString("Fiji", comment: "Country option for a site address.")
+        case .FI: return NSLocalizedString("Finland", comment: "Country option for a site address.")
+        case .FR: return NSLocalizedString("France", comment: "Country option for a site address.")
+        case .GF: return NSLocalizedString("French Guiana", comment: "Country option for a site address.")
+        case .PF: return NSLocalizedString("French Polynesia", comment: "Country option for a site address.")
+        case .TF: return NSLocalizedString("French Southern Territories", comment: "Country option for a site address.")
 
             // G
-            case .GA: return NSLocalizedString("Gabon", comment: "Country option for a site address.")
-            case .GM: return NSLocalizedString("Gambia", comment: "Country option for a site address.")
-            case .GE: return NSLocalizedString("Georgia", comment: "Country option for a site address.")
-            case .DE: return NSLocalizedString("Germany", comment: "Country option for a site address.")
-            case .GH: return NSLocalizedString("Ghana", comment: "Country option for a site address.")
-            case .GI: return NSLocalizedString("Gibraltar", comment: "Country option for a site address.")
-            case .GR: return NSLocalizedString("Greece", comment: "Country option for a site address.")
-            case .GL: return NSLocalizedString("Greenland", comment: "Country option for a site address.")
-            case .GD: return NSLocalizedString("Grenada", comment: "Country option for a site address.")
-            case .GP: return NSLocalizedString("Guadeloupe", comment: "Country option for a site address.")
-            case .GU: return NSLocalizedString("Guam", comment: "Country option for a site address.")
-            case .GT: return NSLocalizedString("Guatemala", comment: "Country option for a site address.")
-            case .GG: return NSLocalizedString("Guernsey", comment: "Country option for a site address.")
-            case .GN: return NSLocalizedString("Guinea", comment: "Country option for a site address.")
-            case .GW: return NSLocalizedString("Guinea-Bissau", comment: "Country option for a site address.")
-            case .GY: return NSLocalizedString("Guyana", comment: "Country option for a site address.")
+        case .GA: return NSLocalizedString("Gabon", comment: "Country option for a site address.")
+        case .GM: return NSLocalizedString("Gambia", comment: "Country option for a site address.")
+        case .GE: return NSLocalizedString("Georgia", comment: "Country option for a site address.")
+        case .DE: return NSLocalizedString("Germany", comment: "Country option for a site address.")
+        case .GH: return NSLocalizedString("Ghana", comment: "Country option for a site address.")
+        case .GI: return NSLocalizedString("Gibraltar", comment: "Country option for a site address.")
+        case .GR: return NSLocalizedString("Greece", comment: "Country option for a site address.")
+        case .GL: return NSLocalizedString("Greenland", comment: "Country option for a site address.")
+        case .GD: return NSLocalizedString("Grenada", comment: "Country option for a site address.")
+        case .GP: return NSLocalizedString("Guadeloupe", comment: "Country option for a site address.")
+        case .GU: return NSLocalizedString("Guam", comment: "Country option for a site address.")
+        case .GT: return NSLocalizedString("Guatemala", comment: "Country option for a site address.")
+        case .GG: return NSLocalizedString("Guernsey", comment: "Country option for a site address.")
+        case .GN: return NSLocalizedString("Guinea", comment: "Country option for a site address.")
+        case .GW: return NSLocalizedString("Guinea-Bissau", comment: "Country option for a site address.")
+        case .GY: return NSLocalizedString("Guyana", comment: "Country option for a site address.")
 
             // H
-            case .HT: return NSLocalizedString("Haiti", comment: "Country option for a site address.")
-            case .HM: return NSLocalizedString("Heard Island and McDonald Islands", comment: "Country option for a site address.")
-            case .HN: return NSLocalizedString("Honduras", comment: "Country option for a site address.")
-            case .HK: return NSLocalizedString("Hong Kong", comment: "Country option for a site address.")
-            case .HU: return NSLocalizedString("Hungary", comment: "Country option for a site address.")
+        case .HT: return NSLocalizedString("Haiti", comment: "Country option for a site address.")
+        case .HM: return NSLocalizedString("Heard Island and McDonald Islands", comment: "Country option for a site address.")
+        case .HN: return NSLocalizedString("Honduras", comment: "Country option for a site address.")
+        case .HK: return NSLocalizedString("Hong Kong", comment: "Country option for a site address.")
+        case .HU: return NSLocalizedString("Hungary", comment: "Country option for a site address.")
 
             // I
-            case .IS: return NSLocalizedString("Iceland", comment: "Country option for a site address.")
-            case .IN: return NSLocalizedString("India", comment: "Country option for a site address.")
-            case .ID: return NSLocalizedString("Indonesia", comment: "Country option for a site address.")
-            case .IR: return NSLocalizedString("Iran", comment: "Country option for a site address.")
-            case .IQ: return NSLocalizedString("Iraq", comment: "Country option for a site address.")
-            case .IE: return NSLocalizedString("Ireland", comment: "Country option for a site address.")
-            case .IM: return NSLocalizedString("Isle of Man", comment: "Country option for a site address.")
-            case .IL: return NSLocalizedString("Israel", comment: "Country option for a site address.")
-            case .IT: return NSLocalizedString("Italy", comment: "Country option for a site address.")
-            case .CI: return NSLocalizedString("Ivory Coast", comment: "Country option for a site address.")
+        case .IS: return NSLocalizedString("Iceland", comment: "Country option for a site address.")
+        case .IN: return NSLocalizedString("India", comment: "Country option for a site address.")
+        case .ID: return NSLocalizedString("Indonesia", comment: "Country option for a site address.")
+        case .IR: return NSLocalizedString("Iran", comment: "Country option for a site address.")
+        case .IQ: return NSLocalizedString("Iraq", comment: "Country option for a site address.")
+        case .IE: return NSLocalizedString("Ireland", comment: "Country option for a site address.")
+        case .IM: return NSLocalizedString("Isle of Man", comment: "Country option for a site address.")
+        case .IL: return NSLocalizedString("Israel", comment: "Country option for a site address.")
+        case .IT: return NSLocalizedString("Italy", comment: "Country option for a site address.")
+        case .CI: return NSLocalizedString("Ivory Coast", comment: "Country option for a site address.")
 
             // J
-            case .JM: return NSLocalizedString("Jamaica", comment: "Country option for a site address.")
-            case .JP: return NSLocalizedString("Japan", comment: "Country option for a site address.")
-            case .JE: return NSLocalizedString("Jersey", comment: "Country option for a site address.")
-            case .JO: return NSLocalizedString("Jordan", comment: "Country option for a site address.")
+        case .JM: return NSLocalizedString("Jamaica", comment: "Country option for a site address.")
+        case .JP: return NSLocalizedString("Japan", comment: "Country option for a site address.")
+        case .JE: return NSLocalizedString("Jersey", comment: "Country option for a site address.")
+        case .JO: return NSLocalizedString("Jordan", comment: "Country option for a site address.")
 
             // K
-            case .KZ: return NSLocalizedString("Kazakhstan", comment: "Country option for a site address.")
-            case .KE: return NSLocalizedString("Kenya", comment: "Country option for a site address.")
-            case .KI: return NSLocalizedString("Kiribati", comment: "Country option for a site address.")
-            case .KW: return NSLocalizedString("Kuwait", comment: "Country option for a site address.")
-            case .KG: return NSLocalizedString("Kyrgyzstan", comment: "Country option for a site address.")
+        case .KZ: return NSLocalizedString("Kazakhstan", comment: "Country option for a site address.")
+        case .KE: return NSLocalizedString("Kenya", comment: "Country option for a site address.")
+        case .KI: return NSLocalizedString("Kiribati", comment: "Country option for a site address.")
+        case .KW: return NSLocalizedString("Kuwait", comment: "Country option for a site address.")
+        case .KG: return NSLocalizedString("Kyrgyzstan", comment: "Country option for a site address.")
 
             // L
-            case .LA: return NSLocalizedString("Laos", comment: "Country option for a site address.")
-            case .LV: return NSLocalizedString("Latvia", comment: "Country option for a site address.")
-            case .LB: return NSLocalizedString("Lebanon", comment: "Country option for a site address.")
-            case .LS: return NSLocalizedString("Lesotho", comment: "Country option for a site address.")
-            case .LR: return NSLocalizedString("Liberia", comment: "Country option for a site address.")
-            case .LY: return NSLocalizedString("Libya", comment: "Country option for a site address.")
-            case .LI: return NSLocalizedString("Liechtenstein", comment: "Country option for a site address.")
-            case .LT: return NSLocalizedString("Lithuania", comment: "Country option for a site address.")
-            case .LU: return NSLocalizedString("Luxembourg", comment: "Country option for a site address.")
+        case .LA: return NSLocalizedString("Laos", comment: "Country option for a site address.")
+        case .LV: return NSLocalizedString("Latvia", comment: "Country option for a site address.")
+        case .LB: return NSLocalizedString("Lebanon", comment: "Country option for a site address.")
+        case .LS: return NSLocalizedString("Lesotho", comment: "Country option for a site address.")
+        case .LR: return NSLocalizedString("Liberia", comment: "Country option for a site address.")
+        case .LY: return NSLocalizedString("Libya", comment: "Country option for a site address.")
+        case .LI: return NSLocalizedString("Liechtenstein", comment: "Country option for a site address.")
+        case .LT: return NSLocalizedString("Lithuania", comment: "Country option for a site address.")
+        case .LU: return NSLocalizedString("Luxembourg", comment: "Country option for a site address.")
 
             // M
-            case .MO: return NSLocalizedString("Macao S.A.R., China", comment: "Country option for a site address.")
-            case .MK: return NSLocalizedString("Macedonia", comment: "Country option for a site address.")
-            case .MG: return NSLocalizedString("Madagascar", comment: "Country option for a site address.")
-            case .MW: return NSLocalizedString("Malawi", comment: "Country option for a site address.")
-            case .MY: return NSLocalizedString("Malaysia", comment: "Country option for a site address.")
-            case .MV: return NSLocalizedString("Maldives", comment: "Country option for a site address.")
-            case .ML: return NSLocalizedString("Mali", comment: "Country option for a site address.")
-            case .MT: return NSLocalizedString("Malta", comment: "Country option for a site address.")
-            case .MH: return NSLocalizedString("Marshall Islands", comment: "Country option for a site address.")
-            case .MQ: return NSLocalizedString("Martinique", comment: "Country option for a site address.")
-            case .MR: return NSLocalizedString("Mauritania", comment: "Country option for a site address.")
-            case .MU: return NSLocalizedString("Mauritius", comment: "Country option for a site address.")
-            case .YT: return NSLocalizedString("Mayotte", comment: "Country option for a site address.")
-            case .MX: return NSLocalizedString("Mexico", comment: "Country option for a site address.")
-            case .FM: return NSLocalizedString("Micronesia", comment: "Country option for a site address.")
-            case .MD: return NSLocalizedString("Moldova", comment: "Country option for a site address.")
-            case .MC: return NSLocalizedString("Monaco", comment: "Country option for a site address.")
-            case .MN: return NSLocalizedString("Mongolia", comment: "Country option for a site address.")
-            case .ME: return NSLocalizedString("Montenegro", comment: "Country option for a site address.")
-            case .MS: return NSLocalizedString("Montserrat", comment: "Country option for a site address.")
-            case .MA: return NSLocalizedString("Morocco", comment: "Country option for a site address.")
-            case .MZ: return NSLocalizedString("Mozambique", comment: "Country option for a site address.")
-            case .MM: return NSLocalizedString("Myanmar", comment: "Country option for a site address.")
+        case .MO: return NSLocalizedString("Macao S.A.R., China", comment: "Country option for a site address.")
+        case .MK: return NSLocalizedString("Macedonia", comment: "Country option for a site address.")
+        case .MG: return NSLocalizedString("Madagascar", comment: "Country option for a site address.")
+        case .MW: return NSLocalizedString("Malawi", comment: "Country option for a site address.")
+        case .MY: return NSLocalizedString("Malaysia", comment: "Country option for a site address.")
+        case .MV: return NSLocalizedString("Maldives", comment: "Country option for a site address.")
+        case .ML: return NSLocalizedString("Mali", comment: "Country option for a site address.")
+        case .MT: return NSLocalizedString("Malta", comment: "Country option for a site address.")
+        case .MH: return NSLocalizedString("Marshall Islands", comment: "Country option for a site address.")
+        case .MQ: return NSLocalizedString("Martinique", comment: "Country option for a site address.")
+        case .MR: return NSLocalizedString("Mauritania", comment: "Country option for a site address.")
+        case .MU: return NSLocalizedString("Mauritius", comment: "Country option for a site address.")
+        case .YT: return NSLocalizedString("Mayotte", comment: "Country option for a site address.")
+        case .MX: return NSLocalizedString("Mexico", comment: "Country option for a site address.")
+        case .FM: return NSLocalizedString("Micronesia", comment: "Country option for a site address.")
+        case .MD: return NSLocalizedString("Moldova", comment: "Country option for a site address.")
+        case .MC: return NSLocalizedString("Monaco", comment: "Country option for a site address.")
+        case .MN: return NSLocalizedString("Mongolia", comment: "Country option for a site address.")
+        case .ME: return NSLocalizedString("Montenegro", comment: "Country option for a site address.")
+        case .MS: return NSLocalizedString("Montserrat", comment: "Country option for a site address.")
+        case .MA: return NSLocalizedString("Morocco", comment: "Country option for a site address.")
+        case .MZ: return NSLocalizedString("Mozambique", comment: "Country option for a site address.")
+        case .MM: return NSLocalizedString("Myanmar", comment: "Country option for a site address.")
 
             // N
-            case .NA: return NSLocalizedString("Namibia", comment: "Country option for a site address.")
-            case .NR: return NSLocalizedString("Nauru", comment: "Country option for a site address.")
-            case .NP: return NSLocalizedString("Nepal", comment: "Country option for a site address.")
-            case .NL: return NSLocalizedString("Netherlands", comment: "Country option for a site address.")
-            case .NC: return NSLocalizedString("New Caledonia", comment: "Country option for a site address.")
-            case .NZ: return NSLocalizedString("New Zealand", comment: "Country option for a site address.")
-            case .NI: return NSLocalizedString("Nicaragua", comment: "Country option for a site address.")
-            case .NE: return NSLocalizedString("Niger", comment: "Country option for a site address.")
-            case .NG: return NSLocalizedString("Nigeria", comment: "Country option for a site address.")
-            case .NU: return NSLocalizedString("Niue", comment: "Country option for a site address.")
-            case .NF: return NSLocalizedString("Norfolk Island", comment: "Country option for a site address.")
-            case .KP: return NSLocalizedString("North Korea", comment: "Country option for a site address.")
-            case .MP: return NSLocalizedString("Northern Mariana Islands", comment: "Country option for a site address.")
-            case .NO: return NSLocalizedString("Norway", comment: "Country option for a site address.")
+        case .NA: return NSLocalizedString("Namibia", comment: "Country option for a site address.")
+        case .NR: return NSLocalizedString("Nauru", comment: "Country option for a site address.")
+        case .NP: return NSLocalizedString("Nepal", comment: "Country option for a site address.")
+        case .NL: return NSLocalizedString("Netherlands", comment: "Country option for a site address.")
+        case .NC: return NSLocalizedString("New Caledonia", comment: "Country option for a site address.")
+        case .NZ: return NSLocalizedString("New Zealand", comment: "Country option for a site address.")
+        case .NI: return NSLocalizedString("Nicaragua", comment: "Country option for a site address.")
+        case .NE: return NSLocalizedString("Niger", comment: "Country option for a site address.")
+        case .NG: return NSLocalizedString("Nigeria", comment: "Country option for a site address.")
+        case .NU: return NSLocalizedString("Niue", comment: "Country option for a site address.")
+        case .NF: return NSLocalizedString("Norfolk Island", comment: "Country option for a site address.")
+        case .KP: return NSLocalizedString("North Korea", comment: "Country option for a site address.")
+        case .MP: return NSLocalizedString("Northern Mariana Islands", comment: "Country option for a site address.")
+        case .NO: return NSLocalizedString("Norway", comment: "Country option for a site address.")
 
             // O
-            case .OM: return NSLocalizedString("Oman", comment: "Country option for a site address.")
+        case .OM: return NSLocalizedString("Oman", comment: "Country option for a site address.")
 
             // P
-            case .PK: return NSLocalizedString("Pakistan", comment: "Country option for a site address.")
-            case .PS: return NSLocalizedString("Palestinian Territory", comment: "Country option for a site address.")
-            case .PA: return NSLocalizedString("Panama", comment: "Country option for a site address.")
-            case .PG: return NSLocalizedString("Papua New Guinea", comment: "Country option for a site address.")
-            case .PY: return NSLocalizedString("Paraguay", comment: "Country option for a site address.")
-            case .PE: return NSLocalizedString("Peru", comment: "Country option for a site address.")
-            case .PH: return NSLocalizedString("Philippines", comment: "Country option for a site address.")
-            case .PN: return NSLocalizedString("Pitcairn", comment: "Country option for a site address.")
-            case .PL: return NSLocalizedString("Poland", comment: "Country option for a site address.")
-            case .PT: return NSLocalizedString("Portugal", comment: "Country option for a site address.")
-            case .PR: return NSLocalizedString("Puerto Rico", comment: "Country option for a site address.")
+        case .PK: return NSLocalizedString("Pakistan", comment: "Country option for a site address.")
+        case .PS: return NSLocalizedString("Palestinian Territory", comment: "Country option for a site address.")
+        case .PA: return NSLocalizedString("Panama", comment: "Country option for a site address.")
+        case .PG: return NSLocalizedString("Papua New Guinea", comment: "Country option for a site address.")
+        case .PY: return NSLocalizedString("Paraguay", comment: "Country option for a site address.")
+        case .PE: return NSLocalizedString("Peru", comment: "Country option for a site address.")
+        case .PH: return NSLocalizedString("Philippines", comment: "Country option for a site address.")
+        case .PN: return NSLocalizedString("Pitcairn", comment: "Country option for a site address.")
+        case .PL: return NSLocalizedString("Poland", comment: "Country option for a site address.")
+        case .PT: return NSLocalizedString("Portugal", comment: "Country option for a site address.")
+        case .PR: return NSLocalizedString("Puerto Rico", comment: "Country option for a site address.")
 
             // Q
-            case .QA: return NSLocalizedString("Qatar", comment: "Country option for a site address.")
+        case .QA: return NSLocalizedString("Qatar", comment: "Country option for a site address.")
 
             // R
-            case .RE: return NSLocalizedString("Reunion", comment: "Country option for a site address.")
-            case .RO: return NSLocalizedString("Romania", comment: "Country option for a site address.")
-            case .RU: return NSLocalizedString("Russia", comment: "Country option for a site address.")
-            case .RW: return NSLocalizedString("Rwanda", comment: "Country option for a site address.")
+        case .RE: return NSLocalizedString("Reunion", comment: "Country option for a site address.")
+        case .RO: return NSLocalizedString("Romania", comment: "Country option for a site address.")
+        case .RU: return NSLocalizedString("Russia", comment: "Country option for a site address.")
+        case .RW: return NSLocalizedString("Rwanda", comment: "Country option for a site address.")
 
             // S
-            case .ST: return NSLocalizedString("São Tomé and Príncipe", comment: "Country option for a site address.")
-            case .BL: return NSLocalizedString("Saint Barthélemy", comment: "Country option for a site address.")
-            case .SH: return NSLocalizedString("Saint Helena", comment: "Country option for a site address.")
-            case .KN: return NSLocalizedString("Saint Kitts and Nevis", comment: "Country option for a site address.")
-            case .LC: return NSLocalizedString("Saint Lucia", comment: "Country option for a site address.")
-            case .SX: return NSLocalizedString("Saint Martin (Dutch part)", comment: "Country option for a site address.")
-            case .MF: return NSLocalizedString("Saint Martin (French part)", comment: "Country option for a site address.")
-            case .PM: return NSLocalizedString("Saint Pierre and Miquelon", comment: "Country option for a site address.")
-            case .VC: return NSLocalizedString("Saint Vincent and the Grenadines", comment: "Country option for a site address.")
-            case .WS: return NSLocalizedString("Samoa", comment: "Country option for a site address.")
-            case .SM: return NSLocalizedString("San Marino", comment: "Country option for a site address.")
-            case .SA: return NSLocalizedString("Saudi Arabia", comment: "Country option for a site address.")
-            case .SN: return NSLocalizedString("Senegal", comment: "Country option for a site address.")
-            case .RS: return NSLocalizedString("Serbia", comment: "Country option for a site address.")
-            case .SC: return NSLocalizedString("Seychelles", comment: "Country option for a site address.")
-            case .SL: return NSLocalizedString("Sierra Leone", comment: "Country option for a site address.")
-            case .SG: return NSLocalizedString("Singapore", comment: "Country option for a site address.")
-            case .SK: return NSLocalizedString("Slovakia", comment: "Country option for a site address.")
-            case .SI: return NSLocalizedString("Slovenia", comment: "Country option for a site address.")
-            case .SB: return NSLocalizedString("Solomon Islands", comment: "Country option for a site address.")
-            case .SO: return NSLocalizedString("Somalia", comment: "Country option for a site address.")
-            case .ZA: return NSLocalizedString("South Africa", comment: "Country option for a site address.")
-            case .GS: return NSLocalizedString("South Georgia/Sandwich Islands", comment: "Country option for a site address.")
-            case .KR: return NSLocalizedString("South Korea", comment: "Country option for a site address.")
-            case .SS: return NSLocalizedString("South Sudan", comment: "Country option for a site address.")
-            case .ES: return NSLocalizedString("Spain", comment: "Country option for a site address.")
-            case .LK: return NSLocalizedString("Sri Lanka", comment: "Country option for a site address.")
-            case .SD: return NSLocalizedString("Sudan", comment: "Country option for a site address.")
-            case .SR: return NSLocalizedString("Suriname", comment: "Country option for a site address.")
-            case .SJ: return NSLocalizedString("Svalbard and Jan Mayen", comment: "Country option for a site address.")
-            case .SZ: return NSLocalizedString("Swaziland", comment: "Country option for a site address.")
-            case .SE: return NSLocalizedString("Sweden", comment: "Country option for a site address.")
-            case .CH: return NSLocalizedString("Switzerland", comment: "Country option for a site address.")
-            case .SY: return NSLocalizedString("Syria", comment: "Country option for a site address.")
+        case .ST: return NSLocalizedString("São Tomé and Príncipe", comment: "Country option for a site address.")
+        case .BL: return NSLocalizedString("Saint Barthélemy", comment: "Country option for a site address.")
+        case .SH: return NSLocalizedString("Saint Helena", comment: "Country option for a site address.")
+        case .KN: return NSLocalizedString("Saint Kitts and Nevis", comment: "Country option for a site address.")
+        case .LC: return NSLocalizedString("Saint Lucia", comment: "Country option for a site address.")
+        case .SX: return NSLocalizedString("Saint Martin (Dutch part)", comment: "Country option for a site address.")
+        case .MF: return NSLocalizedString("Saint Martin (French part)", comment: "Country option for a site address.")
+        case .PM: return NSLocalizedString("Saint Pierre and Miquelon", comment: "Country option for a site address.")
+        case .VC: return NSLocalizedString("Saint Vincent and the Grenadines", comment: "Country option for a site address.")
+        case .WS: return NSLocalizedString("Samoa", comment: "Country option for a site address.")
+        case .SM: return NSLocalizedString("San Marino", comment: "Country option for a site address.")
+        case .SA: return NSLocalizedString("Saudi Arabia", comment: "Country option for a site address.")
+        case .SN: return NSLocalizedString("Senegal", comment: "Country option for a site address.")
+        case .RS: return NSLocalizedString("Serbia", comment: "Country option for a site address.")
+        case .SC: return NSLocalizedString("Seychelles", comment: "Country option for a site address.")
+        case .SL: return NSLocalizedString("Sierra Leone", comment: "Country option for a site address.")
+        case .SG: return NSLocalizedString("Singapore", comment: "Country option for a site address.")
+        case .SK: return NSLocalizedString("Slovakia", comment: "Country option for a site address.")
+        case .SI: return NSLocalizedString("Slovenia", comment: "Country option for a site address.")
+        case .SB: return NSLocalizedString("Solomon Islands", comment: "Country option for a site address.")
+        case .SO: return NSLocalizedString("Somalia", comment: "Country option for a site address.")
+        case .ZA: return NSLocalizedString("South Africa", comment: "Country option for a site address.")
+        case .GS: return NSLocalizedString("South Georgia/Sandwich Islands", comment: "Country option for a site address.")
+        case .KR: return NSLocalizedString("South Korea", comment: "Country option for a site address.")
+        case .SS: return NSLocalizedString("South Sudan", comment: "Country option for a site address.")
+        case .ES: return NSLocalizedString("Spain", comment: "Country option for a site address.")
+        case .LK: return NSLocalizedString("Sri Lanka", comment: "Country option for a site address.")
+        case .SD: return NSLocalizedString("Sudan", comment: "Country option for a site address.")
+        case .SR: return NSLocalizedString("Suriname", comment: "Country option for a site address.")
+        case .SJ: return NSLocalizedString("Svalbard and Jan Mayen", comment: "Country option for a site address.")
+        case .SZ: return NSLocalizedString("Swaziland", comment: "Country option for a site address.")
+        case .SE: return NSLocalizedString("Sweden", comment: "Country option for a site address.")
+        case .CH: return NSLocalizedString("Switzerland", comment: "Country option for a site address.")
+        case .SY: return NSLocalizedString("Syria", comment: "Country option for a site address.")
 
             // T
-            case .TW: return NSLocalizedString("Taiwan", comment: "Country option for a site address.")
-            case .TJ: return NSLocalizedString("Tajikistan", comment: "Country option for a site address.")
-            case .TZ: return NSLocalizedString("Tanzania", comment: "Country option for a site address.")
-            case .TH: return NSLocalizedString("Thailand", comment: "Country option for a site address.")
-            case .TL: return NSLocalizedString("Timor-Leste", comment: "Country option for a site address.")
-            case .TG: return NSLocalizedString("Togo", comment: "Country option for a site address.")
-            case .TK: return NSLocalizedString("Tokelau", comment: "Country option for a site address.")
-            case .TO: return NSLocalizedString("Tonga", comment: "Country option for a site address.")
-            case .TT: return NSLocalizedString("Trinidad and Tobago", comment: "Country option for a site address.")
-            case .TN: return NSLocalizedString("Tunisia", comment: "Country option for a site address.")
-            case .TR: return NSLocalizedString("Turkey", comment: "Country option for a site address.")
-            case .TM: return NSLocalizedString("Turkmenistan", comment: "Country option for a site address.")
-            case .TC: return NSLocalizedString("Turks and Caicos Islands", comment: "Country option for a site address.")
-            case .TV: return NSLocalizedString("Tuvalu", comment: "Country option for a site address.")
+        case .TW: return NSLocalizedString("Taiwan", comment: "Country option for a site address.")
+        case .TJ: return NSLocalizedString("Tajikistan", comment: "Country option for a site address.")
+        case .TZ: return NSLocalizedString("Tanzania", comment: "Country option for a site address.")
+        case .TH: return NSLocalizedString("Thailand", comment: "Country option for a site address.")
+        case .TL: return NSLocalizedString("Timor-Leste", comment: "Country option for a site address.")
+        case .TG: return NSLocalizedString("Togo", comment: "Country option for a site address.")
+        case .TK: return NSLocalizedString("Tokelau", comment: "Country option for a site address.")
+        case .TO: return NSLocalizedString("Tonga", comment: "Country option for a site address.")
+        case .TT: return NSLocalizedString("Trinidad and Tobago", comment: "Country option for a site address.")
+        case .TN: return NSLocalizedString("Tunisia", comment: "Country option for a site address.")
+        case .TR: return NSLocalizedString("Turkey", comment: "Country option for a site address.")
+        case .TM: return NSLocalizedString("Turkmenistan", comment: "Country option for a site address.")
+        case .TC: return NSLocalizedString("Turks and Caicos Islands", comment: "Country option for a site address.")
+        case .TV: return NSLocalizedString("Tuvalu", comment: "Country option for a site address.")
 
             // U
-            case .UG: return NSLocalizedString("Uganda", comment: "Country option for a site address.")
-            case .UA: return NSLocalizedString("Ukraine", comment: "Country option for a site address.")
-            case .AE: return NSLocalizedString("United Arab Emirates", comment: "Country option for a site address.")
-            case .GB: return NSLocalizedString("United Kingdom", comment: "Country option for a site address.")
-            case .US: return NSLocalizedString("United States", comment: "Country option for a site address.")
-            case .UM: return NSLocalizedString("United States Minor Outlying Islands", comment: "Country option for a site address.")
-            case .VI: return NSLocalizedString("United States Virgin Islands", comment: "Country option for a site address.")
-            case .UY: return NSLocalizedString("Uruguay", comment: "Country option for a site address.")
-            case .UZ: return NSLocalizedString("Uzbekistan", comment: "Country option for a site address.")
+        case .UG: return NSLocalizedString("Uganda", comment: "Country option for a site address.")
+        case .UA: return NSLocalizedString("Ukraine", comment: "Country option for a site address.")
+        case .AE: return NSLocalizedString("United Arab Emirates", comment: "Country option for a site address.")
+        case .GB: return NSLocalizedString("United Kingdom", comment: "Country option for a site address.")
+        case .US: return NSLocalizedString("United States", comment: "Country option for a site address.")
+        case .UM: return NSLocalizedString("United States Minor Outlying Islands", comment: "Country option for a site address.")
+        case .VI: return NSLocalizedString("United States Virgin Islands", comment: "Country option for a site address.")
+        case .UY: return NSLocalizedString("Uruguay", comment: "Country option for a site address.")
+        case .UZ: return NSLocalizedString("Uzbekistan", comment: "Country option for a site address.")
 
             // V
-            case .VU: return NSLocalizedString("Vanuatu", comment: "Country option for a site address.")
-            case .VA: return NSLocalizedString("Vatican", comment: "Country option for a site address.")
-            case .VE: return NSLocalizedString("Venezuela", comment: "Country option for a site address.")
-            case .VN: return NSLocalizedString("Vietnam", comment: "Country option for a site address.")
+        case .VU: return NSLocalizedString("Vanuatu", comment: "Country option for a site address.")
+        case .VA: return NSLocalizedString("Vatican", comment: "Country option for a site address.")
+        case .VE: return NSLocalizedString("Venezuela", comment: "Country option for a site address.")
+        case .VN: return NSLocalizedString("Vietnam", comment: "Country option for a site address.")
 
             // W
-            case .WF: return NSLocalizedString("Wallis and Futuna", comment: "Country option for a site address.")
-            case .EH: return NSLocalizedString("Western Sahara", comment: "Country option for a site address.")
+        case .WF: return NSLocalizedString("Wallis and Futuna", comment: "Country option for a site address.")
+        case .EH: return NSLocalizedString("Western Sahara", comment: "Country option for a site address.")
 
             // Y
-            case .YE: return NSLocalizedString("Yemen", comment: "Country option for a site address.")
+        case .YE: return NSLocalizedString("Yemen", comment: "Country option for a site address.")
 
             // Z
-            case .ZM: return NSLocalizedString("Zambia", comment: "Country option for a site address.")
-            case .ZW: return NSLocalizedString("Zimbabwe", comment: "Country option for a site address.")
-            }
+        case .ZM: return NSLocalizedString("Zambia", comment: "Country option for a site address.")
+        case .ZW: return NSLocalizedString("Zimbabwe", comment: "Country option for a site address.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -287,7 +287,7 @@ private extension PaymentCaptureOrchestrator {
     }
 
     private func applicationFee(for orderTotal: NSDecimalNumber, country: String) -> Decimal? {
-        guard country.uppercased() == SiteAddress.CountryCode.CA.rawValue else {
+        guard country.uppercased() == CountryCode.CA.rawValue else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -88,7 +88,7 @@ final class OrderDetailsDataSource: NSObject {
         let plugin = resultsControllers.sitePlugins.first { $0.name == SitePlugin.SupportedPlugin.WCShip }
         let isPluginInstalled = plugin != nil && resultsControllers.sitePlugins.count > 0
         let isPluginActive = plugin?.status.isActive ?? false
-        let isCountryCodeUS = SiteAddress(siteSettings: siteSettings).countryCode == SiteAddress.CountryCode.US.rawValue
+        let isCountryCodeUS = SiteAddress(siteSettings: siteSettings).countryCode == CountryCode.US.rawValue
         let isCurrencyUSD = currencySettings.currencyCode == .USD
 
         guard isFeatureFlagEnabled,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
@@ -1,6 +1,7 @@
 import Combine
 import XCTest
 @testable import WooCommerce
+import WooFoundation
 
 @MainActor
 final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
@@ -29,7 +30,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
         let viewModel = StoreCreationCountryQuestionViewModel(currentLocale: .init(identifier: "zzzz")) { _ in } onSupport: {}
 
         // Then
-        XCTAssertEqual(viewModel.countryCodes, SiteAddress.CountryCode.allCases.sorted(by: { $0.readableCountry < $1.readableCountry }))
+        XCTAssertEqual(viewModel.countryCodes, CountryCode.allCases.sorted(by: { $0.readableCountry < $1.readableCountry }))
     }
 
     func test_countryCodes_do_not_include_currentCountryCode_from_locale() throws {
@@ -38,7 +39,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.countryCodes.contains(.FR))
-        XCTAssertEqual(viewModel.countryCodes.count, SiteAddress.CountryCode.allCases.count - 1)
+        XCTAssertEqual(viewModel.countryCodes.count, CountryCode.allCases.count - 1)
     }
 
     func test_selecting_a_country_updates_selectedCountryCode() throws {

--- a/WooCommerce/WooCommerceTests/Extensions/CountryCode+FlagEmojiTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/CountryCode+FlagEmojiTests.swift
@@ -1,10 +1,11 @@
 import XCTest
 @testable import WooCommerce
+import WooFoundation
 
 final class CountryCode_FlagEmojiTests: XCTestCase {
     func test_us_flag_emoji_is_returned_for_US() {
         // Given
-        let countryCode = SiteAddress.CountryCode.US
+        let countryCode = CountryCode.US
 
         // Then
         XCTAssertEqual(countryCode.flagEmoji, "🇺🇸")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -388,7 +388,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             .copy(
                 siteID: sampleSiteID,
                 settingID: "woocommerce_default_country",
-                value: SiteAddress.CountryCode.US.rawValue,
+                value: CountryCode.US.rawValue,
                 settingGroupKey: SiteSettingGroup.general.rawValue
             )
 
@@ -421,7 +421,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             .copy(
                 siteID: sampleSiteID,
                 settingID: "woocommerce_default_country",
-                value: SiteAddress.CountryCode.US.rawValue,
+                value: CountryCode.US.rawValue,
                 settingGroupKey: SiteSettingGroup.general.rawValue
             )
 

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		035BA3A6290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A5290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift */; };
 		036563D728F93F8D00D84BFD /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 036563D628F93F8D00D84BFD /* TestKit */; };
 		03B8C3892914083F002235B1 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8C3882914083F002235B1 /* Bundle+Woo.swift */; };
+		203758752AD55670000E4281 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203758742AD55670000E4281 /* CountryCode.swift */; };
 		265C99D828B93F04005E6117 /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 265C99D728B93F04005E6117 /* ColorPalette.xcassets */; };
 		265C99DD28B941D5005E6117 /* UIColor+Muriel-Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265C99DC28B941D5005E6117 /* UIColor+Muriel-Tests.swift */; };
 		265C99DF28B94271005E6117 /* MurielColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265C99DE28B94271005E6117 /* MurielColorTests.swift */; };
@@ -69,6 +70,7 @@
 		03597A9C28F93409005E4A98 /* WooCommerceComUTMProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooCommerceComUTMProviderTests.swift; sourceTree = "<group>"; };
 		035BA3A5290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMProviderProtocolExtensionTests.swift; sourceTree = "<group>"; };
 		03B8C3882914083F002235B1 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
+		203758742AD55670000E4281 /* CountryCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCode.swift; sourceTree = "<group>"; };
 		265C99D728B93F04005E6117 /* ColorPalette.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorPalette.xcassets; sourceTree = "<group>"; };
 		265C99DC28B941D5005E6117 /* UIColor+Muriel-Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Muriel-Tests.swift"; sourceTree = "<group>"; };
 		265C99DE28B94271005E6117 /* MurielColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MurielColorTests.swift; sourceTree = "<group>"; };
@@ -133,6 +135,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		203758732AD5564F000E4281 /* Countries */ = {
+			isa = PBXGroup;
+			children = (
+				203758742AD55670000E4281 /* CountryCode.swift */,
+			);
+			path = Countries;
+			sourceTree = "<group>";
+		};
 		265C99DB28B941D5005E6117 /* Colors */ = {
 			isa = PBXGroup;
 			children = (
@@ -238,11 +248,12 @@
 			isa = PBXGroup;
 			children = (
 				26AF1F4E28B8362800937BA9 /* Colors */,
+				203758732AD5564F000E4281 /* Countries */,
+				B9C9C65A283E71C8001B879F /* Currency */,
 				689D11D12891B7B100F6A83F /* Mocks */,
 				689D11CE2891B37400F6A83F /* Protocols */,
 				686BE910288EE09B00967C86 /* Utilities */,
 				B9C9C661283E7296001B879F /* Internal */,
-				B9C9C65A283E71C8001B879F /* Currency */,
 				B9C9C657283E7174001B879F /* Extensions */,
 				26AF1F5728B9011100937BA9 /* ViewModifiers */,
 			);
@@ -508,6 +519,7 @@
 				B9C9C663283E7296001B879F /* Logging.swift in Sources */,
 				6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */,
 				B97190D1292CF3BC0065E413 /* Result+Extensions.swift in Sources */,
+				203758752AD55670000E4281 /* CountryCode.swift in Sources */,
 				B9C9C65D283E71C8001B879F /* CurrencyFormatter.swift in Sources */,
 				AE948D0A28CF67CF009F3246 /* Date+StartAndEnd.swift in Sources */,
 				03597A9428F85686005E4A98 /* UTMParameters.swift in Sources */,

--- a/WooFoundation/WooFoundation/Countries/CountryCode.swift
+++ b/WooFoundation/WooFoundation/Countries/CountryCode.swift
@@ -1,0 +1,308 @@
+import Foundation
+
+// MARK: - Mapping between country codes and readable names
+// The country names were extracted from the response to `/wp-json/wc/v3/settings/general`
+// The default countries are listed under `woocommerce_default_country`
+// in one of the following formats:
+// - `"COUNTRY_CODE": "READABALE_COUNTRY_NAME"
+// - `"COUNTRY_CODE:COUNTRY_REGION": "READABLE_COUNTRY_NAME - READABLE_COUNTRY_REGION"
+public enum CountryCode: String, CaseIterable {
+    // A
+    case AX
+    case AF
+    case AL
+    case DZ
+    case AS
+    case AD
+    case AO
+    case AI
+    case AQ
+    case AG
+    case AR
+    case AM
+    case AW
+    case AU
+    case AT
+    case AZ
+
+    // B
+    case BS
+    case BH
+    case BD
+    case BB
+    case BY
+    case PW
+    case BE
+    case BZ
+    case BJ
+    case BM
+    case BT
+    case BO
+    case BQ
+    case BA
+    case BW
+    case BV
+    case BR
+    case IO
+    case VG
+    case BN
+    case BG
+    case BF
+    case BI
+
+    // C
+    case KH
+    case CM
+    case CA
+    case CV
+    case KY
+    case CF
+    case TD
+    case CL
+    case CN
+    case CX
+    case CC
+    case CO
+    case KM
+    case CG
+    case CD
+    case CK
+    case CR
+    case HR
+    case CU
+    case CW
+    case CY
+    case CZ
+
+    // D
+    case DK
+    case DJ
+    case DM
+    case DO
+
+    // E
+    case EC
+    case EG
+    case SV
+    case GQ
+    case ER
+    case EE
+    case ET
+
+    // F
+    case FK
+    case FO
+    case FJ
+    case FI
+    case FR
+    case GF
+    case PF
+    case TF
+
+    // G
+    case GA
+    case GM
+    case GE
+    case DE
+    case GH
+    case GI
+    case GR
+    case GL
+    case GD
+    case GP
+    case GU
+    case GT
+    case GG
+    case GN
+    case GW
+    case GY
+
+    // H
+    case HT
+    case HM
+    case HN
+    case HK
+    case HU
+
+    // I
+    case IS
+    case IN
+    case ID
+    case IR
+    case IQ
+    case IE
+    case IM
+    case IL
+    case IT
+    case CI
+
+    // J
+    case JM
+    case JP
+    case JE
+    case JO
+
+    // K
+    case KZ
+    case KE
+    case KI
+    case KW
+    case KG
+
+    // L
+    case LA
+    case LV
+    case LB
+    case LS
+    case LR
+    case LY
+    case LI
+    case LT
+    case LU
+
+    // M
+    case MO
+    case MK
+    case MG
+    case MW
+    case MY
+    case MV
+    case ML
+    case MT
+    case MH
+    case MQ
+    case MR
+    case MU
+    case YT
+    case MX
+    case FM
+    case MD
+    case MC
+    case MN
+    case ME
+    case MS
+    case MA
+    case MZ
+    case MM
+
+    // N
+    case NA
+    case NR
+    case NP
+    case NL
+    case NC
+    case NZ
+    case NI
+    case NE
+    case NG
+    case NU
+    case NF
+    case KP
+    case MP
+    case NO
+
+    // O
+    case OM
+
+    // P
+    case PK
+    case PS
+    case PA
+    case PG
+    case PY
+    case PE
+    case PH
+    case PN
+    case PL
+    case PT
+    case PR
+
+    // Q
+    case QA
+
+    // R
+    case RE
+    case RO
+    case RU
+    case RW
+
+    // S
+    case ST
+    case BL
+    case SH
+    case KN
+    case LC
+    case SX
+    case MF
+    case PM
+    case VC
+    case WS
+    case SM
+    case SA
+    case SN
+    case RS
+    case SC
+    case SL
+    case SG
+    case SK
+    case SI
+    case SB
+    case SO
+    case ZA
+    case GS
+    case KR
+    case SS
+    case ES
+    case LK
+    case SD
+    case SR
+    case SJ
+    case SZ
+    case SE
+    case CH
+    case SY
+
+    // T
+    case TW
+    case TJ
+    case TZ
+    case TH
+    case TL
+    case TG
+    case TK
+    case TO
+    case TT
+    case TN
+    case TR
+    case TM
+    case TC
+    case TV
+
+    // U
+    case UG
+    case UA
+    case AE
+    case GB
+    case US
+    case UM
+    case VI
+    case UY
+    case UZ
+
+    // V
+    case VU
+    case VA
+    case VE
+    case VN
+
+    // W
+    case WF
+    case EH
+
+    // Y
+    case YE
+
+    // Z
+    case ZM
+    case ZW
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10890
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Sorry this is long! Don't be put off – it's straightforward, and can't really be shorter, because of the move of a big list of countries.

We'll add Tap to Pay on iPhone support for UK WooPayments merchants. This PR extracts the CountryCode enum to WooFoundation, with a view to using it in the `CardPresentPaymentsConfiguration` instead of a raw string, for safer country checks and simpler localization in the app layer. This will enable us to keep app layer checks out of the business logic layer configuration.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check the unit tests pass

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
