### PR TITLE
[TTPUK] Use country code in card configuration

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 /// This struct represents an analytics event. It is a combination of `WooAnalyticsStat` and
 /// its properties.
@@ -1280,10 +1281,10 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
         ///
-        static func cardReaderSelectTypeShown(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderSelectTypeShown(forGatewayID: String?, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSelectTypeShown,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )
@@ -1296,10 +1297,10 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
         ///
-        static func cardReaderSelectTypeBuiltInTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderSelectTypeBuiltInTapped(forGatewayID: String?, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSelectTypeBuiltInTapped,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )
@@ -1312,10 +1313,10 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
         ///
-        static func cardReaderSelectTypeBluetoothTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderSelectTypeBluetoothTapped(forGatewayID: String?, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSelectTypeBluetoothTapped,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )
@@ -1327,10 +1328,10 @@ extension WooAnalyticsEvent {
         ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///   - countryCode: the country code of the store.
         ///
-        static func manageCardReadersBuiltInReaderAutoDisconnect(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+        static func manageCardReadersBuiltInReaderAutoDisconnect(forGatewayID: String?, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .manageCardReadersBuiltInReaderAutoDisconnect,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )
@@ -1344,12 +1345,12 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///
         static func cardReaderAutomaticDisconnect(cardReaderModel: String?,
-                                                  forGatewayID: String?, countryCode: String,
+                                                  forGatewayID: String?, countryCode: CountryCode,
                                                   connectionType: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderAutomaticDisconnect,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.connectionType: connectionType
                               ]
@@ -1365,12 +1366,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderDiscoveryFailed(forGatewayID: String?,
                                               error: Error,
-                                              countryCode: String,
+                                              countryCode: CountryCode,
                                               siteID: Int64,
                                               connectionType: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDiscoveryFailed,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription,
                                 Keys.siteID: siteID,
@@ -1389,12 +1390,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderConnectionSuccess(forGatewayID: String?,
                                                 batteryLevel: Float?,
-                                                countryCode: String,
+                                                countryCode: CountryCode,
                                                 cardReaderModel: String?,
                                                 connectionType: String) -> WooAnalyticsEvent {
             var properties = [
                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                Keys.countryCode: countryCode,
+                Keys.countryCode: countryCode.rawValue,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                 Keys.connectionType: connectionType
             ]
@@ -1416,14 +1417,14 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderConnectionFailed(forGatewayID: String?,
                                                error: Error,
-                                               countryCode: String,
+                                               countryCode: CountryCode,
                                                cardReaderModel: String?,
                                                siteID: Int64,
                                                connectionType: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderConnectionFailed,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription,
                                 Keys.siteID: siteID,
@@ -1440,11 +1441,11 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDisconnectTapped,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
             )
@@ -1460,12 +1461,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderSoftwareUpdateTapped(forGatewayID: String?,
                                                    updateType: SoftwareUpdateTypeProperty,
-                                                   countryCode: String,
+                                                   countryCode: CountryCode,
                                                    cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateTapped,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -1482,12 +1483,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderSoftwareUpdateStarted(forGatewayID: String?,
                                                     updateType: SoftwareUpdateTypeProperty,
-                                                    countryCode: String,
+                                                    countryCode: CountryCode,
                                                     cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateStarted,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -1506,13 +1507,13 @@ extension WooAnalyticsEvent {
         static func cardReaderSoftwareUpdateFailed(forGatewayID: String?,
                                                    updateType: SoftwareUpdateTypeProperty,
                                                    error: Error,
-                                                   countryCode: String,
+                                                   countryCode: CountryCode,
                                                    cardReaderModel: String
         ) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateFailed,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue,
                                 Keys.errorDescription: error.localizedDescription
@@ -1530,12 +1531,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?,
                                                     updateType: SoftwareUpdateTypeProperty,
-                                                    countryCode: String,
+                                                    countryCode: CountryCode,
                                                     cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateSuccess,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -1552,12 +1553,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderSoftwareUpdateCancelTapped(forGatewayID: String?,
                                                          updateType: SoftwareUpdateTypeProperty,
-                                                         countryCode: String,
+                                                         countryCode: CountryCode,
                                                          cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCancelTapped,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -1574,12 +1575,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?,
                                                      updateType: SoftwareUpdateTypeProperty,
-                                                     countryCode: String,
+                                                     countryCode: CountryCode,
                                                      cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCanceled,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
@@ -1596,7 +1597,7 @@ extension WooAnalyticsEvent {
         ///
         static func collectPaymentFailed(forGatewayID: String?,
                                          error: Error,
-                                         countryCode: String,
+                                         countryCode: CountryCode,
                                          cardReaderModel: String?,
                                          siteID: Int64) -> WooAnalyticsEvent {
             let paymentMethod: PaymentMethod? = {
@@ -1626,7 +1627,7 @@ extension WooAnalyticsEvent {
             }()
             let properties: [String: WooAnalyticsEventPropertyType] = [
                 Keys.cardReaderModel: cardReaderModel,
-                Keys.countryCode: countryCode,
+                Keys.countryCode: countryCode.rawValue,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                 Keys.paymentMethodType: paymentMethod?.analyticsValue,
                 Keys.errorDescription: errorDescription,
@@ -1644,14 +1645,14 @@ extension WooAnalyticsEvent {
         ///   - cardReaderModel: the model type of the card reader.
         ///
         static func collectPaymentCanceled(forGatewayID: String?,
-                                           countryCode: String,
+                                           countryCode: CountryCode,
                                            cardReaderModel: String?,
                                            cancellationSource: CancellationSource,
                                            siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentCanceled,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.cancellationSource: cancellationSource.rawValue,
                                 Keys.siteID: siteID
@@ -1683,7 +1684,7 @@ extension WooAnalyticsEvent {
         ///   - cardReaderModel: the model type of the card reader.
         ///
         static func collectPaymentSuccess(forGatewayID: String?,
-                                          countryCode: String,
+                                          countryCode: CountryCode,
                                           paymentMethod: PaymentMethod,
                                           cardReaderModel: String?,
                                           millisecondsSinceOrderAddNew: Int64?,
@@ -1691,7 +1692,7 @@ extension WooAnalyticsEvent {
                                           siteID: Int64) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [
                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                Keys.countryCode: countryCode,
+                Keys.countryCode: countryCode.rawValue,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                 Keys.paymentMethodType: paymentMethod.analyticsValue,
                 Keys.siteID: siteID
@@ -1718,13 +1719,13 @@ extension WooAnalyticsEvent {
         ///   - cardReaderModel: the model type of the card reader.
         ///
         static func collectInteracPaymentSuccess(gatewayID: String?,
-                                                 countryCode: String,
+                                                 countryCode: CountryCode,
                                                  cardReaderModel: String?,
                                                  siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
                                 Keys.siteID: siteID
                               ])
@@ -1738,13 +1739,13 @@ extension WooAnalyticsEvent {
         ///   - cardReaderModel: the model type of the card reader.
         ///
         static func interacRefundSuccess(gatewayID: String?,
-                                         countryCode: String,
+                                         countryCode: CountryCode,
                                          cardReaderModel: String?,
                                          siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundSuccess,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
                                 Keys.siteID: siteID
                               ])
@@ -1760,13 +1761,13 @@ extension WooAnalyticsEvent {
         ///
         static func interacRefundFailed(error: Error,
                                         gatewayID: String?,
-                                        countryCode: String,
+                                        countryCode: CountryCode,
                                         cardReaderModel: String?,
                                         siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundFailed,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
                                 Keys.siteID: siteID
                               ],
@@ -1781,13 +1782,13 @@ extension WooAnalyticsEvent {
         ///   - cardReaderModel: the model type of the card reader.
         ///
         static func interacRefundCanceled(gatewayID: String?,
-                                          countryCode: String,
+                                          countryCode: CountryCode,
                                           cardReaderModel: String?,
                                           siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundCanceled,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
                                 Keys.siteID: siteID
                               ])
@@ -1797,10 +1798,10 @@ extension WooAnalyticsEvent {
         ///
         /// - Parameter countryCode: the country code of the store.
         ///
-        static func cardPresentOnboardingLearnMoreTapped(reason: String, countryCode: String) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingLearnMoreTapped(reason: String, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingLearnMoreTapped,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason
                               ])
         }
@@ -1811,10 +1812,10 @@ extension WooAnalyticsEvent {
         ///   - reason: the reason why the onboarding is not completed.
         ///   - countryCode: the country code of the store.
         ///
-        static func cardPresentOnboardingNotCompleted(reason: String, countryCode: String) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingNotCompleted(reason: String, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingNotCompleted,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason
                               ])
         }
@@ -1826,10 +1827,10 @@ extension WooAnalyticsEvent {
         ///   - remindLater: whether the user will see this onboarding step again
         ///   - countryCode: the country code of the store.
         ///
-        static func cardPresentOnboardingStepSkipped(reason: String, remindLater: Bool, countryCode: String) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingStepSkipped(reason: String, remindLater: Bool, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingStepSkipped,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
                                 Keys.remindLater: remindLater
                               ])
@@ -1841,10 +1842,10 @@ extension WooAnalyticsEvent {
         ///   - reason: the reason why the onboarding step was shown (effectively the name of the step.)
         ///   - countryCode: the country code of the store.
         ///
-        static func cardPresentOnboardingCtaTapped(reason: String, countryCode: String) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingCtaTapped(reason: String, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCtaTapped,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason
                               ])
         }
@@ -1856,10 +1857,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store
         ///   - error: the logged error response from the API, if any.
         ///
-        static func cardPresentOnboardingCtaFailed(reason: String, countryCode: String, error: Error? = nil) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingCtaFailed(reason: String, countryCode: CountryCode, error: Error? = nil) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCtaFailed,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
                               ], error: error)
         }
@@ -1875,10 +1876,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - source: the screen which the enable attempt was made on     
         ///
-        static func enableCashOnDeliverySuccess(countryCode: String, source: CashOnDeliverySource) -> WooAnalyticsEvent {
+        static func enableCashOnDeliverySuccess(countryCode: CountryCode, source: CashOnDeliverySource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .enableCashOnDeliverySuccess,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.source: source.rawValue
                               ])
         }
@@ -1889,12 +1890,12 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - source: the screen which the enable attempt was made on
         ///
-        static func enableCashOnDeliveryFailed(countryCode: String,
+        static func enableCashOnDeliveryFailed(countryCode: CountryCode,
                                                error: Error?,
                                                source: CashOnDeliverySource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .enableCashOnDeliveryFailed,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.source: source.rawValue
                               ],
                               error: error)
@@ -1906,10 +1907,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - source: the screen which the disable attempt was made on
         ///
-        static func disableCashOnDeliverySuccess(countryCode: String, source: CashOnDeliverySource) -> WooAnalyticsEvent {
+        static func disableCashOnDeliverySuccess(countryCode: CountryCode, source: CashOnDeliverySource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .disableCashOnDeliverySuccess,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.source: source.rawValue
                               ])
         }
@@ -1920,12 +1921,12 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - source: the screen which the disable attempt was made on
         ///
-        static func disableCashOnDeliveryFailed(countryCode: String,
+        static func disableCashOnDeliveryFailed(countryCode: CountryCode,
                                                error: Error?,
                                                source: CashOnDeliverySource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .disableCashOnDeliveryFailed,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.source: source.rawValue
                               ],
                               error: error)
@@ -1937,10 +1938,10 @@ extension WooAnalyticsEvent {
         ///   - enabled: the reason why the onboarding step was shown (effectively the name of the step.)
         ///   - countryCode: the country code of the store.
         ///
-        static func paymentsHubCashOnDeliveryToggled(enabled: Bool, countryCode: String) -> WooAnalyticsEvent {
+        static func paymentsHubCashOnDeliveryToggled(enabled: Bool, countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .paymentsHubCashOnDeliveryToggled,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.enabled: enabled
                               ])
         }
@@ -1948,19 +1949,19 @@ extension WooAnalyticsEvent {
         /// Tracked when the user taps on the "See Receipt" button to view a receipt.
         /// - Parameter countryCode: the country code of the store.
         ///
-        static func receiptViewTapped(countryCode: String) -> WooAnalyticsEvent {
+        static func receiptViewTapped(countryCode: CountryCode) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptViewTapped,
-                              properties: [Keys.countryCode: countryCode])
+                              properties: [Keys.countryCode: countryCode.rawValue])
         }
 
         /// Tracked when the user taps on the "Email receipt" button after successfully collecting a payment to email a receipt.
         /// - Parameter countryCode: the country code of the store.
         /// - Parameter cardReaderModel: the model type of the card reader.
         ///
-        static func receiptEmailTapped(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptEmailTapped(countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailTapped,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.cardReaderModel: cardReaderModel
                               ].compactMapValues { $0 })
         }
@@ -1971,10 +1972,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func receiptEmailFailed(error: Error, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptEmailFailed(error: Error, countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailFailed,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.cardReaderModel: cardReaderModel
                               ].compactMapValues { $0 },
                               error: error)
@@ -1984,10 +1985,10 @@ extension WooAnalyticsEvent {
         /// - Parameter countryCode: the country code of the store.
         /// - Parameter cardReaderModel: the model type of the card reader.
         ///
-        static func receiptEmailCanceled(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptEmailCanceled(countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailCanceled,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.cardReaderModel: cardReaderModel
                               ].compactMapValues { $0 })
         }
@@ -1995,10 +1996,10 @@ extension WooAnalyticsEvent {
         /// Tracked when the receipt was sent by email.
         /// - Parameter countryCode: the country code of the store.
         ///
-        static func receiptEmailSuccess(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptEmailSuccess(countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .receiptEmailSuccess,
                               properties: [
-                                Keys.countryCode: countryCode,
+                                Keys.countryCode: countryCode.rawValue,
                                 Keys.cardReaderModel: cardReaderModel
                               ].compactMapValues { $0 })
         }
@@ -2006,9 +2007,9 @@ extension WooAnalyticsEvent {
         /// Tracked when the user tapped on the button to print a receipt.
         /// - Parameter countryCode: the country code of the store.
         ///
-        static func receiptPrintTapped(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptPrintTapped(countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [
-                Keys.countryCode: countryCode,
+                Keys.countryCode: countryCode.rawValue,
                 Keys.cardReaderModel: cardReaderModel
             ]
             return WooAnalyticsEvent(statName: .receiptPrintTapped,
@@ -2021,9 +2022,9 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the country code of the store.
         ///
-        static func receiptPrintFailed(error: Error, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptPrintFailed(error: Error, countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [
-                Keys.countryCode: countryCode,
+                Keys.countryCode: countryCode.rawValue,
                 Keys.cardReaderModel: cardReaderModel
             ]
             return WooAnalyticsEvent(statName: .receiptPrintFailed,
@@ -2035,9 +2036,9 @@ extension WooAnalyticsEvent {
         /// - Parameter countryCode: the country code of the store.
         /// - Parameter cardReaderModel: the country code of the store.
         ///
-        static func receiptPrintCanceled(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptPrintCanceled(countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [
-                Keys.countryCode: countryCode,
+                Keys.countryCode: countryCode.rawValue,
                 Keys.cardReaderModel: cardReaderModel
             ]
             return WooAnalyticsEvent(statName: .receiptPrintCanceled,
@@ -2048,9 +2049,9 @@ extension WooAnalyticsEvent {
         /// - Parameter countryCode: the country code of the store.
         /// - Parameter cardReaderModel: the country code of the store.
         ///
-        static func receiptPrintSuccess(countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func receiptPrintSuccess(countryCode: CountryCode, cardReaderModel: String?) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [
-                Keys.countryCode: countryCode,
+                Keys.countryCode: countryCode.rawValue,
                 Keys.cardReaderModel: cardReaderModel
             ]
             return WooAnalyticsEvent(statName: .receiptPrintSuccess,

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 final class CardPresentConfigurationLoader {
     init(stores: StoresManager = ServiceLocator.stores) {
@@ -9,8 +10,15 @@ final class CardPresentConfigurationLoader {
     }
 
     var configuration: CardPresentPaymentsConfiguration {
-        .init(
-            country: SiteAddress().countryCode
+        // The `.unknown` country avoids us unwrapping an optional everywhere.
+        // The configuration it results in will not support any card payments.
+        guard let countryCode = CountryCode(rawValue: SiteAddress().countryCode) else {
+            DDLogError("⛔️ Could not determine card payment configuration for country \(SiteAddress().countryCode)")
+            return .init(country: .unknown)
+        }
+
+        return .init(
+            country: countryCode
         )
     }
 }

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -12,13 +12,8 @@ final class CardPresentConfigurationLoader {
     var configuration: CardPresentPaymentsConfiguration {
         // The `.unknown` country avoids us unwrapping an optional everywhere.
         // The configuration it results in will not support any card payments.
-        guard let countryCode = CountryCode(rawValue: SiteAddress().countryCode) else {
-            DDLogError("⛔️ Could not determine card payment configuration for country \(SiteAddress().countryCode)")
-            return .init(country: .unknown)
-        }
+        let countryCode = SiteAddress().countryCode
 
-        return .init(
-            country: countryCode
-        )
+        return .init(country: countryCode)
     }
 }

--- a/WooCommerce/Classes/Tools/SiteAddress.swift
+++ b/WooCommerce/Classes/Tools/SiteAddress.swift
@@ -24,6 +24,7 @@ final class SiteAddress {
         return getValueFromSiteSettings(Constants.postalCode) ?? ""
     }
 
+    //TODO: make this an optional CountryCode
     var countryCode: String {
         return getValueFromSiteSettings(Constants.countryAndState)?.components(separatedBy: ":").first ?? ""
     }
@@ -36,7 +37,7 @@ final class SiteAddress {
         guard
             let code = getValueFromSiteSettings(Constants.countryAndState)?.components(separatedBy: ":").first,
             let countryCode = CountryCode(rawValue: code) else {
-                return nil
+            return nil
         }
 
         return countryCode.readableCountry
@@ -377,6 +378,8 @@ extension CountryCode {
             // Z
         case .ZM: return NSLocalizedString("Zambia", comment: "Country option for a site address.")
         case .ZW: return NSLocalizedString("Zimbabwe", comment: "Country option for a site address.")
+
+        case .unknown: return NSLocalizedString("Unknown country", comment: "Fallback country option for a site address.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
@@ -1,10 +1,11 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 struct ReceiptActionCoordinator {
     static func printReceipt(for order: Order,
                              params: CardPresentReceiptParameters,
-                             countryCode: String,
+                             countryCode: CountryCode,
                              cardReaderModel: String?,
                              stores: StoresManager,
                              analytics: Analytics = ServiceLocator.analytics) async {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -1,12 +1,13 @@
 import Combine
 import MessageUI
 import Yosemite
+import WooFoundation
 
 /// ViewModel supporting the receipt preview.
 final class ReceiptViewModel {
     private let order: Order
     private let receipt: CardPresentReceiptParameters
-    private let countryCode: String
+    private let countryCode: CountryCode
     private let stores: StoresManager
     private let analytics: Analytics
 
@@ -26,7 +27,7 @@ final class ReceiptViewModel {
     ///   - analytics: analytics to track receipt events
     init(order: Order,
          receipt: CardPresentReceiptParameters,
-         countryCode: String,
+         countryCode: CountryCode,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.order = order
@@ -66,7 +67,7 @@ final class ReceiptViewModel {
     /// Called when the user initiates emailing a receipt. Returns a tuple of:
     /// - Observable of necessary data for the email form
     /// - Country code for analytics in the email form
-    func emailReceiptTapped() -> AnyPublisher<(formData: CardPresentPaymentReceiptEmailCoordinator.EmailFormData, countryCode: String), Never> {
+    func emailReceiptTapped() -> AnyPublisher<(formData: CardPresentPaymentReceiptEmailCoordinator.EmailFormData, countryCode: CountryCode), Never> {
         analytics.track(event: .InPersonPayments
             .receiptEmailTapped(countryCode: countryCode,
                                 cardReaderModel: nil))

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -88,7 +88,7 @@ final class OrderDetailsDataSource: NSObject {
         let plugin = resultsControllers.sitePlugins.first { $0.name == SitePlugin.SupportedPlugin.WCShip }
         let isPluginInstalled = plugin != nil && resultsControllers.sitePlugins.count > 0
         let isPluginActive = plugin?.status.isActive ?? false
-        let isCountryCodeUS = SiteAddress(siteSettings: siteSettings).countryCode == CountryCode.US.rawValue
+        let isCountryCodeUS = SiteAddress(siteSettings: siteSettings).countryCode == CountryCode.US
         let isCurrencyUSD = currencySettings.currencyCode == .USD
 
         guard isFeatureFlagEnabled,

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import Yosemite
+import WooFoundation
 
 /// Tracks events during card reader connection flow, including reader connection and optional/required software update events.
 final class CardReaderConnectionAnalyticsTracker {
@@ -18,7 +19,7 @@ final class CardReaderConnectionAnalyticsTracker {
         (connectedReader ?? candidateReader)?.readerType.model ?? ""
     }
 
-    private var countryCode: String {
+    private var countryCode: CountryCode {
         configuration.countryCode
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -272,7 +272,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func checkOnboardingState() -> CardPresentPaymentOnboardingState {
-        guard let countryCode = storeCountryCode else {
+        guard storeCountryCode != .unknown else {
             DDLogError("[CardPresentPaymentsOnboarding] Couldn't determine country for store")
             return .genericError
         }
@@ -286,7 +286,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         // If isSupportedCountry is false, IPP is not supported in the country through any
         // payment gateway
         guard configuration.isSupportedCountry else {
-            return .countryNotSupported(countryCode: countryCode)
+            return .countryNotSupported(countryCode: storeCountryCode)
         }
 
         switch (wcPay, stripe) {
@@ -356,11 +356,11 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
     func stripeGatewayOnlyOnboardingState(plugin: SystemPlugin) -> CardPresentPaymentOnboardingState {
         guard isStripeSupportedInCountry else {
-            guard let countryCode = storeCountryCode else {
+            guard storeCountryCode != .unknown else {
                 DDLogError("[CardPresentPaymentsOnboarding] Couldn't determine country for store")
                 return .genericError
             }
-            return .countryNotSupportedStripe(plugin: .stripe, countryCode: countryCode)
+            return .countryNotSupportedStripe(plugin: .stripe, countryCode: storeCountryCode)
         }
 
         guard cardPresentPluginsDataProvider.isStripeVersionSupported(plugin: plugin)
@@ -433,12 +433,10 @@ private extension CardPresentPaymentsOnboardingUseCase {
         stores.sessionManager.defaultStoreID
     }
 
-    var storeCountryCode: CountryCode? {
+    var storeCountryCode: CountryCode {
         let siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager).siteSettings
         let storeAddress = SiteAddress(siteSettings: siteSettings)
-        let storeCountryCode = storeAddress.countryCode
-
-        return CountryCode(rawValue: storeCountryCode)
+        return storeAddress.countryCode
     }
 
     var storedPreferredPlugin: CardPresentPaymentsPlugin? {
@@ -558,12 +556,8 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func trackCardPresentPluginActionFailed(_ error: Error, trigger: PluginFailureTrigger) {
-        guard let countryCode = self.storeCountryCode else {
-            return
-        }
-
         analytics.track(event: .InPersonPayments.cardPresentOnboardingCtaFailed(reason: trigger.rawValue,
-                                                                                countryCode: countryCode,
+                                                                                countryCode: storeCountryCode,
                                                                                 error: error))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -3,6 +3,7 @@ import Foundation
 import Storage
 import Yosemite
 import Experiments
+import WooFoundation
 
 private typealias SystemPlugin = Yosemite.SystemPlugin
 private typealias PaymentGatewayAccount = Yosemite.PaymentGatewayAccount
@@ -432,12 +433,12 @@ private extension CardPresentPaymentsOnboardingUseCase {
         stores.sessionManager.defaultStoreID
     }
 
-    var storeCountryCode: String? {
+    var storeCountryCode: CountryCode? {
         let siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager).siteSettings
         let storeAddress = SiteAddress(siteSettings: siteSettings)
         let storeCountryCode = storeAddress.countryCode
 
-        return storeCountryCode.nonEmptyString()
+        return CountryCode(rawValue: storeCountryCode)
     }
 
     var storedPreferredPlugin: CardPresentPaymentsPlugin? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Yosemite
 import Experiments
+import WooFoundation
 
 final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPresentedViewModel {
     @Published var state: CardPresentPaymentOnboardingState
@@ -143,7 +144,7 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
 }
 
 private extension InPersonPaymentsViewModel {
-    var countryCode: String {
+    var countryCode: CountryCode {
         CardPresentConfigurationLoader().configuration.countryCode
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
@@ -40,7 +40,7 @@ struct InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView: View {
 struct InPersonPaymentsCodPaymentGatewayNotSetUp_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(
-            configuration: CardPresentPaymentsConfiguration(country: "US"),
+            configuration: CardPresentPaymentsConfiguration(country: .US),
             plugin: .wcPay,
             analyticReason: "",
             completion: {})

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -1,7 +1,8 @@
 import SwiftUI
+import WooFoundation
 
 struct InPersonPaymentsCountryNotSupported: View {
-    let countryCode: String
+    let countryCode: CountryCode
     let analyticReason: String
 
     var body: some View {
@@ -19,8 +20,8 @@ struct InPersonPaymentsCountryNotSupported: View {
     }
 
     var title: String {
-        guard let countryName = Locale.current.localizedString(forRegionCode: countryCode) else {
-            DDLogError("In-Person Payments unsupported in country code \(countryCode), which can't be localized")
+        guard let countryName = Locale.current.localizedString(forRegionCode: countryCode.rawValue) else {
+            DDLogError("In-Person Payments unsupported in country code \(countryCode.rawValue), which can't be localized")
             return Localization.titleUnknownCountry
         }
         return String(format: Localization.title, countryName)
@@ -47,8 +48,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupported_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "ES", analyticReason: "")
+        InPersonPaymentsCountryNotSupported(countryCode: .ES, analyticReason: "")
         // Invalid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "OO", analyticReason: "")
+        InPersonPaymentsCountryNotSupported(countryCode: .unknown, analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -1,7 +1,8 @@
 import SwiftUI
+import WooFoundation
 
 struct InPersonPaymentsCountryNotSupportedStripe: View {
-    let countryCode: String
+    let countryCode: CountryCode
     let analyticReason: String
 
     var body: some View {
@@ -19,8 +20,8 @@ struct InPersonPaymentsCountryNotSupportedStripe: View {
     }
 
     var title: String {
-        guard let countryName = Locale.current.localizedString(forRegionCode: countryCode) else {
-            DDLogError("In-Person Payments unsupported in country code \(countryCode), which can't be localized")
+        guard let countryName = Locale.current.localizedString(forRegionCode: countryCode.rawValue) else {
+            DDLogError("In-Person Payments unsupported in country code \(countryCode.rawValue), which can't be localized")
             return Localization.titleUnknownCountry
         }
         return String(format: Localization.title, countryName)
@@ -47,8 +48,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupportedStripe_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES", analyticReason: "")
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: .ES, analyticReason: "")
         // Invalid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO", analyticReason: "")
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: .unknown, analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentReceiptEmailCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentReceiptEmailCoordinator.swift
@@ -1,11 +1,12 @@
 import MessageUI
 import UIKit
 import struct Yosemite.Order
+import WooFoundation
 
 /// Coordinates the navigation from a given view controller to present a mail composer for a card-present payment receipt.
 final class CardPresentPaymentReceiptEmailCoordinator: NSObject {
     private let analytics: Analytics
-    private let countryCode: String
+    private let countryCode: CountryCode
     private let cardReaderModel: String?
 
     private var completion: (() -> Void)?
@@ -22,7 +23,7 @@ final class CardPresentPaymentReceiptEmailCoordinator: NSObject {
         let storeName: String?
     }
 
-    init(analytics: Analytics = ServiceLocator.analytics, countryCode: String, cardReaderModel: String?) {
+    init(analytics: Analytics = ServiceLocator.analytics, countryCode: CountryCode, cardReaderModel: String?) {
         self.analytics = analytics
         self.countryCode = countryCode
         self.cardReaderModel = cardReaderModel

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -595,7 +595,7 @@ private extension ShippingLabelFormViewModel {
                               city: siteAddress.city,
                               state: siteAddress.state,
                               postcode: siteAddress.postalCode,
-                              country: siteAddress.countryCode,
+                              country: siteAddress.countryCode.rawValue,
                               phone: userDefaults[.storePhoneNumber] ?? "",
                               email: account?.email)
         return fromAddressToShippingLabelAddress(address: address)
@@ -713,7 +713,7 @@ private extension ShippingLabelFormViewModel {
                       value: item.value,
                       weight: item.weight,
                       hsTariffNumber: "",
-                      originCountry: originAddress?.country ?? SiteAddress().countryCode,
+                      originCountry: originAddress?.country ?? SiteAddress().countryCode.rawValue,
                       productID: item.productOrVariationID)
             }
             return ShippingLabelCustomsForm(packageID: package.id, packageName: packageName, items: items)

--- a/WooCommerce/WooCommerceTests/Tools/SiteAddressTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/SiteAddressTests.swift
@@ -16,7 +16,7 @@ final class SiteAddressTests: XCTestCase {
         XCTAssertEqual(siteAddress.address2, "")
         XCTAssertEqual(siteAddress.city, "Auburn")
         XCTAssertEqual(siteAddress.postalCode, "13021")
-        XCTAssertEqual(siteAddress.countryCode, "US")
+        XCTAssertEqual(siteAddress.countryCode, .US)
         XCTAssertEqual(siteAddress.countryName, "United States")
         XCTAssertEqual(siteAddress.state, "NY")
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentPaymentReceiptEmailCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentPaymentReceiptEmailCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+import WooFoundation
 
 final class CardPresentPaymentReceiptEmailCoordinatorTests: XCTestCase {
     private var coordinator: CardPresentPaymentReceiptEmailCoordinator!
@@ -100,7 +101,7 @@ final class CardPresentPaymentReceiptEmailCoordinatorTests: XCTestCase {
 
 private extension CardPresentPaymentReceiptEmailCoordinatorTests {
     enum Mocks {
-        static let countryCode = "CA"
+        static let countryCode = CountryCode.CA
         static let cardReaderModel = "CHIPPER_2X"
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -220,7 +220,7 @@ private extension CollectOrderPaymentUseCaseTests {
 
 private extension CollectOrderPaymentUseCaseTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US")
+        static let configuration = CardPresentPaymentsConfiguration(country: .US)
         static let cardReaderModel: String = "WISEPAD_3"
         static let paymentGatewayAccount: String = "woocommerce-payments"
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -483,7 +483,7 @@ private extension RefundSubmissionUseCaseTests {
 
 private extension RefundSubmissionUseCaseTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US")
+        static let configuration = CardPresentPaymentsConfiguration(country: .US)
         static let cardReaderModel: String = "WISEPAD_3"
         static let paymentGatewayID: String = "woocommerce-payments"
         static let siteID: Int64 = 322

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -95,7 +95,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .countryNotSupported(countryCode: "ES"))
+        XCTAssertEqual(state, .countryNotSupported(countryCode: .ES))
     }
 
     func test_onboarding_does_not_return_country_unsupported_with_canada_when_neither_wcpay_nor_stripe_plugin_installed() {
@@ -109,7 +109,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: .CA))
     }
 
     func test_onboarding_returns_country_unsupported_with_canada_when_stripe_plugin_installed() {
@@ -124,7 +124,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .countryNotSupportedStripe(plugin: .stripe, countryCode: "CA"))
+        XCTAssertEqual(state, .countryNotSupportedStripe(plugin: .stripe, countryCode: .CA))
     }
 
     func test_onboarding_returns_setup_not_completed_stripe_when_stripe_and_wcPay_plugins_are_installed_in_Canada() {
@@ -185,7 +185,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: .CA))
     }
 
     func test_onboarding_does_not_return_country_unsupported_with_uk_when_neither_wcpay_nor_stripe_plugin_installed() {
@@ -199,7 +199,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "GB"))
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: .GB))
     }
 
     func test_onboarding_returns_country_unsupported_with_uk_when_stripe_plugin_installed() {
@@ -214,7 +214,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .countryNotSupportedStripe(plugin: .stripe, countryCode: "GB"))
+        XCTAssertEqual(state, .countryNotSupportedStripe(plugin: .stripe, countryCode: .GB))
     }
 
     func test_onboarding_returns_setup_not_completed_stripe_when_stripe_and_wcPay_plugins_are_installed_in_UK() {
@@ -275,7 +275,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "GB"))
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: .GB))
     }
 
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -526,6 +526,6 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
 private extension CardReaderConnectionControllerTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US")
+        static let configuration = CardPresentPaymentsConfiguration(country: .US)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/ReceiptActionCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/ReceiptActionCoordinatorTests.swift
@@ -35,11 +35,11 @@ final class ReceiptActionCoordinatorTests: XCTestCase {
 
         // When
         await ReceiptActionCoordinator.printReceipt(for: order,
-                                              params: params,
-                                              countryCode: "CA",
-                                              cardReaderModel: "WISEPAD_3",
-                                              stores: storesManager,
-                                              analytics: WooAnalytics(analyticsProvider: analytics))
+                                                    params: params,
+                                                    countryCode: .CA,
+                                                    cardReaderModel: "WISEPAD_3",
+                                                    stores: storesManager,
+                                                    analytics: WooAnalytics(analyticsProvider: analytics))
 
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.receiptPrintTapped.rawValue}))
@@ -68,10 +68,10 @@ final class ReceiptActionCoordinatorTests: XCTestCase {
 
         // When
         await ReceiptActionCoordinator.printReceipt(for: order,
-                                              params: params,
-                                              countryCode: "CA",
-                                              cardReaderModel: nil,
-                                              stores: storesManager, analytics: ServiceLocator.analytics)
+                                                    params: params,
+                                                    countryCode: .CA,
+                                                    cardReaderModel: nil,
+                                                    stores: storesManager, analytics: ServiceLocator.analytics)
 
         //Then
         XCTAssertEqual(storesManager.receivedActions.count, 1)
@@ -122,11 +122,11 @@ extension ReceiptActionCoordinatorTests {
 
         // When
         await ReceiptActionCoordinator.printReceipt(for: order,
-                                              params: params,
-                                              countryCode: "CA",
-                                              cardReaderModel: cardReaderModel,
-                                              stores: storesManager,
-                                              analytics: WooAnalytics(analyticsProvider: analytics))
+                                                    params: params,
+                                                    countryCode: .CA,
+                                                    cardReaderModel: cardReaderModel,
+                                                    stores: storesManager,
+                                                    analytics: WooAnalytics(analyticsProvider: analytics))
 
         // Then
         let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == analytic.rawValue}))

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/ReceiptViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/ReceiptViewModelTests.swift
@@ -20,7 +20,7 @@ final class ReceiptViewModelTests: XCTestCase {
 
     func test_generateContent_dispatches_ReceiptAction_and_sends_content() {
         // Given
-        let viewModel = ReceiptViewModel(order: .fake(), receipt: .fake(), countryCode: "", stores: stores)
+        let viewModel = ReceiptViewModel(order: .fake(), receipt: .fake(), countryCode: .unknown, stores: stores)
         let mockContent = "A receipt"
         stores.whenReceivingAction(ofType: ReceiptAction.self) { action in
             if case let .generateContent(_, _, onContent) = action {
@@ -43,7 +43,7 @@ final class ReceiptViewModelTests: XCTestCase {
     func test_emailReceiptTapped_after_generateContent_does_not_dispatch_ReceiptAction_and_returns_latest_content() {
         // Given
         let order = Order.fake()
-        let viewModel = ReceiptViewModel(order: order, receipt: .fake(), countryCode: "CA", stores: stores)
+        let viewModel = ReceiptViewModel(order: order, receipt: .fake(), countryCode: .CA, stores: stores)
 
         let mockStoreName = "All the sweets"
         var sessionManager = stores.sessionManager
@@ -70,7 +70,7 @@ final class ReceiptViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(dataAndCountryCode.formData, .init(content: mockContent, order: order, storeName: mockStoreName))
-        XCTAssertEqual(dataAndCountryCode.countryCode, "CA")
+        XCTAssertEqual(dataAndCountryCode.countryCode, .CA)
         XCTAssertEqual(generateContentInvocationCount, 1)
     }
 
@@ -80,7 +80,7 @@ final class ReceiptViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let viewModel = ReceiptViewModel(order: order,
                                          receipt: .fake(),
-                                         countryCode: "CA",
+                                         countryCode: .CA,
                                          analytics: WooAnalytics(analyticsProvider: analyticsProvider))
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
@@ -606,6 +606,6 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
 
 private extension BluetoothCardReaderSettingsConnectedViewModelTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US")
+        static let configuration = CardPresentPaymentsConfiguration(country: .US)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsSearchingViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 private struct TestConstants {
     static let mockReaderID = "CHB204909005931"
-    static let mockConfiguration = CardPresentPaymentsConfiguration(country: "US")
+    static let mockConfiguration = CardPresentPaymentsConfiguration(country: .US)
 }
 
 final class CardReaderSettingsSearchingViewModelTests: XCTestCase {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift
@@ -32,7 +32,7 @@ final class InPersonPaymentsCashOnDeliveryToggleRowViewModelTests: XCTestCase {
         noticePresenter = MockNoticePresenter()
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        configuration = CardPresentPaymentsConfiguration(country: .US)
 
         dependencies = InPersonPaymentsCashOnDeliveryToggleRowViewModel.Dependencies(
             stores: stores,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -25,7 +25,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         let dependencies = InPersonPaymentsMenuViewModel.Dependencies(stores: stores,
                                                                       analytics: analytics)
 
-        configuration = CardPresentPaymentsConfiguration(country: "US")
+        configuration = CardPresentPaymentsConfiguration(country: .US)
 
         sut = InPersonPaymentsMenuViewModel(dependencies: dependencies,
                                             cardPresentPaymentsConfiguration: configuration)
@@ -81,7 +81,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         let dependencies = InPersonPaymentsMenuViewModel.Dependencies(stores: stores,
                                                                       analytics: analytics)
 
-        let configuration = CardPresentPaymentsConfiguration(countryCode: "IN",
+        let configuration = CardPresentPaymentsConfiguration(countryCode: .IN,
                                                              paymentMethods: [.cardPresent],
                                                              currencies: [.INR],
                                                              paymentGateways: [WCPayAccount.gatewayID],
@@ -106,7 +106,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         let dependencies = InPersonPaymentsMenuViewModel.Dependencies(stores: stores,
                                                                       analytics: analytics)
 
-        let configuration = CardPresentPaymentsConfiguration(countryCode: "IN",
+        let configuration = CardPresentPaymentsConfiguration(countryCode: .IN,
                                                              paymentMethods: [.cardPresent],
                                                              currencies: [.INR],
                                                              paymentGateways: [WCPayAccount.gatewayID],

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
@@ -25,7 +25,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         noticePresenter = MockNoticePresenter()
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        configuration = CardPresentPaymentsConfiguration(country: .US)
         dependencies = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.Dependencies(
             stores: stores,
             noticePresenter: noticePresenter,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -12,7 +12,7 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
     private var onboardingCache: CardPresentPaymentOnboardingStateCache!
     private var sut: TapToPayReconnectionController!
     private let sampleSiteID: Int64 = 12891
-    private let sampleConfiguration: CardPresentPaymentsConfiguration = CardPresentPaymentsConfiguration(country: "US")
+    private let sampleConfiguration: CardPresentPaymentsConfiguration = CardPresentPaymentsConfiguration(country: .US)
 
     override func setUp() {
         let sessionManager = SessionManager.makeForTesting()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -427,7 +427,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration(country: "US"),
+                                                cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration(country: .US),
                                                 currencySettings: currencySettings,
                                                 siteSettings: [siteSetting],
                                                 userIsAdmin: true,
@@ -733,6 +733,6 @@ private extension OrderDetailsDataSourceTests {
 
 private extension OrderDetailsDataSourceTests {
     enum Mocks {
-        static let configuration = CardPresentPaymentsConfiguration(country: "US")
+        static let configuration = CardPresentPaymentsConfiguration(country: .US)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -268,7 +268,7 @@ final class OrderListViewModelTests: XCTestCase {
         // Given
         insertCODPaymentGateway()
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "US"),
+                                           cardPresentPaymentsConfiguration: .init(country: .US),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -321,7 +321,7 @@ final class OrderListViewModelTests: XCTestCase {
         insertCODPaymentGateway()
         let isIPPFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner)
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "US"),
+                                           cardPresentPaymentsConfiguration: .init(country: .US),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -566,7 +566,7 @@ final class OrderListViewModelTests: XCTestCase {
         )
 
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "US"),
+                                           cardPresentPaymentsConfiguration: .init(country: .US),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -593,7 +593,7 @@ final class OrderListViewModelTests: XCTestCase {
         )
 
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "US"),
+                                           cardPresentPaymentsConfiguration: .init(country: .US),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -622,7 +622,7 @@ final class OrderListViewModelTests: XCTestCase {
         )
 
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "AQ"), // Antarctica ;)
+                                           cardPresentPaymentsConfiguration: .init(country: .AQ), // Antarctica ;)
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -652,7 +652,7 @@ final class OrderListViewModelTests: XCTestCase {
         )
 
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "US"),
+                                           cardPresentPaymentsConfiguration: .init(country: .US),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -670,7 +670,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_feedbackBannerSurveySource_when_there_are_less_than_ten_wcpay_orders_then_assigns_inPersonPaymentsFirstTransaction_survey() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "CA"),
+                                           cardPresentPaymentsConfiguration: .init(country: .CA),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -700,7 +700,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_feedbackBannerSurveySource_when_there_are_less_than_ten_wcpay_orders_all_older_than_30_days_then_no_survey() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "CA"),
+                                           cardPresentPaymentsConfiguration: .init(country: .CA),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -731,7 +731,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_feedbackBannerSurveySource_when_there_are_more_than_ten_wcpay_orders_then_assigns_inPersonPaymentsPowerUsers_survey() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "CA"),
+                                           cardPresentPaymentsConfiguration: .init(country: .CA),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
@@ -761,7 +761,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_feedbackBannerSurveySource_when_there_are_ten_or_more_wcpay_ipp_orders_all_older_than_30_days_then_assigns_inPersonPaymentsPowerUsers_survey() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: "CA"),
+                                           cardPresentPaymentsConfiguration: .init(country: .CA),
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -521,7 +521,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storage = MockStorageManager()
-        let configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
 
         // When
         simulate(cardPaymentEligibility: true, tapToPayDeviceAvailability: false, on: stores)
@@ -542,7 +542,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storage = MockStorageManager()
-        let configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
 
         simulate(cardPaymentEligibility: true, tapToPayDeviceAvailability: true, on: stores)
 
@@ -563,7 +563,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storage = MockStorageManager()
-        let configuration = CardPresentPaymentsConfiguration.init(country: "CA")
+        let configuration = CardPresentPaymentsConfiguration(country: .CA)
 
         simulate(cardPaymentEligibility: true, tapToPayDeviceAvailability: true, on: stores)
 
@@ -584,7 +584,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storage = MockStorageManager()
-        let configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
         stores.whenReceivingAction(ofType: OrderCardPresentPaymentEligibilityAction.self) { action in
             switch action {
             case let .orderIsEligibleForCardPresentPayment(_, _, _, completion):
@@ -611,7 +611,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storage = MockStorageManager()
-        let configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
 
         simulate(cardPaymentEligibility: false, tapToPayDeviceAvailability: true, on: stores)
 
@@ -632,7 +632,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storage = MockStorageManager()
-        let configuration = CardPresentPaymentsConfiguration.init(country: "AQ")
+        let configuration = CardPresentPaymentsConfiguration(country: .AQ)
 
         simulate(cardPaymentEligibility: true, tapToPayDeviceAvailability: true, on: stores)
 

--- a/WooFoundation/WooFoundation/Countries/CountryCode.swift
+++ b/WooFoundation/WooFoundation/Countries/CountryCode.swift
@@ -305,4 +305,6 @@ public enum CountryCode: String, CaseIterable {
     // Z
     case ZM
     case ZW
+
+    case unknown
 }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -1,3 +1,5 @@
+import WooFoundation
+
 /// Represents the possible states for onboarding to In-Person payments
 public enum CardPresentPaymentOnboardingState: Equatable {
     /// The app is loading the required data to check for the current state
@@ -21,11 +23,11 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 
     /// Store is not located in one of the supported countries.
     ///
-    case countryNotSupported(countryCode: String)
+    case countryNotSupported(countryCode: CountryCode)
 
     /// Only Stripe is installed and activated, but the store is not located in one of the supported countries for Stripe (but it is for WCPay).
     ///
-    case countryNotSupportedStripe(plugin: CardPresentPaymentsPlugin, countryCode: String)
+    case countryNotSupportedStripe(plugin: CardPresentPaymentsPlugin, countryCode: CountryCode)
 
     /// No CPP plugin is installed on the store.
     ///

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -2,7 +2,7 @@ import Foundation
 import WooFoundation
 
 public struct CardPresentPaymentsConfiguration: Equatable {
-    public let countryCode: String
+    public let countryCode: CountryCode
     public let paymentMethods: [WCPayPaymentMethodType]
     public let currencies: [CurrencyCode]
     public let paymentGateways: [String]
@@ -11,7 +11,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
     public let minimumAllowedChargeAmount: NSDecimalNumber
     public let stripeSmallestCurrencyUnitMultiplier: Decimal
 
-    init(countryCode: String,
+    init(countryCode: CountryCode,
          paymentMethods: [WCPayPaymentMethodType],
          currencies: [CurrencyCode],
          paymentGateways: [String],
@@ -29,10 +29,10 @@ public struct CardPresentPaymentsConfiguration: Equatable {
         self.stripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
     }
 
-    public init(country: String) {
+    public init(country: CountryCode) {
         /// Changing `minimumVersion` values here? You'll need to also update `CardPresentPaymentsOnboardingUseCaseTests`
         switch country {
-        case "US":
+        case .US:
             self.init(
                 countryCode: country,
                 paymentMethods: [.cardPresent],
@@ -46,7 +46,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
-        case "CA":
+        case .CA:
             self.init(
                 countryCode: country,
                 paymentMethods: [.cardPresent, .interacPresent],
@@ -57,7 +57,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
-        case "GB":
+        case .GB:
             self.init(
                 countryCode: country,
                 paymentMethods: [.cardPresent],
@@ -89,7 +89,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
     /// Given a two character country code, returns a URL where the merchant can purchase a card reader.
     ///
     public func purchaseCardReaderUrl(utmProvider: UTMParametersProviding) -> URL {
-        let urlString = Constants.purchaseReaderForCountryUrlBase + countryCode
+        let urlString = Constants.purchaseReaderForCountryUrlBase + countryCode.rawValue
         return utmProvider.urlWithUtmParams(string: urlString) ?? Constants.fallbackInPersonPaymentsUrl
     }
 }

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -6,7 +6,7 @@ import WooFoundation
 class CardPresentConfigurationTests: XCTestCase {
     // MARK: - US Tests
     func test_configuration_for_US() throws {
-        let configuration = CardPresentPaymentsConfiguration(country: "US")
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
         XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [.USD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
@@ -16,7 +16,7 @@ class CardPresentConfigurationTests: XCTestCase {
 
     // MARK: - Canada Tests
     func test_configuration_for_Canada() throws {
-        let configuration = CardPresentPaymentsConfiguration(country: "CA")
+        let configuration = CardPresentPaymentsConfiguration(country: .CA)
         XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [.CAD])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])

--- a/Yosemite/YosemiteTests/Stores/Order/Order+CardPresentPaymentTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/Order+CardPresentPaymentTests.swift
@@ -2,10 +2,11 @@
 
 import Foundation
 import XCTest
+import WooFoundation
 
 final class Order_CardPresentPaymentTests: XCTestCase {
     private static let currency = "USD"
-    private static let country = "US"
+    private static let country = CountryCode.US
     private let configuration = CardPresentPaymentsConfiguration(country: Order_CardPresentPaymentTests.country)
     private let eligibleOrder = Order.fake().copy(status: .pending,
                                                currency: Order_CardPresentPaymentTests.currency,

--- a/Yosemite/YosemiteTests/Stores/OrderCardPresentPaymentEligibilityStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderCardPresentPaymentEligibilityStoreTests.swift
@@ -58,7 +58,7 @@ final class OrderCardPresentPaymentEligibilityStoreTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: nonSubscriptionProduct)
         storageManager.insertSampleOrder(readOnlyOrder: cppEligibleOrder)
 
-        let configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
 
         // When
         let result = waitFor { promise in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10890
Merge after: #10909
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We'll add Tap to Pay on iPhone support for UK WooPayments merchants. 

This PR uses the previously extracted CountryCode enum in the CardPresentPaymentsConfiguration (as well as in Shipping Labels) instead of a raw string, for safer country checks and simpler localization in the app layer. This will enable us to keep app layer checks out of the business logic layer configuration.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This PR doesn't make any functional changes. Affected areas are CardPresentPaymentConfiguration, and Shipping Labels.

In particular, check for: 
- Country code should still be present in Card Present Payment related analytic events
- Shipping Labels should be promoted on the Order Details page for completed orders in the US – either as a prompt to install the plugin, or a button to purchase a shipping label if it's already installed.
- The `From` address should correctly show the country (as a code initially, then with its name when you tap on `Next` and see the detailed form)

It's worth checking some payment flows – the TTPUK work is not in this tree, so on this PR, only US should offer TTP and card readers, while GB and CA should offer card readers only.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
