### PR TITLE
[TTPUK] Rename Tap to Pay row after first transaction

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 15.8
 -----
 - [*] Users can now navigate to other orders without leaving the Order Detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/10849]
-
+- [*] The Set up Tap to Pay on iPhone row in the Payments menu now reflects when you've completed set up for the current device and store [https://github.com/woocommerce/woocommerce-ios/pull/10923]
 
 15.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -385,7 +385,7 @@ private extension InPersonPaymentsMenuViewController {
         prepareForReuse(cell)
         cell.accessibilityIdentifier = "set-up-tap-to-pay"
         cell.configure(image: .tapToPayOnIPhoneIcon,
-                       text: Localization.tapToPayOnIPhone,
+                       text: viewModel.titleForTapToPayOnIPhone,
                        showBadge: viewModel.shouldBadgeTapToPayOnIPhone)
     }
 
@@ -443,6 +443,14 @@ private extension InPersonPaymentsMenuViewController {
         }.store(in: &cancellables)
 
         viewModel.$shouldBadgeTapToPayOnIPhone.sink { [weak self] _ in
+            self?.configureSections()
+            // ensures that the cell will be configured with the correct value for the badge
+            DispatchQueue.main.async {
+                self?.tableView.reloadData()
+            }
+        }.store(in: &cancellables)
+
+        viewModel.$titleForTapToPayOnIPhone.sink { [weak self] _ in
             self?.configureSections()
             // ensures that the cell will be configured with the correct value for the badge
             DispatchQueue.main.async {
@@ -729,11 +737,6 @@ private extension InPersonPaymentsMenuViewController {
             "Collect Payment",
             comment: "Navigates to Collect a payment via the Simple Payment screen"
         )
-
-        static let tapToPayOnIPhone = NSLocalizedString(
-            "Set up Tap to Pay on iPhone",
-            comment: "Navigates to the Tap to Pay on iPhone set up flow. The full name is expected by Apple. " +
-            "The destination screen also allows for a test payment, after set up.")
 
         static let aboutTapToPayOnIPhone = NSLocalizedString(
             "About Tap to Pay on iPhone",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -44,6 +44,7 @@ final class InPersonPaymentsMenuViewModel {
     @Published private(set) var shouldShowTapToPayOnIPhoneFeedbackRow: Bool = false
     @Published private(set) var shouldBadgeTapToPayOnIPhone: Bool = false
     @Published private(set) var depositsOverviewViewModels: [WooPaymentsDepositsCurrencyOverviewViewModel] = []
+    @Published private(set) var titleForTapToPayOnIPhone: String = Localization.setUpTapToPayOnIPhoneRowTitle
 
     let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
@@ -61,6 +62,7 @@ final class InPersonPaymentsMenuViewModel {
         synchronizePaymentGateways(siteID: siteID)
         checkTapToPaySupport(siteID: siteID)
         checkShouldShowTapToPayFeedbackRow(siteID: siteID)
+        refreshTitleForTapToPay(siteID: siteID)
         registerForNotifications()
         updateDepositsOverview()
     }
@@ -87,32 +89,54 @@ final class InPersonPaymentsMenuViewModel {
     }
 
     private func checkShouldShowTapToPayFeedbackRow(siteID: Int64) {
-        let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(
-            siteID: siteID,
-            cardReaderType: .appleBuiltIn) { [weak self] firstTapToPayTransactionDate in
-                guard let self = self else { return }
-                guard let firstTapToPayTransactionDate = firstTapToPayTransactionDate,
-                      let thirtyDaysAgo = Calendar.current.date(byAdding: DateComponents(day: -30), to: Date()) else {
-                    return self.shouldShowTapToPayOnIPhoneFeedbackRow = false
-                }
+        Task { @MainActor in
+            guard let firstTapToPayTransactionDate = await firstTapToPayTransactionDate(siteID: siteID),
+                  let thirtyDaysAgo = Calendar.current.date(byAdding: DateComponents(day: -30), to: Date()) else {
+                return self.shouldShowTapToPayOnIPhoneFeedbackRow = false
+            }
 
-                self.shouldShowTapToPayOnIPhoneFeedbackRow = firstTapToPayTransactionDate >= thirtyDaysAgo
+            self.shouldShowTapToPayOnIPhoneFeedbackRow = firstTapToPayTransactionDate >= thirtyDaysAgo
         }
-        stores.dispatch(action)
+    }
+
+    @MainActor
+    private func firstTapToPayTransactionDate(siteID: Int64) async -> Date? {
+        let date = await withCheckedContinuation { continuation in
+            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(
+                siteID: siteID,
+                cardReaderType: .appleBuiltIn) { firstTapToPayTransactionDate in
+                    continuation.resume(with: .success(firstTapToPayTransactionDate))
+            }
+            stores.dispatch(action)
+        }
+        return date
+    }
+
+    private func refreshTitleForTapToPay(siteID: Int64) {
+        Task { @MainActor in
+            let firstTapToPayTransactionDate = await firstTapToPayTransactionDate(siteID: siteID)
+            switch firstTapToPayTransactionDate {
+            case .none:
+                self.titleForTapToPayOnIPhone = Localization.setUpTapToPayOnIPhoneRowTitle
+            case .some:
+                self.titleForTapToPayOnIPhone = Localization.tryOutTapToPayOnIPhoneRowTitle
+            }
+        }
     }
 
     private func registerForNotifications() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(refreshTapToPayFeedbackVisibility),
+                                               selector: #selector(refreshTapToPayRows),
                                                name: .firstInPersonPaymentsTransactionsWereUpdated,
                                                object: nil)
     }
 
-    @objc func refreshTapToPayFeedbackVisibility() {
+    @objc func refreshTapToPayRows() {
         guard let siteID = siteID else {
             return
         }
         checkShouldShowTapToPayFeedbackRow(siteID: siteID)
+        refreshTitleForTapToPay(siteID: siteID)
     }
 
     func orderCardReaderPressed() {
@@ -158,4 +182,18 @@ final class InPersonPaymentsMenuViewModel {
 private enum Constants {
     static let utmCampaign = "payments_menu_item"
     static let utmSource = "payments_menu"
+}
+
+private extension InPersonPaymentsMenuViewModel {
+    enum Localization {
+        static let setUpTapToPayOnIPhoneRowTitle = NSLocalizedString(
+            "Set up Tap to Pay on iPhone",
+            comment: "Navigates to the Tap to Pay on iPhone set up flow. The full name is expected by Apple. " +
+            "The destination screen also allows for a test payment, after set up.")
+
+        static let tryOutTapToPayOnIPhoneRowTitle = NSLocalizedString(
+            "Try out Tap to Pay on iPhone",
+            comment: "Navigates to the Tap to Pay on iPhone set up flow, after set up has been completed, when it " +
+            "primarily allows for a test payment. The full name is expected by Apple.")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10866
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We previously showed the `Set up Tap to Pay on iPhone` row with that title even after set up was complete. This was because it’s not possible for us to query the phone or Stripe for whether set up has been completed.

Set up needs to be completed for each store/device that’s used with TTP.

This PR adds a check for whether a TTP transaction has taken place using this site and phone, and if it has, changes the title to `Try out Tap to Pay`.

Users still may see a `Set up` screen when they tap on it, if they’re not connected to the built in reader. Most users will be connected though, due to TTP autoconnection on foreground.

This Set up screen simply connects to the reader and then leads them in to the Try out flow.

By making this change, we avoid making people on the Payments Menu think that they’ve not successfully set up Tap to Pay.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Delete the app (this removes any previously stored first TTP transaction date)
2. Build and run the app from Xcode
3. Log in to your account, and select a WooPayments store for the US or UK
4. Navigate to `Menu > Payments`
5. Observe that the `Set up Tap to Pay on iPhone` row is visible
6. Tap it, and go through the set up flow. 
7. Do a test payment
8. Close the order details screen you see at the end of the test payment flow
9. Observe that the row is now titled `Try out Tap to Pay on iPhone`
10. Force quit and relaunch the app with the same store – navigate back and see that the row is still correctly titled.
11. Switch to another US/UK WooPayments store
12. Navigate to the Payments menu and observe that the row is `Set up Tap to Pay on iPhone` for this store.



Note that if you close at the end of the set up flow without doing a test payment, the title will remain `Set up Tap to Pay on iPhone` – this is a known issue, we're just making it a bit better using the tools we have. We could make it better by also storing the first TTP reader connection date per site, but not in this project.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/b68f98f5-4393-40f8-8f29-f494282b0d79


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
