### PR TITLE
Configure UI tests to always store screenshots

### DIFF
--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -20,7 +20,8 @@
 
     ],
     "maximumTestRepetitions" : 2,
-    "testRepetitionMode" : "retryOnFailure"
+    "testRepetitionMode" : "retryOnFailure",
+    "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [
     {


### PR DESCRIPTION
## Description

Previously, the UI tests would deleted the screenshots in case of a successful run. I feel that's a reasonable default because it does not waste space. However, storage is cheap and we can build tooling to garbage collect if necessary and I just run an investigation in which it would have been useful to observe the recording for a successful test. It's conceivable to imagine we'll run in similar situations in the future and I believe we won't regret storing these assets.

![image](https://github.com/woocommerce/woocommerce-ios/assets/1218433/e9f2271f-0bab-4e97-b803-28f4d27cb8b7)

What do you think? Is it worth it?

## Testing instructions
Ensure CI is green.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.
