### PR TITLE
Blaze Optimization: Campaign list item UI

### DIFF
--- a/Networking/Networking/Model/BlazeCampaign.swift
+++ b/Networking/Networking/Model/BlazeCampaign.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Ads campaign powered by Blaze
 ///
-public final class BlazeCampaign: Decodable, GeneratedFakeable, GeneratedCopiable {
+public struct BlazeCampaign: Decodable, GeneratedFakeable, GeneratedCopiable {
 
     /// Site Identifier.
     ///

--- a/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import Yosemite
+
+/// Customizations for campaign status
+extension BlazeCampaign.Status {
+    var displayText: String {
+        switch self {
+        case .active:
+            return Localization.active
+        case .approved:
+            return Localization.approved
+        case .created:
+            return Localization.created
+        case .scheduled:
+            return Localization.scheduled
+        case .finished:
+            return Localization.completed
+        case .canceled:
+            return Localization.canceled
+        case .rejected:
+            return Localization.rejected
+        case .processing:
+            return Localization.inModeration
+        case .unknown:
+            return Localization.unknown
+        }
+    }
+
+    var textColor: Color {
+        switch self {
+        case .active, .approved, .created, .scheduled:
+            return .withColorStudio(name: .green, shade: .shade60)
+        case .finished:
+            return .withColorStudio(name: .blue, shade: .shade80)
+        case .canceled, .rejected:
+            return .withColorStudio(name: .red, shade: .shade60)
+        case .processing:
+            return .withColorStudio(name: .yellow, shade: .shade70)
+        case .unknown:
+            return .withColorStudio(name: .gray, shade: .shade70)
+        }
+    }
+
+    var backgroundColor: Color {
+        switch self {
+        case .active, .approved, .created, .scheduled:
+            return .withColorStudio(name: .green, shade: .shade5)
+        case .finished:
+            return .withColorStudio(name: .blue, shade: .shade5)
+        case .canceled, .rejected:
+            return .withColorStudio(name: .red, shade: .shade5)
+        case .processing:
+            return .withColorStudio(name: .yellow, shade: .shade5)
+        case .unknown:
+            return .withColorStudio(name: .gray, shade: .shade5)
+        }
+    }
+
+    enum Localization {
+        static let active = NSLocalizedString("Active", comment: "Status name of an active Blaze campaign")
+        static let approved = NSLocalizedString("Approved", comment: "Status name of an approved Blaze campaign")
+        static let created = NSLocalizedString("Created", comment: "Status name of a newly created Blaze campaign")
+        static let scheduled = NSLocalizedString("Scheduled", comment: "Status name of a scheduled Blaze campaign")
+        static let completed = NSLocalizedString("Completed", comment: "Status name of a completed Blaze campaign")
+        static let canceled = NSLocalizedString("Canceled", comment: "Status name of a canceled Blaze campaign")
+        static let rejected = NSLocalizedString("Rejected", comment: "Status name of a rejected Blaze campaign")
+        static let inModeration = NSLocalizedString("In Moderation", comment: "Status name of a Blaze campaign under moderation")
+        static let unknown = NSLocalizedString("Unknown", comment: "Status name of a Blaze campaign without specified state")
+    }
+}

--- a/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import Yosemite
+import struct Yosemite.BlazeCampaign
 
 /// Customizations for campaign status
 extension BlazeCampaign.Status {
@@ -56,7 +56,7 @@ extension BlazeCampaign.Status {
         }
     }
 
-    enum Localization {
+    private enum Localization {
         static let active = NSLocalizedString("Active", comment: "Status name of an active Blaze campaign")
         static let approved = NSLocalizedString("Approved", comment: "Status name of an approved Blaze campaign")
         static let created = NSLocalizedString("Created", comment: "Status name of a newly created Blaze campaign")

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -15,7 +15,7 @@ struct BlazeCampaignItemView: View {
 
     var body: some View {
         VStack(spacing: Layout.contentSpacing) {
-            AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Layout.contentSpacing) {
+            AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .center, spacing: Layout.contentSpacing) {
                 // campaign image
                 VStack {
                     Image(uiImage: .productPlaceholderImage)
@@ -28,7 +28,7 @@ struct BlazeCampaignItemView: View {
                 // campaign status and name
                 VStack(alignment: .leading, spacing: Layout.titleSpacing) {
                     BadgeView(
-                        text: campaign.status.rawValue.uppercased(),
+                        text: campaign.status.displayText.uppercased(),
                         customizations: .init(textColor: campaign.status.textColor,
                                               backgroundColor: campaign.status.backgroundColor)
                     )
@@ -130,6 +130,29 @@ struct BlazeCampaignItemView_Previews: PreviewProvider {
 
 // MARK: Customizations for campaign status
 private extension BlazeCampaign.Status {
+    var displayText: String {
+        switch self {
+        case .active:
+            return Localization.active
+        case .approved:
+            return Localization.approved
+        case .created:
+            return Localization.created
+        case .scheduled:
+            return Localization.scheduled
+        case .finished:
+            return Localization.completed
+        case .canceled:
+            return Localization.canceled
+        case .rejected:
+            return Localization.rejected
+        case .processing:
+            return Localization.inModeration
+        case .unknown:
+            return Localization.unknown
+        }
+    }
+
     var textColor: Color {
         switch self {
         case .active, .approved, .created, .scheduled:
@@ -158,5 +181,17 @@ private extension BlazeCampaign.Status {
         case .unknown:
             return .withColorStudio(name: .gray, shade: .shade5)
         }
+    }
+
+    enum Localization {
+        static let active = NSLocalizedString("Active", comment: "Status name of an active Blaze campaign")
+        static let approved = NSLocalizedString("Approved", comment: "Status name of an approved Blaze campaign")
+        static let created = NSLocalizedString("Created", comment: "Status name of a newly created Blaze campaign")
+        static let scheduled = NSLocalizedString("Scheduled", comment: "Status name of a scheduled Blaze campaign")
+        static let completed = NSLocalizedString("Completed", comment: "Status name of a completed Blaze campaign")
+        static let canceled = NSLocalizedString("Canceled", comment: "Status name of a canceled Blaze campaign")
+        static let rejected = NSLocalizedString("Rejected", comment: "Status name of a rejected Blaze campaign")
+        static let inModeration = NSLocalizedString("In Moderation", comment: "Status name of a Blaze campaign under moderation")
+        static let unknown = NSLocalizedString("Unknown", comment: "Status name of a Blaze campaign without specified state")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Yosemite
+import Kingfisher
 
 /// View to display basic details for a Blaze campaign.
 ///
@@ -18,8 +19,12 @@ struct BlazeCampaignItemView: View {
             AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .center, spacing: Layout.contentSpacing) {
                 // campaign image
                 VStack {
-                    Image(uiImage: .productPlaceholderImage)
+                    KFImage(URL(string: campaign.contentImageURL ?? ""))
+                        .placeholder {
+                            Image(uiImage: .productPlaceholderImage)
+                        }
                         .resizable()
+                        .aspectRatio(contentMode: .fill)
                         .frame(width: Layout.imageSize * scale, height: Layout.imageSize * scale)
                         .cornerRadius(Layout.cornerRadius)
                     Spacer()
@@ -125,73 +130,5 @@ struct BlazeCampaignItemView_Previews: PreviewProvider {
                                                totalBudget: 35)
     static var previews: some View {
         BlazeCampaignItemView(campaign: campaign)
-    }
-}
-
-// MARK: Customizations for campaign status
-private extension BlazeCampaign.Status {
-    var displayText: String {
-        switch self {
-        case .active:
-            return Localization.active
-        case .approved:
-            return Localization.approved
-        case .created:
-            return Localization.created
-        case .scheduled:
-            return Localization.scheduled
-        case .finished:
-            return Localization.completed
-        case .canceled:
-            return Localization.canceled
-        case .rejected:
-            return Localization.rejected
-        case .processing:
-            return Localization.inModeration
-        case .unknown:
-            return Localization.unknown
-        }
-    }
-
-    var textColor: Color {
-        switch self {
-        case .active, .approved, .created, .scheduled:
-            return .withColorStudio(name: .green, shade: .shade60)
-        case .finished:
-            return .withColorStudio(name: .blue, shade: .shade80)
-        case .canceled, .rejected:
-            return .withColorStudio(name: .red, shade: .shade60)
-        case .processing:
-            return .withColorStudio(name: .yellow, shade: .shade70)
-        case .unknown:
-            return .withColorStudio(name: .gray, shade: .shade70)
-        }
-    }
-
-    var backgroundColor: Color {
-        switch self {
-        case .active, .approved, .created, .scheduled:
-            return .withColorStudio(name: .green, shade: .shade5)
-        case .finished:
-            return .withColorStudio(name: .blue, shade: .shade5)
-        case .canceled, .rejected:
-            return .withColorStudio(name: .red, shade: .shade5)
-        case .processing:
-            return .withColorStudio(name: .yellow, shade: .shade5)
-        case .unknown:
-            return .withColorStudio(name: .gray, shade: .shade5)
-        }
-    }
-
-    enum Localization {
-        static let active = NSLocalizedString("Active", comment: "Status name of an active Blaze campaign")
-        static let approved = NSLocalizedString("Approved", comment: "Status name of an approved Blaze campaign")
-        static let created = NSLocalizedString("Created", comment: "Status name of a newly created Blaze campaign")
-        static let scheduled = NSLocalizedString("Scheduled", comment: "Status name of a scheduled Blaze campaign")
-        static let completed = NSLocalizedString("Completed", comment: "Status name of a completed Blaze campaign")
-        static let canceled = NSLocalizedString("Canceled", comment: "Status name of a canceled Blaze campaign")
-        static let rejected = NSLocalizedString("Rejected", comment: "Status name of a rejected Blaze campaign")
-        static let inModeration = NSLocalizedString("In Moderation", comment: "Status name of a Blaze campaign under moderation")
-        static let unknown = NSLocalizedString("Unknown", comment: "Status name of a Blaze campaign without specified state")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -41,7 +41,7 @@ struct BlazeCampaignItemView: View {
 
                 // campaign total impressions
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
-                    Text("Impressions")
+                    Text(Localization.impressions)
                         .subheadlineStyle()
                     Text("1245")
                         .font(.title2)
@@ -52,7 +52,7 @@ struct BlazeCampaignItemView: View {
 
                 // campaign total clicks
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
-                    Text("Clicks")
+                    Text(Localization.clicks)
                         .subheadlineStyle()
                     Text("1245")
                         .font(.title2)
@@ -63,7 +63,7 @@ struct BlazeCampaignItemView: View {
 
                 // campaign total budget
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
-                    Text("Budget")
+                    Text(Localization.budget)
                         .subheadlineStyle()
                     Text("1245")
                         .font(.title2)
@@ -93,6 +93,12 @@ private extension BlazeCampaignItemView {
         static let cornerRadius: CGFloat = 8
         static let titleSpacing: CGFloat = 4
         static let statsVerticalSpacing: CGFloat = 6
+    }
+
+    enum Localization {
+        static let impressions = NSLocalizedString("Impressions", comment: "Title label for the total impressions of a Blaze ads campaign")
+        static let clicks = NSLocalizedString("Clicks", comment: "Title label for the total clicks of a Blaze ads campaign")
+        static let budget = NSLocalizedString("Budget", comment: "Title label for the total budget of a Blaze campaign")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -27,7 +27,11 @@ struct BlazeCampaignItemView: View {
 
                 // campaign status and name
                 VStack(alignment: .leading, spacing: Layout.titleSpacing) {
-                    BadgeView(text: campaign.status.rawValue.uppercased())
+                    BadgeView(
+                        text: campaign.status.rawValue.uppercased(),
+                        customizations: .init(textColor: campaign.status.textColor,
+                                              backgroundColor: campaign.status.backgroundColor)
+                    )
                     Text(campaign.name)
                         .headlineStyle()
                 }
@@ -113,7 +117,7 @@ struct BlazeCampaignItemView_Previews: PreviewProvider {
     static let campaign: BlazeCampaign = .init(siteID: 123,
                                                campaignID: 11,
                                                name: "Fluffy bunny pouch",
-                                               uiStatus: BlazeCampaign.Status.active.rawValue,
+                                               uiStatus: BlazeCampaign.Status.finished.rawValue,
                                                contentImageURL: nil,
                                                contentClickURL: nil,
                                                totalImpressions: 112,
@@ -121,5 +125,38 @@ struct BlazeCampaignItemView_Previews: PreviewProvider {
                                                totalBudget: 35)
     static var previews: some View {
         BlazeCampaignItemView(campaign: campaign)
+    }
+}
+
+// MARK: Customizations for campaign status
+private extension BlazeCampaign.Status {
+    var textColor: Color {
+        switch self {
+        case .active, .approved, .created, .scheduled:
+            return .withColorStudio(name: .green, shade: .shade60)
+        case .finished:
+            return .withColorStudio(name: .blue, shade: .shade80)
+        case .canceled, .rejected:
+            return .withColorStudio(name: .red, shade: .shade60)
+        case .processing:
+            return .withColorStudio(name: .yellow, shade: .shade70)
+        case .unknown:
+            return .withColorStudio(name: .gray, shade: .shade70)
+        }
+    }
+
+    var backgroundColor: Color {
+        switch self {
+        case .active, .approved, .created, .scheduled:
+            return .withColorStudio(name: .green, shade: .shade5)
+        case .finished:
+            return .withColorStudio(name: .blue, shade: .shade5)
+        case .canceled, .rejected:
+            return .withColorStudio(name: .red, shade: .shade5)
+        case .processing:
+            return .withColorStudio(name: .yellow, shade: .shade5)
+        case .unknown:
+            return .withColorStudio(name: .gray, shade: .shade5)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 /// View to display basic details for a Blaze campaign.
 ///
@@ -6,9 +7,15 @@ struct BlazeCampaignItemView: View {
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
+    private let campaign: BlazeCampaign
+
+    init(campaign: BlazeCampaign) {
+        self.campaign = campaign
+    }
+
     var body: some View {
         VStack(spacing: Layout.contentSpacing) {
-            HStack(spacing: Layout.contentSpacing) {
+            AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Layout.contentSpacing) {
                 // campaign image
                 VStack {
                     Image(uiImage: .productPlaceholderImage)
@@ -19,12 +26,12 @@ struct BlazeCampaignItemView: View {
                 }
 
                 // campaign status and name
-                VStack(spacing: Layout.titleSpacing) {
-                    BadgeView(text: "Active")
-                    Text("Test")
+                VStack(alignment: .leading, spacing: Layout.titleSpacing) {
+                    BadgeView(text: campaign.status.rawValue.uppercased())
+                    Text(campaign.name)
                         .headlineStyle()
                 }
-                .fixedSize()
+                .fixedSize(horizontal: false, vertical: false)
 
                 Spacer()
 
@@ -35,7 +42,7 @@ struct BlazeCampaignItemView: View {
             }
 
             // campaign stats
-            AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top) {
+            AdaptiveStack {
                 Spacer()
                     .frame(width: Layout.imageSize * scale + Layout.contentSpacing)
 
@@ -43,33 +50,33 @@ struct BlazeCampaignItemView: View {
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
                     Text(Localization.impressions)
                         .subheadlineStyle()
-                    Text("1245")
+                    Text("\(campaign.totalImpressions)")
                         .font(.title2)
                         .foregroundColor(.init(UIColor.text))
                 }
-                .fixedSize(horizontal: true, vertical: false)
+                .fixedSize()
                 .frame(maxWidth: .infinity)
 
                 // campaign total clicks
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
                     Text(Localization.clicks)
                         .subheadlineStyle()
-                    Text("1245")
+                    Text("\(campaign.totalClicks)")
                         .font(.title2)
                         .foregroundColor(.init(UIColor.text))
                 }
-                .fixedSize(horizontal: true, vertical: false)
+                .fixedSize()
                 .frame(maxWidth: .infinity)
 
                 // campaign total budget
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
                     Text(Localization.budget)
                         .subheadlineStyle()
-                    Text("1245")
+                    Text(String(format: "%.2f", campaign.totalBudget))
                         .font(.title2)
                         .foregroundColor(.init(UIColor.text))
                 }
-                .fixedSize(horizontal: true, vertical: false)
+                .fixedSize()
                 .frame(maxWidth: .infinity)
 
                 Spacer()
@@ -103,7 +110,16 @@ private extension BlazeCampaignItemView {
 }
 
 struct BlazeCampaignItemView_Previews: PreviewProvider {
+    static let campaign: BlazeCampaign = .init(siteID: 123,
+                                               campaignID: 11,
+                                               name: "Fluffy bunny pouch",
+                                               uiStatus: BlazeCampaign.Status.active.rawValue,
+                                               contentImageURL: nil,
+                                               contentClickURL: nil,
+                                               totalImpressions: 112,
+                                               totalClicks: 22,
+                                               totalBudget: 35)
     static var previews: some View {
-        BlazeCampaignItemView()
+        BlazeCampaignItemView(campaign: campaign)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// View to display basic details for a Blaze campaign.
+///
+struct BlazeCampaignItemView: View {
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    var body: some View {
+        VStack(spacing: Layout.contentSpacing) {
+            HStack(spacing: Layout.contentSpacing) {
+                // campaign image
+                VStack {
+                    Image(uiImage: .productPlaceholderImage)
+                        .resizable()
+                        .frame(width: Layout.imageSize * scale, height: Layout.imageSize * scale)
+                        .cornerRadius(Layout.cornerRadius)
+                    Spacer()
+                }
+
+                // campaign status and name
+                VStack(spacing: Layout.titleSpacing) {
+                    BadgeView(text: "Active")
+                    Text("Test")
+                        .headlineStyle()
+                }
+                .fixedSize()
+
+                Spacer()
+
+                // disclosure indicator
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.secondary)
+                    .font(.headline)
+            }
+
+            // campaign stats
+            AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top) {
+                Spacer()
+                    .frame(width: Layout.imageSize * scale + Layout.contentSpacing)
+
+                // campaign total impressions
+                VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
+                    Text("Impressions")
+                        .subheadlineStyle()
+                    Text("1245")
+                        .font(.title2)
+                        .foregroundColor(.init(UIColor.text))
+                }
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: .infinity)
+
+                // campaign total clicks
+                VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
+                    Text("Clicks")
+                        .subheadlineStyle()
+                    Text("1245")
+                        .font(.title2)
+                        .foregroundColor(.init(UIColor.text))
+                }
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: .infinity)
+
+                // campaign total budget
+                VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
+                    Text("Budget")
+                        .subheadlineStyle()
+                    Text("1245")
+                        .font(.title2)
+                        .foregroundColor(.init(UIColor.text))
+                }
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: .infinity)
+
+                Spacer()
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity)
+        .padding(Layout.contentSpacing)
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(uiColor: .separator))
+        }
+        .padding(Layout.contentSpacing)
+    }
+}
+
+private extension BlazeCampaignItemView {
+    enum Layout {
+        static let imageSize: CGFloat = 44
+        static let contentSpacing: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
+        static let titleSpacing: CGFloat = 4
+        static let statsVerticalSpacing: CGFloat = 6
+    }
+}
+
+struct BlazeCampaignItemView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlazeCampaignItemView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import Yosemite
+import struct Yosemite.BlazeCampaign
 import Kingfisher
 
 /// View to display basic details for a Blaze campaign.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2246,6 +2246,7 @@
 		DECE13FC27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */; };
 		DECE1400279A595200816ECD /* Coupon+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13FF279A595200816ECD /* Coupon+Woo.swift */; };
 		DED91DFA2AD78A3A00CDCC53 /* BlazeCampaignItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF92AD78A3A00CDCC53 /* BlazeCampaignItemView.swift */; };
+		DED974092AD7A55600122EB4 /* BlazeCampaignStatus+Customizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED974082AD7A55600122EB4 /* BlazeCampaignStatus+Customizations.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4775,6 +4776,7 @@
 		DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndSubtitleAndStatusTableViewCell.xib; sourceTree = "<group>"; };
 		DECE13FF279A595200816ECD /* Coupon+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+Woo.swift"; sourceTree = "<group>"; };
 		DED91DF92AD78A3A00CDCC53 /* BlazeCampaignItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignItemView.swift; sourceTree = "<group>"; };
+		DED974082AD7A55600122EB4 /* BlazeCampaignStatus+Customizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeCampaignStatus+Customizations.swift"; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -9715,6 +9717,7 @@
 			isa = PBXGroup;
 			children = (
 				DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */,
+				DED974082AD7A55600122EB4 /* BlazeCampaignStatus+Customizations.swift */,
 				B58B4ABF2108FF6100076FDD /* Array+Helpers.swift */,
 				B59C09D82188CBB100AB41D6 /* Array+Notes.swift */,
 				45EF7983244F26BB00B22BA2 /* Array+IndexPath.swift */,
@@ -12808,6 +12811,7 @@
 				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,
 				DEF36DE92898D3CF00178AC2 /* AuthenticatedWebViewController.swift in Sources */,
 				68E674A72A4DAAA60034BA1E /* UpgradeWaitingView.swift in Sources */,
+				DED974092AD7A55600122EB4 /* BlazeCampaignStatus+Customizations.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				D8610D762570AE1F00A5DF27 /* NotWPErrorViewModel.swift in Sources */,
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2245,6 +2245,7 @@
 		DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */; };
 		DECE13FC27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */; };
 		DECE1400279A595200816ECD /* Coupon+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13FF279A595200816ECD /* Coupon+Woo.swift */; };
+		DED91DFA2AD78A3A00CDCC53 /* BlazeCampaignItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF92AD78A3A00CDCC53 /* BlazeCampaignItemView.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4773,6 +4774,7 @@
 		DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndStatusTableViewCell.swift; sourceTree = "<group>"; };
 		DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndSubtitleAndStatusTableViewCell.xib; sourceTree = "<group>"; };
 		DECE13FF279A595200816ECD /* Coupon+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+Woo.swift"; sourceTree = "<group>"; };
+		DED91DF92AD78A3A00CDCC53 /* BlazeCampaignItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignItemView.swift; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -8617,6 +8619,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				DED91DF72AD78A0C00CDCC53 /* Blaze */,
 				EE45E2AB2A409B4C0085F227 /* Feature Highlight */,
 				02B1AA6329A4704C00D54FCB /* FilterTabBar */,
 				DEF8CF0829A71ED400800A60 /* JetpackSetup */,
@@ -10767,6 +10770,22 @@
 			path = SystemStatusReport;
 			sourceTree = "<group>";
 		};
+		DED91DF72AD78A0C00CDCC53 /* Blaze */ = {
+			isa = PBXGroup;
+			children = (
+				DED91DF82AD78A1A00CDCC53 /* BlazeCampaignList */,
+			);
+			path = Blaze;
+			sourceTree = "<group>";
+		};
+		DED91DF82AD78A1A00CDCC53 /* BlazeCampaignList */ = {
+			isa = PBXGroup;
+			children = (
+				DED91DF92AD78A3A00CDCC53 /* BlazeCampaignItemView.swift */,
+			);
+			path = BlazeCampaignList;
+			sourceTree = "<group>";
+		};
 		DEE4BBCA27FED9390002C818 /* ProductListSelector */ = {
 			isa = PBXGroup;
 			children = (
@@ -12344,6 +12363,7 @@
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,
 				26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */,
 				EE7707C52ABB3F55009FD564 /* AIToneVoiceView.swift in Sources */,
+				DED91DFA2AD78A3A00CDCC53 /* BlazeCampaignItemView.swift in Sources */,
 				31FC8CE727B47591004B9456 /* CardReaderSettingsDataSource.swift in Sources */,
 				02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10928 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new view for displaying details of Blaze campaigns in a list following the design in mBhyoV7OPhFnOugxLy6SMS-fi.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Since the view hasn't been integrated yet, please test the view in Xcode SwiftUI Preview. Please feel free to use Preview's dynamic type variants to check accessibility.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Light mode | Dark mode | 
| ----- | ----- | 
| <img width="279" alt="Screenshot 2023-10-12 at 15 40 18" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/09ed8719-cdb3-40a9-b4d4-119b85a9d5b4"> | <img width="294" alt="Screenshot 2023-10-12 at 15 40 34" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/fee72202-1bf1-40a8-be12-ed6883f40878"> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
