### PR TITLE
[TTPUK] Show appropriate system requirements for TTP

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -78,6 +78,7 @@ extension StripeCardReaderService: CardReaderService {
                                                      simulated: shouldUseSimulatedCardReader)
         switch result {
         case .success:
+            /// Note that while this will now never be nil, we can still remove this check if Stripe update `supportsReaders` to be country-aware
             if let minimumOperatingSystemVersionOverride {
                 return ProcessInfo().isOperatingSystemAtLeast(minimumOperatingSystemVersionOverride)
             } else {

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -458,8 +458,10 @@ extension UnderlyingError: LocalizedError {
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "there is an issue with the merchant account or device")
         case .unsupportedMobileDeviceConfiguration:
+            /// Strictly, 16.0 is required in the US, 16.4 in the UK... but it's overly complicated to make this country specific.
+            /// Any device running 16.0 can run 16.4, so this seems clear enough.
             return NSLocalizedString("Please check that your phone meets these requirements: " +
-                                     "iPhone XS or newer running iOS 16.0 or above. Contact support if this error " +
+                                     "iPhone XS or newer running iOS 16.4 or above. Contact support if this error " +
                                      "shows on a supported device.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device does not meet minimum requirements.")

--- a/WooCommerce/Classes/Extensions/OperatingSystemVersion+Localization.swift
+++ b/WooCommerce/Classes/Extensions/OperatingSystemVersion+Localization.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+
+extension OperatingSystemVersion {
+
+    /// Provides a localized string for the Operating System version
+    /// e.g. 16.0.0 -> 16
+    /// 16.1.0 -> 16.1
+    /// 16.0.1 -> 16.0.1
+    /// Note that ProcessInfo.operatingSystemName may be more appropriate for the running OS version
+    /// This function is intended for use with other OS versions we need to reference, e.g. to communicate system requirements.
+    var localizedFormattedString: String {
+        let formatString: String
+
+        switch self {
+        case let version where version.patchVersion > 0:
+            formatString = NSLocalizedString(
+                "os.version.format.major.minor.patch",
+                value: "%1$@.%2$@.%3$@",
+                comment: "A format string for a software version with major, minor, and patch components. " +
+                "%1$@ will be replaced with the major, %2$@ with the minor, and %3$@ with the patch.")
+        case let version where version.minorVersion > 0:
+            formatString = NSLocalizedString(
+                "os.version.format.major.minor",
+                value: "%1$@.%2$@",
+                comment: "A format string for a software version with major and minor components. " +
+                "%1$@ will be replaced with the major, %2$@ with the minor.")
+        default:
+            formatString = NSLocalizedString(
+                "os.version.format.major.only",
+                value: "%1$@",
+                comment: "A format string for a software version with only a major component. " +
+                "%1$@ will be replaced with the major version number.")
+        }
+
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.locale = Locale.current
+
+        let major = formatter.string(from: NSNumber(value: majorVersion)) ?? "\(majorVersion)"
+        let minor = formatter.string(from: NSNumber(value: minorVersion)) ?? "\(minorVersion)"
+        let patch = formatter.string(from: NSNumber(value: patchVersion)) ?? "\(patchVersion)"
+
+
+        return String(format: formatString, major, minor, patch)
+    }
+}

--- a/WooCommerce/Classes/Extensions/OperatingSystemVersion+Localization.swift
+++ b/WooCommerce/Classes/Extensions/OperatingSystemVersion+Localization.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 extension OperatingSystemVersion {
 
     /// Provides a localized string for the Operating System version

--- a/WooCommerce/Classes/Extensions/OperatingSystemVersion+Localization.swift
+++ b/WooCommerce/Classes/Extensions/OperatingSystemVersion+Localization.swift
@@ -14,23 +14,11 @@ extension OperatingSystemVersion {
 
         switch self {
         case let version where version.patchVersion > 0:
-            formatString = NSLocalizedString(
-                "os.version.format.major.minor.patch",
-                value: "%1$@.%2$@.%3$@",
-                comment: "A format string for a software version with major, minor, and patch components. " +
-                "%1$@ will be replaced with the major, %2$@ with the minor, and %3$@ with the patch.")
+            formatString = Localization.patchVersionFormat
         case let version where version.minorVersion > 0:
-            formatString = NSLocalizedString(
-                "os.version.format.major.minor",
-                value: "%1$@.%2$@",
-                comment: "A format string for a software version with major and minor components. " +
-                "%1$@ will be replaced with the major, %2$@ with the minor.")
+            formatString = Localization.minorVersionFormat
         default:
-            formatString = NSLocalizedString(
-                "os.version.format.major.only",
-                value: "%1$@",
-                comment: "A format string for a software version with only a major component. " +
-                "%1$@ will be replaced with the major version number.")
+            formatString = Localization.majorVersionFormat
         }
 
         let formatter = NumberFormatter()
@@ -43,5 +31,25 @@ extension OperatingSystemVersion {
 
 
         return String(format: formatString, major, minor, patch)
+    }
+
+    private enum Localization {
+        static let patchVersionFormat = NSLocalizedString(
+            "os.version.format.major.minor.patch",
+            value: "%1$@.%2$@.%3$@",
+            comment: "A format string for a software version with major, minor, and patch components. " +
+            "%1$@ will be replaced with the major, %2$@ with the minor, and %3$@ with the patch.")
+
+        static let minorVersionFormat = NSLocalizedString(
+            "os.version.format.major.minor",
+            value: "%1$@.%2$@",
+            comment: "A format string for a software version with major and minor components. " +
+            "%1$@ will be replaced with the major, %2$@ with the minor.")
+
+        static let majorVersionFormat = NSLocalizedString(
+            "os.version.format.major.only",
+            value: "%1$@",
+            comment: "A format string for a software version with only a major component. " +
+            "%1$@ will be replaced with the major version number.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -32,7 +32,8 @@ struct AboutTapToPayView: View {
                     }
                     .padding(.vertical)
 
-                    Text(Localization.systemRequirementsDetails)
+                    Text(String(format: Localization.systemRequirementsDetails,
+                                viewModel.formattedMinimumOperatingSystemVersionForTapToPay))
                         .footnoteStyle(isError: false)
                 }
                 .padding()
@@ -113,10 +114,10 @@ private extension AboutTapToPayView {
             comment: "Step 5 of the 'How it works' list, instructing the merchant to wait until processing is complete.")
 
         static let systemRequirementsDetails = NSLocalizedString(
-            "Requires iPhone XS or later with iOS 16 or later. The Contactless Symbol is a trademark owned by and " +
+            "Requires iPhone XS or later with iOS %1$@ or later. The Contactless Symbol is a trademark owned by and " +
             "used with permission of EMVCo, LLC.",
             comment: "Requirements for Tap to Pay on iPhone, and other small print shown on the About Tap to Pay on " +
-            "iPhone screen.")
+            "iPhone screen. %1$@ will be replaced with the relevant iOS version number.")
 
         static let setUpTapToPayOnIPhoneButtonTitle = NSLocalizedString(
             "Set Up Tap to Pay on iPhone",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 import WooFoundation
 
 class AboutTapToPayViewModel: ObservableObject {
-    @Published var configuration: CardPresentPaymentsConfiguration
+    let configuration: CardPresentPaymentsConfiguration
     private let buttonAction: (() -> Void)?
 
     @Published var shouldShowContactlessLimit: Bool = false
@@ -16,12 +16,15 @@ class AboutTapToPayViewModel: ObservableObject {
             authenticated: false)
     }()
 
+    let formattedMinimumOperatingSystemVersionForTapToPay: String
+
     init(configuration: CardPresentPaymentsConfiguration,
          buttonAction: (() -> Void)?) {
         self.configuration = configuration
         self.buttonAction = buttonAction
         shouldShowButton = buttonAction != nil
         shouldShowContactlessLimit = configuration.contactlessLimitAmount != nil
+        self.formattedMinimumOperatingSystemVersionForTapToPay = configuration.minimumOperatingSystemVersionForTapToPay.localizedFormattedString
     }
 
     func callToActionTapped() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -705,6 +705,7 @@
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
+		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
 		20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* AboutTapToPayView.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -3219,6 +3220,7 @@
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
+		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* AboutTapToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayView.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
@@ -9776,6 +9778,7 @@
 				571CDD59250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift */,
 				025C00B925514A7100FAC222 /* BarcodeScannerFrameScaler.swift */,
 				023D877825EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift */,
+				209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */,
 				DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */,
 				DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */,
 				DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */,
@@ -13524,6 +13527,7 @@
 				020DD0AF294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
 				DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */,
+				209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */,
 				020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */,
 				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -91,7 +91,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
             minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
             stripeSmallestCurrencyUnitMultiplier: 100,
             contactlessLimitAmount: nil,
-            minimumOperatingSystemVersionForTapToPay: nil)
+            minimumOperatingSystemVersionForTapToPay: .init(majorVersion: 16, minorVersion: 0, patchVersion: 0))
 
         sut = InPersonPaymentsMenuViewModel(dependencies: dependencies,
                                             cardPresentPaymentsConfiguration: configuration)
@@ -119,7 +119,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
             minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
             stripeSmallestCurrencyUnitMultiplier: 100,
             contactlessLimitAmount: nil,
-            minimumOperatingSystemVersionForTapToPay: nil)
+            minimumOperatingSystemVersionForTapToPay: .init(majorVersion: 16, minorVersion: 0, patchVersion: 0))
 
         sut = InPersonPaymentsMenuViewModel(dependencies: dependencies,
                                             cardPresentPaymentsConfiguration: configuration)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -87,7 +87,7 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
         // Then
         assertEqual(sampleSiteID, connectionControllerFactory.spyCreateConnectionControllerSiteID)
         assertEqual(false, connectionControllerFactory.spyCreateConnectionControllerAllowTermsOfServiceAcceptance)
-        assertEqual(sampleConfiguration, connectionControllerFactory.spyCreateConnectionControllerConfiguration)
+        XCTAssertEqual(sampleConfiguration, connectionControllerFactory.spyCreateConnectionControllerConfiguration)
         assertEqual(CardReaderConnectionAnalyticsTracker.ConnectionType.automaticReconnection,
                     connectionControllerFactory.spyCreateConnectionControllerAnalyticsTracker?.connectionType)
     }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -124,11 +124,9 @@ private enum Constants {
 }
 
 extension OperatingSystemVersion: Equatable {
-
     public static func == (lhs: OperatingSystemVersion, rhs: OperatingSystemVersion) -> Bool {
-        return lhs.majorVersion == rhs.minorVersion &&
+        return lhs.majorVersion == rhs.majorVersion &&
         lhs.minorVersion == rhs.minorVersion &&
         lhs.patchVersion == rhs.patchVersion
     }
-
 }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -18,8 +18,8 @@ public struct CardPresentPaymentsConfiguration: Equatable {
     /// `minimumOperatingSystemVersionOverride` allows us to override Stripe's `supportsReaders` check
     /// such that if it returns `true`, we additionally check for the user's phone meeting this version.
     /// E.g. we check for iOS 16.4 if they're connected to a GB store, which Stripe only check during discovery.
-    /// This can be removed if Stripe make `supportsReaders` location aware
-    public let minimumOperatingSystemVersionForTapToPay: OperatingSystemVersion?
+    /// This usage can be removed if Stripe make `supportsReaders` location aware
+    public let minimumOperatingSystemVersionForTapToPay: OperatingSystemVersion
 
     init(countryCode: CountryCode,
          paymentMethods: [WCPayPaymentMethodType],
@@ -30,7 +30,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
          minimumAllowedChargeAmount: NSDecimalNumber,
          stripeSmallestCurrencyUnitMultiplier: Decimal,
          contactlessLimitAmount: Int?,
-         minimumOperatingSystemVersionForTapToPay: OperatingSystemVersion?) {
+         minimumOperatingSystemVersionForTapToPay: OperatingSystemVersion) {
         self.countryCode = countryCode
         self.paymentMethods = paymentMethods
         self.currencies = currencies
@@ -60,7 +60,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100,
                 contactlessLimitAmount: nil,
-                minimumOperatingSystemVersionForTapToPay: nil
+                minimumOperatingSystemVersionForTapToPay: .init(majorVersion: 16, minorVersion: 0, patchVersion: 0)
             )
         case .CA:
             self.init(
@@ -73,7 +73,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100,
                 contactlessLimitAmount: 25000,
-                minimumOperatingSystemVersionForTapToPay: nil
+                minimumOperatingSystemVersionForTapToPay: .init(majorVersion: 16, minorVersion: 0, patchVersion: 0)
             )
         case .GB:
             self.init(
@@ -101,7 +101,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100,
                 contactlessLimitAmount: nil,
-                minimumOperatingSystemVersionForTapToPay: nil
+                minimumOperatingSystemVersionForTapToPay: .init(majorVersion: 16, minorVersion: 0, patchVersion: 0)
             )
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10911
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've found that Tap to Pay in the UK requires iOS 16.4, rather than iOS 16.0 as required in the US.

This PR updates our strings to appropriately communicate the required version to users.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Select a UK-based WooPayments store
3. Navigate to `Menu > Payments > About Tap to Pay`
4. Scroll down, and observe that the required version is shown as 16.4.
5. Switch to a US-based WooPayments store
6. Check the required version again – observe that it's shown as 16.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
