### PR TITLE
[TTPUK] Design updates in the Set Up Tap to Pay flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -29,6 +29,8 @@ final class SetUpTapToPayCompleteViewController: UIHostingController<SetUpTapToP
 struct SetUpTapToPayCompleteView: View {
     @ObservedObject var viewModel: SetUpTapToPayCompleteViewModel
 
+    @State var showingAboutTapToPay: Bool = false
+
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
     var isCompact: Bool {
@@ -78,8 +80,19 @@ struct SetUpTapToPayCompleteView: View {
                 viewModel.doneTapped()
             })
             .buttonStyle(PrimaryButtonStyle())
+
+            InPersonPaymentsLearnMore(
+                viewModel: LearnMoreViewModel(
+                    formatText: Localization.learnMore,
+                    tappedAnalyticEvent: WooAnalyticsEvent.InPersonPayments.learnMoreTapped(source: .tapToPaySummary)))
+            .customOpenURL(action: { _ in
+                showingAboutTapToPay = true
+            })
         }
         .padding()
+        .sheet(isPresented: $showingAboutTapToPay) {
+            AboutTapToPayViewInNavigationView()
+        }
     }
 }
 
@@ -115,6 +128,15 @@ private extension SetUpTapToPayCompleteView {
             "Continue",
             comment: "Settings > Set up Tap to Pay on iPhone > Complete > A button to move to the " +
             "next for testing Tap to Pay on iPhone"
+        )
+
+        static let learnMore = NSLocalizedString(
+            "%1$@ about accepting payments with Tap to Pay on iPhone.",
+            comment: """
+                     A label prompting users to learn more about Tap to Pay on iPhone"
+                     %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                     which should be translated separately and considered part of this sentence.
+                     """
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -74,7 +74,7 @@ struct SetUpTapToPayCompleteView: View {
                 .padding()
                 .fixedSize(horizontal: false, vertical: true)
 
-            Button(Localization.doneButton, action: {
+            Button(Localization.continueButton, action: {
                 viewModel.doneTapped()
             })
             .buttonStyle(PrimaryButtonStyle())
@@ -107,13 +107,12 @@ private extension SetUpTapToPayCompleteView {
         )
 
         static let setUpCompleteDetail = NSLocalizedString(
-            "You can find Tap to Pay on iPhone in Menu > Payments > Collect Payment, or from " +
-            "Order Details. Choose Tap to Pay on iPhone as the payment method.",
+            "Choose Tap to Pay on iPhone from the Collect Payment options in Order Details Menu → Payments.",
             comment: "Settings > Set up Tap to Pay on iPhone > Complete > Detail"
         )
 
-        static let doneButton = NSLocalizedString(
-            "Done",
+        static let continueButton = NSLocalizedString(
+            "Continue",
             comment: "Settings > Set up Tap to Pay on iPhone > Complete > A button to move to the " +
             "next for testing Tap to Pay on iPhone"
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -138,23 +138,6 @@ struct SetUpTapToPayInformationView: View {
     }
 }
 
-private struct AboutTapToPayViewInNavigationView: View {
-    @Environment(\.dismiss) var dismiss
-
-    var body: some View {
-        NavigationView {
-            AboutTapToPayView()
-            .toolbar() {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.doneButton) {
-                        dismiss()
-                    }
-                }
-            }
-        }
-    }
-}
-
 private enum Constants {
     // maxHeight should be 208, but that hides the button on iPhone SE
     // TODO: make this 208, or proportional to screen height for small screens
@@ -223,10 +206,6 @@ private enum Localization {
     static let cancelButton = NSLocalizedString(
         "Cancel",
         comment: "Settings > Set up Tap to Pay on iPhone > Information > Cancel button")
-
-    static let doneButton = NSLocalizedString(
-        "Done",
-        comment: "Done navigation button in About Tap to Pay on iPhone screen, when presented from the set up flow")
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -147,14 +147,13 @@ private enum Constants {
 private extension SetUpTapToPayPaymentPromptView {
     enum Localization {
         static let setUpTryPaymentPromptTitle = NSLocalizedString(
-            "Try a payment",
+            "Would you like to try a payment",
             comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Inform user that " +
             "Tap to Pay on iPhone is ready"
         )
 
         static let setUpTryPaymentPromptDescription = NSLocalizedString(
-            "Try taking a payment of %1$@ to see how Tap to Pay on iPhone works. Use your " +
-            "debit or credit card: you can refund it when you're done.",
+            "Try a %1$@ payment with your debit or credit card. You can refund the payment when you’re done.",
             comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Description. %1$@ will be replaced " +
             "with the amount of the trial payment, in the store's currency."
         )
@@ -166,7 +165,7 @@ private extension SetUpTapToPayPaymentPromptView {
         )
 
         static let skipButton = NSLocalizedString(
-            "Skip",
+            "Return to Payments",
             comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > A button to skip " +
             "to the trial payment and dismiss the Set up Tap to Pay on iPhone flow"
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -192,3 +192,28 @@ private extension AboutTapToPayContactlessLimitView {
         static let cornerRadius: CGFloat = 8
     }
 }
+
+struct AboutTapToPayViewInNavigationView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationView {
+            AboutTapToPayView()
+            .toolbar() {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.doneButton) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension AboutTapToPayViewInNavigationView {
+    enum Localization {
+        static let doneButton = NSLocalizedString(
+            "Done",
+            comment: "Done navigation button in About Tap to Pay on iPhone screen, when presented from the set up flow")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10945
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While we were working in the Set Up/Try Out Tap to Pay flows for Tap to Pay in the UK, we decided to make some small tweaks to the designs in these screens.

This PR updates strings throughout the flow, and adds the `Learn More` view to the set up complete screen.

### Updated designs

![Designs for Set Up/Try Out Tap to Pay with updated button strings, descriptions, and a new Learn More view](https://github.com/woocommerce/woocommerce-ios/assets/2472348/337ae408-68d9-4dd3-aabc-7d69f0f15d33)


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Using a UK or US WooPayments store
2. Navigate to `Menu > Payments > Set Up (Try Out) Tap to Pay on iPhone`
3. Observe that the screens match the designs

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/a571e575-af12-4a81-a00f-e14b21a917ad


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
