### PR TITLE
[TTPUK] Enable `tapToPayOnIPhoneInUK` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -103,7 +103,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .orderCustomAmountsM1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .tapToPayOnIPhoneInUK:
-            return buildConfig == .localDeveloper
+            return true
         case .optimizedBlazeExperience:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 15.9
 -----
-
+- [***] Payments: UK-based merchants can take payments using Tap to Pay on iPhone [https://github.com/woocommerce/woocommerce-ios/pull/10957]
 
 15.8
 -----


### PR DESCRIPTION
## Description
This PR enables Tap to Pay on iPhone in UK in release builds.

## Testing instructions
- Edit the WooCommerce scheme to run a release build
- Run the app on a physical device
- On a UK-based store, running iOS 16.4+, confirm that Tap to Pay in UK is available
- Perform a test payment.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
