### PR TITLE
Blaze Optimization: UI for Blaze campaign section on Dashboard

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -102,8 +102,13 @@ struct BlazeCampaignItemView: View {
         .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: .infinity)
         .padding(Layout.contentSpacing)
+        .background(
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(Color(uiColor: .init(light: UIColor.clear,
+                                           dark: UIColor.systemGray5)))
+        )
         .overlay {
-            RoundedRectangle(cornerRadius: 8)
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .stroke(Color(uiColor: .separator), lineWidth: Layout.strokeWidth)
         }
         .padding(Layout.strokeWidth)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -9,9 +9,12 @@ struct BlazeCampaignItemView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     private let campaign: BlazeCampaign
+    private let showBudget: Bool
 
-    init(campaign: BlazeCampaign) {
+    init(campaign: BlazeCampaign,
+         showBudget: Bool = true) {
         self.campaign = campaign
+        self.showBudget = showBudget
     }
 
     var body: some View {
@@ -91,6 +94,7 @@ struct BlazeCampaignItemView: View {
                 }
                 .fixedSize()
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .renderedIf(showBudget)
 
                 Spacer()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -206,6 +206,11 @@ private struct ProductInfoView: View {
                 .foregroundColor(Color(.textTertiary))
         }
         .padding(Layout.contentPadding)
+        .background(
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(Color(uiColor: .init(light: UIColor.clear,
+                                           dark: UIColor.systemGray5)))
+        )
         .overlay {
             RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .stroke(Color(uiColor: .separator), lineWidth: Layout.strokeWidth)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -71,7 +71,7 @@ struct BlazeCampaignDashboardView: View {
                     .subheadlineStyle()
                     .renderedIf(!viewModel.shouldShowShowAllCampaignsButton)
             }
-            .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+            .redacted(reason: viewModel.shouldRedactView ? .placeholder : [])
 
             if case .showProduct(let product) = viewModel.state {
                 ProductInfoView(product: product)
@@ -93,7 +93,7 @@ struct BlazeCampaignDashboardView: View {
 
             // Create campaign button
             createCampaignButton
-                .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                .redacted(reason: viewModel.shouldRedactView ? .placeholder : [])
         }
         .padding(insets: Layout.insets)
         .background(Color(uiColor: .listForeground(modal: false)))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -129,7 +129,8 @@ private extension BlazeCampaignDashboardView {
                     .foregroundColor(Color(.textTertiary))
             }
             .padding(insets: Layout.insets)
-            .background(Color(.systemColor(.systemGray6)))
+            .background(Color(uiColor: .init(light: UIColor.systemGray6,
+                                             dark: UIColor.systemGray5)))
             .cornerRadius(Layout.cornerRadius)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -1,0 +1,228 @@
+import SwiftUI
+import struct Yosemite.BlazeCampaign
+import struct Yosemite.Product
+import Kingfisher
+
+/// Hosting controller for `BlazeCampaignDashboardView`.
+///
+final class BlazeCampaignDashboardViewHostingController: SelfSizingHostingController<BlazeCampaignDashboardView> {
+    private let viewModel: BlazeCampaignDashboardViewModel
+
+    init(viewModel: BlazeCampaignDashboardViewModel) {
+        self.viewModel = viewModel
+        super.init(rootView: BlazeCampaignDashboardView(viewModel: viewModel))
+        if #unavailable(iOS 16.0) {
+            viewModel.onStateChange = { [weak self] in
+                self?.view.invalidateIntrinsicContentSize()
+            }
+        }
+
+        // TODO: Assign callback handlers and handle navigation
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reload()
+    }
+
+    private func reload() {
+        Task { @MainActor in
+            await viewModel.reload()
+        }
+    }
+}
+
+/// Blaze campaigns in dashboard screen.
+struct BlazeCampaignDashboardView: View {
+    /// Set externally in the hosting controller.
+    var campaignTapped: (() -> Void)?
+
+    /// Set externally in the hosting controller.
+    var productTapped: (() -> Void)?
+
+    /// Set externally in the hosting controller.
+    var showAllCampaignsTapped: (() -> Void)?
+
+    /// Set externally in the hosting controller.
+    var createCampaignTapped: (() -> Void)?
+
+    @ObservedObject private var viewModel: BlazeCampaignDashboardViewModel
+
+    init(viewModel: BlazeCampaignDashboardViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+            VStack(alignment: .leading, spacing: Layout.HeadingBlock.verticalSpacing) {
+                // Title
+                Text(Localization.title)
+                    .fontWeight(.semibold)
+                    .bodyStyle()
+
+                // Subtitle
+                Text(Localization.subtitle)
+                    .fontWeight(.regular)
+                    .subheadlineStyle()
+                    .renderedIf(!viewModel.shouldShowShowAllCampaignsButton)
+            }
+            .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+
+            if case .showProduct(let product) = viewModel.state {
+                ProductInfoView(product: product)
+                    .onTapGesture {
+                        productTapped?()
+                    }
+            } else if case .showCampaign(let campaign) = viewModel.state {
+                BlazeCampaignItemView(campaign: campaign, showBudget: false)
+                    .onTapGesture {
+                        campaignTapped?()
+                    }
+            }
+
+            // Show All Campaigns button
+            showAllCampaignsButton
+                .renderedIf(viewModel.shouldShowShowAllCampaignsButton)
+
+            Divider()
+
+            // Create campaign button
+            createCampaignButton
+                .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+        }
+        .padding(insets: Layout.insets)
+        .background(Color(uiColor: .listForeground(modal: false)))
+    }
+}
+
+private extension BlazeCampaignDashboardView {
+    var createCampaignButton: some View {
+        Button {
+            createCampaignTapped?()
+        } label: {
+            Text(Localization.createCampaign)
+                .fontWeight(.semibold)
+                .foregroundColor(.init(uiColor: .accent))
+                .bodyStyle()
+        }
+    }
+
+    var showAllCampaignsButton: some View {
+        Button {
+            showAllCampaignsTapped?()
+        } label: {
+            HStack {
+                Text(Localization.showAllCampaigns)
+                    .fontWeight(.regular)
+                    .bodyStyle()
+
+                Spacer()
+
+                // Chevron icon
+                Image(uiImage: .chevronImage)
+                    .flipsForRightToLeftLayoutDirection(true)
+                    .foregroundColor(Color(.textTertiary))
+            }
+            .padding(insets: Layout.insets)
+            .background(Color(.systemColor(.systemGray6)))
+            .cornerRadius(Layout.cornerRadius)
+        }
+    }
+}
+
+private extension BlazeCampaignDashboardView {
+    enum Layout {
+        static let verticalSpacing: CGFloat = 16
+        enum HeadingBlock {
+            static let verticalSpacing: CGFloat = 8
+        }
+        static let insets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let cornerRadius: CGFloat = 8
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "🔥 Blaze campaign",
+            comment: "Title of the Blaze campaign view."
+        )
+
+        static let subtitle = NSLocalizedString(
+            "Increase visibility and get your products sold quickly.",
+            comment: "Subtitle of the Blaze campaign view."
+        )
+
+        static let showAllCampaigns = NSLocalizedString(
+            "Show All Campaigns",
+            comment: "Button when tapped will show the Blaze campaign list."
+        )
+
+        static let createCampaign = NSLocalizedString(
+            "Create campaign",
+            comment: "Button when tapped will launch create Blaze campaign flow."
+        )
+    }
+}
+
+private struct ProductInfoView: View {
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    private let product: Product
+
+    init(product: Product) {
+        self.product = product
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: Layout.contentSpacing) {
+            KFImage(product.imageURL)
+                .placeholder {
+                    Image(uiImage: .productPlaceholderImage)
+                }
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: Layout.imageSize * scale, height: Layout.imageSize * scale)
+                .cornerRadius(Layout.cornerRadius)
+
+            Text(product.name)
+                .fontWeight(.semibold)
+                .foregroundColor(.init(UIColor.text))
+                .subheadlineStyle()
+                .multilineTextAlignment(.leading)
+                // This size modifier is necessary so that the product name is never truncated.
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
+            // Chevron icon
+            Image(uiImage: .chevronImage)
+                .flipsForRightToLeftLayoutDirection(true)
+                .foregroundColor(Color(.textTertiary))
+        }
+        .padding(Layout.contentPadding)
+        .overlay {
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(Color(uiColor: .separator), lineWidth: Layout.strokeWidth)
+        }
+    }
+
+    private enum Layout {
+        static let imageSize: CGFloat = 44
+        static let contentSpacing: CGFloat = 16
+        static let contentPadding: CGFloat = 16
+        static let strokeWidth: CGFloat = 0.5
+        static let cornerRadius: CGFloat = 8
+    }
+}
+
+
+struct BlazeCampaignDashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlazeCampaignDashboardView(viewModel: .init(siteID: 0))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -49,19 +49,20 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         self.state = .loading
     }
 
+    @MainActor
     func reload() async {
-        await update(state: .loading)
+        update(state: .loading)
         guard await blazeEligibilityChecker.isSiteEligible() else {
-            await update(state: .empty)
+            update(state: .empty)
             return
         }
 
         if let campaign = try? await loadLatestBlazeCampaign() {
-            await update(state: .showCampaign(campaign: campaign))
+            update(state: .showCampaign(campaign: campaign))
         } else if let product = try? await loadFirstPublishedProduct() {
-            await update(state: .showProduct(product: product))
+            update(state: .showProduct(product: product))
         } else {
-            await update(state: .empty)
+            update(state: .empty)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -85,7 +85,7 @@ private extension BlazeCampaignDashboardViewModel {
         // TODO: Replace with remote call
         try await Task.sleep(nanoseconds: 150_000_000)
         if Bool.random() {
-            return Product.swiftUIPreviewSample()
+            return ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: siteID)
         } else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -20,7 +20,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
     @Published private(set) var shouldShowInDashboard: Bool = false
 
-    private(set) var isRedacted: Bool = true
+    private(set) var shouldRedactView: Bool = true
 
     var shouldShowShowAllCampaignsButton: Bool {
         if case .showCampaign = state {
@@ -95,13 +95,13 @@ private extension BlazeCampaignDashboardViewModel {
         self.state = state
         switch state {
         case .loading:
-            isRedacted = true
+            shouldRedactView = true
             shouldShowInDashboard = true
         case .showCampaign, .showProduct:
-            isRedacted = false
+            shouldRedactView = false
             shouldShowInDashboard = true
         case .empty:
-            isRedacted = true
+            shouldRedactView = true
             shouldShowInDashboard = false
         }
         onStateChange?()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -23,7 +23,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     private(set) var isRedacted: Bool = true
 
     var shouldShowShowAllCampaignsButton: Bool {
-        if case .showCampaign(_) = state {
+        if case .showCampaign = state {
             return true
         } else {
             return false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -1,0 +1,109 @@
+import UIKit
+import Yosemite
+import Combine
+
+/// View model for `BlazeCampaignDashboardView`.
+final class BlazeCampaignDashboardViewModel: ObservableObject {
+    /// UI state of the Blaze campaign view in dashboard.
+    enum State {
+        /// Shows placeholder views in redacted state.
+        case loading
+        /// Shows info about the latest Blaze campaign
+        case showCampaign(campaign: BlazeCampaign)
+        /// Shows info about the latest published Product
+        case showProduct(product: Product)
+        /// When there is no campaign or published product
+        case empty
+    }
+
+    @Published private(set) var state: State
+
+    @Published private(set) var shouldShowInDashboard: Bool = false
+
+    private(set) var isRedacted: Bool = true
+
+    var shouldShowShowAllCampaignsButton: Bool {
+        if case .showCampaign(_) = state {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    /// Set externally in the hosting controller to invalidate the SwiftUI `BlazeCampaignDashboardView`'s intrinsic content size as a workaround with UIKit.
+    var onStateChange: (() -> Void)?
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let analytics: Analytics
+    private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
+         blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker()) {
+        self.siteID = siteID
+        self.stores = stores
+        self.analytics = analytics
+        self.blazeEligibilityChecker = blazeEligibilityChecker
+        self.state = .loading
+    }
+
+    func reload() async {
+        await update(state: .loading)
+        guard await blazeEligibilityChecker.isSiteEligible() else {
+            await update(state: .empty)
+            return
+        }
+
+        if let campaign = try? await loadLatestBlazeCampaign() {
+            await update(state: .showCampaign(campaign: campaign))
+        } else if let product = try? await loadFirstPublishedProduct() {
+            await update(state: .showProduct(product: product))
+        } else {
+            await update(state: .empty)
+        }
+    }
+}
+
+private extension BlazeCampaignDashboardViewModel {
+    @MainActor
+    func loadLatestBlazeCampaign() async throws -> BlazeCampaign? {
+        // TODO: Replace with remote call
+        try await Task.sleep(nanoseconds: 150_000_000)
+        if Bool.random() {
+            // swiftlint:disable:next line_length
+            return .init(siteID: siteID, campaignID: 1, name: "Test", uiStatus: "finished", contentImageURL: "https://m.media-amazon.com/images/I/718JGhYeDXL.jpg", contentClickURL: "https://www.google.com/", totalImpressions: 1434, totalClicks: 211, totalBudget: 6563.2)
+        } else {
+            return nil
+        }
+    }
+
+    @MainActor
+    func loadFirstPublishedProduct() async throws -> Product? {
+        // TODO: Replace with remote call
+        try await Task.sleep(nanoseconds: 150_000_000)
+        if Bool.random() {
+            return Product.swiftUIPreviewSample()
+        } else {
+            return nil
+        }
+    }
+
+    @MainActor
+    func update(state: State) {
+        self.state = state
+        switch state {
+        case .loading:
+            isRedacted = true
+            shouldShowInDashboard = true
+        case .showCampaign, .showProduct:
+            isRedacted = false
+            shouldShowInDashboard = true
+        case .empty:
+            isRedacted = true
+            shouldShowInDashboard = false
+        }
+        onStateChange?()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -988,6 +988,9 @@ private extension DashboardViewController {
             group.addTask { [weak self] in
                 await self?.viewModel.updateBlazeBannerVisibility()
             }
+            group.addTask { [weak self] in
+                await self?.viewModel.reloadBlazeCampaignView()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -104,6 +104,10 @@ final class DashboardViewController: UIViewController {
     ///
     private var blazeBannerHostingController: BlazeBannerHostingController?
 
+    /// Hosting controller for the Blaze Campaign View.
+    ///
+    private var blazeCampaignHostingController: BlazeCampaignDashboardViewHostingController?
+
     /// Bottom Jetpack benefits banner, shown when the site is connected to Jetpack without Jetpack-the-plugin.
     private lazy var bottomJetpackBenefitsBannerController = JetpackBenefitsBannerHostingController()
     private var isJetpackBenefitsBannerShown: Bool {
@@ -165,6 +169,7 @@ final class DashboardViewController: UIViewController {
         observeShowWebViewSheet()
         observeAddProductTrigger()
         observeOnboardingVisibility()
+        observeBlazeCampaignViewVisibility()
         observeBlazeBannerVisibility()
         configureStorePlanBannerPresenter()
         presentPrivacyBannerIfNeeded()
@@ -780,6 +785,46 @@ private extension DashboardViewController {
     ///
     func presentPrivacyBannerIfNeeded() {
         privacyBannerPresenter.presentIfNeeded(from: self)
+    }
+}
+
+// MARK: - Blaze campaign view
+extension DashboardViewController {
+    func observeBlazeCampaignViewVisibility() {
+        viewModel.$showBlazeCampaignView.removeDuplicates()
+            .sink { [weak self] showBlazeCampaignView in
+                guard let self else { return }
+                if showBlazeCampaignView {
+                    self.showBlazeCampaignView()
+                } else {
+                    self.removeBlazeCampaignView()
+                }
+            }
+            .store(in: &subscriptions)
+    }
+
+    func showBlazeCampaignView() {
+        if blazeCampaignHostingController != nil {
+            removeBlazeCampaignView()
+        }
+        let hostingController = BlazeCampaignDashboardViewHostingController(viewModel: viewModel.blazeCampaignDashboardViewModel)
+        guard let campaignView = hostingController.view else {
+            return
+        }
+        campaignView.translatesAutoresizingMaskIntoConstraints = false
+        addViewBelowOnboardingCard(campaignView)
+        addChild(hostingController)
+        hostingController.didMove(toParent: self)
+        blazeCampaignHostingController = hostingController
+    }
+
+    func removeBlazeCampaignView() {
+        guard let blazeCampaignHostingController,
+              blazeCampaignHostingController.parent == self else { return }
+        blazeCampaignHostingController.willMove(toParent: nil)
+        blazeCampaignHostingController.view.removeFromSuperview()
+        blazeCampaignHostingController.removeFromParent()
+        self.blazeCampaignHostingController = nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -786,6 +786,9 @@ private extension DashboardViewController {
 // MARK: - Blaze banner
 extension DashboardViewController {
     func observeBlazeBannerVisibility() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.optimizedBlazeExperience) == false else {
+            return
+        }
         viewModel.$showBlazeBanner.removeDuplicates()
             .sink { [weak self] showsBlazeBanner in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -88,6 +88,12 @@ final class DashboardViewModel {
         await storeOnboardingViewModel.reloadTasks()
     }
 
+    /// Reloads Blaze dashboard campaign view
+    ///
+    func reloadBlazeCampaignView() async {
+        await blazeCampaignDashboardViewModel.reload()
+    }
+
     /// Syncs store stats for dashboard UI.
     func syncStats(for siteID: Int64,
                    siteTimezone: TimeZone,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -21,11 +21,15 @@ final class DashboardViewModel {
 
     let storeOnboardingViewModel: StoreOnboardingViewModel
 
+    let blazeCampaignDashboardViewModel: BlazeCampaignDashboardViewModel
+
     @Published private(set) var showWebViewSheet: WebViewSheetViewModel? = nil
 
     @Published private(set) var showOnboarding: Bool = false
 
     @Published private(set) var showBlazeBanner: Bool = false
+
+    @Published private(set) var showBlazeCampaignView: Bool = false
 
     /// Trigger to start the Add Product flow
     ///
@@ -66,8 +70,10 @@ final class DashboardViewModel {
         self.justInTimeMessagesManager = JustInTimeMessagesProvider(stores: stores, analytics: analytics)
         self.localAnnouncementsProvider = .init(stores: stores, analytics: analytics, featureFlagService: featureFlags)
         self.storeOnboardingViewModel = .init(siteID: siteID, isExpanded: false, stores: stores, defaults: userDefaults)
+        self.blazeCampaignDashboardViewModel = .init(siteID: siteID)
         self.storeCreationProfilerUploadAnswersUseCase = storeCreationProfilerUploadAnswersUseCase ?? StoreCreationProfilerUploadAnswersUseCase(siteID: siteID)
         setupObserverForShowOnboarding()
+        setupObserverForBlazeCampaignView()
     }
 
     /// Uploads the answers from the store creation profiler flow
@@ -300,6 +306,17 @@ final class DashboardViewModel {
 
         storeOnboardingViewModel.$shouldShowInDashboard
             .assign(to: &$showOnboarding)
+    }
+
+    /// Sets up observer to decide Blaze campaign view visibility
+    ///
+    private func setupObserverForBlazeCampaignView() {
+        guard featureFlagService.isFeatureFlagEnabled(.optimizedBlazeExperience) else {
+            return
+        }
+
+        blazeCampaignDashboardViewModel.$shouldShowInDashboard
+            .assign(to: &$showBlazeCampaignView)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2396,6 +2396,8 @@
 		EEB4E2DE29B61AAD00371C3C /* CouponInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */; };
 		EEB917C82A6FE52F004D364B /* FreeTrialSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB917C72A6FE52F004D364B /* FreeTrialSurveyView.swift */; };
 		EEB917CA2A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB917C92A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift */; };
+		EEBA02A32ADD6005001FE8E4 /* BlazeCampaignDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBA02A22ADD6005001FE8E4 /* BlazeCampaignDashboardView.swift */; };
+		EEBA02A52ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBA02A42ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift */; };
 		EEBDF7DA2A2EF69B00EFEF47 /* ShareProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */; };
 		EEBDF7DF2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7DE2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift */; };
 		EEBDF7E22A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */; };
@@ -2403,6 +2405,7 @@
 		EEBDF7E72A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */; };
 		EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */; };
 		EEC2D281292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */; };
+		EEC5C8DA2ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5C8D92ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift */; };
 		EEC5E01129A70CC300416CAC /* StoreSetupProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */; };
 		EECB7EE02862115C0028C888 /* MockProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */; };
 		EECB7EE62864647F0028C888 /* ProductImagesProductIDUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB7EE52864647F0028C888 /* ProductImagesProductIDUpdater.swift */; };
@@ -4930,6 +4933,8 @@
 		EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponInputTransformer.swift; sourceTree = "<group>"; };
 		EEB917C72A6FE52F004D364B /* FreeTrialSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyView.swift; sourceTree = "<group>"; };
 		EEB917C92A6FE6D8004D364B /* FreeTrialSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSurveyViewModel.swift; sourceTree = "<group>"; };
+		EEBA02A22ADD6005001FE8E4 /* BlazeCampaignDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignDashboardView.swift; sourceTree = "<group>"; };
+		EEBA02A42ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignDashboardViewModel.swift; sourceTree = "<group>"; };
 		EEBDF7D92A2EF69B00EFEF47 /* ShareProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductCoordinator.swift; sourceTree = "<group>"; };
 		EEBDF7DE2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareProductAIEligibilityChecker.swift; sourceTree = "<group>"; };
 		EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShareProductAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
@@ -4937,6 +4942,7 @@
 		EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstProductCreatedViewModelTests.swift; sourceTree = "<group>"; };
 		EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupHostingControllerTests.swift; sourceTree = "<group>"; };
 		EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginHostingViewControllerTests.swift; sourceTree = "<group>"; };
+		EEC5C8D92ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignDashboardViewModelTests.swift; sourceTree = "<group>"; };
 		EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSetupProgressView.swift; sourceTree = "<group>"; };
 		EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImageUploader.swift; sourceTree = "<group>"; };
 		EECB7EE52864647F0028C888 /* ProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
@@ -6290,6 +6296,7 @@
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				EEC5C8D82ADE2FB80071E852 /* Blaze */,
 				02D7E7CA2A4CE4E20003049A /* LocalAnnouncements */,
 				EE3272A229A88F670015F8D0 /* Onboarding */,
 				B6440FB7292E73E50012D506 /* Analytics Hub */,
@@ -10020,6 +10027,7 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				EEBA029F2ADD5F0E001FE8E4 /* Blaze */,
 				2647F7B329280A5000D59FDF /* Analytics Hub */,
 				DE23CFF827462CD2003BE54E /* JCPJetpackInstall */,
 				02F843D8273646190017FE12 /* JetpackConnectionPackageSites */,
@@ -11183,6 +11191,15 @@
 			path = FreeTrialSurvey;
 			sourceTree = "<group>";
 		};
+		EEBA029F2ADD5F0E001FE8E4 /* Blaze */ = {
+			isa = PBXGroup;
+			children = (
+				EEBA02A22ADD6005001FE8E4 /* BlazeCampaignDashboardView.swift */,
+				EEBA02A42ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift */,
+			);
+			path = Blaze;
+			sourceTree = "<group>";
+		};
 		EEBDF7D62A2EF65D00EFEF47 /* ShareProduct */ = {
 			isa = PBXGroup;
 			children = (
@@ -11208,6 +11225,14 @@
 				EEBDF7E42A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift */,
 			);
 			path = FirstProductCreated;
+			sourceTree = "<group>";
+		};
+		EEC5C8D82ADE2FB80071E852 /* Blaze */ = {
+			isa = PBXGroup;
+			children = (
+				EEC5C8D92ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift */,
+			);
+			path = Blaze;
 			sourceTree = "<group>";
 		};
 		EED028622A7AB4C800C5DE03 /* Challenges */ = {
@@ -12397,6 +12422,7 @@
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
 				D8C251D9230D256F00F49782 /* NoticePresenter.swift in Sources */,
 				02063C8929260AA000130906 /* StoreCreationSuccessView.swift in Sources */,
+				EEBA02A52ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift in Sources */,
 				77E53EB8250E6A4E003D385F /* ProductDownloadListViewController.swift in Sources */,
 				020EF5EB2A8C7105009D2169 /* SiteSnapshotTracker.swift in Sources */,
 				E1325EFB28FD544E00EC9B2A /* InAppPurchasesDebugView.swift in Sources */,
@@ -12493,6 +12519,7 @@
 				7E7C5F832719A93C00315B61 /* ProductCategoryListViewModel.swift in Sources */,
 				CC666F2427F329DC0045AF1E /* View+DiscardChanges.swift in Sources */,
 				0282DD94233C9465006A5FDB /* SearchUICommand.swift in Sources */,
+				EEBA02A32ADD6005001FE8E4 /* BlazeCampaignDashboardView.swift in Sources */,
 				028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */,
 				024DF32123744798006658FE /* AztecFormatBarCommandCoordinator.swift in Sources */,
 				B5AA7B3F20ED81C2004DA14F /* UserDefaults+Woo.swift in Sources */,
@@ -14175,6 +14202,7 @@
 				267C01D129E9B18E00FCC97B /* StorePlanSynchronizerTests.swift in Sources */,
 				EE45E2C42A4A85350085F227 /* TooltipPresenterTests.swift in Sources */,
 				0388E1A629E04433007DF84D /* PaymentsRouteTests.swift in Sources */,
+				EEC5C8DA2ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,
 				CC04918F292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift in Sources */,
 				02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -1,0 +1,9 @@
+import Foundation
+import XCTest
+
+@testable import WooCommerce
+
+/// Test cases for `BlazeCampaignDashboardViewModel`.
+///
+final class BlazeCampaignDashboardViewModelTests: XCTestCase {
+}


### PR DESCRIPTION
Part of: #10952

## Description

Adds UI for the new Blaze campaign view in the dashboard screen.

Pending tasks
- Unit tests should be added in a future PR after we add the logic to load remote content.

## Testing instructions

- Login into a store with Blaze 
- Pull down to refresh the Dashboard
- I have mocked the "Blaze campaign" related remotes to show campaign and published product randomly
- Validate that the views match the design.
- You can pull down to refresh to switch between randomly generated view states. 

## Screenshots

| Dark | Ligh |
|--------|--------|
| ![D1](https://github.com/woocommerce/woocommerce-ios/assets/524475/65a7376c-3bd0-493d-8417-53950930b0fa) | ![L1](https://github.com/woocommerce/woocommerce-ios/assets/524475/c8ca230f-fd13-41f6-982f-45c1320e645d) |
| ![D2](https://github.com/woocommerce/woocommerce-ios/assets/524475/5e7d9815-42a9-48c9-833f-1a0e3ba42268) | ![L2](https://github.com/woocommerce/woocommerce-ios/assets/524475/50fa62eb-b7d8-4d86-810c-ce4546bcea6e) | 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
