### PR TITLE
Blaze Optimization: Show campaign list after creation

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -45,6 +45,9 @@ extension UserDefaults {
 
         // AI prompt tone
         case aiPromptTone
+
+        // Celebration view after Blaze campaign creation
+        case hasDisplayedTipAfterBlazeCampaignCreation
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -176,6 +176,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.numberOfTimesWriteWithAITooltipIsShown] = nil
         defaults[.storeProfilerAnswers] = nil
         defaults[.aiPromptTone] = nil
+        defaults[.hasDisplayedTipAfterBlazeCampaignCreation] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -15,7 +15,7 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
 
     /// View model for the list.
     private let viewModel: BlazeCampaignListViewModel
-    
+
     /// Whether the list is displayed right after a campaign is created.
     private let isPostCreation: Bool
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -125,7 +125,9 @@ private extension BlazeCampaignListView {
         CelebrationView(title: Localization.celebrationTitle,
                         subtitle: Localization.celebrationSubtitle,
                         closeButtonTitle: Localization.celebrationCTA,
-                        onTappingDone: {})
+                        onTappingDone: {
+            viewModel.shouldDisplayPostCampaignCreationTip = false
+        })
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -13,7 +13,10 @@ enum BlazeCampaignSource: String {
 ///
 final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaignListView> {
 
+    /// View model for the list.
     private let viewModel: BlazeCampaignListViewModel
+    
+    /// Whether the list is displayed right after a campaign is created.
     private let isPostCreation: Bool
 
     init(site: Site,

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -18,6 +18,7 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
 
         rootView.onCreateCampaign = { [weak self] in
             let webViewModel = BlazeWebViewModel(source: .campaignList, site: site, productID: nil) {
+                self?.navigationController?.popViewController(animated: true)
                 viewModel.loadCampaigns()
             }
             let webViewController = AuthenticatedWebViewController(viewModel: webViewModel)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -13,17 +13,36 @@ enum BlazeCampaignSource: String {
 ///
 final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaignListView> {
 
-    init(site: Site, viewModel: BlazeCampaignListViewModel) {
+    private let viewModel: BlazeCampaignListViewModel
+    private let isPostCreation: Bool
+
+    init(site: Site,
+         viewModel: BlazeCampaignListViewModel,
+         isPostCreation: Bool = false) {
+        self.viewModel = viewModel
+        self.isPostCreation = isPostCreation
         super.init(rootView: BlazeCampaignListView(viewModel: viewModel, siteURL: site.url.trimHTTPScheme()))
 
         rootView.onCreateCampaign = { [weak self] in
             let webViewModel = BlazeWebViewModel(source: .campaignList, site: site, productID: nil) {
-                self?.navigationController?.popViewController(animated: true)
-                viewModel.loadCampaigns()
+                self?.handlePostCreation()
             }
             let webViewController = AuthenticatedWebViewController(viewModel: webViewModel)
             self?.navigationController?.show(webViewController, sender: self)
         }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if isPostCreation {
+            viewModel.checkIfPostCreationTipIsNeeded()
+        }
+    }
+
+    func handlePostCreation() {
+        navigationController?.popViewController(animated: true)
+        viewModel.loadCampaigns()
+        viewModel.checkIfPostCreationTipIsNeeded()
     }
 
     @available(*, unavailable)
@@ -92,11 +111,31 @@ struct BlazeCampaignListView: View {
         .sheet(item: $selectedCampaignURL) { url in
             detailView(url: url)
         }
+        .sheet(isPresented: $viewModel.shouldDisplayPostCampaignCreationTip) {
+            celebrationBottomSheet()
+        }
     }
 }
 
 private extension BlazeCampaignListView {
+    var celebrationView: some View {
+        CelebrationView(title: Localization.celebrationTitle,
+                        subtitle: Localization.celebrationSubtitle,
+                        closeButtonTitle: Localization.celebrationCTA,
+                        onTappingDone: {})
+    }
+
     @ViewBuilder
+    func celebrationBottomSheet() -> some View {
+        if #available(iOS 16.0, *) {
+            celebrationView
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        } else {
+            celebrationView
+        }
+    }
+
     func detailView(url: URL) -> some View {
         NavigationView {
             AuthenticatedWebView(isPresented: .constant(true),
@@ -133,6 +172,18 @@ private extension BlazeCampaignListView {
         )
         static let done = NSLocalizedString("Done", comment: "Button to dismiss the Blaze campaign detail view")
         static let detailTitle = NSLocalizedString("Campaign Details", comment: "Title of the Blaze campaign details view.")
+        static let celebrationTitle = NSLocalizedString(
+            "All set!",
+            comment: "Title of the celebration view when a Blaze campaign is successfully created."
+        )
+        static let celebrationSubtitle = NSLocalizedString(
+            "The ad has been submitted for approval. We'll send you a confirmation email once it's approved and running.",
+            comment: "Subtitle of the celebration view when a Blaze campaign is successfully created."
+        )
+        static let celebrationCTA = NSLocalizedString(
+            "Got it",
+            comment: "Button to dismiss the celebration view when a Blaze campaign is successfully created."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -169,7 +169,7 @@ extension UserDefaults {
         return hasDisplayed?[idAsString] == true
     }
 
-    /// Mark the tip after Blaze campaign creation as displayed a site.
+    /// Mark the tip after Blaze campaign creation as displayed for a site.
     ///
     func setBlazePostCreationTipAsDisplayed(for siteID: Int64) {
         let idAsString = "\(siteID)"

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -79,7 +79,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
     func checkIfPostCreationTipIsNeeded() {
         let hasDisplayed = userDefaults.hasDisplayedTipAfterBlazeCampaignCreation(for: siteID)
         if !hasDisplayed {
-            shouldDisplayPostCampaignCreationTip = hasDisplayed
+            shouldDisplayPostCampaignCreationTip = true
             userDefaults.setBlazePostCreationTipAsDisplayed(for: siteID)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -160,7 +160,7 @@ extension BlazeCampaignListViewModel {
     }
 }
 
-private extension UserDefaults {
+extension UserDefaults {
     /// Checks if the Blaze post campaign creation tip has been displayed for a site.
     ///
     func hasDisplayedTipAfterBlazeCampaignCreation(for siteID: Int64) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -12,10 +12,12 @@ extension BlazeCampaign: Identifiable {
 /// View model for `BlazeCampaignListView`
 final class BlazeCampaignListViewModel: ObservableObject {
     @Published private(set) var campaigns: [BlazeCampaign] = []
+    @Published var shouldDisplayPostCampaignCreationTip = false
 
     private let siteID: Int64
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private let userDefaults: UserDefaults
     private let analytics: Analytics
 
     /// Keeps track of the current state of the syncing
@@ -41,10 +43,12 @@ final class BlazeCampaignListViewModel: ObservableObject {
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
+         userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager
+        self.userDefaults = userDefaults
         self.analytics = analytics
         self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex)
 
@@ -52,6 +56,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
         configurePaginationTracker()
     }
 
+    /// Called when loading the first page of campaigns.
     func loadCampaigns() {
         paginationTracker.syncFirstPage()
     }
@@ -66,6 +71,16 @@ final class BlazeCampaignListViewModel: ObservableObject {
     func onRefreshAction(completion: @escaping () -> Void) {
         paginationTracker.resync(reason: nil) {
             completion()
+        }
+    }
+
+    /// Called after a Blaze campaign is successfully created.
+    ///
+    func checkIfPostCreationTipIsNeeded() {
+        let hasDisplayed = userDefaults.hasDisplayedTipAfterBlazeCampaignCreation(for: siteID)
+        if !hasDisplayed {
+            shouldDisplayPostCampaignCreationTip = hasDisplayed
+            userDefaults.setBlazePostCreationTipAsDisplayed(for: siteID)
         }
     }
 }
@@ -142,5 +157,27 @@ extension BlazeCampaignListViewModel {
     func transitionToResultsUpdatedState() {
         shouldShowBottomActivityIndicator = false
         syncState = campaigns.isNotEmpty ? .results : .empty
+    }
+}
+
+private extension UserDefaults {
+    /// Checks if the Blaze post campaign creation tip has been displayed for a site.
+    ///
+    func hasDisplayedTipAfterBlazeCampaignCreation(for siteID: Int64) -> Bool {
+        let hasDisplayed = self[.hasDisplayedTipAfterBlazeCampaignCreation] as? [String: Bool]
+        let idAsString = "\(siteID)"
+        return hasDisplayed?[idAsString] == true
+    }
+
+    /// Mark the tip after Blaze campaign creation as displayed a site.
+    ///
+    func setBlazePostCreationTipAsDisplayed(for siteID: Int64) {
+        let idAsString = "\(siteID)"
+        if var hasDisplayed = self[.hasDisplayedTipAfterBlazeCampaignCreation] as? [String: Bool] {
+            hasDisplayed[idAsString] = true
+            self[.hasDisplayedTipAfterBlazeCampaignCreation] = hasDisplayed
+        } else {
+            self[.hasDisplayedTipAfterBlazeCampaignCreation] = [idAsString: true]
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -228,7 +228,7 @@ private extension StoreOnboardingCoordinator {
 
             static let subtitle = NSLocalizedString(
                 "Congratulations! You've successfully navigated through the setup and your payment system is ready to roll.",
-                comment: "Subtitle in Woo Payments setup  celebration screen."
+                comment: "Subtitle in Woo Payments setup celebration screen."
             )
             static let done = NSLocalizedString(
                 "Done",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -221,13 +221,19 @@ private extension StoreOnboardingCoordinator {
         }
 
         enum Celebration {
-            static let title = NSLocalizedString("You did it!",
-                                                      comment: "Title in Woo Payments setup celebration screen.")
+            static let title = NSLocalizedString(
+                "You did it!",
+                comment: "Title in Woo Payments setup celebration screen."
+            )
 
-            static let subtitle = NSLocalizedString("Congratulations! You've successfully navigated through the setup and your payment system is ready to roll.",
-                                                        comment: "Subtitle in Woo Payments setup  celebration screen.")
-            static let done = NSLocalizedString("Done",
-                                                 comment: "Dismiss button title in Woo Payments setup celebration screen.")
+            static let subtitle = NSLocalizedString(
+                "Congratulations! You've successfully navigated through the setup and your payment system is ready to roll.",
+                comment: "Subtitle in Woo Payments setup  celebration screen."
+            )
+            static let done = NSLocalizedString(
+                "Done",
+                comment: "Dismiss button title in Woo Payments setup celebration screen."
+            )
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -175,6 +175,7 @@ private extension StoreOnboardingCoordinator {
         let controller = CelebrationHostingController(
             title: Localization.Celebration.title,
             subtitle: Localization.Celebration.subtitle,
+            closeButtonTitle: Localization.Celebration.done,
             onTappingDone: { [weak self] in
             self?.wooPaySetupCelebrationViewBottomSheetPresenter?.dismiss()
             self?.wooPaySetupCelebrationViewBottomSheetPresenter = nil
@@ -225,6 +226,8 @@ private extension StoreOnboardingCoordinator {
 
             static let subtitle = NSLocalizedString("Congratulations! You've successfully navigated through the setup and your payment system is ready to roll.",
                                                         comment: "Subtitle in Woo Payments setup  celebration screen.")
+            static let done = NSLocalizedString("Done",
+                                                 comment: "Dismiss button title in Woo Payments setup celebration screen.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -172,7 +172,10 @@ private extension StoreOnboardingCoordinator {
 
     func showWooPaySetupCelebrationView() {
         wooPaySetupCelebrationViewBottomSheetPresenter = buildBottomSheetPresenter()
-        let controller = WooPaymentSetupCelebrationHostingController(onTappingDone: { [weak self] in
+        let controller = CelebrationHostingController(
+            title: Localization.Celebration.title,
+            subtitle: Localization.Celebration.subtitle,
+            onTappingDone: { [weak self] in
             self?.wooPaySetupCelebrationViewBottomSheetPresenter?.dismiss()
             self?.wooPaySetupCelebrationViewBottomSheetPresenter = nil
         })
@@ -214,6 +217,14 @@ private extension StoreOnboardingCoordinator {
                 "To change again, visit Store Settings.",
                 comment: "Subtitle on the notice presented when the store name is updated"
             )
+        }
+
+        enum Celebration {
+            static let title = NSLocalizedString("You did it!",
+                                                      comment: "Title in Woo Payments setup celebration screen.")
+
+            static let subtitle = NSLocalizedString("Congratulations! You've successfully navigated through the setup and your payment system is ready to roll.",
+                                                        comment: "Subtitle in Woo Payments setup  celebration screen.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CelebrationView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CelebrationView.swift
@@ -5,10 +5,12 @@ import SwiftUI
 final class CelebrationHostingController: UIHostingController<CelebrationView> {
     init(title: String,
          subtitle: String,
+         closeButtonTitle: String,
          image: UIImage = .checkSuccessImage,
          onTappingDone: @escaping () -> Void) {
         super.init(rootView: CelebrationView(title: title,
                                              subtitle: subtitle,
+                                             closeButtonTitle: closeButtonTitle,
                                              image: image,
                                              onTappingDone: onTappingDone))
     }
@@ -23,21 +25,24 @@ final class CelebrationHostingController: UIHostingController<CelebrationView> {
 struct CelebrationView: View {
     private let title: String
     private let subtitle: String
+    private let closeButtonTitle: String
     private let image: UIImage
     private let onTappingDone: () -> Void
 
     init(title: String,
          subtitle: String,
+         closeButtonTitle: String,
          image: UIImage = .checkSuccessImage,
          onTappingDone: @escaping () -> Void) {
         self.title = title
         self.subtitle = subtitle
+        self.closeButtonTitle = closeButtonTitle
         self.image = image
         self.onTappingDone = onTappingDone
     }
 
     var body: some View {
-        VStack(spacing: Layout.verticalSpacing) {
+        ScrollableVStack(spacing: Layout.verticalSpacing) {
             Image(uiImage: image)
                 .padding(.vertical, Layout.imageVerticalPadding)
 
@@ -53,7 +58,7 @@ struct CelebrationView: View {
             }
             .padding(.horizontal, Layout.textHorizontalPadding)
 
-            Button(Localization.done) {
+            Button(closeButtonTitle) {
                 onTappingDone()
             }
             .buttonStyle(PrimaryButtonStyle())
@@ -71,21 +76,18 @@ private extension CelebrationView {
         static let buttonHorizontalPadding: CGFloat = 16
         static let insets: EdgeInsets = .init(top: 40, leading: 0, bottom: 16, trailing: 0)
     }
-
-    enum Localization {
-        static let done = NSLocalizedString("Done",
-                                             comment: "Dismiss button title in Woo Payments setup celebration screen.")
-    }
 }
 
 struct CelebrationView_Previews: PreviewProvider {
     static var previews: some View {
         CelebrationView(title: "Success!",
                         subtitle: "You did it!",
+                        closeButtonTitle: "Done",
                         onTappingDone: {})
 
         CelebrationView(title: "Success!",
                         subtitle: "You did it!",
+                        closeButtonTitle: "Done",
                         onTappingDone: {})
             .preferredColorScheme(.dark)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CelebrationView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CelebrationView.swift
@@ -1,10 +1,16 @@
 import SwiftUI
 
-/// Hosting controller for `WooPaymentSetupCelebrationView`.
+/// Hosting controller for `CelebrationView`.
 ///
-final class WooPaymentSetupCelebrationHostingController: UIHostingController<WooPaymentSetupCelebrationView> {
-    init(onTappingDone: @escaping () -> Void) {
-        super.init(rootView: WooPaymentSetupCelebrationView(onTappingDone: onTappingDone))
+final class CelebrationHostingController: UIHostingController<CelebrationView> {
+    init(title: String,
+         subtitle: String,
+         image: UIImage = .checkSuccessImage,
+         onTappingDone: @escaping () -> Void) {
+        super.init(rootView: CelebrationView(title: title,
+                                             subtitle: subtitle,
+                                             image: image,
+                                             onTappingDone: onTappingDone))
     }
 
     @available(*, unavailable)
@@ -13,25 +19,34 @@ final class WooPaymentSetupCelebrationHostingController: UIHostingController<Woo
     }
 }
 
-/// Celebration view presented after Woo Payment setup
-struct WooPaymentSetupCelebrationView: View {
+/// Celebration view presented after a successful task.
+struct CelebrationView: View {
+    private let title: String
+    private let subtitle: String
+    private let image: UIImage
     private let onTappingDone: () -> Void
 
-    init(onTappingDone: @escaping () -> Void) {
+    init(title: String,
+         subtitle: String,
+         image: UIImage = .checkSuccessImage,
+         onTappingDone: @escaping () -> Void) {
+        self.title = title
+        self.subtitle = subtitle
+        self.image = image
         self.onTappingDone = onTappingDone
     }
 
     var body: some View {
         VStack(spacing: Layout.verticalSpacing) {
-            Image(uiImage: .checkSuccessImage)
+            Image(uiImage: image)
                 .padding(.vertical, Layout.imageVerticalPadding)
 
             Group {
-                Text(Localization.title)
+                Text(title)
                     .headlineStyle()
                     .multilineTextAlignment(.center)
 
-                Text(Localization.subtitle)
+                Text(subtitle)
                     .foregroundColor(Color(.text))
                     .subheadlineStyle()
                     .multilineTextAlignment(.center)
@@ -48,7 +63,7 @@ struct WooPaymentSetupCelebrationView: View {
     }
 }
 
-private extension WooPaymentSetupCelebrationView {
+private extension CelebrationView {
     enum Layout {
         static let verticalSpacing: CGFloat = 16
         static let imageVerticalPadding: CGFloat = 18
@@ -58,22 +73,20 @@ private extension WooPaymentSetupCelebrationView {
     }
 
     enum Localization {
-        static let title = NSLocalizedString("You did it!",
-                                                  comment: "Title in Woo Payments setup celebration screen.")
-
-        static let subtitle = NSLocalizedString("Congratulations! You've successfully navigated through the setup and your payment system is ready to roll.",
-                                                    comment: "Subtitle in Woo Payments setup  celebration screen.")
-
         static let done = NSLocalizedString("Done",
                                              comment: "Dismiss button title in Woo Payments setup celebration screen.")
     }
 }
 
-struct WooPaymentSetupCelebrationView_Previews: PreviewProvider {
+struct CelebrationView_Previews: PreviewProvider {
     static var previews: some View {
-        WooPaymentSetupCelebrationView(onTappingDone: {})
+        CelebrationView(title: "Success!",
+                        subtitle: "You did it!",
+                        onTappingDone: {})
 
-        WooPaymentSetupCelebrationView(onTappingDone: {})
+        CelebrationView(title: "Success!",
+                        subtitle: "You did it!",
+                        onTappingDone: {})
             .preferredColorScheme(.dark)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2338,7 +2338,7 @@
 		EE2EDFE12987A189004E702B /* MockABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */; };
 		EE3272A429A88F750015F8D0 /* StoreOnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3272A329A88F750015F8D0 /* StoreOnboardingViewModelTests.swift */; };
 		EE3B17AF2A9EFE97004D3E0C /* WooPaymentsSetupInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B17AE2A9EFE96004D3E0C /* WooPaymentsSetupInstructionsView.swift */; };
-		EE3B17B62AA03837004D3E0C /* WooPaymentSetupCelebrationView.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B17B52AA03837004D3E0C /* WooPaymentSetupCelebrationView.swift.swift */; };
+		EE3B17B62AA03837004D3E0C /* CelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B17B52AA03837004D3E0C /* CelebrationView.swift */; };
 		EE45E29D2A381A250085F227 /* ProductDescriptionGenerationCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE45E29C2A381A250085F227 /* ProductDescriptionGenerationCelebrationView.swift */; };
 		EE45E29F2A381A2E0085F227 /* ProductDescriptionGenerationCelebrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE45E29E2A381A2E0085F227 /* ProductDescriptionGenerationCelebrationViewModel.swift */; };
 		EE45E2B72A409BA40085F227 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE45E2B22A409B9E0085F227 /* Tooltip.swift */; };
@@ -4871,7 +4871,7 @@
 		EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockABTestVariationProvider.swift; sourceTree = "<group>"; };
 		EE3272A329A88F750015F8D0 /* StoreOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		EE3B17AE2A9EFE96004D3E0C /* WooPaymentsSetupInstructionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WooPaymentsSetupInstructionsView.swift; sourceTree = "<group>"; };
-		EE3B17B52AA03837004D3E0C /* WooPaymentSetupCelebrationView.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupCelebrationView.swift.swift; sourceTree = "<group>"; };
+		EE3B17B52AA03837004D3E0C /* CelebrationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CelebrationView.swift; sourceTree = "<group>"; };
 		EE45E29C2A381A250085F227 /* ProductDescriptionGenerationCelebrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionGenerationCelebrationView.swift; sourceTree = "<group>"; };
 		EE45E29E2A381A2E0085F227 /* ProductDescriptionGenerationCelebrationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionGenerationCelebrationViewModel.swift; sourceTree = "<group>"; };
 		EE45E2B02A409B9D0085F227 /* ProductDescriptionAITooltipUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAITooltipUseCase.swift; sourceTree = "<group>"; };
@@ -7570,6 +7570,7 @@
 		45D875D72611EA3D00226C3F /* SwiftUI Components */ = {
 			isa = PBXGroup;
 			children = (
+				EE3B17B52AA03837004D3E0C /* CelebrationView.swift */,
 				D449C51926DE6B5000D75B02 /* IconListItem.swift */,
 				D449C51A26DE6B5000D75B02 /* LargeTitle.swift */,
 				D449C51826DE6B5000D75B02 /* ReportList.swift */,
@@ -11009,7 +11010,6 @@
 		EE3B17AB2A9EF478004D3E0C /* Payments */ = {
 			isa = PBXGroup;
 			children = (
-				EE3B17B52AA03837004D3E0C /* WooPaymentSetupCelebrationView.swift.swift */,
 				DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */,
 				EE3B17AE2A9EFE96004D3E0C /* WooPaymentsSetupInstructionsView.swift */,
 				02D681A829C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift */,
@@ -12384,7 +12384,7 @@
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,
 				E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */,
 				CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */,
-				EE3B17B62AA03837004D3E0C /* WooPaymentSetupCelebrationView.swift.swift in Sources */,
+				EE3B17B62AA03837004D3E0C /* CelebrationView.swift in Sources */,
 				D85A3C5226C15DE200C0E026 /* InPersonPaymentsPluginNotSupportedVersionView.swift in Sources */,
 				EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */,
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -297,6 +297,28 @@ class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.aiPromptTone])
     }
 
+    /// Verifies that `hasDisplayedTipAfterBlazeCampaignCreation` is set to `nil` upon reset
+    ///
+    func test_hasDisplayedTipAfterBlazeCampaignCreation_is_set_to_nil_upon_reset() throws {
+        // Given
+        let siteID: Int64 = 123
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[.hasDisplayedTipAfterBlazeCampaignCreation] = ["\(siteID)": true]
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(defaults.hasDisplayedTipAfterBlazeCampaignCreation(for: siteID)))
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[.hasDisplayedTipAfterBlazeCampaignCreation])
+    }
+
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
     func testDefaultCredentialsAreEffectivelyNuked() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -278,6 +278,35 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
         XCTAssertEqual(syncPageNumber, 1)
         XCTAssertEqual(invocationCountOfLoadCampaigns, 1)
     }
+
+    // MARK: - checkIfPostCreationTipIsNeeded
+
+    func test_checkIfPostCreationTipIsNeeded_sets_shouldDisplayPostCampaignCreationTip_to_true_if_the_tip_has_not_been_displayed() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, userDefaults: userDefaults)
+
+        // When
+        viewModel.checkIfPostCreationTipIsNeeded()
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisplayPostCampaignCreationTip)
+    }
+
+    func test_checkIfPostCreationTipIsNeeded_keeps_shouldDisplayPostCampaignCreationTip_as_false_if_the_tip_has_been_displayed() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        userDefaults[.hasDisplayedTipAfterBlazeCampaignCreation] = ["\(sampleSiteID)": true]
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, userDefaults: userDefaults)
+
+        // When
+        viewModel.checkIfPostCreationTipIsNeeded()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisplayPostCampaignCreationTip)
+    }
 }
 
 private extension BlazeCampaignListViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: 10955
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Initially the Blaze creation flow was designed to display the campaign list when tapping the "Go to my campaigns" button on the web view. This is not reliable, and the view can be hidden if the user asks to not display it again. 

This PR updates the flow to detect when the creation completes and navigates to the campaign list. If it is the first time the user creates a campaign on the app for their site, a bottom sheet is displayed saying that their campaign is awaiting approval.

Technical details:
- The bottom sheet looks similar to the celebration view of the WCPay setup flow, so I updated the view to be reusable.
- A new `UserDefaults` key was added to track whether the bottom sheet has been displayed yet.
- `BlazeCampaignListViewModel` has been updated with a new method and property to check and configure the displaying of the new bottom sheet.
- `BlazeCampaignListHostingController`:
  - Triggers the check to display the bottom sheet after a campaign is created.
  - The initializer accepts a new param `isPostCreation` to display the bottom sheet if needed. This will be used when we handle the campaign creation from outside of the campaign list (e.g. the Blaze section on My Store)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in as an admin to a site that is eligible for Blaze.
- Switch to Menu tab and select Blaze.
- Tap Create to create a new campaign in a web view.
- When the creation succeeds, the web view should be dismissed, and a bottom sheet should be presented saying the new campaign is under review.
- Try again to create another campaign, this time the bottom sheet should not be displayed after creation.
- Cancel or reject your test campaigns if needed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/03b465ea-6c75-4d5a-97e4-c2bd23d4645f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
