### PR TITLE
Blaze Optimization: Display intro screen on top of the empty campaign list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignIntroView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignIntroView.swift
@@ -6,6 +6,15 @@ struct BlazeCampaignIntroView: View {
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
+    private let onStartCampaign: () -> Void
+    private let onDismiss: () -> Void
+
+    init(onStartCampaign: @escaping () -> Void,
+         onDismiss: @escaping () -> Void) {
+        self.onStartCampaign = onStartCampaign
+        self.onDismiss = onDismiss
+    }
+
     var body: some View {
         NavigationView {
             ScrollView {
@@ -38,7 +47,7 @@ struct BlazeCampaignIntroView: View {
                         .frame(height: Layout.dividerHeight)
                         .foregroundColor(Color(.separator))
                     Button(Localization.startBlazeCampaign) {
-                        // todo
+                        onStartCampaign()
                     }
                     .buttonStyle(PrimaryButtonStyle())
                     .padding(Layout.buttonPadding)
@@ -48,7 +57,7 @@ struct BlazeCampaignIntroView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.cancel) {
-                        // todo
+                        onDismiss()
                     }
                 }
             }
@@ -101,6 +110,6 @@ private enum Layout {
 
 struct BlazeCampaignIntroView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeCampaignIntroView()
+        BlazeCampaignIntroView(onStartCampaign: {}, onDismiss: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -117,6 +117,14 @@ struct BlazeCampaignListView: View {
         .sheet(isPresented: $viewModel.shouldDisplayPostCampaignCreationTip) {
             celebrationBottomSheet()
         }
+        .sheet(isPresented: $viewModel.shouldShowIntroView) {
+            BlazeCampaignIntroView(onStartCampaign: {
+                viewModel.shouldShowIntroView = false
+                onCreateCampaign()
+            }, onDismiss: {
+                viewModel.shouldShowIntroView = false
+            })
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -13,6 +13,10 @@ extension BlazeCampaign: Identifiable {
 final class BlazeCampaignListViewModel: ObservableObject {
     @Published private(set) var campaigns: [BlazeCampaign] = []
     @Published var shouldDisplayPostCampaignCreationTip = false
+    @Published var shouldShowIntroView = false
+
+    /// Tracks whether the intro view has been presented.
+    private var didShowIntroView = false
 
     private let siteID: Int64
     private let stores: StoresManager
@@ -157,6 +161,10 @@ extension BlazeCampaignListViewModel {
     func transitionToResultsUpdatedState() {
         shouldShowBottomActivityIndicator = false
         syncState = campaigns.isNotEmpty ? .results : .empty
+        if !didShowIntroView {
+            shouldShowIntroView = campaigns.isEmpty
+            didShowIntroView = true
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -13,7 +13,13 @@ extension BlazeCampaign: Identifiable {
 final class BlazeCampaignListViewModel: ObservableObject {
     @Published private(set) var campaigns: [BlazeCampaign] = []
     @Published var shouldDisplayPostCampaignCreationTip = false
-    @Published var shouldShowIntroView = false
+    @Published var shouldShowIntroView = false {
+        didSet {
+            if shouldShowIntroView {
+                didShowIntroView = true
+            }
+        }
+    }
 
     /// Tracks whether the intro view has been presented.
     private var didShowIntroView = false
@@ -133,7 +139,9 @@ extension BlazeCampaignListViewModel: PaginationTrackerDelegate {
                 DDLogError("⛔️ Error synchronizing Blaze campaigns: \(error)")
                 onCompletion?(.failure(error))
             }
+
             self?.updateResults()
+            self?.displayIntroViewIfNeeded()
         }
         stores.dispatch(action)
     }
@@ -161,9 +169,11 @@ extension BlazeCampaignListViewModel {
     func transitionToResultsUpdatedState() {
         shouldShowBottomActivityIndicator = false
         syncState = campaigns.isNotEmpty ? .results : .empty
+    }
+
+    func displayIntroViewIfNeeded() {
         if !didShowIntroView {
-            shouldShowIntroView = campaigns.isEmpty
-            didShowIntroView = true
+            shouldShowIntroView = syncState == .empty
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10942 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the campaign list to display the intro screen when the campaign list is opened but the user has not created any campaigns. This intro screen helps them understand the purpose of Blaze and hopefully drives them to create new campaigns.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in as an admin to a site that is eligible for Blaze.
- Navigate to the Menu tab and select Blaze.
- After the list is loaded, you should see the intro screen being presented.
- Tap Cancel, the intro should be dismissed and not displayed again.
- Navigate back and select Blaze again.
- The intro screen should be displayed again.
- Tap the Start Blaze Campaign button, the intro should be dismissed and the web view for creating campaigns should be displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/766dfc2f-a0d6-42bb-baf6-b3a917491a83



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
