### PR TITLE
[UI Tests] - Fix top flaky UI tests

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
@@ -37,7 +37,7 @@ public final class CardReaderManualsScreen: ScreenObject {
         let chipperManualPredicate = NSPredicate(format: "label CONTAINS[c] %@", "ChipperTM 2X BT")
         let chipperManualText = app.webViews.textViews.containing(chipperManualPredicate).element
 
-        XCTAssert(chipperManualText.waitForExistence(timeout: 10), "Chipper manual not displayed on WebView!")
+        XCTAssert(chipperManualText.waitForExistence(timeout: 30), "Chipper manual not displayed on WebView!")
         return self
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -104,6 +104,6 @@ public final class PaymentsScreen: ScreenObject {
     }
 
     public func verifyIPPDocumentationLoadedInWebView() throws {
-        XCTAssertTrue(IPPDocumentationHeaderText.waitForExistence(timeout: 10), "IPP Documentation not displayed on WebView!")
+        XCTAssertTrue(IPPDocumentationHeaderText.waitForExistence(timeout: 30), "IPP Documentation not displayed on WebView!")
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -2,7 +2,7 @@ import ScreenObject
 import XCTest
 
 public final class ProductsScreen: ScreenObject {
-    
+
     private let productsNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
         $0.navigationBars["Products"]
     }
@@ -49,7 +49,7 @@ public final class ProductsScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [
-                productsNavigationBarGetter, 
+                productsNavigationBarGetter,
                 productAddButtonGetter,
                 productSearchButtonGetter
             ],

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -2,6 +2,10 @@ import ScreenObject
 import XCTest
 
 public final class ProductsScreen: ScreenObject {
+    
+    private let productsNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Products"]
+    }
 
     private let productAddButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["product-add-button"]
@@ -44,7 +48,11 @@ public final class ProductsScreen: ScreenObject {
         tabBar = try TabNavComponent(app: app)
 
         try super.init(
-            expectedElementGetters: [ productAddButtonGetter, productSearchButtonGetter ],
+            expectedElementGetters: [
+                productsNavigationBarGetter, 
+                productAddButtonGetter,
+                productSearchButtonGetter
+            ],
             app: app
         )
     }

--- a/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
@@ -2,6 +2,10 @@ import ScreenObject
 import XCTest
 
 public final class SettingsScreen: ScreenObject {
+    private let settingsNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Settings"]
+    }
+
     private let betaFeaturesGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["settings-beta-features-button"]
     }
@@ -13,6 +17,7 @@ public final class SettingsScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
+                settingsNavigationBarGetter,
                 betaFeaturesGetter
             ],
             app: app


### PR DESCRIPTION
## Description
The top 3 flaky test in the project are: `LoginTests test_site_address_login_logout`, `PaymentsTests test_load_learn_more_link` and `PaymentsTests test_load_chipper_card_reader_manual`

1. For `LoginTests test_site_address_login_logout`, the attempted fix is to look for an element higher in the element tree on the Settings screen. Additionally, I have made a similar change in ProductsScreen via https://github.com/woocommerce/woocommerce-ios/pull/10967/commits/5bce1ed5d2ad530717d4ca43a2752f32e44c90f9 because it was flaky in one of the test runs in this PR.
2. For the `PaymentsTests`, it looks like a legit slowness where it takes longer than usual for the WebView to load, the attempted fix is increasing the timeout from 10 seconds to 30 seconds (if it takes shorter than 30 seconds, the test would continue, 30 seconds is the max wait time before test times out).

## Testing instructions
Ran UI tests 5 times in a row in CI without instances of flaky tests