### PR TITLE
Site Creation: Add missing tracking for site creation flow when started from prologue screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -28,6 +28,11 @@ extension WooAnalyticsEvent {
                               properties: [Key.source: source.rawValue])
         }
 
+        static func siteCreationFlowStarted(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationFlowStarted,
+                              properties: [Key.source: source.rawValue])
+        }
+
         /// Tracked when a site is created from the store creation flow.
         static func siteCreated(source: Source, siteURL: String, flow: Flow, isFreeTrial: Bool, waitingTime: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreated,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -215,6 +215,7 @@ public enum WooAnalyticsStat: String {
     case siteCreated = "login_woocommerce_site_created"
     case siteCreationFailed = "site_creation_failed"
     case siteCreationDismissed = "site_creation_dismissed"
+    case siteCreationFlowStarted = "site_creation_flow_started"
     case siteCreationStep = "site_creation_step"
     case siteCreationSitePreviewed = "site_creation_site_previewed"
     case siteCreationManageStoreTapped = "site_creation_store_management_opened"

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -60,6 +60,7 @@ final class StoreCreationCoordinator: Coordinator {
     }
 
     func start() {
+        analytics.track(event: .StoreCreation.siteCreationFlowStarted(source: source.analyticsValue))
         Task { @MainActor in
             let storeCreationNavigationController = WooNavigationController()
             startStoreCreation(from: storeCreationNavigationController)

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
@@ -6,6 +6,8 @@ import Yosemite
 final class StoreCreationCoordinatorTests: XCTestCase {
     private var navigationController: UINavigationController!
     private let window = UIWindow(frame: UIScreen.main.bounds)
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
 
     override func setUp() {
         super.setUp()
@@ -13,6 +15,9 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         window.makeKeyAndVisible()
         navigationController = .init()
         window.rootViewController = navigationController
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
 
     override func tearDown() {
@@ -20,7 +25,26 @@ final class StoreCreationCoordinatorTests: XCTestCase {
         window.resignKey()
         window.rootViewController = nil
 
+        analytics = nil
+        analyticsProvider = nil
+
         super.tearDown()
+    }
+
+    func test_siteCreationFlowStarted_is_tracked_upon_start() throws {
+        // Given
+        let coordinator = StoreCreationCoordinator(source: .loggedOut(source: .prologue),
+                                                   navigationController: navigationController,
+                                                   analytics: analytics)
+
+        // When
+        coordinator.start()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("site_creation_flow_started"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "site_creation_flow_started"))
+        let eventProperties = analyticsProvider.receivedProperties[index]
+        XCTAssertEqual(eventProperties["source"] as? String, "prologue")
     }
 
     func test_FreeTrialSummaryHostingController_is_presented_upon_start() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10964
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new event to track the start of the site creation flow with the entry point of where the flow was triggered.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app if needed.
- On the prologue screen, select Create a new store.
- Enter an email address that's not associated with any WPCom account.
- Enter a password for the new account.
- After a new account is created, the site creation summary screen should be displayed.
- Notice in Xcode console: `🔵 Tracked site_creation_flow_started, properties: [AnyHashable("source"): "prologue"]`.
- Proceed to create the new store or log in to an account with existing stores.
- Navigate to the Menu tab and open the store picker.
- Scroll to the bottom and select Add a store > Create a new store.
- Notice in Xcode console: `🔵 Tracked site_creation_flow_started, properties: [AnyHashable("source"): "store_picker", ...]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
