### PR TITLE
Blaze Optimization: Navigation from the section on My Store

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -58,6 +58,12 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeCampaignListEntryPointSelected,
                               properties: [Key.source: source.rawValue])
         }
+
+        /// Tracked when a Blaze campaign detail is selected.
+        static func blazeCampaignDetailSelected(source: BlazeCampaignDetailSource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeCampaignDetailSelected,
+                              properties: [Key.source: source.rawValue])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -52,6 +52,12 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeBannerDismissed,
                               properties: [Key.source: entryPoint.blazeSource.analyticsValue])
         }
+
+        /// Tracked when the Blaze campaign list entry point is selected.
+        static func blazeCampaignListEntryPointSelected(source: BlazeCampaignListSource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeCampaignListEntryPointSelected,
+                              properties: [Key.source: source.rawValue])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -95,6 +95,12 @@ extension BlazeSource {
             return "my_store_banner"
         case .campaignList:
             return "campaign_list"
+        case .myStoreProductItem:
+            return "my_store_product_item"
+        case .myStoreSectionCreateCampaignButton:
+            return "my_store_section_create_campaign_button"
+        case .introView:
+            return "intro_view"
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -95,8 +95,6 @@ extension BlazeSource {
             return "my_store_banner"
         case .campaignList:
             return "campaign_list"
-        case .myStoreProductItem:
-            return "my_store_product_item"
         case .myStoreSectionCreateCampaignButton:
             return "my_store_section_create_campaign_button"
         case .introView:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -64,6 +64,11 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeCampaignDetailSelected,
                               properties: [Key.source: source.rawValue])
         }
+
+        /// Tracked when then intro screen for Blaze is displayed.
+        static func blazeIntroDisplayed() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeIntroDisplayed, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -181,6 +181,9 @@ public enum WooAnalyticsStat: String {
     case blazeFlowCompleted = "blaze_flow_completed"
     case blazeFlowError = "blaze_flow_error"
     case blazeBannerDismissed = "blaze_banner_dismissed"
+    case blazeCampaignListEntryPointSelected = "blaze_campaign_list_entry_point_selected"
+    case blazeCampaignDetailSelected = "blaze_campaign_detail_selected"
+    case blazeIntroDisplayed = "blaze_intro_displayed"
 
     // MARK: Products Onboarding Events
     //

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -14,6 +14,12 @@ enum BlazeSource {
     case myStoreBanner
     /// From the Blaze campaign list
     case campaignList
+    /// From the Blaze intro view
+    case introView
+    /// From the Create campaign button on the Blaze section of the My Store screen
+    case myStoreSectionCreateCampaignButton
+    /// From the product item on the Blaze section of the My Store screen
+    case myStoreProductItem
 }
 
 /// View model for Blaze webview.

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -18,8 +18,6 @@ enum BlazeSource {
     case introView
     /// From the Create campaign button on the Blaze section of the My Store screen
     case myStoreSectionCreateCampaignButton
-    /// From the product item on the Blaze section of the My Store screen
-    case myStoreProductItem
 }
 
 /// View model for Blaze webview.

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignIntroView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignIntroView.swift
@@ -16,7 +16,12 @@ struct BlazeCampaignIntroView: View {
     }
 
     var body: some View {
-        NavigationView {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(Localization.cancel) {
+                onDismiss()
+            }
+            .padding(Layout.buttonPadding)
+
             ScrollView {
                 VStack(alignment: .leading, spacing: Layout.elementVerticalSpacing) {
                     ZStack {
@@ -53,13 +58,6 @@ struct BlazeCampaignIntroView: View {
                     .padding(Layout.buttonPadding)
                 }
                 .background(Color(UIColor.systemBackground))
-            }
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(Localization.cancel) {
-                        onDismiss()
-                    }
-                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -119,6 +119,7 @@ struct BlazeCampaignListView: View {
         }
         .onAppear {
             viewModel.loadCampaigns()
+            viewModel.onViewAppear()
         }
         .sheet(item: $selectedCampaignURL) { url in
             detailView(url: url)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -1,12 +1,19 @@
 import SwiftUI
 import struct Yosemite.Site
 
-/// Blaze campaign entry points.
-enum BlazeCampaignSource: String {
+/// Blaze campaign detail entry points.
+enum BlazeCampaignDetailSource: String {
     /// From the Blaze section on My Store tab.
     case myStoreSection = "my_store_section"
     /// From the Blaze campaign list
     case campaignList = "campaign_list"
+}
+
+enum BlazeCampaignListSource: String {
+    /// From the Menu tab
+    case menu
+    /// From the Blaze section on My Store tab
+    case myStoreSection = "my_store_section"
 }
 
 /// Hosting controller for `BlazeCampaignListView`

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -89,9 +89,10 @@ struct BlazeCampaignListView: View {
                     ForEach(viewModel.campaigns) { item in
                         BlazeCampaignItemView(campaign: item)
                             .onTapGesture {
+                                ServiceLocator.analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .campaignList))
                                 let path = String(format: Constants.campaignDetailsURLFormat,
                                                   item.campaignID, siteURL,
-                                                  BlazeCampaignSource.campaignList.rawValue)
+                                                  BlazeCampaignDetailSource.campaignList.rawValue)
                                 selectedCampaignURL = URL(string: path)
                             }
                     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -89,7 +89,7 @@ struct BlazeCampaignListView: View {
                     ForEach(viewModel.campaigns) { item in
                         BlazeCampaignItemView(campaign: item)
                             .onTapGesture {
-                                ServiceLocator.analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .campaignList))
+                                viewModel.didSelectCampaignDetails()
                                 let path = String(format: Constants.campaignDetailsURLFormat,
                                                   item.campaignID, siteURL,
                                                   BlazeCampaignDetailSource.campaignList.rawValue)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -113,6 +113,7 @@ struct BlazeCampaignListView: View {
             ToolbarItem(placement: .confirmationAction) {
                 Button(Localization.create) {
                     onCreateCampaign()
+                    viewModel.didSelectCreateCampaign(source: .campaignList)
                 }
             }
         }
@@ -129,6 +130,7 @@ struct BlazeCampaignListView: View {
             BlazeCampaignIntroView(onStartCampaign: {
                 viewModel.shouldShowIntroView = false
                 onCreateCampaign()
+                viewModel.didSelectCreateCampaign(source: .introView)
             }, onDismiss: {
                 viewModel.shouldShowIntroView = false
             })

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -17,7 +17,6 @@ final class BlazeCampaignListViewModel: ObservableObject {
         didSet {
             if shouldShowIntroView {
                 didShowIntroView = true
-                analytics.track(event: .Blaze.blazeIntroDisplayed())
                 analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .introView))
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -18,6 +18,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
             if shouldShowIntroView {
                 didShowIntroView = true
                 analytics.track(event: .Blaze.blazeIntroDisplayed())
+                analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .introView))
             }
         }
     }
@@ -65,6 +66,8 @@ final class BlazeCampaignListViewModel: ObservableObject {
 
         configureResultsController()
         configurePaginationTracker()
+
+        analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .campaignList))
     }
 
     /// Called when loading the first page of campaigns.

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -17,6 +17,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
         didSet {
             if shouldShowIntroView {
                 didShowIntroView = true
+                analytics.track(event: .Blaze.blazeIntroDisplayed())
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -94,6 +94,10 @@ final class BlazeCampaignListViewModel: ObservableObject {
             userDefaults.setBlazePostCreationTipAsDisplayed(for: siteID)
         }
     }
+
+    func didSelectCampaignDetails() {
+        analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .campaignList))
+    }
 }
 
 // MARK: Configuration

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -66,7 +66,10 @@ final class BlazeCampaignListViewModel: ObservableObject {
 
         configureResultsController()
         configurePaginationTracker()
+    }
 
+    /// Called when view first appears.
+    func onViewAppear() {
         analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .campaignList))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -98,6 +98,10 @@ final class BlazeCampaignListViewModel: ObservableObject {
     func didSelectCampaignDetails() {
         analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .campaignList))
     }
+
+    func didSelectCreateCampaign(source: BlazeSource) {
+        analytics.track(event: .Blaze.blazeEntryPointTapped(source: source))
+    }
 }
 
 // MARK: Configuration

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -50,6 +50,7 @@ private extension BlazeCampaignDashboardViewHostingController {
         }
         let webViewController = AuthenticatedWebViewController(viewModel: webViewModel)
         parentNavigationController?.show(webViewController, sender: self)
+        viewModel.didSelectCreateCampaign(source: source)
     }
 
     /// Reloads data and shows campaign list.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -28,10 +28,6 @@ final class BlazeCampaignDashboardViewHostingController: SelfSizingHostingContro
             self?.navigateToCampaignCreation(source: .introView, productID: productID)
         }
 
-        rootView.productTapped = { [weak self] productID in
-            self?.navigateToCampaignCreation(source: .myStoreProductItem, productID: productID)
-        }
-
         rootView.showAllCampaignsTapped = { [weak self] in
             self?.showCampaignList(isPostCreation: false)
         }
@@ -81,9 +77,6 @@ private extension BlazeCampaignDashboardViewHostingController {
 struct BlazeCampaignDashboardView: View {
 
     /// Set externally in the hosting controller.
-    var productTapped: ((Int64) -> Void)?
-
-    /// Set externally in the hosting controller.
     var showAllCampaignsTapped: (() -> Void)?
 
     /// Set externally in the hosting controller.
@@ -119,11 +112,8 @@ struct BlazeCampaignDashboardView: View {
             if case .showProduct(let product) = viewModel.state {
                 ProductInfoView(product: product)
                     .onTapGesture {
-                        viewModel.checkIfIntroViewIsNeeded()
                         selectedProductID = product.productID
-                        if !viewModel.shouldShowIntroView {
-                            productTapped?(product.productID)
-                        }
+                        viewModel.shouldShowIntroView = true
                     }
             } else if case .showCampaign(let campaign) = viewModel.state {
                 BlazeCampaignItemView(campaign: campaign, showBudget: false)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -61,6 +61,9 @@ private extension BlazeCampaignDashboardViewHostingController {
         showCampaignList(isPostCreation: true)
     }
 
+    /// Navigates to the campaign list.
+    /// Parameter isPostCreation: Whether the list is opened after creating a campaign successfully.
+    ///
     func showCampaignList(isPostCreation: Bool) {
         guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -124,7 +124,7 @@ struct BlazeCampaignDashboardView: View {
                         let path = String(format: Constants.campaignDetailsURLFormat,
                                           campaign.campaignID,
                                           site.url.trimHTTPScheme(),
-                                          BlazeCampaignSource.myStoreSection.rawValue)
+                                          BlazeCampaignDetailSource.myStoreSection.rawValue)
                         selectedCampaignURL = URL(string: path)
                     }
             }
@@ -172,6 +172,7 @@ private extension BlazeCampaignDashboardView {
 
     var showAllCampaignsButton: some View {
         Button {
+            ServiceLocator.analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .myStoreSection))
             showAllCampaignsTapped?()
         } label: {
             HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -121,6 +121,7 @@ struct BlazeCampaignDashboardView: View {
                         guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
                             return
                         }
+                        ServiceLocator.analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .myStoreSection))
                         let path = String(format: Constants.campaignDetailsURLFormat,
                                           campaign.campaignID,
                                           site.url.trimHTTPScheme(),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -144,7 +144,7 @@ struct BlazeCampaignDashboardView: View {
         .padding(insets: Layout.insets)
         .background(Color(uiColor: .listForeground(modal: false)))
         .sheet(item: $selectedCampaignURL) { url in
-            detailView(url: url)
+            campaignDetailView(url: url)
         }
         .sheet(isPresented: $viewModel.shouldShowIntroView) {
             BlazeCampaignIntroView(onStartCampaign: {
@@ -196,7 +196,7 @@ private extension BlazeCampaignDashboardView {
         }
     }
 
-    func detailView(url: URL) -> some View {
+    func campaignDetailView(url: URL) -> some View {
         NavigationView {
             AuthenticatedWebView(isPresented: .constant(true),
                                  url: url)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -121,7 +121,7 @@ struct BlazeCampaignDashboardView: View {
                         guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
                             return
                         }
-                        ServiceLocator.analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .myStoreSection))
+                        viewModel.didSelectCampaignDetails()
                         let path = String(format: Constants.campaignDetailsURLFormat,
                                           campaign.campaignID,
                                           site.url.trimHTTPScheme(),
@@ -173,7 +173,7 @@ private extension BlazeCampaignDashboardView {
 
     var showAllCampaignsButton: some View {
         Button {
-            ServiceLocator.analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .myStoreSection))
+            viewModel.didSelectCampaignList()
             showAllCampaignsTapped?()
         } label: {
             HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -21,7 +21,13 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
     @Published private(set) var shouldShowInDashboard: Bool = false
 
-    @Published var shouldShowIntroView: Bool = false
+    @Published var shouldShowIntroView: Bool = false {
+        didSet {
+            if shouldShowIntroView {
+                analytics.track(event: .Blaze.blazeIntroDisplayed())
+            }
+        }
+    }
 
     private(set) var shouldRedactView: Bool = true
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -25,6 +25,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         didSet {
             if shouldShowIntroView {
                 analytics.track(event: .Blaze.blazeIntroDisplayed())
+                analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .introView))
             }
         }
     }
@@ -83,6 +84,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         self.state = .loading
 
         configureResultsController()
+        analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .myStoreSectionCreateCampaignButton))
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -19,7 +19,13 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
     @Published private(set) var state: State
 
-    @Published private(set) var shouldShowInDashboard: Bool = false
+    @Published private(set) var shouldShowInDashboard: Bool = false {
+        didSet {
+            if shouldShowInDashboard {
+                analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .myStoreSectionCreateCampaignButton))
+            }
+        }
+    }
 
     @Published var shouldShowIntroView: Bool = false {
         didSet {
@@ -84,7 +90,6 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         self.state = .loading
 
         configureResultsController()
-        analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .myStoreSectionCreateCampaignButton))
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -122,6 +122,10 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     func didSelectCampaignDetails() {
         analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .myStoreSection))
     }
+
+    func didSelectCreateCampaign(source: BlazeSource) {
+        analytics.track(event: .Blaze.blazeEntryPointTapped(source: source))
+    }
 }
 
 // MARK: - Blaze campaigns

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -24,7 +24,6 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     @Published var shouldShowIntroView: Bool = false {
         didSet {
             if shouldShowIntroView {
-                analytics.track(event: .Blaze.blazeIntroDisplayed())
                 analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .introView))
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -114,6 +114,14 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
             shouldShowIntroView = true
         }
     }
+
+    func didSelectCampaignList() {
+        analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .myStoreSection))
+    }
+
+    func didSelectCampaignDetails() {
+        analytics.track(event: .Blaze.blazeCampaignDetailSelected(source: .myStoreSection))
+    }
 }
 
 // MARK: - Blaze campaigns

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -21,6 +21,8 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
     @Published private(set) var shouldShowInDashboard: Bool = false
 
+    @Published var shouldShowIntroView: Bool = false
+
     private(set) var shouldRedactView: Bool = true
 
     var shouldShowShowAllCampaignsButton: Bool {
@@ -99,6 +101,12 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
         // No Blaze campaign or published product available
         update(state: .empty)
+    }
+
+    func checkIfIntroViewIsNeeded() {
+        if blazeCampaignResultsController.numberOfObjects == 0 {
+            shouldShowIntroView = true
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -811,7 +811,10 @@ extension DashboardViewController {
         if blazeCampaignHostingController != nil {
             removeBlazeCampaignView()
         }
-        let hostingController = BlazeCampaignDashboardViewHostingController(viewModel: viewModel.blazeCampaignDashboardViewModel)
+        let hostingController = BlazeCampaignDashboardViewHostingController(
+            viewModel: viewModel.blazeCampaignDashboardViewModel,
+            parentNavigationController: navigationController
+        )
         guard let campaignView = hostingController.view else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -195,6 +195,7 @@ final class HubMenuViewModel: ObservableObject {
             // shows campaign list for the new Blaze experience.
             let controller = BlazeCampaignListHostingController(site: site, viewModel: .init(siteID: site.siteID))
             navigationController?.show(controller, sender: self)
+            ServiceLocator.analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .menu))
         } else {
             let viewModel = BlazeWebViewModel(source: .menu, site: site, productID: nil)
             let webViewController = AuthenticatedWebViewController(viewModel: viewModel)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -367,15 +367,52 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
 
     // MARK: - Analytics
 
+    func test_blazeEntryPointDisplayed_is_tracked_upon_view_appear() throws {
+        // Given
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // Confidence check
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+
+        // When
+        viewModel.onViewAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "blaze_entry_point_displayed"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(eventProperties["source"] as? String, "campaign_list")
+    }
+
     func test_blazeIntroDisplayed_is_tracked_when_shouldShowIntroView_is_set_to_true() {
         // Given
         let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // Confidence check
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
 
         // When
         viewModel.shouldShowIntroView = true
 
         // Then
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
+    }
+
+    func test_blazeEntryPointDisplayed_is_tracked_when_intro_view_is_shown() throws {
+        // Given
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // Confidence check
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+
+        // When
+        viewModel.shouldShowIntroView = true
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "blaze_entry_point_displayed"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(eventProperties["source"] as? String, "intro_view")
     }
 
     func test_blazeIntroDisplayed_is_not_tracked_when_shouldShowIntroView_is_set_to_false() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -214,7 +214,6 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     func test_campaignModels_are_empty_when_loaded_campaigns_are_empty() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         stores.whenReceivingAction(ofType: BlazeAction.self) { action in
             guard case let .synchronizeCampaigns(_, _, onCompletion) = action else {
                 return
@@ -402,6 +401,20 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
         let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "blaze_campaign_detail_selected"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         XCTAssertEqual(eventProperties["source"] as? String, "campaign_list")
+    }
+
+    func test_didSelectCreateCampaign_tracks_blazeEntryPointTapped() throws {
+        // Given
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // When
+        viewModel.didSelectCreateCampaign(source: .introView)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_entry_point_tapped"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_entry_point_tapped"))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(properties["source"] as? String, "intro_view")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -384,20 +384,6 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
         XCTAssertEqual(eventProperties["source"] as? String, "campaign_list")
     }
 
-    func test_blazeIntroDisplayed_is_tracked_when_shouldShowIntroView_is_set_to_true() {
-        // Given
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
-
-        // Confidence check
-        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
-
-        // When
-        viewModel.shouldShowIntroView = true
-
-        // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
-    }
-
     func test_blazeEntryPointDisplayed_is_tracked_when_intro_view_is_shown() throws {
         // Given
         let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
@@ -413,17 +399,6 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
         let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "blaze_entry_point_displayed"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         XCTAssertEqual(eventProperties["source"] as? String, "intro_view")
-    }
-
-    func test_blazeIntroDisplayed_is_not_tracked_when_shouldShowIntroView_is_set_to_false() {
-        // Given
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
-
-        // When
-        viewModel.shouldShowIntroView = false
-
-        // Then
-        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
     }
 
     func test_didSelectCampaignDetails_tracks_blazeCampaignDetailSelected_with_correct_source() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -587,6 +587,39 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
             XCTFail("Wrong state")
         }
     }
+
+    // MARK: shouldShowIntroView
+
+    func test_checkIfIntroViewIsNeeded_sets_shouldShowIntroView_to_false_if_there_exists_at_least_one_campaign() {
+        // Given
+        let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // Confidence check
+        XCTAssertFalse(viewModel.shouldShowIntroView)
+
+        // When
+        insertCampaigns([campaign])
+        viewModel.checkIfIntroViewIsNeeded()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowIntroView)
+    }
+
+    func test_checkIfIntroViewIsNeeded_sets_shouldShowIntroView_to_true_if_there_is_no_existing_campaign() {
+        // Given
+        let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // Confidence check
+        XCTAssertFalse(viewModel.shouldShowIntroView)
+
+        // When
+        viewModel.checkIfIntroViewIsNeeded()
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowIntroView)
+    }
 }
 
 private extension BlazeCampaignDashboardViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -21,15 +21,22 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         storageManager.viewStorage
     }
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
     override func setUp() {
         super.setUp()
         stores = MockStoresManager(sessionManager: .testingInstance)
         storageManager = MockStorageManager()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
 
     override func tearDown() {
         storageManager = nil
         stores = nil
+        analyticsProvider = nil
+        analytics = nil
         super.tearDown()
     }
 
@@ -608,7 +615,6 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     func test_checkIfIntroViewIsNeeded_sets_shouldShowIntroView_to_true_if_there_is_no_existing_campaign() {
         // Given
-        let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // Confidence check
@@ -619,6 +625,72 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.shouldShowIntroView)
+    }
+
+    // MARK: Analytics
+
+    func test_blazeIntroDisplayed_is_tracked_when_shouldShowIntroView_is_set_to_true() {
+        // Given
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // When
+        viewModel.shouldShowIntroView = true
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
+    }
+
+    func test_blazeIntroDisplayed_is_not_tracked_when_shouldShowIntroView_is_set_to_false() {
+        // Given
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // When
+        viewModel.shouldShowIntroView = false
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
+    }
+
+    func test_didSelectCampaignList_tracks_blazeCampaignListEntryPointSelected_with_the_correct_source() throws {
+        // Given
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // When
+        viewModel.didSelectCampaignList()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_campaign_list_entry_point_selected"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_campaign_list_entry_point_selected"))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(properties["source"] as? String, "my_store_section")
+    }
+
+    func test_didSelectCampaignDetails_tracks_blazeCampaignDetailSelected_with_the_correct_source() throws {
+        // Given
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // When
+        viewModel.didSelectCampaignDetails()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_campaign_detail_selected"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_campaign_detail_selected"))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(properties["source"] as? String, "my_store_section")
+    }
+
+    func test_didSelectCreateCampaign_tracks_blazeEntryPointTapped() throws {
+        // Given
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+
+        // When
+        viewModel.didSelectCreateCampaign(source: .introView)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_entry_point_tapped"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_entry_point_tapped"))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(properties["source"] as? String, "intro_view")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -629,7 +629,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     // MARK: Analytics
 
-    func test_blazeIntroDisplayed_is_tracked_when_shouldShowIntroView_is_set_to_true() {
+    func test_blazeEntryPointDisplayed_is_tracked_when_shouldShowIntroView_is_set_to_true() throws {
         // Given
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
 
@@ -637,18 +637,10 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         viewModel.shouldShowIntroView = true
 
         // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
-    }
-
-    func test_blazeIntroDisplayed_is_not_tracked_when_shouldShowIntroView_is_set_to_false() {
-        // Given
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
-
-        // When
-        viewModel.shouldShowIntroView = false
-
-        // Then
-        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_entry_point_displayed"))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(eventProperties["source"] as? String, "intro_view")
     }
 
     func test_didSelectCampaignList_tracks_blazeCampaignListEntryPointSelected_with_the_correct_source() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10951 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds navigation to the Blaze section on the My Store screen. Changes include:
- Added new sources for the Blaze entry point.
- Intro view: replace the `NavigationView` with a `VStack` to get rid of the divider under the navigation bar.
- `BlazeCampaignDashboardViewHostingController`:
  - Injected a parent navigation controller to the initializer. This is needed to navigate to other screens.
  - Handled navigation to the campaign creation flow and the campaign list.
- `BlazeCampaignDashboardView` and its model:
  - Check if there is any existing campaign to show the intro view upon selecting campaign creation.
  - Handle navigation to campaign detail.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in as an admin to a site that is eligible for Blaze but doesn't have any campaign yet.
- If the site has any existing product, the My Store screen should show the Blaze section with the latest product. If not, create one.
- Tap the Create campaign button. The intro screen should be displayed.
- Tap the Start campaign button on the intro screen, the campaign creation flow should start. Notice in Xcode console: `🔵 Tracked blaze_flow_started, properties: [AnyHashable("source"): "intro_view", ...]`
- Navigate back, tap the product item > tap Start campaign on the intro view. A web view for campaign creation should be displayed with details for that product right away.
- Create a campaign - upon completion, the web view should be dismissed and the campaign list should be displayed.
- Notice that a bottom sheet is displayed saying the new campaign has been submitted for review.
- Tap Back, the My Store screen should displayed the new campaign in the Blaze section now.
- Tap the campaign, the detail screen for the campaign should be displayed.
- Dismiss the detail screen and tap the Create campaign button. The campaign creation flow should be displayed immediately without the intro screen. Notice in Xcode console: `🔵 Tracked blaze_flow_started, properties: [AnyHashable("source"): "my_store_section_create_campaign_button", ...]`
- Navigate back, and tap the Show all campaigns button. The campaign list should be displayed without the tip about any created campaign.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/58da902f-b8ea-45b0-8f9d-7a4ee12beb8a



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
