### PR TITLE
Blaze Optimization: UI for Blaze flow entry on Product editing form screen

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Resizing.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Resizing.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+extension UIImage {
+    func resize(to size: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, UIScreen.main.scale)
+        self.draw(in: CGRect(origin: .zero, size: size))
+        defer { UIGraphicsEndImageContext() }
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -74,6 +74,8 @@ private extension DefaultProductFormTableViewModel {
                     return [descriptionRow, .separator]
                 }
                 return [descriptionRow, .descriptionAI, .learnMoreAboutAI, .separator]
+            case .promoteWithBlaze:
+                return [.promoteWithBlaze]
             default:
                 fatalError("Unexpected action in the primary section: \(action)")
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -75,7 +75,7 @@ private extension DefaultProductFormTableViewModel {
                 }
                 return [descriptionRow, .descriptionAI, .learnMoreAboutAI, .separator]
             case .promoteWithBlaze:
-                return [.promoteWithBlaze]
+                return [.promoteWithBlaze, .separator]
             default:
                 fatalError("Unexpected action in the primary section: \(action)")
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -6,6 +6,7 @@ enum ProductFormEditAction: Equatable {
     case linkedProductsPromo(viewModel: FeatureAnnouncementCardViewModel)
     case name(editable: Bool)
     case description(editable: Bool)
+    case promoteWithBlaze
     case priceSettings(editable: Bool, hideSeparator: Bool)
     case reviews
     case productType(editable: Bool)
@@ -54,6 +55,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
 
     private let product: EditableProductModel
     private let formType: ProductFormType
+    private let isEligibleForBlaze: Bool
     private let editable: Bool
     private let addOnsFeatureEnabled: Bool
     private let variationsPrice: VariationsPrice
@@ -68,19 +70,23 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let isCompositeProductsEnabled: Bool
     private let isSubscriptionProductsEnabled: Bool
     private let isMinMaxQuantitiesEnabled: Bool
+    private let isOptimizedBlazeExperienceEnabled: Bool
 
     // TODO: Remove default parameter
     init(product: EditableProductModel,
          formType: ProductFormType,
+         isEligibleForBlaze: Bool = false,
          addOnsFeatureEnabled: Bool = true,
          isLinkedProductsPromoEnabled: Bool = false,
          isBundledProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles),
          isCompositeProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.compositeProducts),
          isSubscriptionProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlySubscriptions),
          isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
+         isOptimizedBlazeExperienceEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.optimizedBlazeExperience),
          variationsPrice: VariationsPrice = .unknown) {
         self.product = product
         self.formType = formType
+        self.isEligibleForBlaze = isEligibleForBlaze
         self.editable = formType != .readonly
         self.addOnsFeatureEnabled = addOnsFeatureEnabled
         self.variationsPrice = variationsPrice
@@ -89,6 +95,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.isCompositeProductsEnabled = isCompositeProductsEnabled
         self.isSubscriptionProductsEnabled = isSubscriptionProductsEnabled
         self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
+        self.isOptimizedBlazeExperienceEnabled = isOptimizedBlazeExperienceEnabled
     }
 
     /// Returns an array of actions that are visible in the product form primary section.
@@ -102,11 +109,14 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         && product.upsellIDs.isEmpty
         && product.crossSellIDs.isEmpty
 
+        let shouldShowPromoteWithBlaze = isOptimizedBlazeExperienceEnabled && isEligibleForBlaze
+
         let actions: [ProductFormEditAction?] = [
             shouldShowImagesRow ? .images(editable: editable): nil,
             shouldShowLinkedProductsPromo ? .linkedProductsPromo(viewModel: newLinkedProductsPromoViewModel) : nil,
             .name(editable: editable),
-            shouldShowDescriptionRow ? .description(editable: editable): nil
+            shouldShowDescriptionRow ? .description(editable: editable): nil,
+            shouldShowPromoteWithBlaze ? .promoteWithBlaze : nil
         ]
         return actions.compactMap { $0 }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -40,6 +40,8 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
             return [TextViewTableViewCell.self]
         case .separator:
             return [SpacerTableViewCell.self]
+        case .promoteWithBlaze:
+            return [ButtonTableViewCell.self]
         }
     }
 
@@ -65,6 +67,8 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
             return TextViewTableViewCell.self
         case .separator:
             return SpacerTableViewCell.self
+        case .promoteWithBlaze:
+            return ButtonTableViewCell.self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -41,7 +41,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
         case .separator:
             return [SpacerTableViewCell.self]
         case .promoteWithBlaze:
-            return [ButtonTableViewCell.self]
+            return [LeftImageTableViewCell.self]
         }
     }
 
@@ -68,7 +68,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
         case .separator:
             return SpacerTableViewCell.self
         case .promoteWithBlaze:
-            return ButtonTableViewCell.self
+            return LeftImageTableViewCell.self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -288,8 +288,7 @@ private extension ProductFormTableViewDataSource {
             comment: "Label for button on product form to open Blaze flow"
         )
 
-        cell.configure(image: .blaze,
-                       text: title)
+        cell.configure(image: .blaze, text: title, size: CGSize(width: 20, height: 20))
     }
 
     func configureSeparator(cell: UITableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -280,7 +280,16 @@ private extension ProductFormTableViewDataSource {
     }
 
     func configurePromoteWithBlaze(cell: UITableViewCell) {
-        // todo
+        guard let cell = cell as? LeftImageTableViewCell else {
+            fatalError()
+        }
+        let title = NSLocalizedString(
+            "Promote with Blaze",
+            comment: "Label for button on product form to open Blaze flow"
+        )
+
+        cell.configure(image: .blaze,
+                       text: title)
     }
 
     func configureSeparator(cell: UITableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -103,6 +103,8 @@ private extension ProductFormTableViewDataSource {
             configureLearnMoreAI(cell: cell)
         case .separator:
             configureSeparator(cell: cell)
+        case .promoteWithBlaze:
+            configurePromoteWithBlaze(cell: cell)
         }
     }
     func configureImages(cell: UITableViewCell, isEditable: Bool, allowsMultipleImages: Bool, isVariation: Bool) {
@@ -275,6 +277,10 @@ private extension ProductFormTableViewDataSource {
         }))
         cell.selectionStyle = .none
         cell.hideSeparator()
+    }
+
+    func configurePromoteWithBlaze(cell: UITableViewCell) {
+        // todo
     }
 
     func configureSeparator(cell: UITableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -288,7 +288,12 @@ private extension ProductFormTableViewDataSource {
             comment: "Label for button on product form to open Blaze flow"
         )
 
-        cell.configure(image: .blaze, text: title, size: CGSize(width: 20, height: 20))
+        cell.configure(
+            image: .blaze,
+            imageSize: CGSize(width: 20, height: 20),
+            text: title,
+            textColor: .accent
+        )
         cell.hideSeparator()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -290,8 +290,7 @@ private extension ProductFormTableViewDataSource {
         )
 
         cell.configure(
-            image: .blaze,
-            imageSize: CGSize(width: 20, height: 20),
+            image: .blaze.resize(to: Constants.blazeButtonIconSize)!,
             text: title,
             textColor: .accent
         )
@@ -418,6 +417,7 @@ private extension ProductFormTableViewDataSource {
         static let learnMoreTextHeight: CGFloat = 16
         static let learnMoreTextInsets: UIEdgeInsets = .init(top: 4, left: 0, bottom: 4, right: 0)
         static let settingsHeaderHeight = CGFloat(16)
+        static let blazeButtonIconSize = CGSize(width: 20, height: 20)
     }
     enum Localization {
         static let legalText = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -281,7 +281,7 @@ private extension ProductFormTableViewDataSource {
 
     func configurePromoteWithBlaze(cell: UITableViewCell) {
         guard let cell = cell as? LeftImageTableViewCell else {
-            fatalError()
+            fatalError("Unexpected table view cell for the promote with Blaze cell")
         }
         let title = NSLocalizedString(
             "Promote with Blaze",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -289,6 +289,7 @@ private extension ProductFormTableViewDataSource {
         )
 
         cell.configure(image: .blaze, text: title, size: CGSize(width: 20, height: 20))
+        cell.hideSeparator()
     }
 
     func configureSeparator(cell: UITableViewCell) {
@@ -297,7 +298,7 @@ private extension ProductFormTableViewDataSource {
         }
         cell.selectionStyle = .none
         cell.backgroundColor = .listBackground
-        cell.showSeparator()
+        cell.hideSeparator()
         cell.configure(height: Constants.settingsHeaderHeight)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -284,7 +284,8 @@ private extension ProductFormTableViewDataSource {
             fatalError("Unexpected table view cell for the promote with Blaze cell")
         }
         let title = NSLocalizedString(
-            "Promote with Blaze",
+            "productFormTableViewDataSource.promoteWithBlazeButton",
+            value: "Promote with Blaze",
             comment: "Label for button on product form to open Blaze flow"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -290,7 +290,7 @@ private extension ProductFormTableViewDataSource {
         )
 
         cell.configure(
-            image: .blaze.resize(to: Constants.blazeButtonIconSize)!,
+            image: .blaze.resize(to: Constants.blazeButtonIconSize),
             text: title,
             textColor: .accent
         )

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -22,6 +22,7 @@ enum ProductFormSection: Equatable {
         case description(description: String?, isEditable: Bool, isDescriptionAIEnabled: Bool)
         case descriptionAI
         case learnMoreAboutAI
+        case promoteWithBlaze
         case separator
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -731,7 +731,8 @@ private extension ProductFormViewController {
     }
 
     /// Updates table rows when Blaze eligibility is computed.
-    /// Needed to show/hide the `.`
+    /// Needed to show/hide the "Promote with Blaze" button accordingly.
+    /// 
     func observeUpdateBlazeEligibility() {
         blazeEligibilitySubscription = viewModel.blazeEligibilityUpdate.sink { [weak self] in
             self?.updateFormTableContent()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -20,6 +20,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     private let viewModel: ViewModel
     private let eventLogger: ProductFormEventLoggerProtocol
+
     private var product: ProductModel {
         viewModel.productModel
     }
@@ -112,6 +113,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: tableViewModel,
                                                                   productImageStatuses: productImageActionHandler.productImageStatuses,
                                                                   productUIImageLoader: productUIImageLoader)
+
         super.init(nibName: "ProductFormViewController", bundle: nil)
         updateDataSourceActions()
     }
@@ -315,7 +317,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             }
         }
 
-        if viewModel.canPromoteWithBlaze() {
+        if viewModel.canPromoteWithBlaze() &&
+            !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.optimizedBlazeExperience) {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.promoteWithBlaze) { [weak self] _ in
                 self?.displayBlaze()
                 ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .productMoreMenu))

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -128,7 +128,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         productNameSubscription?.cancel()
         updateEnabledSubscription?.cancel()
         newVariationsPriceSubscription?.cancel()
-        updateBlazeEligibility?.cancel()
+        blazeEligibilitySubscription?.cancel()
     }
 
     override func viewDidLoad() {
@@ -733,7 +733,7 @@ private extension ProductFormViewController {
     /// Updates table rows when Blaze eligibility is computed.
     /// Needed to show/hide the `.`
     func observeUpdateBlazeEligibility() {
-        updateBlazeEligibility = viewModel.isEligibleForBlazeUpdate.sink { [weak self] in
+        blazeEligibilitySubscription = viewModel.blazeEligibilityUpdate.sink { [weak self] in
             self?.updateFormTableContent()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -70,7 +70,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private var updateEnabledSubscription: AnyCancellable?
     private var newVariationsPriceSubscription: AnyCancellable?
     private var productImageStatusesSubscription: AnyCancellable?
-    private var updateBlazeEligibility: AnyCancellable?
+    private var blazeEligibilitySubscription: AnyCancellable?
 
     private let aiEligibilityChecker: ProductFormAIEligibilityChecker
     private var descriptionAICoordinator: ProductDescriptionAICoordinator?

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -726,7 +726,7 @@ private extension ProductFormViewController {
     ///
     func observeVariationsPriceChanges() {
         newVariationsPriceSubscription = viewModel.newVariationsPrice.sink { [weak self] in
-            self?.onVariationsPriceChanged()
+            self?.updateFormTableContent()
         }
     }
 
@@ -734,7 +734,7 @@ private extension ProductFormViewController {
     /// Needed to show/hide the `.`
     func observeUpdateBlazeEligibility() {
         updateBlazeEligibility = viewModel.isEligibleForBlazeUpdate.sink { [weak self] in
-            self?.onBlazeEligibilityChanged()
+            self?.updateFormTableContent()
         }
 
     }
@@ -812,14 +812,6 @@ private extension ProductFormViewController {
                                                           currency: currency,
                                                           isDescriptionAIEnabled: aiEligibilityChecker.isFeatureEnabled(.description))
         reconfigureDataSource(tableViewModel: tableViewModel, statuses: statuses)
-    }
-
-    func onVariationsPriceChanged() {
-        updateFormTableContent()
-    }
-
-    func onBlazeEligibilityChanged() {
-        updateFormTableContent()
     }
 
     /// Recreates the `tableViewModel` and reloads the `table` & `datasource`.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -681,11 +681,12 @@ private extension ProductFormViewModel {
         stores.dispatch(action)
     }
 
-    /// Recreates `actionsFactory` with the latest `product`, `formType`, and `isAddOnsFeatureEnabled` information.
+    /// Recreates `actionsFactory` with the latest `product`, `formType`, `isEligibleForBlaze` and `isAddOnsFeatureEnabled` information.
     ///
     func updateActionsFactory() {
         actionsFactory = ProductFormActionsFactory(product: product,
                                                    formType: formType,
+                                                   isEligibleForBlaze: canPromoteWithBlaze(),
                                                    addOnsFeatureEnabled: isAddOnsFeatureEnabled,
                                                    isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                                    variationsPrice: calculateVariationPriceState())
@@ -701,6 +702,7 @@ private extension ProductFormViewModel {
         Task { @MainActor in
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible
+            updateActionsFactory()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -32,7 +32,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     /// Emits a void value informing when Blaze eligibility is computed
     var blazeEligibilityUpdate: AnyPublisher<Void, Never> {
-        isEligibleForBlazeSubject.eraseToAnyPublisher()
+        blazeEligiblityUpdateSubject.eraseToAnyPublisher()
     }
 
     /// The latest product value.
@@ -55,7 +55,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     private let productNameSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
     private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never> = PassthroughSubject<Bool, Never>()
     private let newVariationsPriceSubject = PassthroughSubject<Void, Never>()
-    private let blazeEligiblityUpdateSubject<Void, Never>()
+    private let blazeEligiblityUpdateSubject = PassthroughSubject<Void, Never>()
 
     private lazy var variationsResultsController = createVariationsResultsController()
 
@@ -709,7 +709,7 @@ private extension ProductFormViewModel {
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible
             updateActionsFactory()
-            isEligibleForBlazeSubject.send()
+            blazeEligiblityUpdateSubject.send()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -31,7 +31,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     }
 
     /// Emits a void value informing when Blaze eligibility is computed
-    var isEligibleForBlazeUpdate: AnyPublisher<Void, Never> {
+    var blazeEligibilityUpdate: AnyPublisher<Void, Never> {
         isEligibleForBlazeSubject.eraseToAnyPublisher()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -30,6 +30,11 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         newVariationsPriceSubject.eraseToAnyPublisher()
     }
 
+    /// Emits a void value informing when Blaze eligibility is computed
+    var isEligibleForBlazeUpdate: AnyPublisher<Void, Never> {
+        isEligibleForBlazeSubject.eraseToAnyPublisher()
+    }
+
     /// The latest product value.
     var productModel: EditableProductModel {
         product
@@ -50,6 +55,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     private let productNameSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
     private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never> = PassthroughSubject<Bool, Never>()
     private let newVariationsPriceSubject = PassthroughSubject<Void, Never>()
+    private let isEligibleForBlazeSubject = PassthroughSubject<Void, Never>()
 
     private lazy var variationsResultsController = createVariationsResultsController()
 
@@ -703,6 +709,7 @@ private extension ProductFormViewModel {
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible
             updateActionsFactory()
+            isEligibleForBlazeSubject.send()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -55,7 +55,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     private let productNameSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
     private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never> = PassthroughSubject<Bool, Never>()
     private let newVariationsPriceSubject = PassthroughSubject<Void, Never>()
-    private let isEligibleForBlazeSubject = PassthroughSubject<Void, Never>()
+    private let blazeEligiblityUpdateSubject<Void, Never>()
 
     private lazy var variationsResultsController = createVariationsResultsController()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -46,6 +46,9 @@ protocol ProductFormViewModelProtocol {
     /// Emits a void value informing when there is a new variation price state available
     var newVariationsPrice: AnyPublisher<Void, Never> { get }
 
+    /// Emits a void value informing when Blaze eligibility is computed
+    var isEligibleForBlazeUpdate: AnyPublisher<Void, Never> { get }
+
     /// Creates actions available on the bottom sheet.
     var actionsFactory: ProductFormActionsFactoryProtocol { get }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -47,7 +47,7 @@ protocol ProductFormViewModelProtocol {
     var newVariationsPrice: AnyPublisher<Void, Never> { get }
 
     /// Emits a void value informing when Blaze eligibility is computed
-    var isEligibleForBlazeUpdate: AnyPublisher<Void, Never> { get }
+    var blazeEligibilityUpdate: AnyPublisher<Void, Never> { get }
 
     /// Creates actions available on the bottom sheet.
     var actionsFactory: ProductFormActionsFactoryProtocol { get }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -28,7 +28,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
 
     /// Unused in variations but needed to satisfy protocol
     var isEligibleForBlazeUpdate: AnyPublisher<Void, Never> {
-        isEligibleForBlazeSubject.eraseToAnyPublisher()
+        Just(Void()).eraseToAnyPublisher()
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -27,7 +27,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     }
 
     /// Unused in variations but needed to satisfy protocol
-    var isEligibleForBlazeUpdate: AnyPublisher<Void, Never> {
+    var blazeEligibilityUpdate: AnyPublisher<Void, Never> {
         Just(Void()).eraseToAnyPublisher()
     }
 
@@ -56,9 +56,6 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
 
     private let productVariationSubject: PassthroughSubject<EditableProductVariationModel, Never> = PassthroughSubject<EditableProductVariationModel, Never>()
     private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never>
-
-    private let isEligibleForBlazeSubject: PassthroughSubject<Void, Never>
-
 
     /// The product variation before any potential edits; reset after a remote update.
     private var originalProductVariation: EditableProductVariationModel {
@@ -129,7 +126,6 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         self.editable = formType != .readonly
         self.actionsFactory = ProductVariationFormActionsFactory(productVariation: productVariation, editable: editable)
         self.isUpdateEnabledSubject = PassthroughSubject<Bool, Never>()
-        self.isEligibleForBlazeSubject = PassthroughSubject<Void, Never>()
         self.productImagesUploader = productImagesUploader
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -26,6 +26,12 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         isUpdateEnabledSubject.eraseToAnyPublisher()
     }
 
+    /// Unused in variations but needed to satisfy protocol
+    var isEligibleForBlazeUpdate: AnyPublisher<Void, Never> {
+        isEligibleForBlazeSubject.eraseToAnyPublisher()
+    }
+
+
     /// The product variation ID
     var productionVariationID: Int64? {
         productVariation.productVariation.productVariationID
@@ -50,6 +56,9 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
 
     private let productVariationSubject: PassthroughSubject<EditableProductVariationModel, Never> = PassthroughSubject<EditableProductVariationModel, Never>()
     private let isUpdateEnabledSubject: PassthroughSubject<Bool, Never>
+
+    private let isEligibleForBlazeSubject: PassthroughSubject<Void, Never>
+
 
     /// The product variation before any potential edits; reset after a remote update.
     private var originalProductVariation: EditableProductVariationModel {
@@ -120,6 +129,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         self.editable = formType != .readonly
         self.actionsFactory = ProductVariationFormActionsFactory(productVariation: productVariation, editable: editable)
         self.isUpdateEnabledSubject = PassthroughSubject<Bool, Never>()
+        self.isEligibleForBlazeSubject = PassthroughSubject<Void, Never>()
         self.productImagesUploader = productImagesUploader
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
@@ -53,14 +53,15 @@ extension LeftImageTableViewCell {
         textLabel?.text = text
     }
 
-    // Configure with icon image size
-    func configure(image: UIImage, text: String, size: CGSize) {
-        UIGraphicsBeginImageContext(size)
-        image.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+    // Custom configure, including image size and text color
+    func configure(image: UIImage, imageSize: CGSize, text: String, textColor: UIColor) {
+        UIGraphicsBeginImageContext(imageSize)
+        image.draw(in: CGRect(x: 0, y: 0, width: imageSize.width, height: imageSize.height))
         let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 
         imageView?.image = resizedImage
         textLabel?.text = text
+        textLabel?.textColor = textColor
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
@@ -52,4 +52,15 @@ extension LeftImageTableViewCell {
         imageView?.image = image
         textLabel?.text = text
     }
+
+    // Configure with icon image size
+    func configure(image: UIImage, text: String, size: CGSize) {
+        UIGraphicsBeginImageContext(size)
+        image.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+        let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        imageView?.image = resizedImage
+        textLabel?.text = text
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
@@ -53,8 +53,8 @@ extension LeftImageTableViewCell {
         textLabel?.text = text
     }
 
-    // Custom configure, including text color
-    func configure(image: UIImage, text: String, textColor: UIColor) {
+    // Custom configure, with optional image and changeable text color
+    func configure(image: UIImage?, text: String, textColor: UIColor) {
         imageView?.image = image
         textLabel?.text = text
         textLabel?.textColor = textColor

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
@@ -53,14 +53,9 @@ extension LeftImageTableViewCell {
         textLabel?.text = text
     }
 
-    // Custom configure, including image size and text color
-    func configure(image: UIImage, imageSize: CGSize, text: String, textColor: UIColor) {
-        UIGraphicsBeginImageContext(imageSize)
-        image.draw(in: CGRect(x: 0, y: 0, width: imageSize.width, height: imageSize.height))
-        let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        imageView?.image = resizedImage
+    // Custom configure, including text color
+    func configure(image: UIImage, text: String, textColor: UIColor) {
+        imageView?.image = image
         textLabel?.text = text
         textLabel?.textColor = textColor
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1429,6 +1429,7 @@
 		80F9176D2A28638C00890A83 /* products_add_new_grouped_2130.json in Resources */ = {isa = PBXBuildFile; fileRef = 80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */; };
 		8194A48313C34FE1782D51BC /* Pods_StoreWidgetsExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2886DE5218EEA78ABAF0BE67 /* Pods_StoreWidgetsExtension.framework */; };
 		860B85F12ADE3A0E00E85884 /* BulletPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860B85F02ADE3A0E00E85884 /* BulletPointView.swift */; };
+		864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864213012AE77C730036E5A6 /* UIImage+Resizing.swift */; };
 		86558EA82AD91B7800E10EDF /* BlazeCampaignIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86558EA72AD91B7800E10EDF /* BlazeCampaignIntroView.swift */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
@@ -3931,6 +3932,7 @@
 		80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterScreen.swift; sourceTree = "<group>"; };
 		80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = products_add_new_grouped_2130.json; sourceTree = "<group>"; };
 		860B85F02ADE3A0E00E85884 /* BulletPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulletPointView.swift; sourceTree = "<group>"; };
+		864213012AE77C730036E5A6 /* UIImage+Resizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resizing.swift"; sourceTree = "<group>"; };
 		86558EA72AD91B7800E10EDF /* BlazeCampaignIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignIntroView.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
 		8CA4F6DD220B257000A47B5D /* WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.debug.xcconfig; path = ../config/WooCommerce.debug.xcconfig; sourceTree = "<group>"; };
@@ -9829,6 +9831,7 @@
 				02D29A9129F7C39200473D6D /* UIImage+Text.swift */,
 				EE45E2BE2A409E250085F227 /* UIColor+Tooltip.swift */,
 				DED974102AD8F05A00122EB4 /* URL+Identifiable.swift */,
+				864213012AE77C730036E5A6 /* UIImage+Resizing.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -12846,6 +12849,7 @@
 				D8EE9692264D328A0033B2F9 /* ReceiptViewController.swift in Sources */,
 				68AC9D292ACE598B0042F784 /* ProductImageThumbnail.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
+				864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */,
 				DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */,
 				311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */,
 				0313651128AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: https://github.com/woocommerce/woocommerce-ios/issues/10961

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR does two things:
1. It removes the Blaze option from the Product editing screen's More menu.
2. It adds a "Promote with Blaze" button on the Product editing screen, above "Price".

Known issue: no related unit test yet especially related to the "Promote with Blaze" button. This will be added in the next PR for functionalities.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Start with a site that is eligible for Blaze,
2. Go to Product details, tap a Product,
4. Ensure that a button that says "Promote with Blaze" appears below "Description" and above "Price".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Dark mode | Light mode |
|-|-|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-10-23 at 20 26 42](https://github.com/woocommerce/woocommerce-ios/assets/266376/57e56ff4-3636-4e99-ad1a-9cbd8cd3046f) | ![Simulator Screenshot - iPhone 14 Pro - 2023-10-23 at 20 24 18](https://github.com/woocommerce/woocommerce-ios/assets/266376/1647dffa-69d7-49dc-a7b4-c05fbc814f17) | 