### PR TITLE
Blaze Optimization Update color and label for some Blaze campaign status

### DIFF
--- a/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
@@ -45,13 +45,13 @@ extension BlazeCampaign.Status {
 
     var backgroundColor: Color {
         switch self {
-        case .active, .approved, .created, .scheduled:
+        case .active, .approved:
             return .withColorStudio(name: .green, shade: .shade5)
-        case .finished:
+        case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade5)
         case .canceled, .rejected:
             return .withColorStudio(name: .red, shade: .shade5)
-        case .processing:
+        case .created, .processing:
             return .withColorStudio(name: .yellow, shade: .shade5)
         case .unknown:
             return .withColorStudio(name: .gray, shade: .shade5)

--- a/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignStatus+Customizations.swift
@@ -10,7 +10,9 @@ extension BlazeCampaign.Status {
         case .approved:
             return Localization.approved
         case .created:
-            return Localization.created
+            // There is no dedicated status for `In Moderation` on the backend.
+            // The app assumes that the campaign goes into moderation after creation.
+            return Localization.inModeration
         case .scheduled:
             return Localization.scheduled
         case .finished:
@@ -20,7 +22,7 @@ extension BlazeCampaign.Status {
         case .rejected:
             return Localization.rejected
         case .processing:
-            return Localization.inModeration
+            return Localization.processing
         case .unknown:
             return Localization.unknown
         }
@@ -28,13 +30,13 @@ extension BlazeCampaign.Status {
 
     var textColor: Color {
         switch self {
-        case .active, .approved, .created, .scheduled:
+        case .active, .approved:
             return .withColorStudio(name: .green, shade: .shade60)
-        case .finished:
+        case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade80)
         case .canceled, .rejected:
             return .withColorStudio(name: .red, shade: .shade60)
-        case .processing:
+        case .created, .processing:
             return .withColorStudio(name: .yellow, shade: .shade70)
         case .unknown:
             return .withColorStudio(name: .gray, shade: .shade70)
@@ -59,12 +61,12 @@ extension BlazeCampaign.Status {
     private enum Localization {
         static let active = NSLocalizedString("Active", comment: "Status name of an active Blaze campaign")
         static let approved = NSLocalizedString("Approved", comment: "Status name of an approved Blaze campaign")
-        static let created = NSLocalizedString("Created", comment: "Status name of a newly created Blaze campaign")
+        static let inModeration = NSLocalizedString("In Moderation", comment: "Status name of a Blaze campaign under moderation")
         static let scheduled = NSLocalizedString("Scheduled", comment: "Status name of a scheduled Blaze campaign")
         static let completed = NSLocalizedString("Completed", comment: "Status name of a completed Blaze campaign")
         static let canceled = NSLocalizedString("Canceled", comment: "Status name of a canceled Blaze campaign")
         static let rejected = NSLocalizedString("Rejected", comment: "Status name of a rejected Blaze campaign")
-        static let inModeration = NSLocalizedString("In Moderation", comment: "Status name of a Blaze campaign under moderation")
+        static let processing = NSLocalizedString("Processing", comment: "Status name of a Blaze campaign under processing")
         static let unknown = NSLocalizedString("Unknown", comment: "Status name of a Blaze campaign without specified state")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to #10928 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, I mapped labels and colors for the Blaze campaign status based on my assumption. This PR aligns the labels and how colors are mapped with the Jetpack iOS app in https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/ViewRelated/Blog/Blog%20Dashboard/Cards/Blaze/BlazeCampaignStatusView.swift.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
It's not easy to test all affected status. The most critical status is `created` so let's test that.
- Log in as an admin to a site that is eligible for Blaze.
- Create a product if your site has no product yet.
- Switch to the Menu tab and select Blaze.
- In the campaign list, select Create.
- Proceed to create a new campaign.
- When the creation completes, you should be navigated back to the campaign list.
- Notice that the status of the new campaign says In Moderation, and the badge is yellow instead of green.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/10e9bc3b-4459-4795-9cfc-9c4075a7c1dc" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
