### PR TITLE
Fix: Replaced UIImage's imageLiteralResourceName initialiser with named

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -447,7 +447,7 @@ extension UIImage {
     /// House Outlined Image
     ///
     static var houseOutlinedImage: UIImage {
-        UIImage(imageLiteralResourceName: "icon-house-outlined")
+        UIImage(named: "icon-house-outlined")
     }
 
     /// Mailbox Icon - used in hub menu
@@ -1122,7 +1122,7 @@ extension UIImage {
     }
 
     static var syncDotIcon: UIImage {
-        return UIImage(imageLiteralResourceName: "icon-sync-dot")
+        return UIImage(named: "icon-sync-dot")
     }
 
     /// Variations Icon
@@ -1146,25 +1146,25 @@ extension UIImage {
     /// No store image
     ///
     static var noStoreImage: UIImage {
-        return UIImage(imageLiteralResourceName: "woo-no-store").imageFlippedForRightToLeftLayoutDirection()
+        return UIImage(named: "woo-no-store").imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Upgrade plan error
     ///
     static var planUpgradeError: UIImage {
-        return UIImage(imageLiteralResourceName: "plan-upgrade-error")
+        return UIImage(named: "plan-upgrade-error")
     }
 
     /// Upgrade plan success celebratory image
     ///
     static var planUpgradeSuccessCelebration: UIImage {
-        return UIImage(imageLiteralResourceName: "plan-upgrade-success-celebration")
+        return UIImage(named: "plan-upgrade-success-celebration")
     }
 
     /// Megaphone Icon
     ///
     static var megaphoneIcon: UIImage {
-        return UIImage(imageLiteralResourceName: "megaphone").imageFlippedForRightToLeftLayoutDirection()
+        return UIImage(named: "megaphone").imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Speaker icon
@@ -1182,13 +1182,13 @@ extension UIImage {
     /// Error image
     ///
     static var errorImage: UIImage {
-        return UIImage(imageLiteralResourceName: "woo-error").imageFlippedForRightToLeftLayoutDirection()
+        return UIImage(named: "woo-error").imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Empty box image
     ///
     static var emptyBoxImage: UIImage {
-        UIImage(imageLiteralResourceName: "empty-box")
+        UIImage(named: "empty-box")
     }
 
     /// Creates a bitmap image of the Woo "bubble" logo based on a vector image in our asset catalog.
@@ -1242,7 +1242,7 @@ extension UIImage {
     /// Welcome Image
     ///
     static var welcomeImage: UIImage {
-        UIImage(imageLiteralResourceName: "img-welcome")
+        UIImage(named: "img-welcome")
     }
 
     /// Icon Circular Rate Discount (used in WCShip onboarding)
@@ -1351,61 +1351,61 @@ extension UIImage {
     }
 
     static var iconBolt: UIImage {
-        UIImage(imageLiteralResourceName: "icon-bolt")
+        UIImage(named: "icon-bolt")
     }
 
     /// Illustration for the free trial summary screen.
     ///
     static var freeTrialIllustration: UIImage {
-        UIImage(imageLiteralResourceName: "free-trial-ilustration")
+        UIImage(named: "free-trial-ilustration")
     }
 
     static var ecommerceIcon: UIImage {
-        UIImage(imageLiteralResourceName: "ecommerce-icon")
+        UIImage(named: "ecommerce-icon")
     }
 
     static var supportIcon: UIImage {
-        UIImage(imageLiteralResourceName: "support-icon")
+        UIImage(named: "support-icon")
     }
 
     static var backupsIcon: UIImage {
-        UIImage(imageLiteralResourceName: "backups-icon")
+        UIImage(named: "backups-icon")
     }
 
     static var giftIcon: UIImage {
-        UIImage(imageLiteralResourceName: "gifts-icon")
+        UIImage(named: "gifts-icon")
     }
 
     static var emailOutlineIcon: UIImage {
-        UIImage(imageLiteralResourceName: "email-outline-icon")
+        UIImage(named: "email-outline-icon")
     }
 
     static var shippingOutlineIcon: UIImage {
-        UIImage(imageLiteralResourceName: "shipping-outline-icon")
+        UIImage(named: "shipping-outline-icon")
     }
 
     static var advertisingIcon: UIImage {
-        UIImage(imageLiteralResourceName: "advertising-icon")
+        UIImage(named: "advertising-icon")
     }
 
     static var launchIcon: UIImage {
-        UIImage(imageLiteralResourceName: "launch-icon")
+        UIImage(named: "launch-icon")
     }
 
     static var paymentOptionsIcon: UIImage {
-        UIImage(imageLiteralResourceName: "payment-options-icon")
+        UIImage(named: "payment-options-icon")
     }
 
     static var premiumThemesIcon: UIImage {
-        UIImage(imageLiteralResourceName: "premium-themes-icon")
+        UIImage(named: "premium-themes-icon")
     }
 
     static var siteSecurityIcon: UIImage {
-        UIImage(imageLiteralResourceName: "site-security-icon")
+        UIImage(named: "site-security-icon")
     }
 
     static var unlimitedProductsIcon: UIImage {
-        UIImage(imageLiteralResourceName: "unlimited-products-icon")
+        UIImage(named: "unlimited-products-icon")
     }
 
     static var feedbackOutlineIcon: UIImage {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10941 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
As described in the issue, initializing images using `UIImage(imageLiteralResourceName: String)` initializer could be an issue, hence it's been replaced with `UIImage(named: String)`
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions
--
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
--
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
