### PR TITLE
[Onboarding Deep Link] Add test cases on app login link navigation

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -179,7 +179,7 @@ class AuthenticationManager: Authentication {
     }
 
     private func isAppLoginUrl(_ url: URL) -> Bool {
-        let expectedPrefix = "\(ApiCredentials.dotcomAuthScheme)\(WooConstants.appLoginURLPrefix)"
+        let expectedPrefix = WooConstants.appLoginURLPrefix
         return url.absoluteString.hasPrefix(expectedPrefix)
     }
 

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -76,7 +76,7 @@ enum WooConstants {
 
     /// App login deep link prefix
     ///
-    static let appLoginURLPrefix = "://app-login"
+    static let appLoginURLPrefix = "woocommerce://app-login"
 }
 
 // MARK: URLs

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -493,6 +493,81 @@ final class AppCoordinatorTests: XCTestCase {
         assertEqual(LocalNotification.Scenario.Identifier.Prefix.freeTrialSurvey24hAfterFreeTrialSubscribed, eventProperties["type"] as? String)
         assertEqual(true, eventProperties["is_iap_available"] as? Bool)
     }
+
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_updates_root_to_LoginNavigationController_when_onboarding_is_shown() throws {
+        // Given
+        let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: false))
+        coordinator = appCoordinator
+        let url = try XCTUnwrap(URL(string: "woocommerce://app-login?siteUrl=http%3A%2F%2Fwcdev.local&username=user"))
+
+        appCoordinator.start()
+        XCTAssertFalse(window.rootViewController is LoginNavigationController)
+        assertThat(window.rootViewController?.topmostPresentedViewController, isAnInstanceOf: LoginOnboardingViewController.self)
+
+        // When
+        let rootViewController = try XCTUnwrap(window.rootViewController)
+        XCTAssertTrue(authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: rootViewController))
+
+        // Then
+        waitUntil {
+            self.window.rootViewController is UINavigationController
+        }
+        let loginNavigationController = try XCTUnwrap(window.rootViewController as? LoginNavigationController)
+        XCTAssertEqual(loginNavigationController.viewControllers.count, 2)
+    }
+
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_pushes_a_view_controller_when_onboarding_is_not_shown() throws {
+        // Given
+        let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
+        coordinator = appCoordinator
+        let url = try XCTUnwrap(URL(string: "woocommerce://app-login?siteUrl=http%3A%2F%2Fwcdev.local&username=user"))
+
+        appCoordinator.start()
+        waitUntil {
+            self.window.rootViewController is UINavigationController
+        }
+        let loginNavigationController = try XCTUnwrap(window.rootViewController as? LoginNavigationController)
+        XCTAssertEqual(loginNavigationController.viewControllers.count, 1)
+
+        // When
+        XCTAssertTrue(authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController))
+
+        // Then
+        XCTAssertEqual(window.rootViewController, loginNavigationController)
+        XCTAssertEqual(loginNavigationController.viewControllers.count, 2)
+    }
+
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_dismisses_modal_and_pushes_view_controller_when_modal_is_shown() throws {
+        // Given
+        let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
+        coordinator = appCoordinator
+        let url = try XCTUnwrap(URL(string: "woocommerce://app-login?siteUrl=http%3A%2F%2Fwcdev.local&username=user"))
+
+        appCoordinator.start()
+        waitUntil {
+            self.window.rootViewController is UINavigationController
+        }
+        let loginNavigationController = try XCTUnwrap(window.rootViewController as? LoginNavigationController)
+        XCTAssertEqual(loginNavigationController.viewControllers.count, 1)
+        XCTAssertNil(loginNavigationController.presentedViewController)
+
+        // When
+        loginNavigationController.present(.init(), animated: false)
+        waitUntil {
+            loginNavigationController.presentedViewController != nil
+        }
+        XCTAssertTrue(authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController))
+
+        // Then
+        XCTAssertEqual(window.rootViewController, loginNavigationController)
+        waitUntil {
+            loginNavigationController.viewControllers.count == 2
+        }
+        XCTAssertNil(loginNavigationController.presentedViewController)
+    }
 }
 
 private extension AppCoordinatorTests {

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -13,11 +13,12 @@ final class AppCoordinatorTests: XCTestCase {
     private var authenticationManager: AuthenticationManager!
     private var coordinator: AppCoordinator?
 
-    private let window = UIWindow(frame: UIScreen.main.bounds)
+    private var window: UIWindow!
 
     override func setUp() {
         super.setUp()
 
+        window = UIWindow(frame: UIScreen.main.bounds)
         window.makeKeyAndVisible()
 
         sessionManager = .makeForTesting(authenticated: false)

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -13,12 +13,11 @@ final class AppCoordinatorTests: XCTestCase {
     private var authenticationManager: AuthenticationManager!
     private var coordinator: AppCoordinator?
 
-    private var window: UIWindow!
+    private let window = UIWindow(frame: UIScreen.main.bounds)
 
     override func setUp() {
         super.setUp()
 
-        window = UIWindow(frame: UIScreen.main.bounds)
         window.makeKeyAndVisible()
 
         sessionManager = .makeForTesting(authenticated: false)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

For #10843 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Originally, I added these test cases while fixing a navigation issue in https://github.com/woocommerce/woocommerce-ios/pull/10974. However, I couldn't figure out the consistent CI failures last Friday even though these tests passed locally consistently and decided to merge the PR first for the release. It turned out the root cause was the use of `ApiCredentials.dotcomAuthScheme` in the URL prefix check for the app login link. The API credentials probably are left blank on CI for security reasons. I see quite a few places in the code base using the URL scheme `woocommerce://` directly, so I thought we could just specify this instead of using `ApiCredentials.dotcomAuthScheme` to fix the CI failures.

## How

In `AuthenticationManager.isAppLoginUrl`, it's now just checking `WooConstants.appLoginURLPrefix` including the URL scheme `woocommerce://` without using `ApiCredentials.dotcomAuthScheme`. The original test cases on the navigation logic from `authenticationManager.handleAuthenticationUrl` were added back.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync does a confidence check on the app login link flow following the testing steps in https://github.com/woocommerce/woocommerce-ios/pull/10974

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
