### PR TITLE
Remove unneeded env vars from Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,6 +19,7 @@ RESOURCES_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'Resources')
 PUBLIC_CONFIG_FILE = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.Public.xcconfig')
 ENV['PUBLIC_CONFIG_FILE'] = PUBLIC_CONFIG_FILE
 RELEASE_NOTES_PATH = File.join(RESOURCES_FOLDER, 'release_notes.txt')
+CHANGELOG_PATH = File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt')
 FASTLANE_DIR = File.join(PROJECT_ROOT_FOLDER, 'fastlane')
 DERIVED_DATA_DIR = File.join(FASTLANE_DIR, 'DerivedData')
 SCREENSHOTS_DIR =  File.join(FASTLANE_DIR, 'screenshots')
@@ -158,9 +159,6 @@ platform :ios do
   ########################################################################
   Dotenv.load(USER_ENV_FILE_PATH)
   Dotenv.load(PROJECT_ENV_FILE_PATH)
-  ENV['PROJECT_NAME'] = 'WooCommerce'
-  ENV['PROJECT_ROOT_FOLDER'] = './'
-  ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'trunk'
 
   ########################################################################
   # Release Lanes
@@ -215,10 +213,13 @@ platform :ios do
     new_version = release_version_current
     extract_release_notes_for_version(
       version: new_version,
-      release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt'),
+      release_notes_file_path: CHANGELOG_PATH,
       extracted_notes_file_path: RELEASE_NOTES_PATH
     )
-    ios_update_release_notes(new_version:)
+    ios_update_release_notes(
+      new_version:,
+      release_notes_file_path: CHANGELOG_PATH
+    )
 
     if prompt_for_confirmation(
       message: 'Ready to push changes to remote and let the automation configure the release on GitHub?',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,7 @@ RESOURCES_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'Resources')
 PUBLIC_CONFIG_FILE = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.Public.xcconfig')
 ENV['PUBLIC_CONFIG_FILE'] = PUBLIC_CONFIG_FILE
 RELEASE_NOTES_PATH = File.join(RESOURCES_FOLDER, 'release_notes.txt')
-CHANGELOG_PATH = File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt')
+RELEASE_NOTES_SOURCE_PATH = File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt')
 FASTLANE_DIR = File.join(PROJECT_ROOT_FOLDER, 'fastlane')
 DERIVED_DATA_DIR = File.join(FASTLANE_DIR, 'DerivedData')
 SCREENSHOTS_DIR =  File.join(FASTLANE_DIR, 'screenshots')
@@ -213,12 +213,12 @@ platform :ios do
     new_version = release_version_current
     extract_release_notes_for_version(
       version: new_version,
-      release_notes_file_path: CHANGELOG_PATH,
+      release_notes_file_path: RELEASE_NOTES_SOURCE_PATH,
       extracted_notes_file_path: RELEASE_NOTES_PATH
     )
     ios_update_release_notes(
       new_version:,
-      release_notes_file_path: CHANGELOG_PATH
+      release_notes_file_path: RELEASE_NOTES_SOURCE_PATH
     )
 
     if prompt_for_confirmation(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,6 @@ DEFAULT_BRANCH = 'trunk'
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 RESOURCES_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'Resources')
 PUBLIC_CONFIG_FILE = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.Public.xcconfig')
-ENV['PUBLIC_CONFIG_FILE'] = PUBLIC_CONFIG_FILE
 RELEASE_NOTES_PATH = File.join(RESOURCES_FOLDER, 'release_notes.txt')
 RELEASE_NOTES_SOURCE_PATH = File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt')
 FASTLANE_DIR = File.join(PROJECT_ROOT_FOLDER, 'fastlane')


### PR DESCRIPTION
## Summary of changes:

This PR removes several unneeded environment variables:
- `PROJECT_ROOT_FOLDER` - The only action used by WCiOS that uses this one is[`ios_update_release_notes`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb) Release Toolkit action. I added a `CHANGELOG_PATH` constant and passed that to the method so that it doesn't rely on the default value of the action, which does use the env var.  
- `FL_RELEASE_TOOLKIT_DEFAULT_BRANCH` - This is used by [`ios_betabuild_prechecks`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb), [`ios_bump_version_release`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb), and [`ios_codefreeze_prechecks`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb), but none of those actions are used by WC anymore after the recent versioning changes. The versioning PR is not merged yet, which is why the base branch of this PR is the versioning PR. The versioning PR is already big enough so I thought it made more sense to break this one out. 
- `PROJECT_NAME` - This env var is used by Android apps in a path like `PROJECT_ROOT_FOLDER/PROJECT_NAME/build.gradle`, but it's not currently used by any iOS actions. I don't know if that was different in the past, but it's not needed at all now. 
- `PUBLIC_CONFIG_FILE` - This env var is also not needed by any of the Release Toolkit actions after the recent versioning changes. 