### PR TITLE
[Bundle products in order form] Add Configure CTA behind a feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -106,6 +106,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .optimizedBlazeExperience:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .productBundlesInOrderForm:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -221,4 +221,8 @@ public enum FeatureFlag: Int {
     /// Enables a new section on the My Store screen and a new entry point to the campaign list.
     ///
     case optimizedBlazeExperience
+
+    /// Enables bundle products support in order creation/editing.
+    ///
+    case bundleProductsInOrderForm
 }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -222,7 +222,7 @@ public enum FeatureFlag: Int {
     ///
     case optimizedBlazeExperience
 
-    /// Enables bundle products support in order creation/editing.
+    /// Enables bundle product configuration support in order creation/editing.
     ///
-    case bundleProductsInOrderForm
+    case productBundlesInOrderForm
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -89,14 +89,16 @@ struct CollapsibleProductRowCard: View {
             Divider()
                 .padding()
 
-            Button(Localization.configureBundleProduct) {
-                viewModel.configure?()
-            }
-            .buttonStyle(IconButtonStyle(icon: .cogImage))
-            .renderedIf(viewModel.isConfigurable)
+            Group {
+                Button(Localization.configureBundleProduct) {
+                    viewModel.configure?()
+                }
+                .buttonStyle(IconButtonStyle(icon: .cogImage))
 
-            Divider()
-                .padding()
+                Divider()
+                    .padding()
+            }
+            .renderedIf(viewModel.isConfigurable)
 
             Button(Localization.removeProductLabel) {
                 viewModel.removeProductIntent()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -85,8 +85,19 @@ struct CollapsibleProductRowCard: View {
             }
             .padding(.top)
             .renderedIf(viewModel.hasDiscount)
+
             Divider()
                 .padding()
+
+            Button(Localization.configureBundleProduct) {
+                viewModel.configure?()
+            }
+            .buttonStyle(IconButtonStyle(icon: .cogImage))
+            .renderedIf(viewModel.isConfigurable)
+
+            Divider()
+                .padding()
+
             Button(Localization.removeProductLabel) {
                 viewModel.removeProductIntent()
             }
@@ -275,6 +286,9 @@ private extension CollapsibleProductRowCard {
         static let discountTooltipDescription = NSLocalizedString(
             "To add a Product Discount, please remove all Coupons from your order",
             comment: "Description text for the product discount row informational tooltip")
+        static let configureBundleProduct = NSLocalizedString(
+            "Configure",
+            comment: "Text in the product row card to configure a bundle product")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -144,7 +144,8 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             stockQuantity: 7,
                                             manageStock: true,
                                             canChangeQuantity: false,
-                                            imageURL: nil)
+                                               imageURL: nil,
+                                               isConfigurable: true)
         let viewModel = ProductInOrderViewModel(productRowViewModel: productRowVM,
                                                 productDiscountConfiguration: nil, showCouponsAndDiscountsAlert: false,
                                                 onRemoveProduct: {})

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -219,7 +219,8 @@ struct ProductRow_Previews: PreviewProvider {
                                             stockQuantity: 7,
                                             manageStock: true,
                                             canChangeQuantity: true,
-                                            imageURL: nil)
+                                            imageURL: nil,
+                                            isConfigurable: true)
         let viewModelWithoutStepper = ProductRowViewModel(productOrVariationID: 1,
                                                           name: "Love Ficus",
                                                           sku: "123456",
@@ -228,7 +229,8 @@ struct ProductRow_Previews: PreviewProvider {
                                                           stockQuantity: 7,
                                                           manageStock: true,
                                                           canChangeQuantity: false,
-                                                          imageURL: nil)
+                                                          imageURL: nil,
+                                                          isConfigurable: false)
 
         ProductRow(viewModel: viewModel)
             .previewDisplayName("ProductRow with stepper")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -309,7 +309,9 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             }
         }()
 
-        let isConfigurable = featureFlagService.isFeatureFlagEnabled(.productBundlesInOrderForm) && product.productType == .bundle
+        let isConfigurable = featureFlagService.isFeatureFlagEnabled(.productBundlesInOrderForm)
+        && product.productType == .bundle
+        && product.bundledItems.isNotEmpty
 
         self.init(id: id,
                   productOrVariationID: product.productID,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -309,7 +309,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             }
         }()
 
-        let isConfigurable = featureFlagService.isFeatureFlagEnabled(.bundleProductsInOrderForm) && product.productType == .bundle
+        let isConfigurable = featureFlagService.isFeatureFlagEnabled(.productBundlesInOrderForm) && product.productType == .bundle
 
         self.init(id: id,
                   productOrVariationID: product.productID,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -1,3 +1,4 @@
+import Experiments
 import Foundation
 import Yosemite
 import WooFoundation
@@ -29,6 +30,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Product name
     ///
     let name: String
+
+    /// Whether a product in an order item is configurable
+    ///
+    let isConfigurable: Bool
 
     /// Product SKU
     ///
@@ -198,6 +203,9 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     var removeProductIntent: () -> Void
 
+    /// Closure to configure a product if it is configurable.
+    var configure: (() -> Void)?
+
     /// Number of variations in a variable product
     ///
     let numberOfVariations: Int
@@ -221,9 +229,11 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          numberOfVariations: Int = 0,
          variationDisplayMode: VariationDisplayMode? = nil,
          selectedState: ProductRow.SelectedState = .notSelected,
+         isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
-         removeProductIntent: @escaping (() -> Void) = {}) {
+         removeProductIntent: @escaping (() -> Void) = {},
+         configure: (() -> Void)? = nil) {
         self.id = id ?? Int64(UUID().uuidString.hashValue)
         self.selectedState = selectedState
         self.productOrVariationID = productOrVariationID
@@ -237,11 +247,13 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.quantity = quantity
         self.canChangeQuantity = canChangeQuantity
         self.imageURL = imageURL
+        self.isConfigurable = isConfigurable
         self.currencyFormatter = currencyFormatter
         self.numberOfVariations = numberOfVariations
         self.variationDisplayMode = variationDisplayMode
         self.quantityUpdatedCallback = quantityUpdatedCallback
         self.removeProductIntent = removeProductIntent
+        self.configure = configure
     }
 
     /// Initialize `ProductRowViewModel` with a `Product`
@@ -255,7 +267,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
                      removeProductIntent: @escaping (() -> Void) = {},
-                     productBundlesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles)) {
+                     featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+                     configure: (() -> Void)? = nil) {
         // Don't show any price for variable products; price will be shown for each product variation.
         let price: String?
         if product.productType == .variable {
@@ -263,6 +276,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         } else {
             price = product.price
         }
+
+        let productBundlesEnabled = featureFlagService.isFeatureFlagEnabled(.productBundles)
 
         // If product is a product bundle with insufficient bundle stock, use that as the product stock status.
         let stockStatusKey: String = {
@@ -294,6 +309,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             }
         }()
 
+        let isConfigurable = featureFlagService.isFeatureFlagEnabled(.bundleProductsInOrderForm) && product.productType == .bundle
+
         self.init(id: id,
                   productOrVariationID: product.productID,
                   name: product.name,
@@ -308,9 +325,11 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   imageURL: product.imageURL,
                   numberOfVariations: product.variations.count,
                   selectedState: selectedState,
+                  isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
                   quantityUpdatedCallback: quantityUpdatedCallback,
-                  removeProductIntent: removeProductIntent)
+                  removeProductIntent: removeProductIntent,
+                  configure: configure)
     }
 
     /// Initialize `ProductRowViewModel` with a `ProductVariation`
@@ -347,6 +366,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   imageURL: imageURL,
                   variationDisplayMode: displayMode,
                   selectedState: selectedState,
+                  isConfigurable: false,
                   currencyFormatter: currencyFormatter,
                   quantityUpdatedCallback: quantityUpdatedCallback,
                   removeProductIntent: removeProductIntent)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -707,7 +707,8 @@ extension ProductSelectorViewModel {
                             stockQuantity: 1,
                             manageStock: false,
                             canChangeQuantity: false,
-                            imageURL: nil)
+                            imageURL: nil,
+                            isConfigurable: false)
     }
 
     /// Add Product to Order notices

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -337,7 +337,8 @@ extension ProductVariationSelectorViewModel {
                             stockQuantity: 1,
                             manageStock: false,
                             canChangeQuantity: false,
-                            imageURL: nil)
+                            imageURL: nil,
+                            isConfigurable: false)
     }
 
     /// Add Product Variation to Order notices

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -93,9 +93,19 @@ struct TextButtonStyle: ButtonStyle {
     }
 }
 
+/// Button that includes an icon to the leading edge of the text.
+struct IconButtonStyle: ButtonStyle {
+    /// Image of the icon.
+    let icon: UIImage
+
+    func makeBody(configuration: Configuration) -> some View {
+        return IconButton(configuration: configuration, icon: icon)
+    }
+}
+
 struct PlusButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
-        return PlusButton(configuration: configuration)
+        return IconButton(configuration: configuration, icon: .plusImage)
     }
 }
 
@@ -367,17 +377,18 @@ private struct TextButton: View {
     }
 }
 
-private struct PlusButton: View {
+private struct IconButton: View {
     @Environment(\.isEnabled) var isEnabled
 
     let configuration: ButtonStyleConfiguration
+    let icon: UIImage
 
     var body: some View {
         HStack {
             Label {
                 configuration.label
             } icon: {
-                Image(uiImage: .plusImage)
+                Image(uiImage: icon)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -457,6 +468,15 @@ struct PrimaryButton_Previews: PreviewProvider {
             }
 
             Group {
+                Button("Icon button") {}
+                    .buttonStyle(IconButtonStyle(icon: .cogImage))
+
+                Button("Icon button (disabled)") {}
+                    .buttonStyle(IconButtonStyle(icon: .cogImage))
+                    .disabled(true)
+            }
+
+            Group {
                 Button("Plus button") {}
                     .buttonStyle(PlusButtonStyle())
 
@@ -516,6 +536,15 @@ struct PrimaryButton_Previews: PreviewProvider {
 
                 Button("Text button (disabled)") {}
                     .buttonStyle(TextButtonStyle())
+                    .disabled(true)
+            }
+
+            Group {
+                Button("Icon button") {}
+                    .buttonStyle(IconButtonStyle(icon: .cogImage))
+
+                Button("Icon button (disabled)") {}
+                    .buttonStyle(IconButtonStyle(icon: .cogImage))
                     .disabled(true)
             }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,6 +22,8 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let betterCustomerSelectionInOrder: Bool
     private let manualTaxesInOrderM2: Bool
     private let productCreationAI: Bool
+    private let productBundles: Bool
+    private let productBundlesInOrderForm: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -42,7 +44,9 @@ struct MockFeatureFlagService: FeatureFlagService {
          isJustInTimeMessagesOnDashboardEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
          manualTaxesInOrderM2: Bool = false,
-         productCreationAI: Bool = false) {
+         productCreationAI: Bool = false,
+         productBundles: Bool = false,
+         productBundlesInOrderForm: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -63,6 +67,8 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
         self.manualTaxesInOrderM2 = manualTaxesInOrderM2
         self.productCreationAI = productCreationAI
+        self.productBundles = productBundles
+        self.productBundlesInOrderForm = productBundlesInOrderForm
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -105,6 +111,10 @@ struct MockFeatureFlagService: FeatureFlagService {
             return manualTaxesInOrderM2
         case .productCreationAI:
             return productCreationAI
+        case .productBundles:
+            return productBundles
+        case .productBundlesInOrderForm:
+            return productBundlesInOrderForm
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -394,9 +394,22 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isConfigurable)
     }
 
-    func test_isConfigurable_is_true_for_bundle_product_when_feature_flag_is_enabled() {
+    func test_isConfigurable_is_false_for_bundle_product_with_empty_bundle_items() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
+
+        // Then
+        XCTAssertFalse(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_is_true_for_bundle_product_with_bundle_items() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle", bundledItems: [.fake()])
 
         // When
         let viewModel = ProductRowViewModel(product: product,
@@ -407,7 +420,7 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isConfigurable)
     }
 
-    func test_isConfigurable_is_false_for_non_bundle_product_when_feature_flag_is_enabled() {
+    func test_isConfigurable_is_false_for_non_bundle_product() {
         let nonBundleProductTypes: [ProductType] = [.simple, .grouped, .affiliate, .variable, .subscription, .variableSubscription, .composite]
 
         nonBundleProductTypes.forEach { nonBundleProductType in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -378,6 +378,51 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockLabel),
                       "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
+
+    // MARK: - `isConfigurable`
+
+    func test_isConfigurable_is_false_for_bundle_product_when_feature_flag_is_disabled() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundlesInOrderForm: false))
+
+        // Then
+        XCTAssertFalse(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_is_true_for_bundle_product_when_feature_flag_is_enabled() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
+
+        // Then
+        XCTAssertTrue(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_is_false_for_non_bundle_product_when_feature_flag_is_enabled() {
+        let nonBundleProductTypes: [ProductType] = [.simple, .grouped, .affiliate, .variable, .subscription, .variableSubscription, .composite]
+
+        nonBundleProductTypes.forEach { nonBundleProductType in
+            // Given
+            let product = Product.fake().copy(productTypeKey: nonBundleProductType.rawValue)
+
+            // When
+            let viewModel = ProductRowViewModel(product: product,
+                                                canChangeQuantity: false,
+                                                featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
+
+            // Then
+            XCTAssertFalse(viewModel.isConfigurable)
+        }
+    }
 }
 
 private extension ProductRowViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -1,10 +1,11 @@
+import Experiments
 import XCTest
 import Yosemite
 import Fakes
 import WooFoundation
 @testable import WooCommerce
 
-class ProductRowViewModelTests: XCTestCase {
+final class ProductRowViewModelTests: XCTestCase {
 
     func test_viewModel_is_created_with_correct_initial_values_from_product() {
         // Given
@@ -304,7 +305,9 @@ class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "instock", bundleStockStatus: .insufficientStock)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, productBundlesEnabled: false)
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundles: false))
 
         // Then
         let expectedStockText = ProductStockStatus.inStock.description
@@ -317,7 +320,9 @@ class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "instock", bundleStockStatus: .insufficientStock)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, productBundlesEnabled: true)
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService())
 
         // Then
         let expectedStockText = ProductStockStatus.insufficientStock.description
@@ -330,7 +335,9 @@ class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "onbackorder", bundleStockStatus: .inStock)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, productBundlesEnabled: true)
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService())
 
         // Then
         let expectedStockText = ProductStockStatus.onBackOrder.description
@@ -343,7 +350,9 @@ class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: "bundle", manageStock: true, stockQuantity: 5, stockStatusKey: "instock", bundleStockQuantity: 1)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, productBundlesEnabled: false)
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundles: false))
 
         // Then
         let localizedStockQuantity = NumberFormatter.localizedString(from: 5 as NSDecimalNumber, number: .decimal)
@@ -358,7 +367,9 @@ class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: "bundle", manageStock: false, stockQuantity: 5, stockStatusKey: "instock", bundleStockQuantity: 1)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, productBundlesEnabled: true)
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService())
 
         // Then
         let localizedStockQuantity = NumberFormatter.localizedString(from: 1 as NSDecimalNumber, number: .decimal)
@@ -366,5 +377,11 @@ class ProductRowViewModelTests: XCTestCase {
         let expectedStockLabel = String.localizedStringWithFormat(format, localizedStockQuantity)
         XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockLabel),
                       "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
+    }
+}
+
+private extension ProductRowViewModelTests {
+    func createFeatureFlagService(productBundles: Bool = true, productBundlesInOrderForm: Bool = false) -> FeatureFlagService {
+        MockFeatureFlagService(productBundles: productBundles, productBundlesInOrderForm: productBundlesInOrderForm)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10428 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As the first part of the UI/UX changes for the support of configuring a bundle product, a CTA was added behind a new feature flag `productBundlesInOrderForm`.

## How

A new property `isConfigurable: Bool` was added to `ProductRowViewModel`, which is used to show the Configure CTA in the new product card in order form (there was a redesign of the card). The value is only true when the product is a bundle product, and the feature flag is enabled. The CTA follows a similar style as the `Add discount` CTA. In order to match the button style, I added `IconButtonStyle` and made the pre-existing `PlusButtonStyle` reuse the new button style to maintain consistency.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and at least one editable order with a bundle product that has non-zero bundle items.

### Order with a bundle product

- Go to the Orders tab
- Tap on an editable order with a bundle product
- Tap `Edit` in order details
- Tap the 🔽 CTA to expand the product card with the bundle product --> a Configure CTA should be shown

### Order with a bundle product

- Go to the Orders tab
- Tap on an editable order with a non bundle product
- Tap `Edit` in order details
- Tap the 🔽 CTA to expand the product card --> no Configure CTA should be shown, the card should look the same as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

bundle product | non bundle product
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/eae946ef-c691-416d-abda-65c067233f49" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/d0e93916-1997-4bf5-af12-9a6d6af384d8" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
