### PR TITLE
[Bundle products in order form] Support syncing a subset of variations

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -7,6 +7,7 @@ import Foundation
 public protocol ProductVariationsRemoteProtocol {
     func loadAllProductVariations(for siteID: Int64,
                                   productID: Int64,
+                                  variationIDs: [Int64],
                                   context: String?,
                                   pageNumber: Int,
                                   pageSize: Int,
@@ -42,6 +43,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch remote product variations.
     ///     - productID: Product for which we'll fetch remote product variations.
+    ///     - variationIDs: A list of variation IDs to fetch from the product. If the value is empty, all variations are returned.
     ///     - context: view or edit. Scope under which the request is made;
     ///                determines fields present in response. Default is view.
     ///     - pageNumber: Number of page that should be retrieved.
@@ -50,15 +52,20 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
     ///
     public func loadAllProductVariations(for siteID: Int64,
                                          productID: Int64,
+                                         variationIDs: [Int64],
                                          context: String? = nil,
                                          pageNumber: Int = Default.pageNumber,
                                          pageSize: Int = Default.pageSize,
                                          completion: @escaping ([ProductVariation]?, Error?) -> Void) {
+        let stringOfVariationIDs = variationIDs.map { String($0) }
+            .joined(separator: ",")
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
-            ParameterKey.contextKey: context ?? Default.context
+            ParameterKey.contextKey: context ?? Default.context,
+            ParameterKey.include: variationIDs.isEmpty ? nil: stringOfVariationIDs
         ]
+            .compactMapValues { $0 }
 
         let path = "\(Path.products)/\(productID)/variations"
         let request = JetpackRequest(wooApiVersion: .mark3,
@@ -278,5 +285,6 @@ public extension ProductVariationsRemote {
         static let perPage: String    = "per_page"
         static let contextKey: String = "context"
         static let image: String = "image"
+        static let include: String    = "include"
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -121,6 +121,36 @@ final class ProductVariationsRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    func test_loadAllProductVariations_with_non_empty_variationIDs_adds_include_parameter() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let includedVariationIDs: [Int64] = [17, 671]
+
+        // When
+        remote.loadAllProductVariations(for: sampleSiteID,
+                                        productID: sampleProductID,
+                                        variationIDs: includedVariationIDs) { _, _ in }
+
+        // Then
+        let queryParameters = try XCTUnwrap(network.queryParameters)
+        let expectedParam = "include=17,671"
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
+    }
+
+    func test_loadAllProductVariations_with_empty_variationIDs_does_not_add_include_parameter() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        remote.loadAllProductVariations(for: sampleSiteID,
+                                        productID: sampleProductID,
+                                        variationIDs: []) { _, _ in }
+
+        // Then
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertFalse(queryParametersDictionary.contains(where: { $0.key == "include" }))
+    }
+
     // MARK: - Load single product variation tests
 
     /// Verifies that loadProductVariation properly parses the `product-variation` sample response.

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -33,7 +33,9 @@ final class ProductVariationsRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
 
-        remote.loadAllProductVariations(for: sampleSiteID, productID: sampleProductID) { productVariations, error in
+        remote.loadAllProductVariations(for: sampleSiteID,
+                                        productID: sampleProductID,
+                                        variationIDs: []) { productVariations, error in
             XCTAssertNil(error)
             XCTAssertNotNil(productVariations)
             XCTAssertEqual(productVariations?.count, 8)
@@ -108,7 +110,9 @@ final class ProductVariationsRemoteTests: XCTestCase {
         let remote = ProductVariationsRemote(network: network)
         let expectation = self.expectation(description: "Load All Product Variations returns error")
 
-        remote.loadAllProductVariations(for: sampleSiteID, productID: sampleProductID) { (productVariations, error) in
+        remote.loadAllProductVariations(for: sampleSiteID,
+                                        productID: sampleProductID,
+                                        variationIDs: []) { (productVariations, error) in
             XCTAssertNil(productVariations)
             XCTAssertNotNil(error)
             expectation.fulfill()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -57,6 +57,10 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     private let onSelectionsCleared: (() -> Void)?
 
+    /// A list of variation IDs that are allowed in the selector.
+    ///
+    private let allowedProductVariationIDs: [Int64]
+
     /// All selected product variations if the selector supports multiple selections.
     ///
     @Published private(set) var selectedProductVariationIDs: [Int64]
@@ -95,7 +99,14 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     /// Product Variations Results Controller.
     ///
     private lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
-        let predicate = NSPredicate(format: "siteID == %lld AND productID == %lld", siteID, productID)
+        let siteAndProductIDPredicate = NSPredicate(format: "siteID == %lld AND productID == %lld", siteID, productID)
+        let predicate: NSPredicate
+        if allowedProductVariationIDs.isNotEmpty {
+            let variationIDsPredicate = NSPredicate(format: "productVariationID IN %@", allowedProductVariationIDs)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [siteAndProductIDPredicate, variationIDsPredicate])
+        } else {
+            predicate = siteAndProductIDPredicate
+        }
         let menuOrderDescriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
         let variationIdDescriptor = NSSortDescriptor(keyPath: \StorageProductVariation.productVariationID, ascending: false)
         let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager,
@@ -112,6 +123,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          productID: Int64,
          productName: String,
          productAttributes: [ProductAttribute],
+         allowedProductVariationIDs: [Int64] = [],
          selectedProductVariationIDs: [Int64] = [],
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -125,6 +137,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.storageManager = storageManager
         self.stores = stores
         self.onVariationSelectionStateChanged = onVariationSelectionStateChanged
+        self.allowedProductVariationIDs = allowedProductVariationIDs
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
         self.onSelectionsCleared = onSelectionsCleared
@@ -136,6 +149,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     convenience init(siteID: Int64,
                      product: Product,
+                     allowedProductVariationIDs: [Int64] = [],
                      selectedProductVariationIDs: [Int64] = [],
                      purchasableItemsOnly: Bool = false,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -146,6 +160,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   productID: product.productID,
                   productName: product.name,
                   productAttributes: product.attributesForVariations,
+                  allowedProductVariationIDs: allowedProductVariationIDs,
                   selectedProductVariationIDs: selectedProductVariationIDs,
                   purchasableItemsOnly: purchasableItemsOnly,
                   storageManager: storageManager,
@@ -188,10 +203,11 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
     ///
     func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)?) {
         transitionToSyncingState()
-        let action = ProductVariationAction.synchronizeProductVariations(siteID: siteID,
-                                                                         productID: productID,
-                                                                         pageNumber: pageNumber,
-                                                                         pageSize: pageSize) { [weak self] result in
+        let action = ProductVariationAction.synchronizeProductVariationsSubset(siteID: siteID,
+                                                                               productID: productID,
+                                                                               variationIDs: allowedProductVariationIDs,
+                                                                               pageNumber: pageNumber,
+                                                                               pageSize: pageSize) { [weak self] result in
             guard let self = self else { return }
 
             switch result {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -68,7 +68,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowScrollIndicator, "Scroll indicator is not disabled at start")
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariationsSubset(_, _, _, _, _, onCompletion):
                 XCTAssertTrue(viewModel.shouldShowScrollIndicator, "Scroll indicator is not enabled during sync")
                 onCompletion(.success(false))
             default:
@@ -89,7 +89,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariationsSubset(_, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
                 onCompletion(.success(false))
             default:
@@ -110,7 +110,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariationsSubset(_, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
                 self.insert(self.sampleProductVariation)
                 onCompletion(.success(false))
@@ -134,7 +134,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: product, storageManager: storageManager, stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariationsSubset(_, _, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .results)
                 onCompletion(.success(false))
             default:
@@ -155,7 +155,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         var timesSynced = 0
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case .synchronizeProductVariations:
+            case .synchronizeProductVariationsSubset:
                 timesSynced += 1
             default:
                 XCTFail("Unsupported Action")
@@ -191,7 +191,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID, product: Product.fake(), stores: stores)
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
-            case let .synchronizeProductVariations(_, _, _, _, onCompletion):
+            case let .synchronizeProductVariationsSubset(_, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -15,6 +15,17 @@ public enum ProductVariationAction: Action {
     ///
     case synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Result<Bool, Error>) -> Void)
 
+    /// Synchronizes a subset of product's `ProductVariation`s matching the specified criteria.
+    /// When `variationIDs` is empty, all variations are returned in a paginated way and it behaves the same as `synchronizeProductVariations`.
+    /// If successful, the result boolean value, will indicate weather there are more variations to fetch or not.
+    ///
+    case synchronizeProductVariationsSubset(siteID: Int64,
+                                            productID: Int64,
+                                            variationIDs: [Int64],
+                                            pageNumber: Int,
+                                            pageSize: Int,
+                                            onCompletion: (Result<Bool, Error>) -> Void)
+
     /// Retrieves the specified ProductVariation.
     ///
     case retrieveProductVariation(siteID: Int64, productID: Int64, variationID: Int64, onCompletion: (Result<ProductVariation, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -42,6 +42,13 @@ public final class ProductVariationStore: Store {
             synchronizeAllProductVariations(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .synchronizeProductVariations(let siteID, let productID, let pageNumber, let pageSize, let onCompletion):
             synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .synchronizeProductVariationsSubset(let siteID, let productID, let variationIDs, let pageNumber, let pageSize, let onCompletion):
+            synchronizeProductVariations(siteID: siteID,
+                                         productID: productID,
+                                         variationIDs: variationIDs,
+                                         pageNumber: pageNumber,
+                                         pageSize: pageSize,
+                                         onCompletion: onCompletion)
         case .retrieveProductVariation(let siteID, let productID, let variationID, let onCompletion):
             retrieveProductVariation(siteID: siteID, productID: productID, variationID: variationID, onCompletion: onCompletion)
         case .createProductVariation(let siteID, let productID, let newVariation, let onCompletion):
@@ -87,12 +94,18 @@ private extension ProductVariationStore {
         }
     }
 
-    /// Synchronizes the product reviews associated with a given Site ID (if any!).
+    /// Synchronizes the product variations associated with a given Site ID, product ID, and an optional list of variation IDs.
     /// If successful, the result boolean value, will indicate weather there are more variations to fetch or not.
     ///
-    func synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+    func synchronizeProductVariations(siteID: Int64,
+                                      productID: Int64,
+                                      variationIDs: [Int64] = [],
+                                      pageNumber: Int,
+                                      pageSize: Int,
+                                      onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         remote.loadAllProductVariations(for: siteID,
                                         productID: productID,
+                                        variationIDs: variationIDs,
                                         context: nil,
                                         pageNumber: pageNumber,
                                         pageSize: pageSize) { [weak self] (productVariations, error) in
@@ -351,7 +364,7 @@ private extension ProductVariationStore {
                                               pageNumber: Int,
                                               pageSize: Int,
                                               onCompletion: @escaping (Result<Bool, Error>) -> Void) {
-        synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
+        synchronizeProductVariations(siteID: siteID, productID: productID, variationIDs: [], pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
             switch result {
             case .success(let hasMoreVariationsToFetch):
                 guard hasMoreVariationsToFetch else {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -83,6 +83,7 @@ final class MockProductVariationsRemote {
 extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
     func loadAllProductVariations(for siteID: Int64,
                                   productID: Int64,
+                                  variationIDs: [Int64],
                                   context: String?,
                                   pageNumber: Int,
                                   pageSize: Int,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10428
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To support configuring product bundles in the order form, a bundle item can be a variable product and the merchant can add settings to only allow certain variations and override the default variation in the order item configuration form. In the form, the merchant can select a variation from the potentially filtered variation list. To support this variation selector UI that only allows a subset of variations, some changes are required in the Networking, Yosemite, and App layers.

## How

### Networking layer

Right now, the variations selector makes an API request through `ProductVariationsRemote.loadAllProductVariations` to load all the variations of a product. When the variable bundle item only allows a subset of variations, we want to add an `include` parameter to only fetch these allowed variations. Thus, a new parameter `variationIDs` was added to the function for optionally filtering the variations.

### Yosemite layer

Since `ProductVariationAction.synchronizeProductVariations` is used for a few other use cases outside of the variations selector, I decided to create another action `synchronizeProductVariationsSubset` (enums can't have the same name with 2 different associated types). Internally, both actions call the same private function to load the variations remotely.

### App layer

In `ProductVariationSelectorViewModel`, `allowedProductVariationIDs` parameter was added and used to:

- Filter the variations in the storage layer - only variations with ID in `allowedProductVariationIDs` are shown in the selector UI
- Sync the variations - when `allowedProductVariationIDs` is non-empty, only a subset of variations is synced

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The new `allowedProductVariationIDs` isn't used in the app yet. Please feel free to do a confidence check on the main affected use case in the order form:

Prerequisite: the store has a variable product with a few variations

- Go to the Orders tab
- Tap on `+`
- Tap `Add Products`
- Tap on a variable product with variations --> the variations selector should behave the same as before
- Select at least one variation, then go back and tap `Done` --> the selected variations should be added to the order form
- Tap `Create` --> the order should be created remotely with the variations

---

- [x] @jaclync tests the coupons use cases
- [x] @jaclync tests pagination 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/ed93f87b-7165-44b0-bdfb-2efa5a428fb4" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
