### PR TITLE
[Tracks] Crash fix – TracksPersistentStoreException and EXC_Breakpoint CFRetain() called with NULL

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.0
 -----
-
+- [*] Fix a crash on launch related to Core Data and Tracks [https://github.com/woocommerce/woocommerce-ios/pull/10994]
 
 15.9
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10999
Closes: #4219

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Two crashes related to Tracks, which occurred on launch, have spiked recently. This appears to have been caused by the tracks library being instantiated twice (or more) concurrently.

### Use type properties for Tracks thread safety
This is a somewhat speculative fix, which uses type properties to ensure thread safety of the creation of the TracksService, and its underlying Core Data store.

A lazy var, as in the previous implementation, is not guaranteed to be thread safe, and it was possible to see crashes in the app when two events were tracked concurrently on different threads.

See p91TBi-aJD-p2 for more details.



## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Force reproduction of the crash by adding the following to the top of the `AppDelegate.willFinishLaunchingWithOptions` function:

```
        DispatchQueue(label: "first", qos: .userInteractive).asyncAfter(deadline: DispatchTime(uptimeNanoseconds: 1)) {
            ServiceLocator.analytics.track(.applicationOpened)
        }
        DispatchQueue(label: "second", qos: .userInteractive).asyncAfter(deadline: DispatchTime(uptimeNanoseconds: 1)) {
            ServiceLocator.analytics.track(.applicationOpened)
        }
```

Note that this is about a 90% reproduction – if you launch the app a few times with it in place on `trunk`, you should see the crash.

Apply it to the fix branch, launch the app, and observe that you do not see the crash.


Test that analytic events are tracked as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
