### PR TITLE
Product creation: Update size of bottom sheet based on size class

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -280,7 +280,7 @@ private extension AddProductCoordinator {
             }
         })
 
-        addProductWithAIBottomSheetPresenter = buildBottomSheetPresenter(height: navigationController.view.frame.height * 0.3)
+        addProductWithAIBottomSheetPresenter = buildBottomSheetPresenter()
         addProductWithAIBottomSheetPresenter?.present(controller, from: navigationController)
         analytics.track(event: .ProductCreationAI.entryPointDisplayed())
     }
@@ -393,7 +393,7 @@ private extension AddProductCoordinator {
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }
 
-    func buildBottomSheetPresenter(height: CGFloat? = nil) -> BottomSheetPresenter {
+    func buildBottomSheetPresenter() -> BottomSheetPresenter {
         BottomSheetPresenter(configure: { [weak self] bottomSheet in
             guard let self else { return }
             var sheet = bottomSheet
@@ -402,15 +402,7 @@ private extension AddProductCoordinator {
             sheet.prefersGrabberVisible = true
             // Sets custom height if possible.
             // Default detents are used otherwise. Large detent is necessary for large font sizes.
-            var detents: [UISheetPresentationController.Detent] = []
-            if #available(iOS 16.0, *), let height {
-                let customHeight = UISheetPresentationController.Detent.custom { _ in
-                    height
-                }
-                detents = [.medium(), customHeight]
-            } else {
-                detents = [.medium()]
-            }
+            var detents: [UISheetPresentationController.Detent] = [.medium()]
 
             // if preferred content size is accessibility or vertical size class is compact,
             // add large detent for accessibility.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -399,7 +399,6 @@ private extension AddProductCoordinator {
             var sheet = bottomSheet
             sheet.prefersEdgeAttachedInCompactHeight = true
             sheet.largestUndimmedDetentIdentifier = .none
-            sheet.prefersGrabberVisible = true
 
             // Sets detents for the sheet.
             // Skips large detent if the device is iPad.
@@ -410,6 +409,7 @@ private extension AddProductCoordinator {
             } else {
                 sheet.detents = [.large(), .medium()]
             }
+            sheet.prefersGrabberVisible = !isIPad
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -401,19 +401,15 @@ private extension AddProductCoordinator {
             sheet.largestUndimmedDetentIdentifier = .none
             sheet.prefersGrabberVisible = true
 
-            var detents: [UISheetPresentationController.Detent] = [.medium()]
-
-            // If preferred content size is accessibility or vertical size class is compact,
-            // add large detent for accessibility.
-            // Skip if the device is iPad.
-            let traitCollection = self.navigationController.traitCollection
-            let isAccessibilityCategory = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-            let compactVertical = traitCollection.verticalSizeClass == .compact
+            // Sets detents for the sheet.
+            // Skips large detent if the device is iPad.
+            let traitCollection = UIScreen.main.traitCollection
             let isIPad = traitCollection.horizontalSizeClass == .regular && traitCollection.verticalSizeClass == .regular
-            if !isIPad && (isAccessibilityCategory || compactVertical) {
-                detents.append(.large())
+            if isIPad {
+                sheet.detents = [.medium()]
+            } else {
+                sheet.detents = [.large(), .medium()]
             }
-            sheet.detents = detents
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -400,13 +400,12 @@ private extension AddProductCoordinator {
             sheet.prefersEdgeAttachedInCompactHeight = true
             sheet.largestUndimmedDetentIdentifier = .none
             sheet.prefersGrabberVisible = true
-            // Sets custom height if possible.
-            // Default detents are used otherwise. Large detent is necessary for large font sizes.
+
             var detents: [UISheetPresentationController.Detent] = [.medium()]
 
-            // if preferred content size is accessibility or vertical size class is compact,
+            // If preferred content size is accessibility or vertical size class is compact,
             // add large detent for accessibility.
-            // skip if the device is iPad.
+            // Skip if the device is iPad.
             let traitCollection = self.navigationController.traitCollection
             let isAccessibilityCategory = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
             let compactVertical = traitCollection.verticalSizeClass == .compact

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/EntryPoint/AddProductWithAIActionSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/EntryPoint/AddProductWithAIActionSheet.swift
@@ -50,8 +50,8 @@ struct AddProductWithAIActionSheet: View {
                             .bodyStyle()
                         Text(Localization.aiDescription)
                             .subheadlineStyle()
-                        Group {
-                            Text(Localization.legalText) + Text(" ") +
+                        AdaptiveStack(horizontalAlignment: .leading) {
+                            Text(Localization.legalText)
                             Text(.init(Localization.learnMore)).underline()
                         }
                         .environment(\.openURL, OpenURLAction { url in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10989 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the large detent mode for the product creation bottom sheet:
- Disables large detent if the device is iPad.
- For iPhones, enable both large and medium detents.

📝 I removed the custom height detent because it doesn't work well. It would be nice if we could calculate the height of the sheet before presenting but I'm not sure if that's possible. Please feel free to suggest any improvements.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom site or self-hosted site with AI assistance available.
- Navigate to the Products tab and select + to add a new product.
- Notice the bottom sheet is displayed properly.
- Repeat with different devices and font sizes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Landscape mode for iPhone: always enable large detent:
![Simulator Screenshot - iPhone 14 Pro - 2023-10-24 at 13 16 15](https://github.com/woocommerce/woocommerce-ios/assets/5533851/84cf5639-3a07-4614-965f-f9b42e0f33af)

Portrait mode for iPhone: enable both large and medium detents:
| Normal font size | Large font size | 
| --- | --- | 
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/76e5ffc6-297e-4346-8096-548ac180337f" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/f579069f-2941-423b-a580-fb8b587c825d" width=320 /> |

On iPad: disable large detent.

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/06acd6ed-073d-4adf-bb42-4eade9728438" width=400 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
