### PR TITLE
[Orders with Coupons] Fix tooltip coupons visibility cases

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.0
 -----
-
+- [*] Orders: Fixed UI issue where an incorrect tooltip is displayed during Order Creation [https://github.com/woocommerce/woocommerce-ios/pull/10998]
 
 15.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -981,15 +981,10 @@ extension EditableOrderViewModel {
         /// Indicates whether the Coupons informational tooltip button should be shown
         /// The tooltip is rendered when an order has no coupons, but has product discounts.
         /// Sincer both are mutually exclusive but they are included in the Order's discounts total as one unique value, we cannot rely
-        /// on `shouldShowCoupon` or `showDiscountsTotal` alone for its visibility:
+        /// on `shouldShowCoupon` or `shouldShowDiscountTotal` alone for its visibility:
         ///
         var shouldRenderCouponsInfoTooltip: Bool {
-            if shouldShowCoupon {
-                return false
-            } else if shouldShowDiscountTotal {
-                return true
-            }
-            return false
+            !shouldShowCoupon && shouldShowDiscountTotal
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -980,7 +980,7 @@ extension EditableOrderViewModel {
 
         /// Indicates whether the Coupons informational tooltip button should be shown
         /// The tooltip is rendered when an order has no coupons, but has product discounts.
-        /// Sincer both are mutually exclusive but they are included in the Order's discounts total as one unique value, we cannot rely
+        /// Since both are mutually exclusive but they are included in the Order's discounts total as one unique value, we cannot rely
         /// on `shouldShowCoupon` or `shouldShowDiscountTotal` alone for its visibility:
         ///
         var shouldRenderCouponsInfoTooltip: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -977,6 +977,20 @@ extension EditableOrderViewModel {
             self.addGiftCardClosure = addGiftCardClosure
             self.setGiftCardClosure = setGiftCardClosure
         }
+
+        /// Indicates whether the Coupons informational tooltip button should be shown
+        /// The tooltip is rendered when an order has no coupons, but has product discounts.
+        /// Sincer both are mutually exclusive but they are included in the Order's discounts total as one unique value, we cannot rely
+        /// on `shouldShowCoupon` or `showDiscountsTotal` alone for its visibility:
+        ///
+        var shouldRenderCouponsInfoTooltip: Bool {
+            if shouldShowCoupon {
+                return false
+            } else if shouldShowDiscountTotal {
+                return true
+            }
+            return false
+        }
     }
 
     /// Representation of order notes data display properties

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -177,7 +177,7 @@ private extension OrderPaymentSection {
                     .resizable()
                     .frame(width: Constants.sectionPadding, height: Constants.sectionPadding)
             }
-            .renderedIf(viewModel.shouldDisableAddingCoupons)
+            .renderedIf(viewModel.shouldRenderCouponsInfoTooltip)
         }
         .padding()
         .accessibilityIdentifier("add-coupon-button")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2554,6 +2554,31 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         XCTAssertTrue(viewModel.shouldDisallowDiscounts)
     }
+
+    func test_PaymentDataViewModel_when_initialized_then_shouldRenderCouponsInfoTooltip_returns_false() {
+        // Given, When
+        let paymentDataViewModel = EditableOrderViewModel.PaymentDataViewModel()
+
+        // Then
+        XCTAssertFalse(paymentDataViewModel.shouldRenderCouponsInfoTooltip)
+    }
+
+
+    func test_PaymentDataViewModel_when_order_should_show_coupons_then_shouldRenderCouponsInfoTooltip_returns_false() {
+        // Given, When
+        let paymentDataViewModel = EditableOrderViewModel.PaymentDataViewModel(shouldShowCoupon: true)
+
+        // Then
+        XCTAssertFalse(paymentDataViewModel.shouldRenderCouponsInfoTooltip)
+    }
+
+    func test_PaymentDataViewModel_when_order_should_show_discounts_then_shouldRenderCouponsInfoTooltip_returns_true() {
+        // Given, When
+        let paymentDataViewModel = EditableOrderViewModel.PaymentDataViewModel(shouldShowDiscountTotal: true)
+
+        // Then
+        XCTAssertTrue(paymentDataViewModel.shouldRenderCouponsInfoTooltip)
+    }
 }
 
 private extension MockStorageManager {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10997 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR addresses a rendering bug with the informational tooltip that appears in the order's row for adding coupons. The `(?)` tooltip should only appear if an order has products with discounts on it, in order to inform the merchant why coupons are disabled for that order.

## Changes
We update the logic when the tooltip must be rendered. Before it relied uniquely on the coupons row being enabled or disabled, but this is not enough as the coupons row could be disabled because either we haven't added coupons yet (so the tooltip shouldn't show either), or because coupons are not eligible due to having product discounts already added (tooltip should show).

## Testing instructions
1. Go to Orders > `+` > Observe how `+ Add coupon` has no informational tooltip.
2. Add a coupon to the order > See how `+ Add coupon` still has no informational tooltip. 
3. Remove the coupon from the order 
4. Tap on the chevron to expand the product row > tap `+ Add discount` > Add a discount and save the order. See how `+ Add coupon` now shows an informational tooltip informing that "coupons are unavailable".


## Screenshots

![Simulator Screen Recording - iPhone 15 - 2023-10-24 at 13 34 19](https://github.com/woocommerce/woocommerce-ios/assets/3812076/83759a7d-7196-450c-b028-c2273570fbd6)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
