### PR TITLE
[Custom Amounts M1] Order Creation - Added custom amounts UI

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -101,7 +101,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .wooPaymentsDepositsOverviewInPaymentsMenu:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .orderCustomAmountsM1:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .tapToPayOnIPhoneInUK:
             return true
         case .optimizedBlazeExperience:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import Foundation
+
+struct CustomAmountRowView: View {
+    let viewModel: CustomAmountRowViewModel
+
+    var body: some View {
+        HStack {
+            Text(viewModel.name)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -7,6 +7,7 @@ struct CustomAmountRowView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     let viewModel: CustomAmountRowViewModel
+    let editable: Bool
 
     var body: some View {
         HStack(alignment: .center) {
@@ -31,6 +32,7 @@ struct CustomAmountRowView: View {
                             .padding(.top, Layout.editIconTopPadding)
                             .frame(width: Layout.editIconImageSize * scale,
                                    height: Layout.editIconImageSize * scale)
+                            .renderedIf(editable)
                     }
                 }
 
@@ -49,6 +51,7 @@ struct CustomAmountRowView: View {
             .tertiaryTitleStyle()
             .frame(width: Layout.closeButtonImageSize * scale,
                    height: Layout.closeButtonImageSize * scale, alignment: .trailing)
+            .renderedIf(editable)
 
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -51,6 +51,7 @@ struct CustomAmountRowView: View {
 
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, Layout.topPadding)
     }
 }
 
@@ -62,6 +63,6 @@ extension CustomAmountRowView {
         static let editIconImageSize: CGFloat = 16
         static let editIconTopPadding: CGFloat = 3
         static let closeButtonImageSize: CGFloat = 25
-
+        static let topPadding: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -41,6 +41,7 @@ struct CustomAmountRowView: View {
             Spacer()
 
             Button {
+                viewModel.onRemoveCustomAmount()
             } label: {
                 Image(systemName: "xmark")
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -1,13 +1,67 @@
 import SwiftUI
 import Foundation
+import WooFoundation
 
 struct CustomAmountRowView: View {
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
     let viewModel: CustomAmountRowViewModel
 
     var body: some View {
-        HStack {
-            Text(viewModel.name)
+        HStack(alignment: .center) {
+            Image(systemName: "tag")
+                .resizable()
+                .foregroundColor(Color(uiColor: .secondaryLabel))
+                .frame(width: Layout.tagIconImageSize * scale, height: Layout.tagIconImageSize * scale)
+                .padding()
+                .overlay {
+                    RoundedRectangle(cornerRadius: Layout.tagBorderCornerRadius)
+                        .stroke(Color(.separator), lineWidth: Layout.tagBorderLineWidth)
+                }
+
+            VStack(alignment: .leading) {
+                HStack(alignment: .top) {
+                    Text(viewModel.name)
+                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                        .bodyStyle()
+                    Button {} label: {
+                        Image(systemName: "pencil")
+                            .resizable()
+                            .padding(.top, Layout.editIconTopPadding)
+                            .frame(width: Layout.editIconImageSize * scale,
+                                   height: Layout.editIconImageSize * scale)
+                    }
+                }
+
+                Text(viewModel.total)
+                    .subheadlineStyle()
+            }
+
+            Spacer()
+
+            Button {
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .foregroundColor(Color(.secondaryLabel))
+            .tertiaryTitleStyle()
+            .frame(width: Layout.closeButtonImageSize * scale,
+                   height: Layout.closeButtonImageSize * scale, alignment: .trailing)
+
         }
-        .frame(maxWidth: .infinity, alignment: .center)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+extension CustomAmountRowView {
+    enum Layout {
+        static let tagBorderCornerRadius: CGFloat = 4
+        static let tagBorderLineWidth: CGFloat = 0.5
+        static let tagIconImageSize: CGFloat = 25
+        static let editIconImageSize: CGFloat = 16
+        static let editIconTopPadding: CGFloat = 3
+        static let closeButtonImageSize: CGFloat = 25
+
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowViewModel.swift
@@ -4,4 +4,5 @@ struct CustomAmountRowViewModel: Identifiable {
     let id: Int64
     let name: String
     let total: String
+    let onRemoveCustomAmount: () -> Void
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct CustomAmountRowViewModel: Identifiable {
+    let id: Int64
+    let name: String
+    let total: String
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct OrderCustomAmountsSection: View {
+    /// View model to drive the view content
+    @ObservedObject var viewModel: EditableOrderViewModel
+
+    /// Defines whether the new custom amount modal is presented.
+    ///
+    @State private var showAddCustomAmount: Bool = false
+
+    var body: some View {
+        VStack {
+            HStack {
+                Button(Localization.addCustomAmount) {
+                    showAddCustomAmount.toggle()
+                }
+                .accessibilityIdentifier(Accessibility.addCustomAmountIdentifier)
+                .buttonStyle(PlusButtonStyle())
+            }
+            .renderedIf(viewModel.customAmountRows.isEmpty)
+
+            Group {
+                HStack {
+                    Text(Localization.customAmounts)
+                        .accessibilityAddTraits(.isHeader)
+                        .headlineStyle()
+
+                    Spacer()
+
+                    Image(uiImage: .lockImage)
+                        .foregroundColor(Color(.brand))
+                        .renderedIf(viewModel.shouldShowNonEditableIndicators)
+
+                    Button(action: {
+                        showAddCustomAmount.toggle()
+                    }) {
+                        Image(uiImage: .plusImage)
+                    }
+                    .scaledToFit()
+                    .renderedIf(!viewModel.shouldShowNonEditableIndicators)
+                }
+
+                ForEach(viewModel.customAmountRows) { customAmountRow in
+                    CustomAmountRowView(viewModel: customAmountRow, editable: !viewModel.shouldShowNonEditableIndicators)
+                }
+            }
+            .renderedIf(viewModel.customAmountRows.isNotEmpty)
+        }
+        .padding()
+        .background(Color(.listForeground(modal: true)))
+        .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
+            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
+        })
+    }
+}
+
+private extension OrderCustomAmountsSection {
+    enum Localization {
+        static let addCustomAmount = NSLocalizedString("Add Custom Amount",
+                                                   comment: "Title text of the button that allows to add a custom amount when creating or editing an order")
+        static let customAmounts = NSLocalizedString("orderForm.customAmounts",
+                                                     value: "Custom Amounts",
+                                                     comment: "Title text of the section that shows the Custom Amounts when creating or editing an order")
+    }
+
+    enum Accessibility {
+        static let addCustomAmountIdentifier = "new-order-add-custom-amount-button"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -2027,7 +2027,7 @@ private extension EditableOrderViewModel {
         static let newTaxRateSetSuccessMessage = NSLocalizedString("🎉 New tax rate set", comment: "Message when a tax rate is set")
         static let stopAddingTaxRateAutomaticallySuccessMessage = NSLocalizedString("Stopped automatically adding tax rate",
                                                                                     comment: "Message when the user disables adding tax rates automatically")
-        static let customAmountDefaultName = NSLocalizedString("EditableOrderViewModel.customAmountDefaultName",
+        static let customAmountDefaultName = NSLocalizedString("editableOrderViewModel.customAmountDefaultName",
                                                                value: "Custom Amount",
                                                                comment: "Default name when the custom amount does not have a name in order creation.")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -212,6 +212,8 @@ final class EditableOrderViewModel: ObservableObject {
         orderHasCoupons
     }
 
+    /// If both products and custom amounts lists are empty we don't split their sections
+    /// 
     var shouldSplitProductsAndCustomAmountsSections: Bool {
         productRows.isNotEmpty || customAmountRows.isNotEmpty
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -212,6 +212,10 @@ final class EditableOrderViewModel: ObservableObject {
         orderHasCoupons
     }
 
+    var shouldSplitProductsAndCustomAmountsSections: Bool {
+        productRows.isNotEmpty || customAmountRows.isNotEmpty
+    }
+
     /// Whether gift card is supported in order form.
     ///
     @Published private var isGiftCardSupported: Bool = false
@@ -271,6 +275,11 @@ final class EditableOrderViewModel: ObservableObject {
     /// View models for each product row in the order.
     ///
     @Published private(set) var productRows: [ProductRowViewModel] = []
+
+    /// View models for each custom amount in the order.
+    ///
+    @Published private(set) var customAmountRows: [CustomAmountRowViewModel] = [CustomAmountRowViewModel(id: 1, name: "Custom Amount 1", total: "$20.00"),
+                                                                                CustomAmountRowViewModel(id: 2, name: "Custom Amount 2", total: "$10.00")]
 
     /// Selected product view model to render.
     /// Used to open the product details in `ProductInOrder`.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1205,10 +1205,13 @@ private extension EditableOrderViewModel {
             .removeDuplicates()
             .map { [weak self] fees -> [CustomAmountRowViewModel] in
                 guard let self = self else { return [] }
-                return fees.compactMap {
-                    CustomAmountRowViewModel(id: $0.feeID,
-                                             name: $0.name ?? Localization.customAmountDefaultName,
-                                             total: self.currencyFormatter.formatAmount($0.total) ?? "")
+                return fees.compactMap { fee in
+                    guard !fee.isDeleted else { return nil }
+
+                    return CustomAmountRowViewModel(id: fee.feeID,
+                                             name: fee.name ?? Localization.customAmountDefaultName,
+                                             total: self.currencyFormatter.formatAmount(fee.total) ?? "",
+                                             onRemoveCustomAmount: { self.removeFee(fee) })
                 }
             }
             .assign(to: &$customAmountRows)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -218,6 +218,14 @@ final class EditableOrderViewModel: ObservableObject {
         productRows.isNotEmpty || customAmountRows.isNotEmpty
     }
 
+    var shouldShowProductsSectionHeader: Bool {
+        !shouldShowCustomAmountsWithProducts || productRows.isNotEmpty
+    }
+
+    var shouldShowAddProductsButton: Bool {
+        !shouldShowCustomAmountsWithProducts || productRows.isEmpty
+    }
+
     /// Whether gift card is supported in order form.
     ///
     @Published private var isGiftCardSupported: Bool = false

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -130,19 +130,15 @@ struct OrderForm: View {
                             ProductsSection(scroll: scroll, viewModel: viewModel, navigationButtonID: $navigationButtonID)
                                 .disabled(viewModel.shouldShowNonEditableIndicators)
 
-                            Divider()
-                            .renderedIf(!viewModel.shouldShowCustomAmountsWithProducts || viewModel.productRows.isNotEmpty)
-
-                            Spacer(minLength: Layout.sectionSpacing)
-                                .renderedIf(viewModel.shouldShowCustomAmountsWithProducts && viewModel.productRows.isNotEmpty)
-
                             Group {
                                 Divider()
-                                    .renderedIf(viewModel.productRows.isNotEmpty)
-                                CustomAmountsSection(viewModel: viewModel)
-                                    .disabled(viewModel.shouldShowNonEditableIndicators)
+                                Spacer(minLength: Layout.sectionSpacing)
+                                Divider()
                             }
-                            .renderedIf(viewModel.shouldShowCustomAmountsWithProducts)
+                            .renderedIf(viewModel.shouldSplitProductsAndCustomAmountsSections)
+
+                            CustomAmountsSection(viewModel: viewModel)
+                                .disabled(viewModel.shouldShowNonEditableIndicators)
 
                             Divider()
 
@@ -568,10 +564,14 @@ private struct CustomAmountsSection: View {
                     AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
                 })
             }
+            .renderedIf(viewModel.customAmountRows.isEmpty)
+
+            ForEach(viewModel.customAmountRows) { customAmountRow in
+                CustomAmountRowView(viewModel: customAmountRow)
+            }
         }
         .padding()
         .background(Color(.listForeground(modal: true)))
-        .renderedIf(viewModel.shouldShowCustomAmountsWithProducts)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -138,7 +138,7 @@ struct OrderForm: View {
                                 }
                                 .renderedIf(viewModel.shouldSplitProductsAndCustomAmountsSections)
 
-                                CustomAmountsSection(viewModel: viewModel)
+                                OrderCustomAmountsSection(viewModel: viewModel)
                                     .disabled(viewModel.shouldShowNonEditableIndicators)
                             }
                             .renderedIf(viewModel.shouldShowCustomAmountsWithProducts)
@@ -501,7 +501,9 @@ private struct ProductsSection: View {
             })
         }
     }
+}
 
+private extension ProductsSection {
     var scanProductButton: some View {
         Button(action: {
             viewModel.trackBarcodeScanningButtonTapped()
@@ -547,60 +549,6 @@ private struct ProductsSection: View {
     }
 }
 
-private struct CustomAmountsSection: View {
-    /// View model to drive the view content
-    @ObservedObject var viewModel: EditableOrderViewModel
-
-    /// Defines whether the new custom amount modal is presented.
-    ///
-    @State private var showAddCustomAmount: Bool = false
-
-    var body: some View {
-        VStack {
-            HStack {
-                Button(OrderForm.Localization.addCustomAmount) {
-                    showAddCustomAmount.toggle()
-                }
-                .accessibilityIdentifier(OrderForm.Accessibility.addCustomAmountIdentifier)
-                .buttonStyle(PlusButtonStyle())
-            }
-            .renderedIf(viewModel.customAmountRows.isEmpty)
-
-            Group {
-                HStack {
-                    Text(OrderForm.Localization.customAmounts)
-                        .accessibilityAddTraits(.isHeader)
-                        .headlineStyle()
-
-                    Spacer()
-
-                    Image(uiImage: .lockImage)
-                        .foregroundColor(Color(.brand))
-                        .renderedIf(viewModel.shouldShowNonEditableIndicators)
-
-                    Button(action: {
-                        showAddCustomAmount.toggle()
-                    }) {
-                        Image(uiImage: .plusImage)
-                    }
-                    .scaledToFit()
-                    .renderedIf(!viewModel.shouldShowNonEditableIndicators)
-                }
-
-                ForEach(viewModel.customAmountRows) { customAmountRow in
-                    CustomAmountRowView(viewModel: customAmountRow, editable: !viewModel.shouldShowNonEditableIndicators)
-                }
-            }
-            .renderedIf(viewModel.customAmountRows.isNotEmpty)
-        }
-        .padding()
-        .background(Color(.listForeground(modal: true)))
-        .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
-            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
-        })
-    }
-}
-
 // MARK: Constants
 private extension OrderForm {
     enum Layout {
@@ -619,13 +567,8 @@ private extension OrderForm {
         static let doneButton = NSLocalizedString("Done", comment: "Button to dismiss the Order Editing screen")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Button to cancel the creation of an order on the New Order screen")
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating or editing an order")
-        static let customAmounts = NSLocalizedString("OrderForm.customAmounts",
-                                                     value: "Custom Amounts",
-                                                     comment: "Title text of the section that shows the Custom Amounts when creating or editing an order")
         static let addProducts = NSLocalizedString("Add Products",
                                                    comment: "Title text of the button that allows to add multiple products when creating or editing an order")
-        static let addCustomAmount = NSLocalizedString("Add Custom Amount",
-                                                   comment: "Title text of the button that allows to add a custom amount when creating or editing an order")
         static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
                                                                    comment: "Accessibility hint for selecting a product in an order form")
         static let permissionsTitle =
@@ -648,7 +591,6 @@ private extension OrderForm {
         static let cancelButtonIdentifier = "new-order-cancel-button"
         static let doneButtonIdentifier = "edit-order-done-button"
         static let addProductButtonIdentifier = "new-order-add-product-button"
-        static let addCustomAmountIdentifier = "new-order-add-custom-amount-button"
         static let addProductViaSKUScannerButtonIdentifier = "new-order-add-product-via-sku-scanner-button"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -412,7 +412,7 @@ private struct ProductsSection: View {
                         .foregroundColor(Color(.brand))
                         .renderedIf(viewModel.shouldShowNonEditableIndicators)
 
-                    HStack(spacing: 20) {
+                    HStack(spacing: OrderForm.Layout.productsHeaderButtonsSpacing) {
                         scanProductButton
                         .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
 
@@ -611,6 +611,7 @@ private extension OrderForm {
         static let storedTaxRateBottomSheetRowCornerRadius: CGFloat = 8.0
         static let storedTaxRateBottomSheetStoredTaxRateCornerRadius: CGFloat = 8.0
         static let storedTaxRateBottomSheetButtonIconSize: CGFloat = 24.0
+        static let productsHeaderButtonsSpacing: CGFloat = 20
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -427,7 +427,7 @@ private struct ProductsSection: View {
                     .scaledToFit()
                     .renderedIf(!viewModel.shouldShowNonEditableIndicators && viewModel.shouldShowCustomAmountsWithProducts)
                 }
-                .renderedIf(!viewModel.shouldShowCustomAmountsWithProducts || viewModel.productRows.isNotEmpty)
+                .renderedIf(viewModel.shouldShowProductsSectionHeader)
 
                 ForEach(viewModel.productRows) { productRow in
                     CollapsibleProductRowCard(viewModel: productRow,
@@ -470,7 +470,7 @@ private struct ProductsSection: View {
                     scanProductButton
                     .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
                 }
-                .renderedIf(!viewModel.shouldShowCustomAmountsWithProducts || viewModel.productRows.isEmpty)
+                .renderedIf(viewModel.shouldShowAddProductsButton)
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -566,9 +566,32 @@ private struct CustomAmountsSection: View {
             }
             .renderedIf(viewModel.customAmountRows.isEmpty)
 
-            ForEach(viewModel.customAmountRows) { customAmountRow in
-                CustomAmountRowView(viewModel: customAmountRow)
+            Group {
+                HStack {
+                    Text(OrderForm.Localization.customAmounts)
+                        .accessibilityAddTraits(.isHeader)
+                        .headlineStyle()
+
+                    Spacer()
+
+                    Image(uiImage: .lockImage)
+                        .foregroundColor(Color(.brand))
+                        .renderedIf(viewModel.shouldShowNonEditableIndicators)
+
+                    Button(action: {
+                        showAddCustomAmount.toggle()
+                    }) {
+                        Image(uiImage: .plusImage)
+                    }
+                    .scaledToFit()
+                    .renderedIf(!viewModel.shouldShowNonEditableIndicators)
+                }
+
+                ForEach(viewModel.customAmountRows) { customAmountRow in
+                    CustomAmountRowView(viewModel: customAmountRow)
+                }
             }
+            .renderedIf(viewModel.customAmountRows.isNotEmpty)
         }
         .padding()
         .background(Color(.listForeground(modal: true)))
@@ -592,6 +615,9 @@ private extension OrderForm {
         static let doneButton = NSLocalizedString("Done", comment: "Button to dismiss the Order Editing screen")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Button to cancel the creation of an order on the New Order screen")
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating or editing an order")
+        static let customAmounts = NSLocalizedString("OrderForm.customAmounts",
+                                                     value: "Custom Amounts",
+                                                     comment: "Title text of the section that shows the Custom Amounts when creating or editing an order")
         static let addProducts = NSLocalizedString("Add Products",
                                                    comment: "Title text of the button that allows to add multiple products when creating or editing an order")
         static let addCustomAmount = NSLocalizedString("Add Custom Amount",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -131,14 +131,17 @@ struct OrderForm: View {
                                 .disabled(viewModel.shouldShowNonEditableIndicators)
 
                             Group {
-                                Divider()
-                                Spacer(minLength: Layout.sectionSpacing)
-                                Divider()
-                            }
-                            .renderedIf(viewModel.shouldSplitProductsAndCustomAmountsSections)
+                                Group {
+                                    Divider()
+                                    Spacer(minLength: Layout.sectionSpacing)
+                                    Divider()
+                                }
+                                .renderedIf(viewModel.shouldSplitProductsAndCustomAmountsSections)
 
-                            CustomAmountsSection(viewModel: viewModel)
-                                .disabled(viewModel.shouldShowNonEditableIndicators)
+                                CustomAmountsSection(viewModel: viewModel)
+                                    .disabled(viewModel.shouldShowNonEditableIndicators)
+                            }
+                            .renderedIf(viewModel.shouldShowCustomAmountsWithProducts)
 
                             Divider()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -588,7 +588,7 @@ private struct CustomAmountsSection: View {
                 }
 
                 ForEach(viewModel.customAmountRows) { customAmountRow in
-                    CustomAmountRowView(viewModel: customAmountRow)
+                    CustomAmountRowView(viewModel: customAmountRow, editable: !viewModel.shouldShowNonEditableIndicators)
                 }
             }
             .renderedIf(viewModel.customAmountRows.isNotEmpty)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -560,9 +560,6 @@ private struct CustomAmountsSection: View {
                 }
                 .accessibilityIdentifier(OrderForm.Accessibility.addCustomAmountIdentifier)
                 .buttonStyle(PlusButtonStyle())
-                .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
-                    AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
-                })
             }
             .renderedIf(viewModel.customAmountRows.isEmpty)
 
@@ -595,6 +592,9 @@ private struct CustomAmountsSection: View {
         }
         .padding()
         .background(Color(.listForeground(modal: true)))
+        .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
+            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformer.swift
@@ -30,7 +30,7 @@ struct FeesInputTransformer {
 
         return order.copy(fees: updatedLines)
     }
-   
+
     /// Adds a fee into an existing order.
     ///
     static func append(input: OrderFeeLine, on order: Order) -> Order {
@@ -45,9 +45,12 @@ struct FeesInputTransformer {
     /// If the order does not have that fee added it does nothing
     ///
     static func remove(input: OrderFeeLine, from order: Order) -> Order {
-        var updatedFeeLines = order.fees
-        updatedFeeLines.removeAll(where: { $0.feeID == input.feeID })
-
-        return order.copy(fees: updatedFeeLines)
+        let updatedLines = order.fees.map { line -> OrderFeeLine in
+            if line.feeID == input.feeID {
+                return OrderFactory.deletedFeeLine(line)
+            }
+            return line
+        }
+        return order.copy(fees: updatedLines)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1722,6 +1722,8 @@
 		B9CA4F352AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */; };
 		B9CB14DC2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */; };
 		B9CB14E02A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CB14DF2A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift */; };
+		B9D19A422AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D19A412AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift */; };
+		B9D19A442AE7B66B00D944D8 /* CustomAmountRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */; };
 		B9DA153C280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DA153B280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift */; };
 		B9DA153E28101BE100FC67DD /* MockOrderRefundsOptionsDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DA153D28101BE100FC67DD /* MockOrderRefundsOptionsDeterminer.swift */; };
 		B9DA154028103ABE00FC67DD /* OrderRefundsOptionsDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DA153F28103ABE00FC67DD /* OrderRefundsOptionsDeterminerTests.swift */; };
@@ -4257,6 +4259,8 @@
 		B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedStoredTaxRateFetcher.swift; sourceTree = "<group>"; };
 		B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerErrorNoticeFactory.swift; sourceTree = "<group>"; };
 		B9CB14DF2A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerErrorNoticeFactoryTests.swift; sourceTree = "<group>"; };
+		B9D19A412AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAmountRowViewModel.swift; sourceTree = "<group>"; };
+		B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAmountRowView.swift; sourceTree = "<group>"; };
 		B9DA153B280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderRefundsOptionsDeterminer.swift; sourceTree = "<group>"; };
 		B9DA153D28101BE100FC67DD /* MockOrderRefundsOptionsDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrderRefundsOptionsDeterminer.swift; sourceTree = "<group>"; };
 		B9DA153F28103ABE00FC67DD /* OrderRefundsOptionsDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderRefundsOptionsDeterminerTests.swift; sourceTree = "<group>"; };
@@ -9215,6 +9219,8 @@
 				B9F148932AD43E1B008FC795 /* AddCustomAmountView.swift */,
 				B9F148972AD5541C008FC795 /* AddCustomAmountViewModel.swift */,
 				B9F148992AD586E5008FC795 /* FormattableAmountTextFieldViewModel.swift */,
+				B9D19A412AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift */,
+				B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */,
 			);
 			path = CustomAmounts;
 			sourceTree = "<group>";
@@ -13030,6 +13036,7 @@
 				4535EE7E281BE04A004212B4 /* CouponAmountInputFormatter.swift in Sources */,
 				209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */,
 				CE35F11B2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift in Sources */,
+				B9D19A422AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift in Sources */,
 				D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */,
 				09468D9027D5014E0054A751 /* BulkUpdatePriceViewController.swift in Sources */,
 				0279F0DA252DB4BE0098D7DE /* ProductVariationDetailsFactory.swift in Sources */,
@@ -13556,6 +13563,7 @@
 				DE96844B2A331AD2000FBF4E /* WooAnalyticsEvent+ProductSharingAI.swift in Sources */,
 				FE28F7182684EE6A004465C7 /* RoleErrorViewModel.swift in Sources */,
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
+				B9D19A442AE7B66B00D944D8 /* CustomAmountRowView.swift in Sources */,
 				03E471C8293A3076001A58AD /* CardPresentModalBuiltInConnectingToReader.swift in Sources */,
 				EE5B5BC72AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift in Sources */,
 				0365986529AF942700F297D3 /* PaymentSettingsFlowHint.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1702,6 +1702,7 @@
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
 		B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */; };
+		B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */; };
 		B98FF4402AAA096200326D16 /* AddressWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98FF43F2AAA096200326D16 /* AddressWooTests.swift */; };
 		B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */; };
 		B99686E02A13C8CC00D1AF62 /* ScanToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99686DF2A13C8CC00D1AF62 /* ScanToPayView.swift */; };
@@ -4239,6 +4240,7 @@
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModelTests.swift; sourceTree = "<group>"; };
+		B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSection.swift; sourceTree = "<group>"; };
 		B98FF43F2AAA096200326D16 /* AddressWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressWooTests.swift; sourceTree = "<group>"; };
 		B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineViewModel.swift; sourceTree = "<group>"; };
 		B99686DF2A13C8CC00D1AF62 /* ScanToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanToPayView.swift; sourceTree = "<group>"; };
@@ -9221,6 +9223,7 @@
 				B9F148992AD586E5008FC795 /* FormattableAmountTextFieldViewModel.swift */,
 				B9D19A412AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift */,
 				B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */,
+				B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */,
 			);
 			path = CustomAmounts;
 			sourceTree = "<group>";
@@ -13139,6 +13142,7 @@
 				AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */,
 				EE6A7BAD2A7B7C1D00D9A028 /* StoreCreationFeaturesQuestionOptions.swift in Sources */,
 				D8752EF7265E60F4008ACC80 /* PaymentCaptureCelebration.swift in Sources */,
+				B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */,
 				EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				2631D4F829ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -431,6 +431,32 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(productRow?.canChangeQuantity, expectedProductRow.canChangeQuantity)
     }
 
+    func test_view_model_is_updated_when_custom_amount_is_added_to_order() {
+        // Given
+        let customAmountName = "Test"
+
+        // When
+        viewModel.addCustomAmountViewModel.name = customAmountName
+        viewModel.addCustomAmountViewModel.doneButtonPressed()
+
+        // Then
+        XCTAssertTrue(viewModel.customAmountRows.contains(where: { $0.name == customAmountName }))
+    }
+
+    func test_view_model_is_updated_when_custom_amount_is_removed_from_order() {
+        // When
+        viewModel.addCustomAmountViewModel.name = "Test"
+        viewModel.addCustomAmountViewModel.doneButtonPressed()
+
+        // Check previous condition
+        XCTAssertEqual(viewModel.customAmountRows.count, 1)
+
+        viewModel.customAmountRows.first?.onRemoveCustomAmount()
+
+        // Then
+        XCTAssertTrue(viewModel.customAmountRows.isEmpty)
+    }
+
     func test_view_model_is_updated_when_address_updated() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -529,7 +529,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         synchronizer.removeFee.send(feeLine)
 
         // Then
-        XCTAssertNil(synchronizer.order.fees.first)
+        XCTAssertTrue(synchronizer.order.fees.first?.isDeleted ?? true)
     }
 
     func test_sending_coupon_input_triggers_order_creation() {

--- a/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
+++ b/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
@@ -47,6 +47,14 @@ public struct SecondaryTitleStyle: ViewModifier {
     }
 }
 
+public struct TertiaryTitleStyle: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .font(.title3.weight(.bold))
+            .foregroundColor(Color(.text))
+    }
+}
+
 public struct SecondaryBodyStyle: ViewModifier {
 
     public init() {}
@@ -195,6 +203,10 @@ public extension View {
 
     func secondaryTitleStyle() -> some View {
         self.modifier(SecondaryTitleStyle())
+    }
+
+    func tertiaryTitleStyle() -> some View {
+        self.modifier(TertiaryTitleStyle())
     }
 
     /// - Parameters:

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -98,3 +98,9 @@ public enum OrderFactory {
     ///
     public static let emptyNewOrder = Order.empty
 }
+
+public extension OrderFeeLine {
+    var isDeleted: Bool {
+        self == OrderFactory.deletedFeeLine(self)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10880
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implemented the UI for added custom amounts in order creation, as well as hooking the events to their actions in the `EditableOrderViewModel`. Note as well that we re-designed the Products section, adding a header title containing the plus button when products are already added. This replaces the old approach, which leaves the Add Product button even if we have products added to the order. (See Video).

In order to keep the PR in a reasonable size we only include the add and delete custom amounts here. Editing a custom amount will be implemented in the next PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. See empty state design
3. Add a product. See how the Products section is added with barcode and add button. Tests these as well.
4. Add a custom amount. See that it's added to the Order creation screen.
5. See that we have now a header for the Custom Amounts section in the same way we have for products when items are added. Tap on + to add a new custom amount and see that it's properly added.
6. Delete a custom amount by tapping on X. See that it's removed.
7. Remove the other custom amount. See that it's removed and the original empty state is shown.

## Notes
- As we've seen in our previous PR, the old Fee logic doesn't work well with this new custom amounts logic. This is fine, as they won't be existing at the same time.
- On that note, please disable the feature flag `orderCustomAmountsM1` to check that everything still works when disabled

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/8075f736-71b7-4b22-815c-9dcd38bb5ddd

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
