### PR TITLE
[Bundle products in order form] Sync order items with updated bundle configuration

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1573,7 +1573,10 @@ private extension EditableOrderViewModel {
     /// Creates a new `OrderSyncProductInput` type meant to update an existing input from `OrderSynchronizer`
     /// If the referenced product can't be found, `nil` is returned.
     ///
-    private func createUpdateProductInput(item: OrderItem, quantity: Decimal, discount: Decimal? = nil) -> OrderSyncProductInput? {
+    private func createUpdateProductInput(item: OrderItem,
+                                          quantity: Decimal,
+                                          discount: Decimal? = nil,
+                                          bundleConfiguration: [BundledProductConfiguration] = []) -> OrderSyncProductInput? {
         // Finds the product or productVariation associated with the order item.
         let product: OrderSyncProductInput.ProductType? = {
             if item.variationID != 0, let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {
@@ -1593,7 +1596,11 @@ private extension EditableOrderViewModel {
         }
 
         // Return a new input with the new quantity but with the same item id to properly reference the update.
-        return OrderSyncProductInput(id: item.itemID, product: product, quantity: quantity, discount: discount ?? currentDiscount(on: item))
+        return OrderSyncProductInput(id: item.itemID,
+                                     product: product,
+                                     quantity: quantity,
+                                     discount: discount ?? currentDiscount(on: item),
+                                     bundleConfiguration: bundleConfiguration)
     }
 
     /// Creates a `ProductInOrderViewModel` based on the provided order item id.
@@ -1673,7 +1680,10 @@ private extension EditableOrderViewModel {
     }
 
     func addBundleConfigurationToOrderItem(item: OrderItem, bundleConfiguration: [BundledProductConfiguration]) {
-        // TODO: 10428 - add bundle configuration to order item
+        guard let productInput = createUpdateProductInput(item: item, quantity: item.quantity, bundleConfiguration: bundleConfiguration) else {
+            return
+        }
+        orderSynchronizer.setProduct.send(productInput)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -13,6 +13,18 @@ enum OrderSyncState {
 /// Product input for an `OrderSynchronizer` type.
 ///
 struct OrderSyncProductInput {
+    init(id: Int64 = .zero,
+         product: OrderSyncProductInput.ProductType,
+         quantity: Decimal,
+         discount: Decimal = .zero,
+         bundleConfiguration: [BundledProductConfiguration] = []) {
+        self.id = id
+        self.product = product
+        self.quantity = quantity
+        self.discount = discount
+        self.bundleConfiguration = bundleConfiguration
+    }
+
     /// Types of products the synchronizer supports
     ///
     enum ProductType {
@@ -23,9 +35,10 @@ struct OrderSyncProductInput {
     let product: ProductType
     let quantity: Decimal
     var discount: Decimal = .zero
+    let bundleConfiguration: [BundledProductConfiguration]
 
     func updating(id: Int64) -> OrderSyncProductInput {
-        .init(id: id, product: self.product, quantity: self.quantity, discount: discount)
+        .init(id: id, product: self.product, quantity: self.quantity, discount: discount, bundleConfiguration: bundleConfiguration)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -158,6 +158,23 @@ private extension ProductInputTransformer {
                          attributes: [],
                          addOns: [],
                          parent: nil,
-                         bundleConfiguration: [])
+                         bundleConfiguration: input.bundleConfiguration.map {
+            switch $0.productOrVariation {
+                case let .product(productID):
+                    return .init(bundledItemID: $0.bundledItemID,
+                                 productID: productID,
+                                 quantity: $0.quantity,
+                                 isOptionalAndSelected: $0.isOptionalAndSelected,
+                                 variationID: nil,
+                                 variationAttributes: nil)
+                case let .variation(productID, variationID, attributes):
+                    return .init(bundledItemID: $0.bundledItemID,
+                                 productID: productID,
+                                 quantity: $0.quantity,
+                                 isOptionalAndSelected: $0.isOptionalAndSelected,
+                                 variationID: variationID,
+                                 variationAttributes: attributes)
+            }
+        })
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -347,4 +347,34 @@ class ProductInputTransformerTests: XCTestCase {
         let item = try XCTUnwrap(orderUpdate.items.first)
         XCTAssertEqual(item.quantity, productInput2.quantity)
     }
+
+    func test_order_item_with_bundle_configuration_of_variable_and_simple_items_are_transformed_when_updateing_OrderSyncProductInput() throws {
+        // Given
+        let product = Product.fake().copy(productID: sampleProductID)
+        let simpleBundledItem = BundledProductConfiguration(bundledItemID: 1,
+                                                            productOrVariation: .product(id: 6),
+                                                            quantity: 2,
+                                                            isOptionalAndSelected: true)
+        let variableBundledItem = BundledProductConfiguration(bundledItemID: 2,
+                                                              productOrVariation: .variation(productID: 25, variationID: 72, attributes: [
+                                                                .init(id: 1, name: "Color", option: "Clear")
+                                                              ]),
+                                                              quantity: 3,
+                                                              isOptionalAndSelected: nil)
+        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1, discount: 0, bundleConfiguration: [
+            simpleBundledItem, variableBundledItem
+        ])
+
+        // When
+        let orderUpdate = ProductInputTransformer.update(input: productInput, on: .fake(), shouldUpdateOrDeleteZeroQuantities: .update)
+
+        // Then
+        let item = try XCTUnwrap(orderUpdate.items.first)
+        XCTAssertEqual(item.bundleConfiguration, [
+            .init(bundledItemID: 1, productID: 6, quantity: 2, isOptionalAndSelected: true, variationID: nil, variationAttributes: nil),
+            .init(bundledItemID: 2, productID: 25, quantity: 3, isOptionalAndSelected: nil, variationID: 72, variationAttributes: [
+                .init(id: 1, name: "Color", option: "Clear")
+            ]),
+        ])
+    }
 }

--- a/Yosemite/YosemiteTests/Mocks/MockNetwork+Path.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockNetwork+Path.swift
@@ -4,22 +4,34 @@ import XCTest
 extension MockNetwork {
     /// Returns the parameters ("\(key)=\(value)") for the WC API query in the first network request URL.
     var queryParameters: [String]? {
+        queryParametersDictionary?.map { "\($0.key)=\($0.value)" }
+    }
+
+    /// Returns the parameters dictionary for the WC API query in the first network request URL.
+    var queryParametersDictionary: [String: Any]? {
         guard let request = requestsForResponseData.first,
-            let urlRequest = try? request.asURLRequest(),
-            let url = urlRequest.url,
-            requestsForResponseData.count == 1 else {
-                return nil
+              let urlRequest = try? request.asURLRequest(),
+              let url = urlRequest.url,
+              requestsForResponseData.count == 1 else {
+            return nil
         }
         guard let urlComponents = URLComponents(string: url.absoluteString) else {
             return nil
         }
+
+        if let dotcomRequest = request as? DotcomRequest {
+            return dotcomRequest.parameters
+        } else if let jetpackRequest = request as? JetpackRequest {
+            return jetpackRequest.parameters
+        }
+
         let parameters = urlComponents.queryItems
 
         guard let queryString = parameters?.first(where: { $0.name == "query" })?.value,
               let queryData = queryString.data(using: .utf8),
-              let queryDictionary = try? JSONSerialization.jsonObject(with: queryData) as? [String: Any] else {
+              let queryDictionary = try? JSONSerialization.jsonObject(with: queryData) as? [String: String] else {
             return nil
         }
-        return queryDictionary.map { "\($0.0)=\($0.1)" }
+        return queryDictionary
     }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1512,6 +1512,43 @@ final class OrderStoreTests: XCTestCase {
         // Then
         XCTAssertEqual(ordersSequence.count, 0)
     }
+
+    // MARK: - Product bundles extension
+
+    func test_updateOrder_with_remote_item_with_bundle_configuration_updates_line_items() throws {
+        // Given
+        let store = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let siteID: Int64 = 6688
+        let order = Order.fake().copy(items: [
+            // Parent order item that is a bundle product with item ID 6.
+            .fake().copy(itemID: 6, quantity: 2, bundleConfiguration: [.fake()]),
+            // Child order item of the bundle product order item (parent item ID 6).
+            .fake().copy(itemID: 7, quantity: 3, parent: 6)
+        ])
+
+        // When
+        store.onAction(OrderAction.updateOrder(siteID: siteID,
+                                               order: order,
+                                               giftCard: nil,
+                                               fields: [.items],
+                                               onCompletion: { _ in }))
+
+        // Then
+        let lineItems = try XCTUnwrap(network.queryParametersDictionary?["line_items"] as? [[String: Any]])
+        XCTAssertEqual(lineItems.count, 3)
+
+        let removedBundleOrderItem = try XCTUnwrap(lineItems.first { ($0["id"] as? Int64) == 6 })
+        XCTAssertEqual(removedBundleOrderItem["quantity"] as? Int64, 0)
+        XCTAssertNil(removedBundleOrderItem["bundle_configuration"])
+
+        let updatedBundleOrderItem = try XCTUnwrap(lineItems.first { ($0["id"] as? Int64) == 0 })
+        XCTAssertEqual(updatedBundleOrderItem["quantity"] as? Int64, 2)
+        XCTAssertNotNil(updatedBundleOrderItem["bundle_configuration"])
+
+        let removedChildBundleOrderItem = try XCTUnwrap(lineItems.first { ($0["id"] as? Int64) == 7 })
+        XCTAssertEqual(removedChildBundleOrderItem["quantity"] as? Int64, 0)
+        XCTAssertNil(removedChildBundleOrderItem["bundle_configuration"])
+    }
 }
 
 

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -331,8 +331,7 @@ final class StatsStoreV4Tests: XCTestCase {
         }
 
         // Then
-        let expectedParam = "force_cache_refresh=0"
-        XCTAssertEqual(network.queryParameters?.contains(expectedParam), true)
+        XCTAssertEqual(network.queryParametersDictionary?["force_cache_refresh"] as? Bool, false)
     }
 
     /// Verifies that `StatsActionV4.retrieveTopEarnerStats` effectively persists any updated TopEarnerStatsItems.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10428
⚠️ Please review https://github.com/woocommerce/woocommerce-ios/pull/10996 first
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After the v0 design was implemented in https://github.com/woocommerce/woocommerce-ios/pull/10996, we want to integrate with the networking layer so that the order's line items are updated after a bundle configuration is updated for an order item.

## How

The entry point is `EditableOrderViewModel.addBundleConfigurationToOrderItem` when the merchant finishes updating the configuration of a bundle product in the order form. Similar to how order syncs work, it creates `OrderSyncProductInput` to trigger a sync on the bundle product order item. In `ProductInputTransformer`, it transforms the app layer bundle configuration to the networking layer one. Finally, if the bundle order item already exists remotely (item ID != 0), some extra updates on the line items are required as mentioned in the code comments (otherwise, the output order items won't be updated as expected):

- Set the original order item with the bundle configuration’s quantity to 0, and remove the bundle configuration
- Create a new order item with the bundle configuration
- Remove the child order items by setting the quantity to 0

The side effect is that the updated bundle product order item will be moved to the last in the line items, but this is the same behavior as in core. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

### Create order

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products`
- Search and select a bundle product in the prerequisite --> the bundle product should be added to the order form
- Tap on the expand  🔽 CTA (🗒️ : there is a future subtask to update the UX to show the configure screen from the product selector)
- Make sure all items have allowed configuration values (🗒️ : there is a future subtask to validate the configuration values)
- Tap `Configure` --> after a bit (products being loaded remotely), the configurable bundle items should be shown
- For the bundle item that is variable, tap `Select variation` and select a variation that doesn't have any "Any" values
- Tap `Done` --> the Configure modal should be dismissed, and the order's line items should be updated with the new bundled items
- After the order items are updated with the bundled items, tap `Create` to create the order (🗒️ : there is a future subtask to prevent a scenario when tapping `Create` before order items are updated, which results in unexpected order items)

### Update order

- Go to the Orders tab
- Tap on an existing order with an existing bundle product
- Tap `Edit`
- Tap on the expand  🔽 CTA on the existing bundle product order item
- Tap `Configure` --> after a bit (products being loaded remotely), the configurable bundle items should be shown
- Update the quantity of a bundled item (but make sure it's within the allowed range as set in core - a future subtask is to limit the stepper)
- For the bundle item that is variable, tap `Select variation` and select a variation that doesn't have any "Any" values
- Tap `Done` --> the Configure modal should be dismissed, and the order's line items should be updated with the newly configured bundled items

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Create order:

https://github.com/woocommerce/woocommerce-ios/assets/1945542/43223881-ab3e-4379-8bdd-f66cfda88a46

Update order:

https://github.com/woocommerce/woocommerce-ios/assets/1945542/733cf8a7-a863-4de9-a1f2-75d5ff280d41



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
