### PR TITLE
Update the CI Toolkit from `2.18.2` to `3.0.0`

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.18.2
+    - automattic/a8c-ci-toolkit#3.0.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.18.2
+    - automattic/a8c-ci-toolkit#3.0.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.18.2
+    - automattic/a8c-ci-toolkit#3.0.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization


### PR DESCRIPTION
## Summary of changes:

This PR updates the CI Toolkit from `2.18.2` to `3.0.0`. 

The breaking change in `3.0.0` is due to removing the `nvm_install` command, but WCiOS doesn't use that anywhere. 

If CI is green, this is good to go. ✅ 