### PR TITLE
Blaze Optimization: Functionality for Blaze flow entry on Product editing form screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -104,6 +104,8 @@ extension BlazeSource {
             return "my_store_section_create_campaign_button"
         case .introView:
             return "intro_view"
+        case .productDetailPromoButton:
+            return "product_detail_promo_button"
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -104,8 +104,8 @@ extension BlazeSource {
             return "my_store_section_create_campaign_button"
         case .introView:
             return "intro_view"
-        case .productDetailPromoButton:
-            return "product_detail_promo_button"
+        case .productDetailPromoteButton:
+            return "product_detail_promote_button"
         }
     }
 }

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -12,6 +12,8 @@ enum BlazeSource {
     case introView
     /// From the Create campaign button on the Blaze section of the My Store screen
     case myStoreSectionCreateCampaignButton
+    /// From the "Promote with Blaze" button on product form
+    case productFormBlazeButton
 }
 
 /// View model for Blaze webview.

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -13,7 +13,7 @@ enum BlazeSource {
     /// From the Create campaign button on the Blaze section of the My Store screen
     case myStoreSectionCreateCampaignButton
     /// From the "Promote with Blaze" button on product form
-    case productDetailPromoButton
+    case productDetailPromoteButton
 }
 
 /// View model for Blaze webview.

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -13,7 +13,7 @@ enum BlazeSource {
     /// From the Create campaign button on the Blaze section of the My Store screen
     case myStoreSectionCreateCampaignButton
     /// From the "Promote with Blaze" button on product form
-    case productFormBlazeButton
+    case productDetailPromoButton
 }
 
 /// View model for Blaze webview.

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignIntroView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignIntroView.swift
@@ -1,5 +1,19 @@
 import SwiftUI
 
+/// Hosting controller for `BlazeCampaignIntroView`.
+///
+final class BlazeCampaignIntroController: UIHostingController<BlazeCampaignIntroView> {
+    init(onStartCampaign: @escaping () -> Void,
+         onDismiss: @escaping () -> Void) {
+        super.init(rootView: BlazeCampaignIntroView(onStartCampaign: onStartCampaign, onDismiss: onDismiss))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// View to display the introduction to the Blaze campaign
 ///
 struct BlazeCampaignIntroView: View {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1,5 +1,6 @@
 import Combine
 import Photos
+import SwiftUI
 import UIKit
 import WordPressUI
 import Yosemite
@@ -1103,8 +1104,30 @@ private extension ProductFormViewController {
         guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
             return
         }
-        let viewModel = BlazeWebViewModel(source: .productMoreMenu, siteURL: site.url, productID: product.productID)
-        let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
+        viewModel.checkIfBlazeIntroViewIsNeeded()
+
+        if viewModel.shouldShowBlazeIntroView {
+            let blazeCampaignIntroView = BlazeCampaignIntroView(onStartCampaign: {
+                self.dismiss(animated: true)
+                self.viewModel.updateShouldShowBlazeIntroView(to: false)
+                self.navigateToBlazeCampaignCreation(siteUrl: site.url)
+            }, onDismiss: {
+                self.dismiss(animated: true)
+                self.viewModel.updateShouldShowBlazeIntroView(to: false)
+            })
+
+            let hostingController = UIHostingController(rootView: blazeCampaignIntroView)
+            hostingController.modalPresentationStyle = .fullScreen
+
+            present(hostingController, animated: true)
+        } else {
+            self.navigateToBlazeCampaignCreation(siteUrl: site.url)
+        }
+    }
+
+    private func navigateToBlazeCampaignCreation(siteUrl: String) {
+        let blazeViewModel = BlazeWebViewModel(source: .productDetailPromoButton, siteURL: siteUrl, productID: product.productID)
+        let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
         navigationController?.show(webViewController, sender: self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -389,6 +389,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 eventLogger.logDescriptionTapped()
                 editProductDescription()
             case .promoteWithBlaze:
+                ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .productDetailPromoteButton))
                 displayBlaze()
             default:
                 break

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1107,7 +1107,7 @@ private extension ProductFormViewController {
             let blazeCampaignIntroView = BlazeCampaignIntroView(onStartCampaign: { [weak self] in
                 guard let self else { return }
                 self.dismiss(animated: true)
-                self.navigateToBlazeCampaignCreation(siteUrl: site.url)
+                navigateToBlazeCampaignCreation(siteUrl: site.url, source: .introView)
                 ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .introView))
             }, onDismiss: { [weak self] in
                 guard let self = self else { return }
@@ -1119,12 +1119,12 @@ private extension ProductFormViewController {
             ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .introView))
 
         } else {
-            self.navigateToBlazeCampaignCreation(siteUrl: site.url)
+            navigateToBlazeCampaignCreation(siteUrl: site.url, source: .productDetailPromoteButton)
         }
     }
 
-    private func navigateToBlazeCampaignCreation(siteUrl: String) {
-        let blazeViewModel = BlazeWebViewModel(source: .productDetailPromoteButton, siteURL: siteUrl, productID: product.productID)
+    private func navigateToBlazeCampaignCreation(siteUrl: String, source: BlazeSource) {
+        let blazeViewModel = BlazeWebViewModel(source: source, siteURL: siteUrl, productID: product.productID)
         let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
         navigationController?.show(webViewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1116,6 +1116,8 @@ private extension ProductFormViewController {
 
             let hostingController = UIHostingController(rootView: blazeCampaignIntroView)
             present(hostingController, animated: true)
+            ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .introView))
+
         } else {
             self.navigateToBlazeCampaignCreation(siteUrl: site.url)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -738,6 +738,9 @@ private extension ProductFormViewController {
     func observeUpdateBlazeEligibility() {
         blazeEligibilitySubscription = viewModel.blazeEligibilityUpdate.sink { [weak self] in
             self?.updateFormTableContent()
+            if self?.viewModel.canPromoteWithBlaze() == true {
+                ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .productDetailPromoteButton))
+            }
         }
 
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1107,7 +1107,8 @@ private extension ProductFormViewController {
         viewModel.checkIfBlazeIntroViewIsNeeded()
 
         if viewModel.shouldShowBlazeIntroView {
-            let blazeCampaignIntroView = BlazeCampaignIntroView(onStartCampaign: {
+            let blazeCampaignIntroView = BlazeCampaignIntroView(onStartCampaign: { [weak self] in
+                guard let self else { return }
                 self.dismiss(animated: true)
                 self.viewModel.updateShouldShowBlazeIntroView(to: false)
                 self.navigateToBlazeCampaignCreation(siteUrl: site.url)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1116,7 +1116,7 @@ private extension ProductFormViewController {
             })
 
             let hostingController = UIHostingController(rootView: blazeCampaignIntroView)
-            hostingController.modalPresentationStyle = .fullScreen
+            hostingController.modalPresentationStyle = .pageSheet
 
             present(hostingController, animated: true)
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -387,6 +387,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 eventLogger.logDescriptionTapped()
                 editProductDescription()
+            case .promoteWithBlaze:
+                displayBlaze() /* todo differentiate between going to intro or to campaign creation directly */
             default:
                 break
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -388,7 +388,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 eventLogger.logDescriptionTapped()
                 editProductDescription()
             case .promoteWithBlaze:
-                displayBlaze() /* todo differentiate between going to intro or to campaign creation directly */
+                displayBlaze()
             default:
                 break
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1,6 +1,5 @@
 import Combine
 import Photos
-import SwiftUI
 import UIKit
 import WordPressUI
 import Yosemite
@@ -1105,7 +1104,7 @@ private extension ProductFormViewController {
         }
 
         if viewModel.shouldShowBlazeIntroView {
-            let blazeCampaignIntroView = BlazeCampaignIntroView(onStartCampaign: { [weak self] in
+            let blazeHostingController = BlazeCampaignIntroController(onStartCampaign: { [weak self] in
                 guard let self else { return }
                 self.dismiss(animated: true)
                 navigateToBlazeCampaignCreation(siteUrl: site.url, source: .introView)
@@ -1115,10 +1114,8 @@ private extension ProductFormViewController {
                 self.dismiss(animated: true)
             })
 
-            let hostingController = UIHostingController(rootView: blazeCampaignIntroView)
-            present(hostingController, animated: true)
+            present(blazeHostingController, animated: true)
             ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .introView))
-
         } else {
             navigateToBlazeCampaignCreation(siteUrl: site.url, source: .productDetailPromoteButton)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1108,6 +1108,7 @@ private extension ProductFormViewController {
                 guard let self else { return }
                 self.dismiss(animated: true)
                 self.navigateToBlazeCampaignCreation(siteUrl: site.url)
+                ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .introView))
             }, onDismiss: { [weak self] in
                 guard let self = self else { return }
                 self.dismiss(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -381,7 +381,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 eventLogger.logDescriptionTapped()
                 editProductDescription()
             case .promoteWithBlaze:
-                ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .productDetailPromoteButton))
+                if !viewModel.shouldShowBlazeIntroView {
+                    ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .productDetailPromoteButton))
+                }
                 displayBlaze()
             default:
                 break

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1104,18 +1104,15 @@ private extension ProductFormViewController {
         guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
             return
         }
-        viewModel.checkIfBlazeIntroViewIsNeeded()
 
         if viewModel.shouldShowBlazeIntroView {
             let blazeCampaignIntroView = BlazeCampaignIntroView(onStartCampaign: { [weak self] in
                 guard let self else { return }
                 self.dismiss(animated: true)
-                self.viewModel.updateShouldShowBlazeIntroView(to: false)
                 self.navigateToBlazeCampaignCreation(siteUrl: site.url)
             }, onDismiss: { [weak self] in
                 guard let self = self else { return }
                 self.dismiss(animated: true)
-                self.viewModel.updateShouldShowBlazeIntroView(to: false)
             })
 
             let hostingController = UIHostingController(rootView: blazeCampaignIntroView)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -732,8 +732,9 @@ private extension ProductFormViewController {
     /// 
     func observeUpdateBlazeEligibility() {
         blazeEligibilitySubscription = viewModel.blazeEligibilityUpdate.sink { [weak self] in
-            self?.updateFormTableContent()
-            if self?.viewModel.canPromoteWithBlaze() == true {
+            guard let self else { return }
+            self.updateFormTableContent()
+            if self.viewModel.canPromoteWithBlaze() && !self.viewModel.shouldShowBlazeIntroView {
                 ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .productDetailPromoteButton))
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1112,7 +1112,8 @@ private extension ProductFormViewController {
                 self.dismiss(animated: true)
                 self.viewModel.updateShouldShowBlazeIntroView(to: false)
                 self.navigateToBlazeCampaignCreation(siteUrl: site.url)
-            }, onDismiss: {
+            }, onDismiss: { [weak self] in
+                guard let self = self else { return }
                 self.dismiss(animated: true)
                 self.viewModel.updateShouldShowBlazeIntroView(to: false)
             })

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1116,8 +1116,6 @@ private extension ProductFormViewController {
             })
 
             let hostingController = UIHostingController(rootView: blazeCampaignIntroView)
-            hostingController.modalPresentationStyle = .pageSheet
-
             present(hostingController, animated: true)
         } else {
             self.navigateToBlazeCampaignCreation(siteUrl: site.url)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1123,7 +1123,7 @@ private extension ProductFormViewController {
     }
 
     private func navigateToBlazeCampaignCreation(siteUrl: String) {
-        let blazeViewModel = BlazeWebViewModel(source: .productDetailPromoButton, siteURL: siteUrl, productID: product.productID)
+        let blazeViewModel = BlazeWebViewModel(source: .productDetailPromoteButton, siteURL: siteUrl, productID: product.productID)
         let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
         navigationController?.show(webViewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -321,14 +321,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             }
         }
 
-        if viewModel.canPromoteWithBlaze() {
-            actionSheet.addDefaultActionWithTitle(ActionSheetStrings.promoteWithBlaze) { [weak self] _ in
-                self?.displayBlaze()
-                ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointTapped(source: .productMoreMenu))
-            }
-            ServiceLocator.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .productMoreMenu))
-        }
-
         if viewModel.canEditProductSettings() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.productSettings) { [weak self] _ in
                 ServiceLocator.analytics.track(.productDetailViewSettingsButtonTapped)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -722,6 +722,7 @@ private extension ProductFormViewModel {
         Task { @MainActor in
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible
+            updateActionsFactory()
             blazeEligiblityUpdateSubject.send()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -64,6 +64,8 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private var isEligibleForBlaze: Bool = false
 
+    private let blazeCampaignResultsController: ResultsController<StorageBlazeCampaign>?
+
     /// Returns `true` if the `Add-ons` beta feature switch is enabled. `False` otherwise.
     /// Assigning this value will recreate the `actionsFactory` property.
     ///
@@ -222,6 +224,17 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.productImagesUploader = productImagesUploader
         self.analytics = analytics
         self.blazeEligibilityChecker = blazeEligibilityChecker
+
+        /// Initialize Blaze Campaign Results Controller
+        ///
+        if let siteID = stores.sessionManager.defaultSite?.siteID {
+            let predicate = NSPredicate(format: "siteID == %lld", siteID)
+            blazeCampaignResultsController = ResultsController<StorageBlazeCampaign>(storageManager: storageManager,
+                                                                                     matching: predicate,
+                                                                                     sortedBy: [])
+        } else {
+            blazeCampaignResultsController = nil
+        }
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             guard let self = self else { return }
@@ -706,7 +719,9 @@ private extension ProductFormViewModel {
 //
 extension ProductFormViewModel {
     func checkIfBlazeIntroViewIsNeeded() {
-        // todo
+        if let controller = blazeCampaignResultsController, controller.numberOfObjects == 0 {
+            shouldShowBlazeIntroView = true
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -723,6 +723,10 @@ extension ProductFormViewModel {
             shouldShowBlazeIntroView = true
         }
     }
+
+    func updateShouldShowBlazeIntroView(to newValue: Bool) {
+        shouldShowBlazeIntroView = newValue
+    }
 }
 
 private extension ProductFormViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -64,7 +64,14 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private var isEligibleForBlaze: Bool = false
 
-    private let blazeCampaignResultsController: ResultsController<StorageBlazeCampaign>?
+    /// Blaze campaign ResultsController.
+    private lazy var blazeCampaignResultsController: ResultsController<StorageBlazeCampaign> = {
+        let predicate = NSPredicate(format: "siteID == %lld", product.siteID)
+        let resultsController = ResultsController<StorageBlazeCampaign>(storageManager: storageManager,
+                                                                        matching: predicate,
+                                                                        sortedBy: [])
+        return resultsController
+    }()
 
     /// Returns `true` if the `Add-ons` beta feature switch is enabled. `False` otherwise.
     /// Assigning this value will recreate the `actionsFactory` property.
@@ -224,15 +231,6 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.productImagesUploader = productImagesUploader
         self.analytics = analytics
         self.blazeEligibilityChecker = blazeEligibilityChecker
-
-        /// Initialize Blaze Campaign Results Controller
-        ///
-        let siteID = product.siteID
-        let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        blazeCampaignResultsController = ResultsController<StorageBlazeCampaign>(storageManager: storageManager,
-                                                                                 matching: predicate,
-                                                                                 sortedBy: [])
-
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             guard let self = self else { return }
@@ -717,7 +715,7 @@ private extension ProductFormViewModel {
 //
 extension ProductFormViewModel {
     func checkIfBlazeIntroViewIsNeeded() {
-        if let controller = blazeCampaignResultsController, controller.numberOfObjects == 0 {
+        if blazeCampaignResultsController.numberOfObjects == 0 {
             shouldShowBlazeIntroView = true
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -45,6 +45,9 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         originalProduct
     }
 
+    /// Whether the "Promote with Blaze" button should show Blaze intro view first or not when tapped.
+    var shouldShowBlazeIntroView: Bool = false
+
     /// The form type could change from .add to .edit after creation.
     private(set) var formType: ProductFormType
 
@@ -696,6 +699,14 @@ private extension ProductFormViewModel {
                                                    addOnsFeatureEnabled: isAddOnsFeatureEnabled,
                                                    isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                                    variationsPrice: calculateVariationPriceState())
+    }
+}
+
+// MARK: Blaze-related
+//
+extension ProductFormViewModel {
+    func checkIfBlazeIntroViewIsNeeded() {
+        // todo
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -241,6 +241,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
         queryAddOnsFeatureState()
         updateVariationsPriceState()
+        configureResultsController()
         updateBlazeEligibility()
     }
 
@@ -724,6 +725,15 @@ private extension ProductFormViewModel {
             isEligibleForBlaze = isEligible
             updateActionsFactory()
             blazeEligiblityUpdateSubject.send()
+        }
+    }
+
+    /// Performs initial fetch from storage and updates results.
+    func configureResultsController() {
+        do {
+            try blazeCampaignResultsController.performFetch()
+        } catch {
+            ServiceLocator.crashLogging.logError(error)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -46,7 +46,9 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     }
 
     /// Whether the "Promote with Blaze" button should show Blaze intro view first or not when tapped.
-    var shouldShowBlazeIntroView: Bool = false
+    var shouldShowBlazeIntroView: Bool {
+        blazeCampaignResultsController.isEmpty
+    }
 
     /// The form type could change from .add to .edit after creation.
     private(set) var formType: ProductFormType
@@ -708,20 +710,6 @@ private extension ProductFormViewModel {
                                                    addOnsFeatureEnabled: isAddOnsFeatureEnabled,
                                                    isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                                    variationsPrice: calculateVariationPriceState())
-    }
-}
-
-// MARK: Blaze-related
-//
-extension ProductFormViewModel {
-    func checkIfBlazeIntroViewIsNeeded() {
-        if blazeCampaignResultsController.numberOfObjects == 0 {
-            shouldShowBlazeIntroView = true
-        }
-    }
-
-    func updateShouldShowBlazeIntroView(to newValue: Bool) {
-        shouldShowBlazeIntroView = newValue
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -227,14 +227,12 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
         /// Initialize Blaze Campaign Results Controller
         ///
-        if let siteID = stores.sessionManager.defaultSite?.siteID {
-            let predicate = NSPredicate(format: "siteID == %lld", siteID)
-            blazeCampaignResultsController = ResultsController<StorageBlazeCampaign>(storageManager: storageManager,
-                                                                                     matching: predicate,
-                                                                                     sortedBy: [])
-        } else {
-            blazeCampaignResultsController = nil
-        }
+        let siteID = product.siteID
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        blazeCampaignResultsController = ResultsController<StorageBlazeCampaign>(storageManager: storageManager,
+                                                                                 matching: predicate,
+                                                                                 sortedBy: [])
+
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -722,7 +722,6 @@ private extension ProductFormViewModel {
         Task { @MainActor in
             let isEligible = await blazeEligibilityChecker.isProductEligible(product: originalProduct, isPasswordProtected: password?.isNotEmpty == true)
             isEligibleForBlaze = isEligible
-            updateActionsFactory()
             blazeEligiblityUpdateSubject.send()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -142,6 +142,8 @@ protocol ProductFormViewModelProtocol {
 
     func checkIfBlazeIntroViewIsNeeded()
 
+    func updateShouldShowBlazeIntroView(to newValue: Bool)
+
     // Remote action
 
     /// Creates/updates a product remotely given an optional product status to override.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -140,10 +140,6 @@ protocol ProductFormViewModelProtocol {
 
     func updateVariationAttributes(_ attributes: [ProductVariationAttribute])
 
-    func checkIfBlazeIntroViewIsNeeded()
-
-    func updateShouldShowBlazeIntroView(to newValue: Bool)
-
     // Remote action
 
     /// Creates/updates a product remotely given an optional product status to override.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -67,6 +67,9 @@ protocol ProductFormViewModelProtocol {
     /// The product variation ID
     var productionVariationID: Int64? { get }
 
+    /// Whether the "Promote with Blaze" button should show Blaze intro view first or not when tapped.
+    var shouldShowBlazeIntroView: Bool { get }
+
     // Unsaved changes
 
     func hasUnsavedChanges() -> Bool
@@ -136,6 +139,8 @@ protocol ProductFormViewModelProtocol {
     func updateLinkedProducts(upsellIDs: [Int64], crossSellIDs: [Int64])
 
     func updateVariationAttributes(_ attributes: [ProductVariationAttribute])
+
+    func checkIfBlazeIntroViewIsNeeded()
 
     // Remote action
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -321,14 +321,6 @@ extension ProductVariationFormViewModel {
     func updateProductVariations(from product: Product) {
         //no-op
     }
-
-    func checkIfBlazeIntroViewIsNeeded() {
-        //no-op
-    }
-
-    func updateShouldShowBlazeIntroView(to newValue: Bool) {
-        //no-op
-    }
 }
 
 // MARK: Remote actions

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -31,6 +31,8 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         Just(Void()).eraseToAnyPublisher()
     }
 
+    /// Also unused in variations but needed to satisfy protocol
+    var shouldShowBlazeIntroView = false
 
     /// The product variation ID
     var productionVariationID: Int64? {
@@ -317,6 +319,10 @@ extension ProductVariationFormViewModel {
     }
 
     func updateProductVariations(from product: Product) {
+        //no-op
+    }
+
+    func checkIfBlazeIntroViewIsNeeded() {
         //no-op
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -325,6 +325,10 @@ extension ProductVariationFormViewModel {
     func checkIfBlazeIntroViewIsNeeded() {
         //no-op
     }
+
+    func updateShouldShowBlazeIntroView(to newValue: Bool) {
+        //no-op
+    }
 }
 
 // MARK: Remote actions

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -46,21 +46,19 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let mockProductImageUploader = MockProductImageUploader()
-        let viewModel = ProductFormViewModel(product: model,
-                                             formType: .edit,
-                                             productImageActionHandler: productImageActionHandler)
         let blazeEligibilityChecker = MockBlazeEligibilityChecker(isProductEligible: true)
         var isBlazeEligibilityUpdated: Bool? = nil
         let expectationForBlazeEligibility = self.expectation(description: "blazeEligibilityUpdateSubject is called")
         expectationForBlazeEligibility.expectedFulfillmentCount = 1
 
-        blazeEligibilitySubscription = viewModel.blazeEligibilityUpdate.sink { _ in
+        // Action
+        let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
+                                             productImageActionHandler: productImageActionHandler)
+        blazeEligibilitySubscription = viewModel.blazeEligibilityUpdate.sink {
             isBlazeEligibilityUpdated = true
             expectationForBlazeEligibility.fulfill()
         }
-
-        // Action
-        // Nothing, as this relates to `updateBlazeEligibility()` that is called during viewmodel init.
 
         // Assert
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10961
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Functionality**

1. Start with a site with no Blaze campaign,
2. Go to Product list and select a Product,
3. Ensure "Promote with Blaze" button appears, then tap it,
4. Ensure the Blaze intro screen is shown.
5. Tap "Start Blaze Campaign" button,
6. Ensure the intro sheet is hidden and the Blaze webview is opened.
7. Have a Blaze campaign created (or start with another size with existing Blaze campaign)
8. Go to Product list and select a Product,
9. Ensure "Promote with Blaze" button appears, then tap it,
10. Ensure the Blaze campaign webview is opened right away (no more intro)

**Tracking**

- When opening product form in a site that's eligible for Blaze, make sure this appears:

`🔵 Tracked blaze_entry_point_displayed, properties: [AnyHashable("site_url"): "URL", AnyHashable("is_wpcom_store"): true, AnyHashable("source"): "product_detail_promote_button", AnyHashable("blog_id"): BLOG_ID, AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "business-bundle"]`

- When tapping "Promote with Blaze" button, make sure this appears:

`🔵 Tracked blaze_entry_point_tapped, properties: [AnyHashable("blog_id"): BLOG_ID, AnyHashable("plan"): "business-bundle", AnyHashable("site_url"): "URL", AnyHashable("was_ecommerce_trial"): false, AnyHashable("is_wpcom_store"): true, AnyHashable("source"): "product_detail_promote_button"]`

## Video
<!-- Include before and after images or gifs when appropriate. -->

*Please ignore the pause before transitions to another screen. It's just because I have a breakpoint in Xcode. In practice the transition should be smooth*

**On a site with no Blaze campaign**: Show intro first
(Ignore the app notification request in the end, what matters is that it loads a webview)

https://github.com/woocommerce/woocommerce-ios/assets/266376/30173c74-72dc-45c4-8a17-c7c24fedc6fa


**On a site with existing Blaze campaign**: Skip intro

https://github.com/woocommerce/woocommerce-ios/assets/266376/ce17e56d-b1ea-4aaa-b9b5-d2765e9d7b23
