### PR TITLE
[Custom Amounts M1] Edit Custom Amount

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -30,7 +30,7 @@ struct AddCustomAmountView: View {
 
                         Spacer()
 
-                        Button(Localization.doneButtonTitle) {
+                        Button(viewModel.doneButtonTitle) {
                             viewModel.doneButtonPressed()
                             dismiss()
                         }
@@ -64,8 +64,6 @@ private extension AddCustomAmountView {
     enum Localization {
         static let amountTitle = NSLocalizedString("Amount", comment: "Title above the amount field on the add custom amount view in orders.")
         static let nameTitle = NSLocalizedString("Name", comment: "Title above the name field on the add custom amount view in orders.")
-        static let doneButtonTitle = NSLocalizedString("Add Custom Amount",
-                                                       comment: "Button title to confirm the custom amount on the add custom amount view in orders.")
         static let navigationTitle = NSLocalizedString("Custom Amount", comment: "Navigation title on the add custom amount view in orders.")
         static let navigationCancelButtonTitle = NSLocalizedString("Cancel",
                                                                 comment: "Cancel button title on the navigation bar on the add custom amount view in orders.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -28,6 +28,11 @@ final class AddCustomAmountViewModel: ObservableObject {
         Localization.customAmountPlaceholder
     }
 
+    var doneButtonTitle: String {
+        let isInEditMode = feeID != nil
+        return isInEditMode ? Localization.editButtonTitle : Localization.addButtonTitle
+    }
+
     func doneButtonPressed() {
         let customAmountName = name.isNotEmpty ? name : customAmountPlaceholder
         onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName, feeID)
@@ -60,6 +65,12 @@ private extension AddCustomAmountViewModel {
 
 private extension AddCustomAmountViewModel {
     enum Localization {
+        static let addButtonTitle = NSLocalizedString("addCustomAmount.doneButton",
+                                                       value: "Add Custom Amount",
+                                                       comment: "Button title to confirm the custom amount on the add custom amount view in orders.")
+        static let editButtonTitle = NSLocalizedString("addCustomAmount.editButton",
+                                                       value: "Edit Custom Amount",
+                                                       comment: "Button title to confirm the custom amount on the edit custom amount view in orders.")
         static let customAmountPlaceholder = NSLocalizedString("Custom amount",
                                                                comment: "Placeholder for the name field on the add custom amount view in orders.")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -4,7 +4,7 @@ import UIKit
 import SwiftUI
 import Yosemite
 
-typealias CustomAmountEntered = (_ amount: String, _ name: String) -> Void
+typealias CustomAmountEntered = (_ amount: String, _ name: String, _ feeID: Int64?) -> Void
 
 final class AddCustomAmountViewModel: ObservableObject {
     let formattableAmountTextFieldViewModel: FormattableAmountTextFieldViewModel
@@ -22,6 +22,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     ///
     @Published var name = ""
     @Published private(set) var shouldDisableDoneButton: Bool = true
+    var feeID: Int64? = nil
 
     var customAmountPlaceholder: String {
         Localization.customAmountPlaceholder
@@ -29,12 +30,13 @@ final class AddCustomAmountViewModel: ObservableObject {
 
     func doneButtonPressed() {
         let customAmountName = name.isNotEmpty ? name : customAmountPlaceholder
-        onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName)
+        onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName, feeID)
         reset()
     }
 
     func reset() {
         name = ""
+        feeID = nil
         shouldDisableDoneButton = true
 
         formattableAmountTextFieldViewModel.reset()
@@ -43,6 +45,8 @@ final class AddCustomAmountViewModel: ObservableObject {
     func preset(with fee: OrderFeeLine) {
         name = fee.name ?? Localization.customAmountPlaceholder
         formattableAmountTextFieldViewModel.amount = fee.total
+        formattableAmountTextFieldViewModel.resetAmountWithNewValue = true
+        feeID = fee.feeID
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -2,6 +2,7 @@ import Combine
 import WooFoundation
 import UIKit
 import SwiftUI
+import Yosemite
 
 typealias CustomAmountEntered = (_ amount: String, _ name: String) -> Void
 
@@ -37,6 +38,11 @@ final class AddCustomAmountViewModel: ObservableObject {
         shouldDisableDoneButton = true
 
         formattableAmountTextFieldViewModel.reset()
+    }
+
+    func preset(with fee: OrderFeeLine) {
+        name = fee.name ?? Localization.customAmountPlaceholder
+        formattableAmountTextFieldViewModel.amount = fee.total
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -36,7 +36,6 @@ final class AddCustomAmountViewModel: ObservableObject {
     func doneButtonPressed() {
         let customAmountName = name.isNotEmpty ? name : customAmountPlaceholder
         onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName, feeID)
-        reset()
     }
 
     func reset() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -22,7 +22,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     ///
     @Published var name = ""
     @Published private(set) var shouldDisableDoneButton: Bool = true
-    var feeID: Int64? = nil
+    private var feeID: Int64? = nil
 
     var customAmountPlaceholder: String {
         Localization.customAmountPlaceholder

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -26,7 +26,9 @@ struct CustomAmountRowView: View {
                     Text(viewModel.name)
                         .foregroundColor(Color(.wooCommercePurple(.shade60)))
                         .bodyStyle()
-                    Button {} label: {
+                    Button {
+                        viewModel.onEditCustomAmount()
+                    } label: {
                         Image(systemName: "pencil")
                             .resizable()
                             .padding(.top, Layout.editIconTopPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowViewModel.swift
@@ -5,4 +5,5 @@ struct CustomAmountRowViewModel: Identifiable {
     let name: String
     let total: String
     let onRemoveCustomAmount: () -> Void
+    let onEditCustomAmount: () -> Void
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -13,9 +13,19 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
         didSet {
             guard amount != oldValue else { return }
 
+            if resetAmountWithNewValue,
+                let newInput = amount.last {
+                amount = String(newInput)
+                resetAmountWithNewValue = false
+            }
+
             amount = priceFieldFormatter.formatAmount(amount)
         }
     }
+
+    /// When true, the amount will be reset with the new input instead of appending
+    /// 
+    var resetAmountWithNewValue = false
 
     var amountIsValid: Bool {
         guard let amountDecimal = priceFieldFormatter.amountDecimal else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -51,6 +51,9 @@ struct OrderCustomAmountsSection: View {
         .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
         })
+        .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
+            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -174,6 +174,10 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     @Published private var storedTaxRate: TaxRate? = nil
 
+    /// Display the custom amount screen to edit it
+    ///
+    @Published var showEditCustomAmount: Bool = false
+
     /// Defines if the toggle to store the tax rate in the selector should be enabled by default
     ///
     var shouldStoreTaxRateInSelectorByDefault: Bool {
@@ -1230,7 +1234,10 @@ private extension EditableOrderViewModel {
                     return CustomAmountRowViewModel(id: fee.feeID,
                                              name: fee.name ?? Localization.customAmountDefaultName,
                                              total: self.currencyFormatter.formatAmount(fee.total) ?? "",
-                                             onRemoveCustomAmount: { self.removeFee(fee) })
+                                             onRemoveCustomAmount: { self.removeFee(fee) },
+                                             onEditCustomAmount: {
+                        self.showEditCustomAmount = true
+                    })
                 }
             }
             .assign(to: &$customAmountRows)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1236,6 +1236,7 @@ private extension EditableOrderViewModel {
                                              total: self.currencyFormatter.formatAmount(fee.total) ?? "",
                                              onRemoveCustomAmount: { self.removeFee(fee) },
                                              onEditCustomAmount: {
+                        self.addCustomAmountViewModel.preset(with: fee)
                         self.showEditCustomAmount = true
                     })
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformer.swift
@@ -6,7 +6,7 @@ import Yosemite
 struct FeesInputTransformer {
     /// Adds, deletes, or updates a fee line input into an existing order.
     ///
-    static func update(input: OrderFeeLine?, on order: Order) -> Order {
+    static func setFee(input: OrderFeeLine?, on order: Order) -> Order {
         // If input is `nil`, then we remove the first existing fee line.
         guard let input = input else {
             let updatedLines = order.fees.enumerated().map { index, line -> OrderFeeLine in
@@ -39,6 +39,19 @@ struct FeesInputTransformer {
         }
 
         return order.copy(fees: order.fees + [input])
+    }
+
+    /// Updates a fee into an existing order. If the fee is not there, it returns the order as it is.
+    ///
+    static func update(input: OrderFeeLine, on order: Order) -> Order {
+        guard let index = order.fees.firstIndex(where: { $0.feeID == input.feeID }) else {
+            return order
+        }
+
+        var updatedLines = order.fees
+        updatedLines[index] = input
+
+        return order.copy(fees: updatedLines)
     }
 
     /// Removes a fee line input from an existing order.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -101,6 +101,10 @@ protocol OrderSynchronizer {
     /// 
     var removeFee: PassthroughSubject<OrderFeeLine, Never> { get }
 
+    /// Updates the fee with the given fee Id.
+    ///
+    var updateFee: PassthroughSubject<OrderFeeLine, Never> { get }
+
     /// Adds an order coupon.
     ///
     var addCoupon: PassthroughSubject<String, Never> { get }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -45,6 +45,8 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
 
     var removeFee = PassthroughSubject<OrderFeeLine, Never>()
 
+    var updateFee = PassthroughSubject<OrderFeeLine, Never>()
+
     var addCoupon = PassthroughSubject<String, Never>()
 
     var removeCoupon = PassthroughSubject<String, Never>()
@@ -221,6 +223,19 @@ private extension RemoteOrderSynchronizer {
             }
             .store(in: &subscriptions)
 
+        updateFee.withLatestFrom(orderPublisher)
+            .map { [weak self] feeLineInput, order -> Order in
+                guard let self = self else { return order }
+                let updatedOrder = FeesInputTransformer.update(input: feeLineInput, on: order)
+                // Calculate order total locally while order is being synced
+                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
+            }
+            .sink { [weak self] order in
+                self?.order = order
+                self?.orderSyncTrigger.send(order)
+            }
+            .store(in: &subscriptions)
+
         removeFee.withLatestFrom(orderPublisher)
             .map { [weak self] feeLineInput, order -> Order in
                 guard let self = self else { return order }
@@ -237,7 +252,7 @@ private extension RemoteOrderSynchronizer {
         setFee.withLatestFrom(orderPublisher)
             .map { [weak self] feeLineInput, order -> Order in
                 guard let self = self else { return order }
-                let updatedOrder = FeesInputTransformer.update(input: feeLineInput, on: order)
+                let updatedOrder = FeesInputTransformer.setFee(input: feeLineInput, on: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -94,9 +94,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
     func test_reset_then_reset_values() {
         // Given
         let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
-        viewModel.formattableAmountTextFieldViewModel.amount = "2"
-        viewModel.name = "test"
-        viewModel.feeID = 12345
+        viewModel.preset(with: OrderFeeLine.fake().copy(feeID: 1234, name: "test", total: "10"))
 
         // When
         viewModel.reset()
@@ -105,6 +103,5 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.formattableAmountTextFieldViewModel.amount.isEmpty)
         XCTAssertTrue(viewModel.name.isEmpty)
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
-        XCTAssertNil(viewModel.feeID)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -1,5 +1,7 @@
 @testable import WooCommerce
+@testable import Yosemite
 import XCTest
+import Fakes
 
 final class AddCustomAmountViewModelTests: XCTestCase {
     func test_shouldDisableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {
@@ -62,11 +64,39 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertEqual(passedAmount, amount)
     }
 
+    func test_doneButtonPressed_when_a_fee_is_preset_then_passes_its_data() {
+        // Given
+        let amount = "23"
+        let name = "Custom amount name"
+        let feeID: Int64 = 12345
+
+        var passedName: String?
+        var passedAmount: String?
+        var passedFeeID: Int64?
+
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, feeID in
+            passedAmount = amount
+            passedName = name
+            passedFeeID = feeID
+        })
+
+        viewModel.preset(with: OrderFeeLine.fake().copy(feeID: feeID, name: name, total: amount))
+
+        // When
+        viewModel.doneButtonPressed()
+
+        // Then
+        XCTAssertEqual(passedName, name)
+        XCTAssertEqual(passedAmount, amount)
+        XCTAssertEqual(passedFeeID, feeID)
+    }
+
     func test_reset_then_reset_values() {
         // Given
         let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
         viewModel.formattableAmountTextFieldViewModel.amount = "2"
         viewModel.name = "test"
+        viewModel.feeID = 12345
 
         // When
         viewModel.reset()
@@ -75,5 +105,6 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.formattableAmountTextFieldViewModel.amount.isEmpty)
         XCTAssertTrue(viewModel.name.isEmpty)
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
+        XCTAssertNil(viewModel.feeID)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class AddCustomAmountViewModelTests: XCTestCase {
     func test_shouldDisableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {
         // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _ in })
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
 
         // When
         viewModel.formattableAmountTextFieldViewModel.amount = "$0"
@@ -15,7 +15,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
     func test_shouldDisableDoneButton_when_there_is_no_amount_then_disables_done_button() {
         // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _ in })
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
 
         // When
         viewModel.formattableAmountTextFieldViewModel.amount = ""
@@ -27,7 +27,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
     func test_doneButtonPressed_when_there_is_no_name_then_passes_placeholder() {
         // Given
         var passedName: String?
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name in
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _ in
             passedName = name
         })
 
@@ -46,7 +46,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         var passedName: String?
         var passedAmount: String?
 
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name in
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _ in
             passedAmount = amount
             passedName = name
         })
@@ -64,7 +64,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
     func test_reset_then_reset_values() {
         // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _ in })
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
         viewModel.formattableAmountTextFieldViewModel.amount = "2"
         viewModel.name = "test"
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -457,6 +457,25 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.customAmountRows.isEmpty)
     }
 
+    func test_view_model_is_updated_when_custom_amount_is_edited() {
+        // Given
+        let newFeeName = "Test 2"
+        
+        // When
+        viewModel.addCustomAmountViewModel.name = "Test"
+        viewModel.addCustomAmountViewModel.doneButtonPressed()
+
+        // Check previous condition
+        XCTAssertEqual(viewModel.customAmountRows.count, 1)
+
+        viewModel.addCustomAmountViewModel.preset(with: OrderFeeLine.fake().copy(feeID: viewModel.customAmountRows.first?.id ?? 0))
+        viewModel.addCustomAmountViewModel.name = newFeeName
+        viewModel.addCustomAmountViewModel.doneButtonPressed()
+
+        // Then
+        XCTAssertEqual(viewModel.customAmountRows.first?.name, newFeeName)
+    }
+
     func test_view_model_is_updated_when_address_updated() {
         // Given
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -460,7 +460,7 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_view_model_is_updated_when_custom_amount_is_edited() {
         // Given
         let newFeeName = "Test 2"
-        
+
         // When
         viewModel.addCustomAmountViewModel.name = "Test"
         viewModel.addCustomAmountViewModel.doneButtonPressed()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformerTests.swift
@@ -54,7 +54,7 @@ class FeesInputTransformerTests: XCTestCase {
         let order = Order.fake().copy(fees: [fee, fee2])
 
         // When
-        let updatedOrder = FeesInputTransformer.update(input: nil, on: order)
+        let updatedOrder = FeesInputTransformer.setFee(input: nil, on: order)
 
         // Then
         let feeLine = try XCTUnwrap(updatedOrder.fees.first)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/FeesInputTransformerTests.swift
@@ -16,7 +16,7 @@ class FeesInputTransformerTests: XCTestCase {
         let input = OrderFeeLine.fake().copy(name: sampleFeeName, total: "10.0")
 
         // When
-        let updatedOrder = FeesInputTransformer.update(input: input, on: order)
+        let updatedOrder = FeesInputTransformer.setFee(input: input, on: order)
 
         // Then
         let feeLine = try XCTUnwrap(updatedOrder.fees.first)
@@ -31,7 +31,7 @@ class FeesInputTransformerTests: XCTestCase {
 
         // When
         let input = OrderFeeLine.fake().copy(name: sampleFeeName, total: "8.0")
-        let updatedOrder = FeesInputTransformer.update(input: input, on: order)
+        let updatedOrder = FeesInputTransformer.setFee(input: input, on: order)
 
         // Then
         let feeLine = try XCTUnwrap(updatedOrder.fees.first)
@@ -68,5 +68,45 @@ class FeesInputTransformerTests: XCTestCase {
 
         let feeLine2 = try XCTUnwrap(updatedOrder.fees[safe: 1])
         XCTAssertEqual(fee2, feeLine2)
+    }
+
+    func test_update_then_updates_existing_fee() throws {
+        // Given
+        let newSampleFeeName = "new"
+        let newFeeTotal = "2.0"
+        let fee = OrderFeeLine.fake().copy(feeID: 1, name: sampleFeeName, total: "10.0")
+        let fee2 = OrderFeeLine.fake().copy(feeID: 2, name: sampleFeeName, total: "12.0")
+        let fee3 = OrderFeeLine.fake().copy(feeID: 3, name: sampleFeeName, total: "12.0")
+        let fees = [fee, fee2, fee3]
+        let order = Order.fake().copy(fees: fees)
+
+        // When
+        let input = OrderFeeLine.fake().copy(feeID: fee2.feeID, name: newSampleFeeName, total: newFeeTotal)
+        let updatedOrder = FeesInputTransformer.update(input: input, on: order)
+
+        // Then
+        let feeLine = try XCTUnwrap(updatedOrder.fees[safe: 1])
+        XCTAssertEqual(feeLine.feeID, fee2.feeID)
+        XCTAssertEqual(feeLine.name, newSampleFeeName)
+        XCTAssertEqual(feeLine.total, newFeeTotal)
+    }
+
+    func test_update_when_the_fee_is_not_included_then_it_does_nothing() throws {
+        // Given
+        let newSampleFeeID: Int64 = 12345
+        let newSampleFeeName = "new"
+        let newFeeTotal = "2.0"
+        let fee = OrderFeeLine.fake().copy(feeID: 1, name: sampleFeeName, total: "10.0")
+        let fee2 = OrderFeeLine.fake().copy(feeID: 2, name: sampleFeeName, total: "12.0")
+        let fee3 = OrderFeeLine.fake().copy(feeID: 3, name: sampleFeeName, total: "12.0")
+        let fees = [fee, fee2, fee3]
+        let order = Order.fake().copy(fees: fees)
+
+        // When
+        let input = OrderFeeLine.fake().copy(feeID: newSampleFeeID, name: newSampleFeeName, total: newFeeTotal)
+        let updatedOrder = FeesInputTransformer.update(input: input, on: order)
+
+        // Then
+        XCTAssertEqual(updatedOrder.fees, fees)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11003 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the capability to edit a custom amount during the order creation flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to orders
2. See empty state design
3. Add a custom amount. See that it's added to the Order creation screen.
4. Tap on the custom amount edit button (the pencil). Change amount and/or name, and see that it's updated.
5. Create order and check in wp-admin that the name and amount are changed.

## Notes
- As we've seen in our previous PR, the old Fee logic doesn't work well with this new custom amounts logic. This is fine, as they won't be existing at the same time.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1864060/44c1299b-6ba1-4b59-9076-0ae5b274d6c0

<img width="1428" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/5f033d67-b2c4-4cb6-9720-601b506ba78a">


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
