### PR TITLE
[Tap to Pay UK] Hide completed Set Up on About Tap to Pay

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -549,13 +549,13 @@ extension InPersonPaymentsMenuViewController {
 
     func aboutTapToPayOnIPhoneWasPressed() {
         ServiceLocator.analytics.track(.aboutTapToPayOnIPhoneTapped)
+        let buttonAction = viewModel.shouldShowSetUpTapToPayOnAboutScreen ? setUpTapToPayOnIPhoneWasPressed : nil
         let hostingController = UIHostingController(
             rootView: AboutTapToPayView(viewModel: AboutTapToPayViewModel(
                     configuration: viewModel.cardPresentPaymentsConfiguration,
-                    buttonAction: setUpTapToPayOnIPhoneWasPressed))
+                    buttonAction: buttonAction))
         )
         show(hostingController, sender: self)
-
     }
 
     func tapToPayOnIPhoneFeedbackWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -46,6 +46,9 @@ final class InPersonPaymentsMenuViewModel {
     @Published private(set) var depositsOverviewViewModels: [WooPaymentsDepositsCurrencyOverviewViewModel] = []
     @Published private(set) var titleForTapToPayOnIPhone: String = Localization.setUpTapToPayOnIPhoneRowTitle
 
+    // This doesn't need to be @Published right now, because it's only checked on tap.
+    private(set) var shouldShowSetUpTapToPayOnAboutScreen: Bool = true
+
     let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     init(dependencies: Dependencies = Dependencies(),
@@ -62,7 +65,7 @@ final class InPersonPaymentsMenuViewModel {
         synchronizePaymentGateways(siteID: siteID)
         checkTapToPaySupport(siteID: siteID)
         checkShouldShowTapToPayFeedbackRow(siteID: siteID)
-        refreshTitleForTapToPay(siteID: siteID)
+        refreshPropertiesDependentOnTapToPaySetUpState(siteID: siteID)
         registerForNotifications()
         updateDepositsOverview()
     }
@@ -112,14 +115,16 @@ final class InPersonPaymentsMenuViewModel {
         return date
     }
 
-    private func refreshTitleForTapToPay(siteID: Int64) {
+    private func refreshPropertiesDependentOnTapToPaySetUpState(siteID: Int64) {
         Task { @MainActor in
             let firstTapToPayTransactionDate = await firstTapToPayTransactionDate(siteID: siteID)
             switch firstTapToPayTransactionDate {
             case .none:
                 self.titleForTapToPayOnIPhone = Localization.setUpTapToPayOnIPhoneRowTitle
+                self.shouldShowSetUpTapToPayOnAboutScreen = true
             case .some:
                 self.titleForTapToPayOnIPhone = Localization.tryOutTapToPayOnIPhoneRowTitle
+                self.shouldShowSetUpTapToPayOnAboutScreen = false
             }
         }
     }
@@ -136,7 +141,7 @@ final class InPersonPaymentsMenuViewModel {
             return
         }
         checkShouldShowTapToPayFeedbackRow(siteID: siteID)
-        refreshTitleForTapToPay(siteID: siteID)
+        refreshPropertiesDependentOnTapToPaySetUpState(siteID: siteID)
     }
 
     func orderCardReaderPressed() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11009
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The About Tap to Pay screen can show a button for `Set up Tap to Pay on iPhone`, and does so by default.

Once we _know_ set up has been completed, that button can be confusing to users as it implies that it hasn’t been successful.

In the designs, we specified that it should be hidden on the About Tap to Pay screen, after it’s been completed.

As with the changes to the title of the `Set up/Try out` button, we rely on the heuristic of “have they completed a test payment” for this condition – if they complete set up but don’t try a payment, the button will remain.

Note that this PR only removes the button for subsequent opens of the About screen – if setup is started from the About screen, the button does not get removed when the order view is dismissed. I'll tackle that in a subsequent PR

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Delete the app from your phone
2. Build and run from Xcode
3. Log in and select a UK or US based Woo Payments store
4. Navigate to `Menu > Payments > About Tap to Pay`
5. Observe that the setup button is present
6. Go back
7. Tap `Set up Tap to Pay on iPhone` from the Payments menu
8. Go through the flow and take a test payment
9. Dismiss the order
10. Tap `About Tap to Pay`
11. Observe that the `Set up Tap to Pay on iPhone` button is not shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/9a849208-2c72-4c2a-ada5-481f26415003



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
