### PR TITLE
[Orders with Coupons] Calculate price with discount when multiple items

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Optimized Blaze experience in My store. Improved Blaze campaign creation and list screens. [https://github.com/woocommerce/woocommerce-ios/pull/10969, https://github.com/woocommerce/woocommerce-ios/pull/10959]
 - [*] Orders: Fixed UI issue where an incorrect tooltip is displayed during Order Creation [https://github.com/woocommerce/woocommerce-ios/pull/10998]
+- [*] Orders: Fixed UI issue showing incorrect discounted total product value in certain cases [https://github.com/woocommerce/woocommerce-ios/pull/11016]
 - [*] Fix a crash on launch related to Core Data and Tracks [https://github.com/woocommerce/woocommerce-ios/pull/10994]
 - [*] Login: Fixed issue checking site info for some users. [https://github.com/woocommerce/woocommerce-ios/pull/11006]
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -81,7 +81,7 @@ struct CollapsibleProductRowCard: View {
             HStack {
                 Text(Localization.priceAfterDiscountLabel)
                 Spacer()
-                Text(viewModel.priceAfterDiscountLabel ?? "")
+                Text(viewModel.totalPriceAfterDiscountLabel ?? "")
             }
             .padding(.top)
             .renderedIf(viewModel.hasDiscount)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -125,7 +125,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         return priceLabelComponent + " - " + discountLabelComponent
     }
 
-    /// Formatted price label based on a product's price and quantity. Accounting for discounts, if any.
+    /// Formatted price label based on a product's price. Accounting for discounts, if any.
     /// e.g: If price is $5 and discount is $1, outputs "$4.00"
     ///
     var priceAfterDiscountLabel: String? {
@@ -138,6 +138,24 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         let priceAfterDiscount = priceDecimal.subtracting((discount ?? Decimal.zero) as NSDecimalNumber)
 
         return currencyFormatter.formatAmount(priceAfterDiscount) ?? ""
+    }
+
+    /// Formatted price label based on a product's price and quantity. Accounting for discounts, if any.
+    /// e.g: If price is $5, quantity is 10, and discount is $1, outputs "$49.00"
+    ///
+    var totalPriceAfterDiscountLabel: String? {
+        guard let price = price else {
+            return nil
+        }
+        guard let priceDecimal = currencyFormatter.convertToDecimal(price) else {
+            return nil
+        }
+        let quantityDecimal = NSDecimalNumber(decimal: quantity)
+        let subtotalDecimal = priceDecimal.multiplying(by: quantityDecimal)
+        let totalPriceAfterDiscount = subtotalDecimal.subtracting((discount ?? Decimal.zero) as NSDecimalNumber)
+
+        return currencyFormatter.formatAmount(totalPriceAfterDiscount) ?? ""
+
     }
 
     /// Formatted price label based on a product's price and quantity.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -144,17 +144,14 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// e.g: If price is $5, quantity is 10, and discount is $1, outputs "$49.00"
     ///
     var totalPriceAfterDiscountLabel: String? {
-        guard let price = price else {
+        guard let price = price,
+              let priceDecimal = currencyFormatter.convertToDecimal(price) else {
             return nil
         }
-        guard let priceDecimal = currencyFormatter.convertToDecimal(price) else {
-            return nil
-        }
-        let quantityDecimal = NSDecimalNumber(decimal: quantity)
-        let subtotalDecimal = priceDecimal.multiplying(by: quantityDecimal)
+        let subtotalDecimal = priceDecimal.multiplying(by: quantity as NSDecimalNumber)
         let totalPriceAfterDiscount = subtotalDecimal.subtracting((discount ?? Decimal.zero) as NSDecimalNumber)
 
-        return currencyFormatter.formatAmount(totalPriceAfterDiscount) ?? ""
+        return currencyFormatter.formatAmount(totalPriceAfterDiscount)
 
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -411,6 +411,30 @@ final class ProductRowViewModelTests: XCTestCase {
         assertEqual("8 × $10.71", viewModel.priceQuantityLine)
     }
 
+    func test_totalPriceAfterDiscountLabel_when_product_row_has_one_item_and_discount_then_returns_properly_formatted_price_after_discount() {
+        let price = "2.50"
+        let discount: Decimal = 0.50
+        let product = Product.fake().copy(price: price)
+
+        let viewModel = ProductRowViewModel(product: product, discount: discount, quantity: 1, canChangeQuantity: true)
+
+        assertEqual("$2.00", viewModel.totalPriceAfterDiscountLabel)
+    }
+
+    func test_totalPriceAfterDiscountLabel_when_product_row_has_multiple_item_and_discount_then_returns_properly_formatted_price_after_discount() {
+        let price = "2.50"
+        let quantity: Decimal = 10
+        let discount: Decimal = 0.50
+        let product = Product.fake().copy(price: price)
+
+        let viewModel = ProductRowViewModel(product: product,
+                                            discount: discount,
+                                            quantity: quantity,
+                                            canChangeQuantity: true)
+
+        assertEqual("$24.50", viewModel.totalPriceAfterDiscountLabel)
+    }
+
     func test_product_row_priceQuantityLine_when_product_has_no_price_then_returns_properly_formatted_priceQuantityLine() {
         // Given
         let quantity: Decimal = 8


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11015 

## Description
This PR addresses a bug in the Order Creation screen when we have an item with a discount applied to it but the `Order Count` is more than 1. The `Price after discount` row currently only shows the price after discount for 1 item, rather than multiple items, causing confusion.

| Before | After |
|--------|--------|
| <img src="https://user-images.githubusercontent.com/3812076/278190516-c56cbdff-d826-4d53-8e0b-7104a8b4436a.png"> | ![Simulator Screenshot - iPhone 15 - 2023-10-26 at 11 34 52](https://github.com/woocommerce/woocommerce-ios/assets/3812076/fb24e1ed-d73d-4101-b177-b546c5f18911) | 

## Testing instructions
- Go to `Orders` > `+` > Add a Product to your order
- Tap on the chevron to expand the product row, tap on `+Add discount`
- Enter a value, and `Add` (please note that there are known bugs with discounts, like being able to add discounts higher than the value of the item).
- Observe that now in Order Creation, if the quantity of the product is increased or decreased via `+` and `-` buttons, we have the correct `Price after discount` being displayed, since takes into account how many products are there, but applies an unique discount to the product row.

| 1 item | More than 1 item |
|--------|--------|
|![Simulator Screenshot - iPhone 15 - 2023-10-26 at 11 34 29](https://github.com/woocommerce/woocommerce-ios/assets/3812076/d5ce089a-25ad-450c-8f38-56fc1e930a42)|![Simulator Screenshot - iPhone 15 - 2023-10-26 at 11 34 52](https://github.com/woocommerce/woocommerce-ios/assets/3812076/fb24e1ed-d73d-4101-b177-b546c5f18911)| 

