### PR TITLE
Move existing tests back to `ProductRowViewModelTests` from merge conflict

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -421,25 +421,55 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // Then
         assertEqual("8 × -", viewModel.priceQuantityLine)
+    }
 
-        // MARK: - `isConfigurable`
+    // MARK: - `isConfigurable`
 
-        func test_isConfigurable_is_false_for_bundle_product_when_feature_flag_is_disabled() {
+    func test_isConfigurable_is_false_for_bundle_product_when_feature_flag_is_disabled() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundlesInOrderForm: false))
+
+        // Then
+        XCTAssertFalse(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_is_false_for_bundle_product_with_empty_bundle_items() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle")
+
+        // When
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
+
+        // Then
+        XCTAssertFalse(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_is_true_for_bundle_product_with_bundle_items() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: "bundle", bundledItems: [.fake()])
+
+        // When
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: false,
+                                            featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
+
+        // Then
+        XCTAssertTrue(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_is_false_for_non_bundle_product() {
+        let nonBundleProductTypes: [ProductType] = [.simple, .grouped, .affiliate, .variable, .subscription, .variableSubscription, .composite]
+
+        nonBundleProductTypes.forEach { nonBundleProductType in
             // Given
-            let product = Product.fake().copy(productTypeKey: "bundle")
-
-            // When
-            let viewModel = ProductRowViewModel(product: product,
-                                                canChangeQuantity: false,
-                                                featureFlagService: createFeatureFlagService(productBundlesInOrderForm: false))
-
-            // Then
-            XCTAssertFalse(viewModel.isConfigurable)
-        }
-
-        func test_isConfigurable_is_false_for_bundle_product_with_empty_bundle_items() {
-            // Given
-            let product = Product.fake().copy(productTypeKey: "bundle")
+            let product = Product.fake().copy(productTypeKey: nonBundleProductType.rawValue)
 
             // When
             let viewModel = ProductRowViewModel(product: product,
@@ -448,36 +478,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
             // Then
             XCTAssertFalse(viewModel.isConfigurable)
-        }
-
-        func test_isConfigurable_is_true_for_bundle_product_with_bundle_items() {
-            // Given
-            let product = Product.fake().copy(productTypeKey: "bundle", bundledItems: [.fake()])
-
-            // When
-            let viewModel = ProductRowViewModel(product: product,
-                                                canChangeQuantity: false,
-                                                featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
-
-            // Then
-            XCTAssertTrue(viewModel.isConfigurable)
-        }
-
-        func test_isConfigurable_is_false_for_non_bundle_product() {
-            let nonBundleProductTypes: [ProductType] = [.simple, .grouped, .affiliate, .variable, .subscription, .variableSubscription, .composite]
-
-            nonBundleProductTypes.forEach { nonBundleProductType in
-                // Given
-                let product = Product.fake().copy(productTypeKey: nonBundleProductType.rawValue)
-
-                // When
-                let viewModel = ProductRowViewModel(product: product,
-                                                    canChangeQuantity: false,
-                                                    featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
-
-                // Then
-                XCTAssertFalse(viewModel.isConfigurable)
-            }
         }
     }
 }


### PR DESCRIPTION
## Description

When merging trunk into a different PR, a closing bracket seem to have moved, making some Unit Tests to be part of another unit test which is unrelated. 

This happened between https://github.com/woocommerce/woocommerce-ios/pull/11001/commits/f9ce0fedf294fd8ef3eecea59b8415a9161f6ea4 and https://github.com/woocommerce/woocommerce-ios/pull/11001/commits/8b7304a6a11d921387a3ae4659fe9531a1753217 when fixing the merge conflicts.

This PR just moves the affected tests back into the `ProductRowViewModelTests: XCTestCase` class.

## Testing instructions
CI should pass
