### PR TITLE
Blaze: Simplify property name for entry point source

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -100,8 +100,8 @@ extension BlazeSource {
             return "product_more_menu"
         case .campaignList:
             return "campaign_list"
-        case .myStoreSectionCreateCampaignButton:
-            return "my_store_section_create_campaign_button"
+        case .myStoreSection:
+            return "my_store_section"
         case .introView:
             return "intro_view"
         }

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -11,7 +11,7 @@ enum BlazeSource {
     /// From the Blaze intro view
     case introView
     /// From the Create campaign button on the Blaze section of the My Store screen
-    case myStoreSectionCreateCampaignButton
+    case myStoreSection
 }
 
 /// View model for Blaze webview.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -21,7 +21,7 @@ final class BlazeCampaignDashboardViewHostingController: SelfSizingHostingContro
         }
 
         rootView.createCampaignTapped = { [weak self] in
-            self?.navigateToCampaignCreation(source: .myStoreSectionCreateCampaignButton)
+            self?.navigateToCampaignCreation(source: .myStoreSection)
         }
 
         rootView.startCampaignFromIntroTapped = { [weak self] productID in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -235,7 +235,7 @@ private extension BlazeCampaignDashboardViewModel {
             .removeDuplicates()
             .filter { $0 == true }
             .sink { [weak self] _ in
-                self?.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .myStoreSectionCreateCampaignButton))
+                self?.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .myStoreSection))
             }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to #10966 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Following the discussion p1698306691320859/1697610271.360359-slack-C03L1NF1EA3 - this PR updates the Blaze source  `my_store_section_create_campaign_button ` to `my_store_section` for simplicty.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in as an admin to a site that has at least a Blaze campaign created before (to avoid the intro screen).
- Notice the Blaze section on the My Store screen. Confirm that `blaze_entry_point_displayed` is tracked with source `my_store_section`.
- Tap the Create campaign. Notice that both `blaze_entry_point_tapped` and `blaze_flow_started` are tracked with source `my_store_section`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.