### PR TITLE
Product Creation AI: Identify language in package flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+AddProductFromImage.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+AddProductFromImage.swift
@@ -43,6 +43,29 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .addProductFromImageScanFailed, properties: [Key.source: source.analyticsValue], error: error)
         }
 
+        /// Tracked when AI identifies a language from scanned text of an image..
+        /// - Parameters:
+        ///   - source: Entry point to product creation.
+        ///   - language: Language detected in the text by AI.
+        ///
+        static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .identifyLanguageSuccess,
+                              properties: [
+                                Key.source: Constants.productDetailsFromScannedTextsSource,
+                                Key.language: identifiedLanguage
+                              ])
+        }
+
+        /// Tracked when AI fails to identify a language from scanned text of an image..
+        /// - Parameters:
+        ///   - error: Detail of the failure.
+        ///
+        static func identifyLanguageFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .identifyLanguageFailed,
+                              properties: [Key.source: Constants.productDetailsFromScannedTextsSource],
+                              error: error)
+        }
+
         /// Tracked when product details are generated from the scanned text of an image.
         /// - Parameters:
         ///   - source: Entry point to product creation.
@@ -87,5 +110,11 @@ extension WooAnalyticsEvent {
                 Key.hasGeneratedDetails: hasGeneratedDetails
             ])
         }
+    }
+}
+
+private extension WooAnalyticsEvent.AddProductFromImage {
+    enum Constants {
+        static let productDetailsFromScannedTextsSource = "product_details_from_scanned_texts"
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+AddProductFromImage.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+AddProductFromImage.swift
@@ -43,10 +43,9 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .addProductFromImageScanFailed, properties: [Key.source: source.analyticsValue], error: error)
         }
 
-        /// Tracked when AI identifies a language from scanned text of an image..
+        /// Tracked when AI identifies a language from scanned text of an image.
         /// - Parameters:
-        ///   - source: Entry point to product creation.
-        ///   - language: Language detected in the text by AI.
+        ///   - identifiedLanguage: Language detected in the text by AI.
         ///
         static func identifiedLanguage(_ identifiedLanguage: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .identifyLanguageSuccess,
@@ -56,7 +55,7 @@ extension WooAnalyticsEvent {
                               ])
         }
 
-        /// Tracked when AI fails to identify a language from scanned text of an image..
+        /// Tracked when AI fails to identify a language from scanned text of an image.
         /// - Parameters:
         ///   - error: Detail of the failure.
         ///

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -159,6 +159,7 @@ private extension AddProductFromImageViewModel {
         // Reset scanned texts and generated content from previous image
         scannedTexts = []
         [nameViewModel, descriptionViewModel].forEach { $0.reset() }
+        languageIdentifiedUsingAI = nil
         textDetectionErrorMessage = nil
 
         Task { @MainActor in

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModel.swift
@@ -78,7 +78,7 @@ final class AddProductFromImageViewModel: ObservableObject {
     private let imageTextScanner: ImageTextScannerProtocol
     private let analytics: Analytics
 
-    /// Language used in product identified by AI
+    /// Language used in the scanned texts
     ///
     private var languageIdentifiedUsingAI: String?
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -92,7 +92,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let imageTextScanner = MockImageTextScanner(result: .success(["test"]))
-        mockGenerateProductDetails(result: .success(.init(name: "Name", description: "Desc", language: "en")))
+        mockGenerateProductDetails(result: .success(.init(name: "Name", description: "Desc")))
         let viewModel = AddProductFromImageViewModel(siteID: 6,
                                                      source: .productsTab,
                                                      productName: nil,
@@ -143,7 +143,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.textGenerationErrorMessage)
 
         // When regenerating product details with success
-        mockGenerateProductDetails(result: .success(.init(name: "", description: "", language: "")))
+        mockGenerateProductDetails(result: .success(.init(name: "", description: "")))
         viewModel.generateProductDetails()
 
         // Then `textGenerationErrorMessage` is reset
@@ -182,11 +182,15 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         })
 
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            guard case let .generateProductDetails(_, _, scannedTexts, _) = action else {
+            switch action {
+            case let .generateProductDetails(_, _, scannedTexts, _, _):
+                // Then
+                XCTAssertEqual(scannedTexts, ["Product"])
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success("en"))
+            default:
                 return XCTFail("Unexpected action: \(action)")
             }
-            // Then
-            XCTAssertEqual(scannedTexts, ["Product"])
         }
 
         // When
@@ -207,8 +211,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         var imageToReturn: MediaPickerImage? = firstImage
         let imageTextScanner = MockImageTextScanner(result: .success(["test"]))
         mockGenerateProductDetails(result: .success(.init(name: "Name",
-                                                          description: "Desc",
-                                                          language: "en")))
+                                                          description: "Desc")))
         let viewModel = AddProductFromImageViewModel(siteID: 123,
                                                      source: .productsTab,
                                                      productName: nil,
@@ -424,7 +427,7 @@ final class AddProductFromImageViewModelTests: XCTestCase {
         // Given
         let image = MediaPickerImage(image: .init(), source: .media(media: .fake()))
         let imageTextScanner = MockImageTextScanner(result: .success(["test"]))
-        mockGenerateProductDetails(result: .success(.init(name: "Name", description: "Desc", language: "en")))
+        mockGenerateProductDetails(result: .success(.init(name: "Name", description: "Desc")))
         let viewModel = AddProductFromImageViewModel(siteID: 6,
                                                      source: .productsTab,
                                                      productName: nil,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageViewModelTests.swift
@@ -548,12 +548,17 @@ final class AddProductFromImageViewModelTests: XCTestCase {
 }
 
 private extension AddProductFromImageViewModelTests {
-    func mockGenerateProductDetails(result: Result<ProductDetailsFromScannedTexts, Error>) {
+    func mockGenerateProductDetails(result: Result<ProductDetailsFromScannedTexts, Error>,
+                                    identifyLanguageResult: Result<String, Error> = .success("en")) {
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            guard case let .generateProductDetails(_, _, _, completion) = action else {
+            switch action {
+            case let .generateProductDetails(_, _, _, _, completion):
+                completion(result)
+            case let .identifyLanguage(_, _, _, completion):
+                completion(identifyLanguageResult)
+            default:
                 return XCTFail("Unexpected action: \(action)")
             }
-            completion(result)
         }
     }
 }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -154,6 +154,7 @@ public enum ProductAction: Action {
     case generateProductDetails(siteID: Int64,
                                 productName: String?,
                                 scannedTexts: [String],
+                                language: String,
                                 completion: (Result<ProductDetailsFromScannedTexts, Error>) -> Void)
 
     /// Fetches the total number of products in the site given the site ID.

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -130,8 +130,8 @@ public class ProductStore: Store {
             generateProductSharingMessage(siteID: siteID, url: url, name: name, description: description, language: language, completion: completion)
         case let .generateProductName(siteID, keywords, language, completion):
             generateProductName(siteID: siteID, keywords: keywords, language: language, completion: completion)
-        case let .generateProductDetails(siteID, productName, scannedTexts, completion):
-            generateProductDetails(siteID: siteID, productName: productName, scannedTexts: scannedTexts, completion: completion)
+        case let .generateProductDetails(siteID, productName, scannedTexts, language, completion):
+            generateProductDetails(siteID: siteID, productName: productName, scannedTexts: scannedTexts, language: language, completion: completion)
         case let .fetchNumberOfProducts(siteID, completion):
             fetchNumberOfProducts(siteID: siteID, completion: completion)
         case let .generateAIProduct(siteID,
@@ -632,6 +632,7 @@ private extension ProductStore {
     func generateProductDetails(siteID: Int64,
                                 productName: String?,
                                 scannedTexts: [String],
+                                language: String,
                                 completion: @escaping (Result<ProductDetailsFromScannedTexts, Error>) -> Void) {
         let keywords: [String] = {
             guard let productName else {

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -645,6 +645,7 @@ private extension ProductStore {
             "Return only a JSON dictionary with the name in `name` field, description in `description` field, " +
             "and the detected language as the locale identifier in `language` field.",
             "The output should be in valid JSON format.",
+            "The output should be in language \(language).",
             "Detect the language in the array and use the same language to write the name and description.",
             "Make the description 50-60 words or less.",
             "Use a 9th grade reading level.",

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -645,7 +645,6 @@ private extension ProductStore {
             "Return only a JSON dictionary with the name in `name` field, description in `description` field.",
             "The output should be in valid JSON format.",
             "The output should be in language \(language).",
-            "Detect the language in the array and use the same language to write the name and description.",
             "Make the description 50-60 words or less.",
             "Use a 9th grade reading level.",
             "Perform in-depth keyword research relating to the product in the same language of the product title, " +

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -642,8 +642,7 @@ private extension ProductStore {
         }()
         let prompt = [
             "Write a name and description of a product for an online store given the keywords at the end.",
-            "Return only a JSON dictionary with the name in `name` field, description in `description` field, " +
-            "and the detected language as the locale identifier in `language` field.",
+            "Return only a JSON dictionary with the name in `name` field, description in `description` field.",
             "The output should be in valid JSON format.",
             "The output should be in language \(language).",
             "Detect the language in the array and use the same language to write the name and description.",
@@ -660,7 +659,7 @@ private extension ProductStore {
                     return completion(.failure(DotcomError.resourceDoesNotExist))
                 }
                 let details = try JSONDecoder().decode(ProductDetailsFromScannedTexts.self, from: jsonData)
-                completion(.success(.init(name: details.name, description: details.description, language: details.language)))
+                completion(.success(.init(name: details.name, description: details.description)))
             } catch {
                 completion(.failure(error))
             }
@@ -1243,13 +1242,10 @@ public struct ProductDetailsFromScannedTexts: Equatable, Decodable {
     public let name: String
     /// Product description.
     public let description: String
-    /// The language code detected for the product.
-    public let language: String
 
-    public init(name: String, description: String, language: String) {
+    public init(name: String, description: String) {
         self.name = name
         self.description = description
-        self.language = language
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -2328,7 +2328,8 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: nil,
-                                                                       scannedTexts: [""]) { result in
+                                                                       scannedTexts: [""],
+                                                                       language: "en") { result in
                 promise(result)
             })
         }
@@ -2336,8 +2337,7 @@ final class ProductStoreTests: XCTestCase {
         // Then
         let productDetails = try XCTUnwrap(result.get())
         XCTAssertEqual(productDetails, .init(name: "Cheese and Garlic Croutons",
-                                             description: "Enhance your salads.",
-                                             language: "en"))
+                                             description: "Enhance your salads."))
     }
 
     func test_generateProductDetails_returns_error_on_failure() throws {
@@ -2354,7 +2354,8 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: nil,
-                                                                       scannedTexts: [""]) { result in
+                                                                       scannedTexts: [""],
+                                                                       language: "en") { result in
                 promise(result)
             })
         }
@@ -2368,6 +2369,7 @@ final class ProductStoreTests: XCTestCase {
         // Given
         let scannedTexts = ["onion", "chives"]
         let productName = "food"
+        let language = "en"
         let generativeContentRemote = MockGenerativeContentRemote()
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
         let productStore = ProductStore(dispatcher: dispatcher,
@@ -2380,7 +2382,8 @@ final class ProductStoreTests: XCTestCase {
         waitFor { promise in
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: productName,
-                                                                       scannedTexts: scannedTexts) { _ in
+                                                                       scannedTexts: scannedTexts,
+                                                                       language: language) { _ in
                 promise(())
             })
         }
@@ -2389,6 +2392,7 @@ final class ProductStoreTests: XCTestCase {
         let base = try XCTUnwrap(generativeContentRemote.generateTextBase)
         let combinedKeywords = scannedTexts + [productName]
         XCTAssertTrue(base.contains("\(combinedKeywords)"))
+        XCTAssertTrue(base.contains("\(language)"))
     }
 
     func test_generateProductDetails_uses_correct_feature() throws {
@@ -2405,7 +2409,8 @@ final class ProductStoreTests: XCTestCase {
         waitFor { promise in
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: nil,
-                                                                       scannedTexts: [""]) { _ in
+                                                                       scannedTexts: [""],
+                                                                       language: "en") { _ in
                 promise(())
             })
         }


### PR DESCRIPTION
Closes: #11017

## Description

To make sure that language is identified properly from the scanned texts we are sending a separate request to identify language. 

## Testing instructions

Follow instructions from #10812 and smoke test that the package flow works as before. 

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/094f81c0-de06-413d-9872-10f969cf4dd5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.