### PR TITLE
[TTPUK] Remove Set Up button from About TTP screen after set up flow run from about screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Orders: Fixed UI issue where an incorrect tooltip is displayed during Order Creation [https://github.com/woocommerce/woocommerce-ios/pull/10998]
 - [*] Fix a crash on launch related to Core Data and Tracks [https://github.com/woocommerce/woocommerce-ios/pull/10994]
 - [*] Login: Fixed issue checking site info for some users. [https://github.com/woocommerce/woocommerce-ios/pull/11006]
+- [*] Payments: hide the `Set up Tap to Pay` button in About Tap to Pay when set up is complete [https://github.com/woocommerce/woocommerce-ios/pull/11025]
 
 15.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import UIKit
 
 final class PaymentSettingsFlowPresentingViewController: UIViewController {
@@ -78,6 +79,17 @@ private extension PaymentSettingsFlowPresentingViewController {
 
 // MARK: - SwiftUI compatibility
 //
+struct PaymentSettingsFlowPresentingView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = PaymentSettingsFlowPresentingViewController
+    let viewModelsAndViews: PaymentSettingsFlowPrioritizedViewModelsProvider
+
+    func makeUIViewController(context: Context) -> PaymentSettingsFlowPresentingViewController {
+        let viewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: PaymentSettingsFlowPresentingViewController, context: Context) {}
+}
 
 // MARK: - Localization
 //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -91,7 +91,7 @@ struct SetUpTapToPayCompleteView: View {
         }
         .padding()
         .sheet(isPresented: $showingAboutTapToPay) {
-            AboutTapToPayViewInNavigationView()
+            AboutTapToPayViewInNavigationView(viewModel: AboutTapToPayViewModel())
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -91,7 +91,7 @@ struct SetUpTapToPayCompleteView: View {
         }
         .padding()
         .sheet(isPresented: $showingAboutTapToPay) {
-            AboutTapToPayViewInNavigationView(viewModel: AboutTapToPayViewModel())
+            AboutTapToPayViewInNavigationView(viewModel: AboutTapToPayViewModel(shouldAlwaysHideSetUpTapToPayButton: true))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -133,7 +133,7 @@ struct SetUpTapToPayInformationView: View {
         .padding()
         .onAppear(perform: viewModel.viewDidAppear)
         .sheet(isPresented: $showingAboutTapToPay) {
-            AboutTapToPayViewInNavigationView(viewModel: AboutTapToPayViewModel())
+            AboutTapToPayViewInNavigationView(viewModel: AboutTapToPayViewModel(shouldAlwaysHideSetUpTapToPayButton: true))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -133,7 +133,7 @@ struct SetUpTapToPayInformationView: View {
         .padding()
         .onAppear(perform: viewModel.viewDidAppear)
         .sheet(isPresented: $showingAboutTapToPay) {
-            AboutTapToPayViewInNavigationView()
+            AboutTapToPayViewInNavigationView(viewModel: AboutTapToPayViewModel())
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -47,7 +47,7 @@ final class SetUpTapToPayTryPaymentPromptViewController: UIHostingController<Set
 struct SetUpTapToPayPaymentPromptView: View {
     @ObservedObject var viewModel: SetUpTapToPayTryPaymentPromptViewModel
     @State var paymentFlowFinished: Bool = false
-    
+
     weak var rootViewController: UIViewController?
 
     @Environment(\.verticalSizeClass) var verticalSizeClass

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -86,8 +86,7 @@ struct AboutTapToPayView_Previews: PreviewProvider {
             AboutTapToPayView(viewModel: AboutTapToPayViewModel(
                 siteID: 123,
                 configuration: .init(country: .GB),
-                cardReaderSupportDeterminer: nil,
-                buttonAction: { }))
+                cardReaderSupportDeterminer: nil))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -5,6 +5,7 @@ import WooFoundation
 struct AboutTapToPayView: View {
     @ObservedObject var viewModel: AboutTapToPayViewModel
     @State private var showingWebView: Bool = false
+    @State private var showingSetUpFlow: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -45,7 +46,7 @@ struct AboutTapToPayView: View {
 
             VStack(alignment: .leading, spacing: Layout.spacing) {
                 Button(Localization.setUpTapToPayOnIPhoneButtonTitle) {
-                    viewModel.callToActionTapped()
+                    showingSetUpFlow = true
                 }
                 .buttonStyle(PrimaryButtonStyle())
 
@@ -57,6 +58,18 @@ struct AboutTapToPayView: View {
             .padding()
             .renderedIf(viewModel.shouldShowButton)
         }
+        .sheet(isPresented: $showingSetUpFlow,
+               onDismiss: viewModel.setUpFlowDismissed,
+               content: {
+            NavigationView {
+                PaymentSettingsFlowPresentingView(
+                    viewModelsAndViews: SetUpTapToPayViewModelsOrderedList(
+                        siteID: viewModel.siteID,
+                        configuration: viewModel.configuration,
+                        onboardingUseCase: viewModel.cardPresentPaymentsOnboardingUseCase))
+                .navigationBarHidden(true)
+            }
+        })
         .sheet(isPresented: $showingWebView) {
             WebViewSheet(viewModel: viewModel.webViewModel) {
                 showingWebView = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -207,7 +207,7 @@ private extension AboutTapToPayContactlessLimitView {
 
 struct AboutTapToPayViewInNavigationView: View {
     @Environment(\.dismiss) var dismiss
-    let viewModel: AboutTapToPayViewModel = AboutTapToPayViewModel()
+    let viewModel: AboutTapToPayViewModel
 
     var body: some View {
         NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -3,9 +3,7 @@ import Yosemite
 import WooFoundation
 
 struct AboutTapToPayView: View {
-    @ObservedObject var viewModel: AboutTapToPayViewModel = AboutTapToPayViewModel(
-        configuration: CardPresentConfigurationLoader().configuration,
-        buttonAction: nil)
+    @ObservedObject var viewModel: AboutTapToPayViewModel
     @State private var showingWebView: Bool = false
 
     var body: some View {
@@ -73,7 +71,9 @@ struct AboutTapToPayView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             AboutTapToPayView(viewModel: AboutTapToPayViewModel(
+                siteID: 123,
                 configuration: .init(country: .GB),
+                cardReaderSupportDeterminer: nil,
                 buttonAction: { }))
         }
     }
@@ -195,10 +195,11 @@ private extension AboutTapToPayContactlessLimitView {
 
 struct AboutTapToPayViewInNavigationView: View {
     @Environment(\.dismiss) var dismiss
+    let viewModel: AboutTapToPayViewModel = AboutTapToPayViewModel()
 
     var body: some View {
         NavigationView {
-            AboutTapToPayView()
+            AboutTapToPayView(viewModel: viewModel)
             .toolbar() {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Localization.doneButton) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -20,14 +20,24 @@ class AboutTapToPayViewModel: ObservableObject {
 
     let formattedMinimumOperatingSystemVersionForTapToPay: String
 
-    var cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase()
+    let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
 
     init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
-         cardReaderSupportDeterminer: CardReaderSupportDetermining? = nil) {
+         cardReaderSupportDeterminer: CardReaderSupportDetermining? = nil,
+         cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase? = nil) {
         self.siteID = siteID
         self.configuration = configuration
         self.cardReaderSupportDeterminer = cardReaderSupportDeterminer ?? CardReaderSupportDeterminer(siteID: siteID, configuration: configuration)
+
+        if let cardPresentPaymentsOnboardingUseCase {
+            self.cardPresentPaymentsOnboardingUseCase = cardPresentPaymentsOnboardingUseCase
+        } else {
+            let onboardingUseCase = CardPresentPaymentsOnboardingUseCase()
+            self.cardPresentPaymentsOnboardingUseCase = onboardingUseCase
+            self.cardPresentPaymentsOnboardingUseCase.refresh()
+        }
+
         shouldShowContactlessLimit = configuration.contactlessLimitAmount != nil
         self.formattedMinimumOperatingSystemVersionForTapToPay = configuration.minimumOperatingSystemVersionForTapToPay.localizedFormattedString
         refreshButtonVisibility()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -5,7 +5,6 @@ import WooFoundation
 class AboutTapToPayViewModel: ObservableObject {
     let configuration: CardPresentPaymentsConfiguration
     private let cardReaderSupportDeterminer: CardReaderSupportDetermining
-    private let buttonAction: (() -> Void)?
 
     @Published var shouldShowContactlessLimit: Bool = false
     @Published var shouldShowButton: Bool = false
@@ -25,19 +24,13 @@ class AboutTapToPayViewModel: ObservableObject {
 
     init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
-         cardReaderSupportDeterminer: CardReaderSupportDetermining? = nil,
-         buttonAction: (() -> Void)? = nil) {
+         cardReaderSupportDeterminer: CardReaderSupportDetermining? = nil) {
         self.siteID = siteID
         self.configuration = configuration
         self.cardReaderSupportDeterminer = cardReaderSupportDeterminer ?? CardReaderSupportDeterminer(siteID: siteID, configuration: configuration)
-        self.buttonAction = buttonAction
-        shouldShowButton = buttonAction != nil
         shouldShowContactlessLimit = configuration.contactlessLimitAmount != nil
         self.formattedMinimumOperatingSystemVersionForTapToPay = configuration.minimumOperatingSystemVersionForTapToPay.localizedFormattedString
-    }
-
-    func callToActionTapped() {
-        buttonAction?()
+        refreshButtonVisibility()
     }
 
     func setUpFlowDismissed() {
@@ -47,7 +40,7 @@ class AboutTapToPayViewModel: ObservableObject {
     private func refreshButtonVisibility() {
         Task { @MainActor in
             let hasTapToPayUsage = await cardReaderSupportDeterminer.hasPreviousTapToPayUsage()
-            shouldShowButton = !hasTapToPayUsage && buttonAction != nil
+            shouldShowButton = !hasTapToPayUsage
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -22,10 +22,13 @@ class AboutTapToPayViewModel: ObservableObject {
 
     let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
 
+    let shouldAlwaysHideSetUpTapToPayButton: Bool
+
     init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
          cardReaderSupportDeterminer: CardReaderSupportDetermining? = nil,
-         cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase? = nil) {
+         cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase? = nil,
+         shouldAlwaysHideSetUpTapToPayButton: Bool = false) {
         self.siteID = siteID
         self.configuration = configuration
         self.cardReaderSupportDeterminer = cardReaderSupportDeterminer ?? CardReaderSupportDeterminer(siteID: siteID, configuration: configuration)
@@ -38,6 +41,7 @@ class AboutTapToPayViewModel: ObservableObject {
             self.cardPresentPaymentsOnboardingUseCase.refresh()
         }
 
+        self.shouldAlwaysHideSetUpTapToPayButton = shouldAlwaysHideSetUpTapToPayButton
         shouldShowContactlessLimit = configuration.contactlessLimitAmount != nil
         self.formattedMinimumOperatingSystemVersionForTapToPay = configuration.minimumOperatingSystemVersionForTapToPay.localizedFormattedString
         refreshButtonVisibility()
@@ -48,6 +52,10 @@ class AboutTapToPayViewModel: ObservableObject {
     }
 
     private func refreshButtonVisibility() {
+        guard !shouldAlwaysHideSetUpTapToPayButton else {
+            return shouldShowButton = false
+        }
+
         Task { @MainActor in
             let hasTapToPayUsage = await cardReaderSupportDeterminer.hasPreviousTapToPayUsage()
             shouldShowButton = !hasTapToPayUsage

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -557,8 +557,10 @@ extension InPersonPaymentsMenuViewController {
     func aboutTapToPayOnIPhoneWasPressed() {
         ServiceLocator.analytics.track(.aboutTapToPayOnIPhoneTapped)
         let hostingController = UIHostingController(
-            rootView: AboutTapToPayView(viewModel: AboutTapToPayViewModel(
-                    configuration: viewModel.cardPresentPaymentsConfiguration))
+            rootView: AboutTapToPayView(
+                viewModel: AboutTapToPayViewModel(
+                    configuration: viewModel.cardPresentPaymentsConfiguration,
+                    cardPresentPaymentsOnboardingUseCase: cardPresentPaymentsOnboardingUseCase))
         )
         show(hostingController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -540,11 +540,18 @@ extension InPersonPaymentsMenuViewController {
         let viewModelsAndViews = SetUpTapToPayViewModelsOrderedList(siteID: siteID,
                                                                     configuration: viewModel.cardPresentPaymentsConfiguration,
                                                                     onboardingUseCase: cardPresentPaymentsOnboardingUseCase)
-        let setUpTapToPayViewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
-        let controller = WooNavigationController(rootViewController: setUpTapToPayViewController)
-        controller.navigationBar.isHidden = true
 
-        navigationController?.present(controller, animated: true)
+        /// OK, so it's strange to host a UIViewControllerRepresentable in a UIHostingController from a UIKit context.
+        /// Why not simply present the UIViewController directly?
+        /// It's so we can use NavigationView from this context and from the AboutTapToPayView, which also presents it.
+        /// With a mix of navigation controllers, there's loads of complexity getting the toolbar hiding to work properly.
+        /// We should probably make a SwiftUI version of the flow view at some point.
+        let hostingController = UIHostingController(
+            rootView: NavigationView {
+                PaymentSettingsFlowPresentingView(viewModelsAndViews: viewModelsAndViews)
+                    .navigationBarHidden(true)
+            })
+        navigationController?.present(hostingController, animated: true)
     }
 
     func aboutTapToPayOnIPhoneWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -549,11 +549,9 @@ extension InPersonPaymentsMenuViewController {
 
     func aboutTapToPayOnIPhoneWasPressed() {
         ServiceLocator.analytics.track(.aboutTapToPayOnIPhoneTapped)
-        let buttonAction = viewModel.shouldShowSetUpTapToPayOnAboutScreen ? setUpTapToPayOnIPhoneWasPressed : nil
         let hostingController = UIHostingController(
             rootView: AboutTapToPayView(viewModel: AboutTapToPayViewModel(
-                    configuration: viewModel.cardPresentPaymentsConfiguration,
-                    buttonAction: buttonAction))
+                    configuration: viewModel.cardPresentPaymentsConfiguration))
         )
         show(hostingController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -46,9 +46,6 @@ final class InPersonPaymentsMenuViewModel {
     @Published private(set) var depositsOverviewViewModels: [WooPaymentsDepositsCurrencyOverviewViewModel] = []
     @Published private(set) var titleForTapToPayOnIPhone: String = Localization.setUpTapToPayOnIPhoneRowTitle
 
-    // This doesn't need to be @Published right now, because it's only checked on tap.
-    private(set) var shouldShowSetUpTapToPayOnAboutScreen: Bool = true
-
     let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     init(dependencies: Dependencies = Dependencies(),
@@ -121,10 +118,8 @@ final class InPersonPaymentsMenuViewModel {
             switch firstTapToPayTransactionDate {
             case .none:
                 self.titleForTapToPayOnIPhone = Localization.setUpTapToPayOnIPhoneRowTitle
-                self.shouldShowSetUpTapToPayOnAboutScreen = true
             case .some:
                 self.titleForTapToPayOnIPhone = Localization.tryOutTapToPayOnIPhoneRowTitle
-                self.shouldShowSetUpTapToPayOnAboutScreen = false
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import UIKit
 import Yosemite
 
@@ -298,4 +299,19 @@ private enum State {
     case loading
     case success(order: Order)
     case failure
+}
+
+// MARK: - SwiftUI Compatibility
+//
+struct OrderLoaderView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = OrderLoaderViewController
+    let orderID: Int64
+    let siteID: Int64
+
+    func makeUIViewController(context: Context) -> OrderLoaderViewController {
+        OrderLoaderViewController(orderID: orderID,
+                                  siteID: siteID)
+    }
+
+    func updateUIViewController(_ uiViewController: OrderLoaderViewController, context: Context) {}
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11009 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Follows on from #11014, addressing the following:

> Note that this PR only removes the button for subsequent opens of the About screen – if setup is started from the About screen, the button does not get removed when the order view is dismissed. I'll tackle that in a subsequent PR

This PR makes quite substantial changes, all focused around getting a signal from the Set Up flow to the About TTP screen, saying that it's done.

When the About TTP screen gets that, it calls `viewModel.setUpFlowDismissed`, which refreshes the button visibility, hiding it.

It's a bit of a long winded way of doing it, but it has made the flow a bit more flexible should we decide to use it anywhere else, particularly from SwiftUI. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Delete the app from your phone
2. Build and run from Xcode
3. Log in and select a UK or US based Woo Payments store
4. Navigate to `Menu > Payments > About Tap to Pay`
5. Tap the `Set up Tap to Pay on iPhone` button on this screen
6. Go through the flow and take a test payment
7. Dismiss the order
8. Observe that the `Set up Tap to Pay on iPhone` button is not shown.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/4a02b0ea-d9a8-4ac3-81cd-419dba63b139


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
