### PR TITLE
[Orders with Coupons] Update track events

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -126,8 +126,16 @@ struct CollapsibleProductRowCard: View {
         .cornerRadius(Layout.frameCornerRadius)
     }
 
-    private func trackEvent(_ event: WooAnalyticsEvent) {
-        ServiceLocator.analytics.track(event: event)
+
+}
+
+private extension CollapsibleProductRowCard {
+    func trackAddDiscountTapped() {
+        viewModel.analytics.track(event: .Orders.productDiscountAddButtonTapped())
+    }
+
+    func trackEditDiscountTapped() {
+        viewModel.analytics.track(event: .Orders.productDiscountEditButtonTapped())
     }
 }
 
@@ -135,7 +143,7 @@ private extension CollapsibleProductRowCard {
     @ViewBuilder var discountRow: some View {
         if !viewModel.hasDiscount || shouldDisallowDiscounts {
             Button(Localization.addDiscountLabel) {
-                trackEvent(.Orders.productDiscountAddButtonTapped())
+                trackAddDiscountTapped()
                 onAddDiscount()
             }
             .buttonStyle(PlusButtonStyle())
@@ -143,7 +151,7 @@ private extension CollapsibleProductRowCard {
         } else {
             HStack {
                 Button(action: {
-                    trackEvent(.Orders.productDiscountEditButtonTapped())
+                    trackEditDiscountTapped()
                     onAddDiscount()
                 }, label: {
                     HStack {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -131,11 +131,11 @@ struct CollapsibleProductRowCard: View {
 
 private extension CollapsibleProductRowCard {
     func trackAddDiscountTapped() {
-        viewModel.analytics.track(event: .Orders.productDiscountAddButtonTapped())
+        viewModel.trackAddDiscountTapped()
     }
 
     func trackEditDiscountTapped() {
-        viewModel.analytics.track(event: .Orders.productDiscountEditButtonTapped())
+        viewModel.trackEditDiscountTapped()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -125,12 +125,17 @@ struct CollapsibleProductRowCard: View {
         }
         .cornerRadius(Layout.frameCornerRadius)
     }
+
+    private func trackEvent(_ event: WooAnalyticsEvent) {
+        ServiceLocator.analytics.track(event: event)
+    }
 }
 
 private extension CollapsibleProductRowCard {
     @ViewBuilder var discountRow: some View {
         if !viewModel.hasDiscount || shouldDisallowDiscounts {
             Button(Localization.addDiscountLabel) {
+                trackEvent(.Orders.productDiscountAddButtonTapped())
                 onAddDiscount()
             }
             .buttonStyle(PlusButtonStyle())
@@ -138,6 +143,7 @@ private extension CollapsibleProductRowCard {
         } else {
             HStack {
                 Button(action: {
+                    trackEvent(.Orders.productDiscountEditButtonTapped())
                     onAddDiscount()
                 }, label: {
                     HStack {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModel.swift
@@ -80,7 +80,7 @@ final class ProductInOrderViewModel: Identifiable, ObservableObject {
     }()
 
     func onAddDiscountTapped() {
-        analytics.track(event: .Orders.productDiscountAddButtonTapped())
+        analytics.track(event: .Orders.productDiscountAdd(type: discountDetailsViewModel.feeOrDiscountType ))
     }
 
     func onEditDiscountTapped() {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -479,6 +479,14 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
         quantityUpdatedCallback(quantity)
     }
+
+    func trackAddDiscountTapped() {
+        analytics.track(event: .Orders.productDiscountAddButtonTapped())
+    }
+
+    func trackEditDiscountTapped() {
+        analytics.track(event: .Orders.productDiscountEditButtonTapped())
+    }
 }
 
 private extension ProductRowViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -243,6 +243,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     let selectedState: ProductRow.SelectedState
 
+    /// Analytics
+    ///
+    let analytics: Analytics
+
     init(id: Int64? = nil,
          productOrVariationID: Int64,
          name: String,
@@ -260,6 +264,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          selectedState: ProductRow.SelectedState = .notSelected,
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         analytics: Analytics = ServiceLocator.analytics,
          quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
          removeProductIntent: @escaping (() -> Void) = {},
          configure: (() -> Void)? = nil) {
@@ -278,6 +283,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.imageURL = imageURL
         self.isConfigurable = isConfigurable
         self.currencyFormatter = currencyFormatter
+        self.analytics = analytics
         self.numberOfVariations = numberOfVariations
         self.variationDisplayMode = variationDisplayMode
         self.quantityUpdatedCallback = quantityUpdatedCallback
@@ -294,6 +300,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      canChangeQuantity: Bool,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                     analytics: Analytics = ServiceLocator.analytics,
                      quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
                      removeProductIntent: @escaping (() -> Void) = {},
                      featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
@@ -358,6 +365,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   selectedState: selectedState,
                   isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
+                  analytics: analytics,
                   quantityUpdatedCallback: quantityUpdatedCallback,
                   removeProductIntent: removeProductIntent,
                   configure: configure)
@@ -374,6 +382,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      displayMode: VariationDisplayMode,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                     analytics: Analytics = ServiceLocator.analytics,
                      quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
                      removeProductIntent: @escaping (() -> Void) = {}) {
         let imageURL: URL?
@@ -399,6 +408,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   selectedState: selectedState,
                   isConfigurable: false,
                   currencyFormatter: currencyFormatter,
+                  analytics: analytics,
                   quantityUpdatedCallback: quantityUpdatedCallback,
                   removeProductIntent: removeProductIntent)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -6,6 +6,12 @@ import WooFoundation
 @testable import WooCommerce
 
 final class ProductRowViewModelTests: XCTestCase {
+    var analytics: MockAnalyticsProvider!
+
+    override func setUp() {
+        super.setUp()
+        analytics = MockAnalyticsProvider()
+    }
 
     func test_viewModel_is_created_with_correct_initial_values_from_product() {
         // Given
@@ -285,6 +291,34 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(productRemoved)
+    }
+
+    func test_productRow_when_add_discount_button_is_tapped_then_orderProductDiscountAddButtonTapped_is_tracked() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: true,
+                                            analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackAddDiscountTapped()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderProductDiscountAddButtonTapped.rawValue)
+    }
+
+    func test_productRow_when_edit_discount_button_is_tapped_then_orderProductDiscountEditButtonTapped_is_tracked() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(product: product,
+                                            canChangeQuantity: true,
+                                            analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackEditDiscountTapped()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderProductDiscountEditButtonTapped.rawValue)
     }
 
     func test_productAccessibilityLabel_is_created_with_expected_details_from_product() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModelTests.swift
@@ -24,7 +24,7 @@ final class ProductInOrderViewModelTests: XCTestCase {
         viewModel.onAddDiscountTapped()
 
         // Then
-        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderProductDiscountAddButtonTapped.rawValue)
+        XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderProductDiscountAdd.rawValue)
     }
 
     func test_onEditDiscountTapped_then_tracks_event() {


### PR DESCRIPTION
## Description
This PR updates the track events that are triggered when adding discounts to products, for parity with Android and taking into account the new designs. Previously these were tracked in the "Product in Order" screen:
<img width="433" alt="Screenshot 2023-10-27 at 11 55 46" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/4cebd575-0c8c-40bb-a145-d12bb2855427">

## Changes
- Adds track event when adding or editing a product discount
- Updates the track event when tapping on `Add` from `order_product_discount_add_button_tapped` to `order_product_discount_add`
- Inject analytics into the view model and add unit tests.

## Testing instructions
* Go to `Orders` > `+` > Add a product to an order > Tap on the chevron icon to expand the product row
* Tap on `+ Add discount`. 
  * Observe that `order_product_discount_add_button_tapped` is tracked
  * Add a discount to the product. Tap on `Add`. Observe that `order_product_discount_add` is tracked
  * Tap on `Discount (pencil)`. Observe that `order_product_discount_edit_button_tapped` is tracked

## Screenshots
| Add Discount | Add | Edit discount |
|--------|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2023-10-27 at 11 51 00](https://github.com/woocommerce/woocommerce-ios/assets/3812076/96531265-1efd-479f-8f23-b21dacda0022) | ![Simulator Screenshot - iPhone 15 - 2023-10-27 at 11 51 06](https://github.com/woocommerce/woocommerce-ios/assets/3812076/44671dec-b3f0-4cec-8ae0-f07d626211d8) | ![Simulator Screenshot - iPhone 15 - 2023-10-27 at 11 51 11](https://github.com/woocommerce/woocommerce-ios/assets/3812076/485bda07-27d2-468e-9e2a-ee68986b0609) | 
