### PR TITLE
Use default root endpoint for REST API

### DIFF
--- a/Networking/Networking/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
@@ -81,7 +81,7 @@ private extension OneTimeApplicationPasswordUseCase {
 
 private extension OneTimeApplicationPasswordUseCase {
     enum Path {
-        static let applicationPasswords = "/wp-json/wp/v2/users/me/application-passwords/"
-        static let introspect = "/wp-json/wp/v2/users/me/application-passwords/introspect"
+        static let applicationPasswords = "/?rest_route=/wp/v2/users/me/application-passwords/"
+        static let introspect = "/?rest_route=/wp/v2/users/me/application-passwords/introspect"
     }
 }

--- a/Networking/Networking/Remote/WordPressSiteRemote.swift
+++ b/Networking/Networking/Remote/WordPressSiteRemote.swift
@@ -16,6 +16,6 @@ public final class WordPressSiteRemote: Remote {
 
 private extension WordPressSiteRemote {
     enum Path {
-        static let root = "/?rest_route="
+        static let root = "/?rest_route=/"
     }
 }

--- a/Networking/Networking/Remote/WordPressSiteRemote.swift
+++ b/Networking/Networking/Remote/WordPressSiteRemote.swift
@@ -16,6 +16,6 @@ public final class WordPressSiteRemote: Remote {
 
 private extension WordPressSiteRemote {
     enum Path {
-        static let root = "/wp-json"
+        static let root = "/?rest_route="
     }
 }

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -103,6 +103,6 @@ struct RESTRequest: Request {
 
 extension RESTRequest {
     enum Settings {
-        static let basePath = "wp-json"
+        static let basePath = "?rest_route="
     }
 }

--- a/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
@@ -19,7 +19,7 @@ final class WordPressSiteRemoteTests: XCTestCase {
     ///
     func test_fetchSiteInfo_properly_returns_site() async throws {
         let remote = WordPressSiteRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=/", filename: "wordpress-site-info")
 
         // When
         let site = try await remote.fetchSiteInfo(for: sampleSiteURL)
@@ -32,7 +32,7 @@ final class WordPressSiteRemoteTests: XCTestCase {
     ///
     func test_fetchSiteInfo_properly_relays_networking_errors() async {
         let remote = WordPressSiteRemote(network: network)
-        network.simulateError(requestUrlSuffix: "?rest_route=", error: NetworkError.notFound)
+        network.simulateError(requestUrlSuffix: "?rest_route=/", error: NetworkError.notFound)
 
         // When
         var fetchError: Error?

--- a/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
@@ -19,7 +19,7 @@ final class WordPressSiteRemoteTests: XCTestCase {
     ///
     func test_fetchSiteInfo_properly_returns_site() async throws {
         let remote = WordPressSiteRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "wp-json", filename: "wordpress-site-info")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info")
 
         // When
         let site = try await remote.fetchSiteInfo(for: sampleSiteURL)
@@ -32,7 +32,7 @@ final class WordPressSiteRemoteTests: XCTestCase {
     ///
     func test_fetchSiteInfo_properly_relays_networking_errors() async {
         let remote = WordPressSiteRemote(network: network)
-        network.simulateError(requestUrlSuffix: "wp-json", error: NetworkError.notFound)
+        network.simulateError(requestUrlSuffix: "?rest_route=", error: NetworkError.notFound)
 
         // When
         var fetchError: Error?

--- a/Networking/NetworkingTests/Requests/RESTRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/RESTRequestTests.swift
@@ -33,7 +33,7 @@ final class RESTRequestTests: XCTestCase {
         let url = try XCTUnwrap(request.asURLRequest().url)
 
         // Then
-        let expectedURL = "https://wordpress.com/wp-json/sample"
+        let expectedURL = "https://wordpress.com/?rest_route=/sample"
         assertEqual(url.absoluteString, expectedURL)
     }
 
@@ -56,7 +56,7 @@ final class RESTRequestTests: XCTestCase {
         let url = try XCTUnwrap(request.asURLRequest().url)
 
         // Then
-        let expectedURL = "https://wordpress.com/wp-json/wc/v3/sample"
+        let expectedURL = "https://wordpress.com/?rest_route=/wc/v3/sample"
         assertEqual(url.absoluteString, expectedURL)
     }
 
@@ -68,7 +68,7 @@ final class RESTRequestTests: XCTestCase {
         let url = try XCTUnwrap(request.asURLRequest().url)
 
         // Then
-        let expectedURL = "https://wordpress.com/wp-json/wp/v2/sample"
+        let expectedURL = "https://wordpress.com/?rest_route=/wp/v2/sample"
         assertEqual(url.absoluteString, expectedURL)
     }
 

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -75,7 +75,7 @@
       },
       {
         "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": null,
           "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",

--- a/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
@@ -21,7 +21,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchSiteInfo_returns_correct_site() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=/", filename: "wordpress-site-info")
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -50,7 +50,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchSiteInfo_relays_error_properly() throws {
         // Given
-        network.simulateError(requestUrlSuffix: "?rest_route=", error: NetworkError.notFound)
+        network.simulateError(requestUrlSuffix: "?rest_route=/", error: NetworkError.notFound)
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -68,7 +68,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchApplicationPasswordAuthorizationURL_returns_nil_authorization_url_if_application_password_is_not_available() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=/", filename: "wordpress-site-info")
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -87,7 +87,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchApplicationPasswordAuthorizationURL_returns_correct_authorization_url_if_available() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info-with-auth-url")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=/", filename: "wordpress-site-info-with-auth-url")
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -106,7 +106,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchApplicationPasswordAuthorizationURL_relays_error_properly() throws {
         // Given
-        network.simulateError(requestUrlSuffix: "?rest_route=", error: NetworkError.notFound)
+        network.simulateError(requestUrlSuffix: "?rest_route=/", error: NetworkError.notFound)
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When

--- a/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
@@ -21,7 +21,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchSiteInfo_returns_correct_site() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "wp-json", filename: "wordpress-site-info")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info")
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -50,7 +50,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchSiteInfo_relays_error_properly() throws {
         // Given
-        network.simulateError(requestUrlSuffix: "wp-json", error: NetworkError.notFound)
+        network.simulateError(requestUrlSuffix: "?rest_route=", error: NetworkError.notFound)
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -68,7 +68,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchApplicationPasswordAuthorizationURL_returns_nil_authorization_url_if_application_password_is_not_available() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "wp-json", filename: "wordpress-site-info")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info")
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -87,7 +87,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchApplicationPasswordAuthorizationURL_returns_correct_authorization_url_if_available() throws {
         // Given
-        network.simulateResponse(requestUrlSuffix: "wp-json", filename: "wordpress-site-info-with-auth-url")
+        network.simulateResponse(requestUrlSuffix: "?rest_route=", filename: "wordpress-site-info-with-auth-url")
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When
@@ -106,7 +106,7 @@ final class WordPressSiteStoreTests: XCTestCase {
 
     func test_fetchApplicationPasswordAuthorizationURL_relays_error_properly() throws {
         // Given
-        network.simulateError(requestUrlSuffix: "wp-json", error: NetworkError.notFound)
+        network.simulateError(requestUrlSuffix: "?rest_route=", error: NetworkError.notFound)
         let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10924 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously we were hardcoding `wp-json` as the root endpoint for REST API. This doesn't work for sites with pretty permalink enabled.

A solution would be to do [site discovery ](https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/#link-header) to find the right endpoint to hit for each site. However, this would be an async request and is not simple to update the app with it (big changes are required).

From my understanding, pretty permalinks are just friendly-looking links that eventually get redirected to the default endpoints. In this PR, I attempt to update the hardcoded `wp-json` with the default `?rest_route=`, which in theory should work for both when pretty permalink is enabled and not.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Prequisite: make sure that you have access to a self-hosted site without Jetpack.
- Disable pretty permalink for your site by navigating to wp-admin > Settings > Permalinks > select Plain for permalink structure.
- On the app, log out if needed.
- On the prologue screen, select Log In.
- Enter the address of your site and enter incorrect credentials.
- On the error alert, select log in with web view.
- Notice that the web view successfully displays the page for log in to your site.
- Authorize application password, notice that you are then logged in successfully and navigated to the My Store screen.
- Smoke test logged-in features to make sure everything works as expected.

Repeat the same test for a self-hosted site with permalink enabled.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
