### PR TITLE
Login: Reuse Jetpack setup logic for connecting Jetpack on Account Mismatch screen

### DIFF
--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -133,37 +133,6 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
         XCTAssertEqual(mockAuthentication.presentSupportFromScreen, .wrongAccountError)
     }
 
-    func test_web_view_is_presented_when_tapping_primary_button_if_site_credentials_are_present() throws {
-        // Given
-        let expectedURL = try XCTUnwrap(URL(string: "http://jetpack.wordpress.com/jetpack.authorize/1/"))
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionURL(let completion):
-                completion(.success(expectedURL))
-            default:
-                break
-            }
-        }
-        let credentials = WordPressOrgCredentials(username: "test", password: "pwd", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
-        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url,
-                                                   showsConnectedStores: false,
-                                                   siteCredentials: credentials,
-                                                   storesManager: stores,
-                                                   onJetpackSetupCompletion: { _, _ in })
-        let viewController = UIViewController()
-        let navigationController = UINavigationController(rootViewController: viewController)
-
-        // When
-        viewModel.didTapPrimaryButton(in: viewController)
-        waitUntil {
-            navigationController.viewControllers.containsMoreThanOne
-        }
-
-        // Then
-        XCTAssertTrue(navigationController.topViewController is AuthenticatedWebViewController)
-    }
-
     func test_fetchSiteInfo_is_triggered_if_credentials_are_not_present() {
         // Given
 
@@ -265,81 +234,6 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_connect_button_tapped" }))
-    }
-
-    func test_primary_button_tap_triggers_site_credential_login_if_credentials_are_not_present_and_fetched_site_info_returns_self_hosted_site() {
-        // Given
-        let siteInfo = WordPressComSiteInfo(remote: ["isWordPressDotCom": false])
-        MockAuthenticator.setMockSiteInfo(siteInfo)
-        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url,
-                                                   showsConnectedStores: false,
-                                                   siteCredentials: nil,
-                                                   authenticatorType: MockAuthenticator.self,
-                                                   onJetpackSetupCompletion: { _, _ in })
-        let viewController = UIViewController()
-
-        // When
-        viewModel.viewDidLoad(viewController)
-        viewModel.didTapPrimaryButton(in: viewController)
-
-        // Then
-        XCTAssertTrue(MockAuthenticator.siteCredentialLoginTriggered)
-    }
-
-    func test_primary_button_tap_does_not_trigger_site_credential_login_if_credentials_are_not_present_and_fetched_site_info_returns_wpcom_site() {
-        // Given
-        let siteInfo = WordPressComSiteInfo(remote: ["isWordPressDotCom": true])
-        MockAuthenticator.setMockSiteInfo(siteInfo)
-        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url,
-                                                   showsConnectedStores: false,
-                                                   siteCredentials: nil,
-                                                   authenticatorType: MockAuthenticator.self,
-                                                   onJetpackSetupCompletion: { _, _ in })
-        let viewController = UIViewController()
-
-        // When
-        viewModel.viewDidLoad(viewController)
-        viewModel.didTapPrimaryButton(in: viewController)
-
-        // Then
-        XCTAssertFalse(MockAuthenticator.siteCredentialLoginTriggered)
-    }
-
-    func test_failure_to_fetch_connection_url_is_tracked() throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        var completed = false
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionURL(let completion):
-                let error = NSError(domain: "Test", code: 123)
-                completion(.failure(error))
-                completed = true
-            default:
-                break
-            }
-        }
-
-        let analyticsProvider = MockAnalyticsProvider()
-        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let credentials = WordPressOrgCredentials(username: "test", password: "pwd", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
-
-        // When
-        _ = WrongAccountErrorViewModel(siteURL: Expectations.url,
-                                       showsConnectedStores: false,
-                                       siteCredentials: credentials,
-                                       storesManager: stores,
-                                       analytics: analytics,
-                                       onJetpackSetupCompletion: { _, _ in })
-        waitUntil {
-            completed == true
-        }
-
-        // Then
-        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_jetpack_connection_url_fetch_failed" }))
-        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
-        XCTAssertEqual(properties["error_code"] as? String, "123")
-        XCTAssertEqual(properties["error_domain"] as? String, "Test")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11037 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When a user tries to log in to a Jetpack site with a WPCom account that is not connected to that site, they reach the account mismatch screen and can connect their account from the CTA on this screen. The Jetpack connection logic is handled directly in the `WrongAccountErrorViewModel` file - this logic is outdated while looking similar to the logic in `JetpackSetupViewModel`.

This PR unifies the logic by removing the duplicated logic and updating `WrongAccountErrorViewModel` to use `LoginJetpackSetupCoordinator` instead. Given that the logic in the Jetpack connection step was most updated on the coordinator, this also helps fix the issue with Jetpack connection mentioned in #11037.

Note: The site credential login step in `LoginJetpackSetupCoordinator` is not handling any failure caused by security plugin. We will align with Android and handle that in a future PR.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a new JN site.
- Install and connect Jetpack using your primary WPCOM account.
- Create a new "Shop Manager" account from the wp-admin page. The email is from a different WPCOM account named Alias.
- Log out of the app if needed.
- On the prologue screen, enter the address of the JN site.
- Proceed to log in with the alias user WPCom account.
- The account mismatched error screen is displayed. Tap on the Connect Jetpack button.
- Enter the site credentials of the alias account.
- Follow the steps to connect Jetpack. After the connection completes, you should be navigated to the My Store screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/8c662f32-87f1-4eb7-91e6-b9f377a84f64



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
