### PR TITLE
Logout when WPCOM token expires

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -506,10 +506,11 @@ extension AppDelegate {
     /// De-authenticates the user upon application password generation failure or WPCOM token expiry.
     ///
     private func listenToAuthenticationFailureNotifications() {
-        if ServiceLocator.stores.isAuthenticatedWithoutWPCom {
-            ServiceLocator.stores.listenToApplicationPasswordGenerationFailureNotification()
+        let stores = ServiceLocator.stores
+        if stores.isAuthenticatedWithoutWPCom {
+            stores.listenToApplicationPasswordGenerationFailureNotification()
         } else {
-            ServiceLocator.stores.listenToWPCOMInvalidWPCOMTokenNotification()
+            stores.listenToWPCOMInvalidWPCOMTokenNotification()
         }
     }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -74,7 +74,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Yosemite Initialization
         synchronizeEntitiesIfPossible()
-        listenToApplicationPasswordGenerationFailureNotification()
+        listenToAuthenticationFailureNotifications()
 
         // Since we are using Injection for refreshing the content of the app in debug mode,
         // we are going to enable Inject.animation that will be used when
@@ -503,14 +503,14 @@ extension AppDelegate {
         ServiceLocator.stores.synchronizeEntities(onCompletion: nil)
     }
 
-    /// Deauthenticates the user upon application password generation failure.
+    /// De-authenticates the user upon application password generation failure or WPCOM token expiry.
     ///
-    private func listenToApplicationPasswordGenerationFailureNotification() {
-        guard ServiceLocator.stores.isAuthenticatedWithoutWPCom else {
-            return
+    private func listenToAuthenticationFailureNotifications() {
+        if ServiceLocator.stores.isAuthenticatedWithoutWPCom {
+            ServiceLocator.stores.listenToApplicationPasswordGenerationFailureNotification()
+        } else {
+            ServiceLocator.stores.listenToWPCOMInvalidWPCOMTokenNotification()
         }
-
-        ServiceLocator.stores.listenToApplicationPasswordGenerationFailureNotification()
     }
 
     /// Runs whenever the Authentication Flow is completed successfully.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -33,6 +33,10 @@ class DefaultStoresManager: StoresManager {
     ///
     private var applicationPasswordGenerationFailureObserver: NSObjectProtocol?
 
+    /// Observes invalid WPCOM token notification
+    ///
+    private var invalidWPCOMTokenNotificationObserver: NSObjectProtocol?
+
     /// NotificationCenter
     ///
     private let notificationCenter: NotificationCenter
@@ -151,16 +155,27 @@ class DefaultStoresManager: StoresManager {
         sessionManager.defaultCredentials = credentials
 
         listenToApplicationPasswordGenerationFailureNotification()
+        listenToWPCOMInvalidWPCOMTokenNotification()
 
         return self
     }
 
-    /// Deauthenticates upon receiving `ApplicationPasswordsGenerationFailed` notification
+    /// De-authenticates upon receiving `ApplicationPasswordsGenerationFailed` notification
     ///
     func listenToApplicationPasswordGenerationFailureNotification() {
         applicationPasswordGenerationFailureObserver = notificationCenter.addObserver(forName: .ApplicationPasswordsGenerationFailed,
                                                                                       object: nil,
                                                                                       queue: .main) { [weak self] note in
+            _ = self?.deauthenticate()
+        }
+    }
+
+    /// De-authenticates upon receiving `RemoteDidReceiveInvalidTokenError` notification
+    ///
+    func listenToWPCOMInvalidWPCOMTokenNotification() {
+        invalidWPCOMTokenNotificationObserver = notificationCenter.addObserver(forName: .RemoteDidReceiveInvalidTokenError,
+                                                                               object: nil,
+                                                                               queue: .main) { [weak self] note in
             _ = self?.deauthenticate()
         }
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -39,6 +39,10 @@ final class MockStoresManager: DefaultStoresManager {
         }
     }
 
+    override func listenToWPCOMInvalidWPCOMTokenNotification() {
+        // Don't listen to WPCOM token expiry notification to avoid de-authenticating while running tests.
+    }
+
     // MARK: - Public Methods
 
     /// Restores the initial state

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -448,6 +448,26 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertFalse(manager.isAuthenticated)
         XCTAssertEqual(isLoggedInValues, [false, true, false])
     }
+
+    /// Verifies that user is logged out when WPCOM token expires
+    ///
+    func test_it_deauthenticates_upon_receiving_invalid_token_error_notification() {
+        // Given
+        let manager = DefaultStoresManager.testingInstance
+        var isLoggedInValues = [Bool]()
+        cancellable = manager.isLoggedInPublisher.sink { isLoggedIn in
+            isLoggedInValues.append(isLoggedIn)
+        }
+        manager.authenticate(credentials: SessionSettings.wpcomCredentials)
+
+        // When
+        let error = DotcomError.invalidToken
+        MockNotificationCenter.testingInstance.post(name: .RemoteDidReceiveInvalidTokenError, object: error, userInfo: nil)
+
+        // Assert
+        XCTAssertFalse(manager.isAuthenticated)
+        XCTAssertEqual(isLoggedInValues, [false, true, false])
+    }
 }
 
 

--- a/Yosemite/Yosemite/Base/StoresManager.swift
+++ b/Yosemite/Yosemite/Base/StoresManager.swift
@@ -80,4 +80,8 @@ public protocol StoresManager {
     /// Deauthenticates upon receiving `ApplicationPasswordsGenerationFailed` notification
     ///
     func listenToApplicationPasswordGenerationFailureNotification()
+
+    /// De-authenticates upon receiving `RemoteDidReceiveInvalidTokenError` notification
+    ///
+    func listenToWPCOMInvalidWPCOMTokenNotification()
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -211,6 +211,10 @@ public class MockStoresManager: StoresManager {
     public func listenToApplicationPasswordGenerationFailureNotification() {
         // no-op
     }
+
+    public func listenToWPCOMInvalidWPCOMTokenNotification() {
+        // no-op
+    }
 }
 
 private extension MockStoresManager {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #2813
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Logout user if received invalid WPCOM token error. 

## Testing instructions

1. Install and login into the app using WPCOM account
2. Pick a store and navigate into the app
3. Open https://wordpress.com/me/security/connected-applications in a web browser
4. Disconnect "WooCommerce"
5. Open the mobile app and reload any screen
6. You should be logged out of the app


## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
