### PR TITLE
[Hotfix] Revert "Enable Tap to Pay in the UK"

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -103,7 +103,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .orderCustomAmountsM1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .tapToPayOnIPhoneInUK:
-            return true
+            return buildConfig == .localDeveloper
         case .optimizedBlazeExperience:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,6 @@
 15.9
 -----
 - [***] User can now use their stored passkeys to log in into WordPress.com [https://github.com/woocommerce/woocommerce-ios/pull/10904]
-- [***] Payments: UK-based merchants can take payments using Tap to Pay on iPhone [https://github.com/woocommerce/woocommerce-ios/pull/10957]
 - [*] App login links are now handled when the onboarding screen is shown. [https://github.com/woocommerce/woocommerce-ios/pull/10974]
 
 15.8


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've learned that this is not intended for release yet. This PR turns it off for release builds

This reverts commit 1e58d34ca4fe9aa26332eb66bc095bcfc5a98d07, reversing changes made to a581a0154afe1be731cc2fdd9a4c370e2109ac18.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Turn on the simulated reader toggle in the scheme
2. Build the app to a simulator with the release config
3. Navigate to Menu > Payments
4. Observe that the Tap to Pay section is not shown
5. Tap Collect payment and follow the flow to the payment methods screen
6. Observe that the Tap to Pay option is not shown

<img width="955" alt="Check for simulated card reader" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/877cf4d9-eb60-4ac6-a7c3-1112e0b0a99a">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
