### PR TITLE
Ensure media upload action and asset export take place on the main thread as an attempted crash fix

### DIFF
--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -94,32 +94,17 @@ private extension MediaStore {
                      altText: String?,
                      filename: String?,
                      onCompletion: @escaping (Result<Media, Error>) -> Void) {
-        Task {
-            await uploadMediaAsync(siteID: siteID,
-                                   productID: productID,
-                                   mediaAsset: mediaAsset,
-                                   altText: altText,
-                                   filename: filename,
-                                   onCompletion: onCompletion)
-        }
-    }
-
-    @MainActor
-    func uploadMediaAsync(siteID: Int64,
-                          productID: Int64,
-                          mediaAsset: ExportableAsset,
-                          altText: String?,
-                          filename: String?,
-                          onCompletion: @escaping (Result<Media, Error>) -> Void) async {
-        do {
-            let uploadableMedia = try await mediaExportService.export(mediaAsset, filename: filename, altText: altText)
-            uploadMedia(siteID: siteID,
-                        productID: productID,
-                        altText: altText,
-                        uploadableMedia: uploadableMedia,
-                        onCompletion: onCompletion)
-        } catch {
-            onCompletion(.failure(error))
+        Task { @MainActor in
+            do {
+                let uploadableMedia = try await mediaExportService.export(mediaAsset, filename: filename, altText: altText)
+                uploadMedia(siteID: siteID,
+                            productID: productID,
+                            altText: altText,
+                            uploadableMedia: uploadableMedia,
+                            onCompletion: onCompletion)
+            } catch {
+                onCompletion(.failure(error))
+            }
         }
     }
 

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -95,16 +95,31 @@ private extension MediaStore {
                      filename: String?,
                      onCompletion: @escaping (Result<Media, Error>) -> Void) {
         Task {
-            do {
-                let uploadableMedia = try await mediaExportService.export(mediaAsset, filename: filename, altText: altText)
-                uploadMedia(siteID: siteID,
-                            productID: productID,
-                            altText: altText,
-                            uploadableMedia: uploadableMedia,
-                            onCompletion: onCompletion)
-            } catch {
-                onCompletion(.failure(error))
-            }
+            await uploadMediaAsync(siteID: siteID,
+                                   productID: productID,
+                                   mediaAsset: mediaAsset,
+                                   altText: altText,
+                                   filename: filename,
+                                   onCompletion: onCompletion)
+        }
+    }
+
+    @MainActor
+    func uploadMediaAsync(siteID: Int64,
+                          productID: Int64,
+                          mediaAsset: ExportableAsset,
+                          altText: String?,
+                          filename: String?,
+                          onCompletion: @escaping (Result<Media, Error>) -> Void) async {
+        do {
+            let uploadableMedia = try await mediaExportService.export(mediaAsset, filename: filename, altText: altText)
+            uploadMedia(siteID: siteID,
+                        productID: productID,
+                        altText: altText,
+                        uploadableMedia: uploadableMedia,
+                        onCompletion: onCompletion)
+        } catch {
+            onCompletion(.failure(error))
         }
     }
 

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -29,6 +29,7 @@ final class MediaAssetExporter: MediaExporter {
         self.mediaDirectoryType = mediaDirectoryType
     }
 
+    @MainActor
     func export() async throws -> UploadableMedia {
         switch asset.mediaType {
             case .image:
@@ -38,6 +39,7 @@ final class MediaAssetExporter: MediaExporter {
         }
     }
 
+    @MainActor
     private func exportImage(forAsset asset: PHAsset) async throws -> UploadableMedia {
         guard asset.mediaType == .image else {
             throw AssetExportError.expectedPHAssetImageType

--- a/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
@@ -18,6 +18,7 @@ protocol MediaExportService {
 /// Encapsulates exporting assets such as PHAssets, images, videos, or files at URLs to `UploadableMedia`.
 ///
 final class DefaultMediaExportService: MediaExportService {
+    @MainActor
     func export(_ exportable: ExportableAsset, filename: String?, altText: String?) async throws -> UploadableMedia {
         guard let exporter = createExporter(for: exportable, filename: filename, altText: altText) else {
             preconditionFailure("An exporter needs to be available for asset: \(exportable)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Attempted repair for https://github.com/woocommerce/woocommerce-ios/issues/11040
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Ref: peaMlT-er-p2

We got a crash report on [this line of code](https://github.com/woocommerce/woocommerce-ios/blob/6678634d0d01889742c8edd44f931123a5fba304/Yosemite/Yosemite/Stores/MediaStore.swift#L99) that started from [release 15.3](https://github.com/woocommerce/woocommerce-ios/milestone/164?closed=1), which included an internal change on the media upload https://github.com/woocommerce/woocommerce-ios/pull/10631 to support a HACK Week project. This change updated the `MediaAction.uploadMedia` to take place on a background thread instead of the main thread, which might have resulted in unexpected crashes from memory management and async code. The individual crashes suggested that the app crashed right after selecting some photos from the device library. I wasn't able to reproduce this after testing on two devices and adding images from a new product. My guess is that it could be due to using `PHImageManager` in the background thread.

## How

To try addressing the memory management crash from async access, this PR updated to keep the `MediaStore.uploadMedia` function plus the relevant export functions back on the main thread with the current async/await syntax by marking them as `@MainActor`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a store if needed
- Go to the Products tab
- Tap on `+` to add a product manually (the menu might differ based on the Woo AI eligibility) and select `Simple physical product`
- Tap on the image header
- From the automatically presented alert, tap `Choose from device`
- Add at least one photo from the device library --> it should go back to the product form, and the image(s) should be uploaded remotely after a bit without crashing

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.