### PR TITLE
[Custom Amounts M2] Edit pencil button everywhere

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 16.1
 -----
 - [**] Orders: order creation sections are optimised for a simpler and more intuitive flow. [https://github.com/woocommerce/woocommerce-ios/pull/11042]
+- [*] Orders: All order edit buttons render now with the pencil system image to make them consistent. [https://github.com/woocommerce/woocommerce-ios/pull/11048]
 
 16.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerNoteSection/CustomerNoteSection.swift
@@ -65,13 +65,9 @@ private struct CustomerNoteSectionContent: View {
     }
 
     private func createEditNotesButton() -> some View {
-        Button(Localization.editButton) {
+        PencilEditButton() {
             showEditNotesView.toggle()
         }
-        .buttonStyle(LinkButtonStyle())
-        .fixedSize(horizontal: true, vertical: true)
-        .padding(.top, -Layout.linkButtonTopPadding) // remove padding to align button title to the top
-        .padding(.trailing, -Layout.linkButtonTrailingPadding) // remove padding to align button title to the side
         .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
     }
 
@@ -99,15 +95,12 @@ private extension CustomerNoteSectionContent {
         static let verticalHeadlineSpacing: CGFloat = 22.0
         static let verticalEmailSpacing: CGFloat = 4.0
         static let verticalAddressSpacing: CGFloat = 6.0
-        static let linkButtonTopPadding: CGFloat = 12.0
-        static let linkButtonTrailingPadding: CGFloat = 22.0
     }
 
     enum Localization {
         static let notes = NSLocalizedString("Customer Note", comment: "Title text of the section that shows the Order customer note when creating a new order")
         static let addNotes = NSLocalizedString("Add Note",
                                                           comment: "Title text of the button that adds customer note data when creating a new order")
-        static let editButton = NSLocalizedString("Edit", comment: "Button to edit the customer note on the New Order screen")
         static let editButtonAccessibilityLabel = NSLocalizedString(
             "Edit customer note",
             comment: "Accessibility label for the button to edit customer note on the New Order screen"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -56,13 +56,9 @@ private struct OrderCustomerSectionContent: View {
                         .headlineStyle()
                     Spacer()
 
-                    Button(Localization.editButton) {
+                    PencilEditButton() {
                         showAddressForm.toggle()
                     }
-                    .buttonStyle(LinkButtonStyle())
-                    .fixedSize(horizontal: true, vertical: true)
-                    .padding(.top, -Layout.linkButtonTopPadding) // remove padding to align button title to the top
-                    .padding(.trailing, -Layout.linkButtonTrailingPadding) // remove padding to align button title to the side
                     .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 }
             }
@@ -121,15 +117,12 @@ private extension OrderCustomerSectionContent {
         static let verticalHeadlineSpacing: CGFloat = 22.0
         static let verticalEmailSpacing: CGFloat = 4.0
         static let verticalAddressSpacing: CGFloat = 6.0
-        static let linkButtonTopPadding: CGFloat = 12.0
-        static let linkButtonTrailingPadding: CGFloat = 22.0
     }
 
     enum Localization {
         static let customer = NSLocalizedString("Customer", comment: "Title text of the section that shows Customer details when creating a new order")
         static let addCustomerDetails = NSLocalizedString("Add Customer Details",
                                                           comment: "Title text of the button that adds customer data when creating a new order")
-        static let editButton = NSLocalizedString("Edit", comment: "Button to edit a customer on the New Order screen")
         static let editButtonAccessibilityLabel = NSLocalizedString(
             "Edit Customer Details",
             comment: "Accessibility label for the button to edit customer details on the New Order screen"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -208,7 +208,10 @@ private extension OrderPaymentSection {
     @ViewBuilder var appliedCouponsRows: some View {
         VStack {
             ForEach(viewModel.couponLineViewModels, id: \.title) { viewModel in
-                TitleAndValueRow(title: viewModel.title, titleSuffixImage: rowsEditImage, value: .content(viewModel.discount), selectionStyle: .highlight) {
+                TitleAndValueRow(title: viewModel.title,
+                                 titleSuffixImage: rowsEditImage,
+                                 value: .content(viewModel.discount),
+                                 selectionStyle: editableRowsSelectionStyle) {
                     selectedCouponLineDetailsViewModel = viewModel.detailsViewModel
                 }
             }
@@ -232,7 +235,8 @@ private extension OrderPaymentSection {
     @ViewBuilder var existingShippingRow: some View {
         TitleAndValueRow(title: Localization.shippingTotal,
                          titleSuffixImage: rowsEditImage,
-                         value: .content(viewModel.shippingTotal), selectionStyle: .highlight) {
+                         value: .content(viewModel.shippingTotal),
+                         selectionStyle: editableRowsSelectionStyle) {
             shouldShowShippingLineDetails = true
         }
         .renderedIf(viewModel.shouldShowShippingTotal)
@@ -404,6 +408,10 @@ private extension OrderPaymentSection {
 
     var rowsEditImage: Image? {
         viewModel.showNonEditableIndicators ? nil : Image(systemName: "pencil")
+    }
+
+    var editableRowsSelectionStyle: TitleAndValueRow.SelectionStyle {
+        viewModel.showNonEditableIndicators ? .none : .highlight
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -208,7 +208,7 @@ private extension OrderPaymentSection {
     @ViewBuilder var appliedCouponsRows: some View {
         VStack {
             ForEach(viewModel.couponLineViewModels, id: \.title) { viewModel in
-                TitleAndValueRow(title: viewModel.title, value: .content(viewModel.discount), selectionStyle: .highlight) {
+                TitleAndValueRow(title: viewModel.title, titleSuffixImage: rowsEditImage, value: .content(viewModel.discount), selectionStyle: .highlight) {
                     selectedCouponLineDetailsViewModel = viewModel.detailsViewModel
                 }
             }
@@ -231,7 +231,7 @@ private extension OrderPaymentSection {
 
     @ViewBuilder var existingShippingRow: some View {
         TitleAndValueRow(title: Localization.shippingTotal,
-                         titleSuffixImage: viewModel.showNonEditableIndicators ? nil : Image(systemName: "pencil"),
+                         titleSuffixImage: rowsEditImage,
                          value: .content(viewModel.shippingTotal), selectionStyle: .highlight) {
             shouldShowShippingLineDetails = true
         }
@@ -400,6 +400,10 @@ private extension OrderPaymentSection {
             .padding(.bottom, Constants.orderTotalBottomPadding)
             .renderedIf(!viewModel.orderIsEmpty)
 
+    }
+
+    var rowsEditImage: Image? {
+        viewModel.showNonEditableIndicators ? nil : Image(systemName: "pencil")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -230,7 +230,9 @@ private extension OrderPaymentSection {
     }
 
     @ViewBuilder var existingShippingRow: some View {
-        TitleAndValueRow(title: Localization.shippingTotal, value: .content(viewModel.shippingTotal), selectionStyle: .highlight) {
+        TitleAndValueRow(title: Localization.shippingTotal,
+                         titleSuffixImage: Image(systemName: "pencil"),
+                         value: .content(viewModel.shippingTotal), selectionStyle: .highlight) {
             shouldShowShippingLineDetails = true
         }
         .renderedIf(viewModel.shouldShowShippingTotal)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -231,7 +231,7 @@ private extension OrderPaymentSection {
 
     @ViewBuilder var existingShippingRow: some View {
         TitleAndValueRow(title: Localization.shippingTotal,
-                         titleSuffixImage: Image(systemName: "pencil"),
+                         titleSuffixImage: viewModel.showNonEditableIndicators ? nil : Image(systemName: "pencil"),
                          value: .content(viewModel.shippingTotal), selectionStyle: .highlight) {
             shouldShowShippingLineDetails = true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -35,10 +35,8 @@ struct OrderStatusSection: View {
 
                 Spacer()
 
-                Button {
+                PencilEditButton {
                     viewModel.shouldShowOrderStatusList = true
-                } label: {
-                    Image(systemName: "pencil")
                 }
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 .accessibilityIdentifier("order-status-section-edit-button")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -35,12 +35,11 @@ struct OrderStatusSection: View {
 
                 Spacer()
 
-                Button(Localization.editButton) {
+                Button {
                     viewModel.shouldShowOrderStatusList = true
+                } label: {
+                    Image(systemName: "pencil")
                 }
-                .buttonStyle(LinkButtonStyle())
-                .fixedSize(horizontal: true, vertical: true)
-                .padding(.trailing, -Layout.linkButtonTrailingPadding) // remove trailing padding to align button title to the side
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 .accessibilityIdentifier("order-status-section-edit-button")
                 .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
@@ -72,7 +71,6 @@ private extension OrderStatusSection {
     }
 
     enum Localization {
-        static let editButton = NSLocalizedString("Edit", comment: "Button to edit an order status on the New Order screen")
         static let editButtonAccessibilityLabel = NSLocalizedString("Edit Status",
                                                                     comment: "Accessibility label for the button to edit order status on the New Order screen")
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/PencilEditButton.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/PencilEditButton.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Renders a button with the pencil system name image
+/// 
+struct PencilEditButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "pencil")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -12,6 +12,7 @@ struct TitleAndValueRow: View {
     }
 
     private let title: String
+    private let titleSuffixImage: Image?
     private let value: Value
     private let valueTextAlignment: TextAlignment
     private let bold: Bool
@@ -37,6 +38,7 @@ struct TitleAndValueRow: View {
     }
 
     init(title: String,
+         titleSuffixImage: Image? = nil,
          titleWidth: Binding<CGFloat?> = .constant(nil),
          value: Value,
          valueTextAlignment: TextAlignment = .trailing,
@@ -44,6 +46,7 @@ struct TitleAndValueRow: View {
          selectionStyle: SelectionStyle = .none,
          action: @escaping () -> Void = {}) {
         self.title = title
+        self.titleSuffixImage = titleSuffixImage
         self._titleWidth = titleWidth
         self.value = value
         self.valueTextAlignment = valueTextAlignment
@@ -63,6 +66,11 @@ struct TitleAndValueRow: View {
                         .multilineTextAlignment(.leading)
                         .modifier(MaxWidthModifier())
                         .frame(width: titleWidth, alignment: .leading)
+
+                    if let titleSuffixImage {
+                        titleSuffixImage
+                            .padding(.leading, Constants.titleSuffixImageTrailingPadding)
+                    }
 
                     Text(value.text)
                         .style(for: value, bold: bold, highlighted: false)
@@ -139,6 +147,7 @@ private extension TitleAndValueRow {
         static let horizontalPadding: CGFloat = 16
         static let verticalPadding: CGFloat = 12
         static let spacing: CGFloat = 20
+        static let titleSuffixImageTrailingPadding: CGFloat = -15
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1723,6 +1723,7 @@
 		B9B6DEEF283F8B9F00901FB7 /* Site+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B6DEEE283F8B9F00901FB7 /* Site+URL.swift */; };
 		B9B6DEF1283F8EB100901FB7 /* SitePluginsURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B6DEF0283F8EB100901FB7 /* SitePluginsURLTests.swift */; };
 		B9B7E2E629FBF96100F9CED1 /* ProductSelectorViewModelTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B7E2E529FBF96100F9CED1 /* ProductSelectorViewModelTracker.swift */; };
+		B9B7E37E2AF105EF00A959CA /* PencilEditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B7E37D2AF105EF00A959CA /* PencilEditButton.swift */; };
 		B9C4AB2527FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */; };
 		B9C4AB2728002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */; };
 		B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */; };
@@ -4266,6 +4267,7 @@
 		B9B6DEEE283F8B9F00901FB7 /* Site+URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Site+URL.swift"; sourceTree = "<group>"; };
 		B9B6DEF0283F8EB100901FB7 /* SitePluginsURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsURLTests.swift; sourceTree = "<group>"; };
 		B9B7E2E529FBF96100F9CED1 /* ProductSelectorViewModelTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSelectorViewModelTracker.swift; sourceTree = "<group>"; };
+		B9B7E37D2AF105EF00A959CA /* PencilEditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PencilEditButton.swift; sourceTree = "<group>"; };
 		B9C4AB2427FDE4B6007008B8 /* CardPresentPluginsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProvider.swift; sourceTree = "<group>"; };
 		B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminer.swift; sourceTree = "<group>"; };
 		B9C4AB28280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReceiptEmailParameterDeterminerTests.swift; sourceTree = "<group>"; };
@@ -7683,6 +7685,7 @@
 				68ED2BD52ADD2C8C00ECA88D /* LineDetailView.swift */,
 				860B85F02ADE3A0E00E85884 /* BulletPointView.swift */,
 				68B6F22A2ADE7ED500D171FC /* TooltipView.swift */,
+				B9B7E37D2AF105EF00A959CA /* PencilEditButton.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -13558,6 +13561,7 @@
 				026CAF7E2AC2B76C002D23BB /* ConfigurableBundleProductViewModel.swift in Sources */,
 				4515C88D25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.swift in Sources */,
 				CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */,
+				B9B7E37E2AF105EF00A959CA /* PencilEditButton.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,
 				0313651728ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift in Sources */,
 				571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10898 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we render the pencil system image for all the edit buttons along the order creation flow. This way we're consistent with the approach we used for custom amounts before. Furthermore, apart from replacing the Edit buttons we had, we also add the pencil button to the editable added rows, i.e. shipping and coupons.
We also take advantage of this PR to optimize from a comment of the previous PR https://github.com/woocommerce/woocommerce-ios/pull/11042 When the order is non editable we showed Shipping lines and coupons as greyed out; this is not necessary anymore to convey that the rows are not tappable: removing the edit button and disabling highlight is enough.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to create a new order
3. Check that the pencil button is used everywhere:

- Order status
- Customer note
- Customer Section
- Shipping row when added (removed when the order is not editable)
- Coupon rows when added (removed when the order is not editable)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/fb701637-e32a-41c7-a743-960928c612f6

### Editable lines are not greyed out when the order is not editable:

#### Before

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/fb5cee45-2c3d-4842-97d5-fdc138bfdb84" width="375">

#### After

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/0edfefd5-ad81-4e3b-9ae4-6ecf844d34ef" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.