### PR TITLE
[Custom Amounts] Tracking - Custom amounts count when the order is created

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -496,6 +496,7 @@ extension WooAnalyticsEvent {
             static let hasDifferentShippingDetails = "has_different_shipping_details"
             static let orderStatus = "order_status"
             static let productCount = "product_count"
+            static let customAmountsCount = "custom_amounts_count"
             static let hasAddOns = "has_addons"
             static let hasCustomerDetails = "has_customer_details"
             static let hasFees = "has_fees"
@@ -709,6 +710,7 @@ extension WooAnalyticsEvent {
         static func orderCreateButtonTapped(order: Order,
                                             status: OrderStatusEnum,
                                             productCount: Int,
+                                            customAmountsCount: Int,
                                             hasCustomerDetails: Bool,
                                             hasFees: Bool,
                                             hasShippingMethod: Bool,
@@ -716,6 +718,7 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreateButtonTapped, properties: [
                 Keys.orderStatus: status.rawValue,
                 Keys.productCount: Int64(productCount),
+                Keys.customAmountsCount: Int64(customAmountsCount),
                 Keys.hasCustomerDetails: hasCustomerDetails,
                 Keys.hasFees: hasFees,
                 Keys.hasShippingMethod: hasShippingMethod,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1572,6 +1572,7 @@ private extension EditableOrderViewModel {
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(order: orderSynchronizer.order,
                                                                                 status: orderSynchronizer.order.status,
                                                                                 productCount: orderSynchronizer.order.items.count,
+                                                                                customAmountsCount: orderSynchronizer.order.fees.count,
                                                                                 hasCustomerDetails: hasCustomerDetails,
                                                                                 hasFees: orderSynchronizer.order.fees.isNotEmpty,
                                                                                 hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10881 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add tracking for the amount of custom amounts when the order is tracked. We do that by adding the property `custom_amounts_count` to the event `order_create_button_tapped`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to created a new order
3. Add a few custom amounts
4. See that their number is properly tracked

`🔵 Tracked order_create_button_tapped, properties: [AnyHashable("order_status"): "pending", AnyHashable("has_shipping_method"): false, AnyHashable("was_ecommerce_trial"): false, AnyHashable("site_url"): "https://americanwootester.wpcomstaging.com", AnyHashable("plan"): "business-bundle", AnyHashable("custom_amounts_count"): 2, AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 214354650, AnyHashable("has_fees"): true, AnyHashable("has_customer_details"): false, AnyHashable("product_count"): 0, AnyHashable("product_types"): ""]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
