### PR TITLE
[Custom Amounts] Fix bug by avoiding resetting the amount when presetting

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -57,8 +57,7 @@ final class AddCustomAmountViewModel: ObservableObject {
 
     func preset(with fee: OrderFeeLine) {
         name = fee.name ?? Localization.customAmountPlaceholder
-        formattableAmountTextFieldViewModel.amount = fee.total
-        formattableAmountTextFieldViewModel.resetAmountWithNewValue = true
+        formattableAmountTextFieldViewModel.presetAmount(fee.total)
         feeID = fee.feeID
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -23,9 +23,10 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
         }
     }
 
-    /// When true, the amount will be reset with the new input instead of appending
+    /// When true, the amount will be reset with the new input instead of appending.
+    /// This is useful when we want to edit the amount with a new one, otherwise we would be appending non visible decimals.
     /// 
-    var resetAmountWithNewValue = false
+    private var resetAmountWithNewValue = false
 
     var amountIsValid: Bool {
         guard let amountDecimal = priceFieldFormatter.amountDecimal else {
@@ -54,5 +55,11 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
 
     func reset() {
         amount = ""
+    }
+
+    func presetAmount(_ newAmount: String) {
+        resetAmountWithNewValue = false
+        amount = newAmount
+        resetAmountWithNewValue = true
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModelTests.swift
@@ -112,4 +112,21 @@ final class FormattableAmountTextFieldViewModelTests: XCTestCase {
         // When & Then
         XCTAssertEqual(viewModel.formattedAmount, "€0,00")
     }
+
+    func test_preset_replaces_old_amount_on_the_next_input() {
+        // Given
+        let storeSettings = CurrencySettings(currencyCode: .EUR, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ",", numberOfDecimals: 2)
+        let viewModel = FormattableAmountTextFieldViewModel(locale: usLocale, storeCurrencySettings: storeSettings)
+
+        let oldAmount = "12.23"
+        let newInput = "1"
+
+        // When
+        viewModel.presetAmount("12.23")
+        // Simulates the input on the text field that appends the new input to the old
+        viewModel.amount = oldAmount + newInput
+
+        XCTAssertEqual(viewModel.formattedAmount, "€\(newInput)")
+
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a bug when presetting the custom amount to the Add Custom Amount when editing a fee. Because we had the `resetAmountWithNewValue` property with a `true` value we were just taking the last digit. E.g. from 1.00 we took 0. With this PR we set the value to false before setting the amount, and enable the property right after.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Tap on + to create a new order
3. Add a custom amount, e.g. $1
4. Tap to edit the custom amount
5. Cancel
6. Tap to edit it again. Before the amount was $0 (wrong), now is $1  (right)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://github.com/woocommerce/woocommerce-ios/assets/1864060/432f54c7-776b-4b68-8c81-4b02d1ae8b58

### After


https://github.com/woocommerce/woocommerce-ios/assets/1864060/615a2ba9-6666-4c66-96da-d72d4e635857

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
