### PR TITLE
Use system status endpoint to check Jetpack plugin status

### DIFF
--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -306,8 +306,8 @@ private extension JetpackSetupCoordinator {
     }
 
     @MainActor
-    func isJetpackInstalledAndActive() async -> Bool {
-        await withCheckedContinuation { continuation in
+    func isJetpackInstalledAndActive() async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(SystemStatusAction.synchronizeSystemPlugins(siteID: 0) { result in
                 switch result {
                 case let .success(plugins):
@@ -319,7 +319,7 @@ private extension JetpackSetupCoordinator {
                     }
                 case let .failure(error):
                     DDLogError("⛔️ Failed to sync system plugins. Error: \(error)")
-                    continuation.resume(returning: false)
+                    continuation.resume(throwing: error)
                 }
             })
         }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -297,15 +297,15 @@ private extension JetpackSetupCoordinator {
     }
 
     @MainActor
-    func fetchJetpackUser() async -> Result<JetpackUser, Error> {
+    func fetchJetpackUser() async throws -> JetpackUser {
         /// Jetpack setup will fail anyway without admin role, so check that first.
         let roles = stores.sessionManager.defaultRoles
         guard roles.contains(.administrator) else {
-            return .failure(JetpackCheckError.missingPermission)
+            throw JetpackCheckError.missingPermission
         }
-        return await withCheckedContinuation { continuation in
+        return try await withCheckedThrowingContinuation { continuation in
             let action = JetpackConnectionAction.fetchJetpackUser { result in
-                continuation.resume(returning: result)
+                continuation.resume(with: result)
             }
             stores.dispatch(action)
         }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -181,19 +181,18 @@ private extension JetpackSetupCoordinator {
                 })
             }
 
-            let result = await fetchJetpackUser()
-            progressView.dismiss(animated: true, completion: { [weak self] in
-                guard let self else { return }
-                do {
-                    try self.saveJetpackConnectionStateIfPossible(result)
-                    self.showSetupSteps(username: username, authToken: authToken)
-                } catch JetpackCheckError.missingPermission {
-                    self.displayAdminRoleRequiredError()
-                } catch {
-                    DDLogError("⛔️ Jetpack status fetched error: \(error)")
-                    self.showAlert(message: Localization.errorCheckingJetpack)
-                }
-            })
+            do {
+                try await checkJetpackConnectionState()
+                await progressView.dismiss(animated: true)
+                showSetupSteps(username: username, authToken: authToken)
+            } catch JetpackCheckError.missingPermission {
+                await progressView.dismiss(animated: true)
+                displayAdminRoleRequiredError()
+            } catch {
+                await progressView.dismiss(animated: true)
+                DDLogError("⛔️ Jetpack status fetched error: \(error)")
+                showAlert(message: Localization.errorCheckingJetpack)
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -199,3 +199,18 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         assertEqual(expectedAccount, stores.sessionManager.defaultAccount)
     }
 }
+
+private extension MockStoresManager {
+    func mockJetpackCheck(isJetpackInstalled: Bool = false,
+                          isJetpackActive: Bool = false) {
+        whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .synchronizeSystemPlugins(_, onCompletion):
+                onCompletion(.success([.fake().copy(name: isJetpackInstalled ? "Jetpack" : "Plugin", active: isJetpackActive)]))
+            default:
+                break
+            }
+        }
+
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -5,11 +5,9 @@ import enum Alamofire.AFError
 
 final class JetpackSetupCoordinatorTests: XCTestCase {
 
-    private var stores: MockStoresManager!
     private var navigationController: UINavigationController!
 
     override func setUp() {
-        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         navigationController = UINavigationController()
 
         let window = UIWindow(frame: UIScreen.main.bounds)
@@ -20,7 +18,6 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     }
 
     override func tearDown() {
-        stores = nil
         navigationController = nil
         super.tearDown()
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -112,6 +112,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
                 break
             }
         }
+        stores.mockJetpackCheck()
 
         // When
         _ = coordinator.handleAuthenticationUrl(url)
@@ -141,6 +142,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
                 break
             }
         }
+        stores.mockJetpackCheck()
 
         // When
         _ = coordinator.handleAuthenticationUrl(url)
@@ -187,6 +189,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
                 break
             }
         }
+        stores.mockJetpackCheck()
 
         // When
         _ = coordinator.handleAuthenticationUrl(url)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11030 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

####  What? 
Starts using the system status endpoint to check the Jetpack plugin installation status. 

####  Why? 

We previously used the `/jetpack/v4/connection/data` endpoint to determine Jetpack installation status. 

The endpoint above is added by the Jetpack Connection Package, so sites that have JCP are detected as having Jetpack the plugin installed which is incorrect. 

We decided to use the `/wc/v3/system_status` endpoint to check the Jetpack installation and activation status. 

Internal - pe5sF9-2aR-p2

####  How? 
- Send a request to the `/wc/v3/system_status` endpoint to determine the Jetpack plugin installation status.
- Continue using `/jetpack/v4/connection/data` endpoint to fetch the Jetpack user email if available.


## Testing instructions
1. Prepare a self-hosted site with WooCommerce but without Jetpack
2. Log in
3. Tap on the Jetpack promotion banner
4. Notice the next screen prompts you to install Jetpack
5. Go back to the main screen
6. Install & activate Jetpack on the site, but don't connect
7. Tap on the Jetpack banner
8. Notice the next screen prompts you to connect an email address to Jetpack
9. From the wp-admin page, setup Jetpack and connect a WPCOM email
10. Tap on the Jetpack banner
11. Notice that the email is prefilled and you are asked to login

## Screenshots
| No Jetpack | Jetpack installed | Jetpack connected |
|--------|--------|--------|
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-11-01 at 10 29 11](https://github.com/woocommerce/woocommerce-ios/assets/524475/09416265-acec-4572-a162-8c41949d6645) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-11-01 at 10 31 23](https://github.com/woocommerce/woocommerce-ios/assets/524475/426c8574-f61a-4bdb-a791-e53507590f95) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-11-01 at 10 36 41](https://github.com/woocommerce/woocommerce-ios/assets/524475/c5fd90b2-bda2-4cce-8b6b-9f9f95b113eb) | 





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.