### PR TITLE
Blaze: Include product ID into Campaign model

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -162,6 +162,7 @@ extension Networking.BlazeCampaign {
         .init(
             siteID: .fake(),
             campaignID: .fake(),
+            productID: .fake(),
             name: .fake(),
             uiStatus: .fake(),
             contentImageURL: .fake(),

--- a/Networking/Networking/Model/BlazeCampaign.swift
+++ b/Networking/Networking/Model/BlazeCampaign.swift
@@ -13,7 +13,7 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
     public let campaignID: Int64
 
     /// ID of the product in the campaign
-    public let productID: Int64
+    public let productID: Int64?
 
     /// Name of the campaign
     public let name: String
@@ -143,14 +143,8 @@ private extension BlazeCampaign {
     /// Extracts the product ID from the `target_urn` response.
     /// The response looks like the following: `urn:wpcom:post:1:134`
     /// The product ID is the last number following the colon in the response (`134`).
-    /// If the product ID cannot be found, zero will be returned, to ensure that the entire Campaign response is not rejected.
-    /// Product ID is currently used only for showing or hiding the Blaze button on product details, and its absence is not a
-    /// dealbreaker.
-    static func extractProductIdFromUrn(_ urn: String) -> Int64 {
-        let components = urn.split(separator: ":")
-        guard let lastComponent = components.last, let productId = Int64(lastComponent) else {
-            return 0
-        }
-        return productId
+    /// If the product ID cannot be extracted, it returns null instead.
+    static func extractProductIdFromUrn(_ urn: String) -> Int64? {
+        return Int64(String(urn.split(separator: ":").last ?? ""))
     }
 }

--- a/Networking/Networking/Model/BlazeCampaign.swift
+++ b/Networking/Networking/Model/BlazeCampaign.swift
@@ -12,6 +12,9 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
     /// ID of the campaign
     public let campaignID: Int64
 
+    /// ID of the product in the campaign
+    public let productID: Int64
+
     /// Name of the campaign
     public let name: String
 
@@ -35,6 +38,7 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
 
     public init(siteID: Int64,
                 campaignID: Int64,
+                productID: Int64,
                 name: String,
                 uiStatus: String,
                 contentImageURL: String?,
@@ -44,6 +48,7 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
                 totalBudget: Double) {
         self.siteID = siteID
         self.campaignID = campaignID
+        self.productID = productID
         self.name = name
         self.uiStatus = uiStatus
         self.contentImageURL = contentImageURL
@@ -64,6 +69,9 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
         campaignID = try container.decode(Int64.self, forKey: .campaignId)
         name = try container.decode(String.self, forKey: .name)
         uiStatus = try container.decode(String.self, forKey: .uiStatus)
+
+        let targetUrn = try container.decode(String.self, forKey: .targetUrn)
+        productID = BlazeCampaign.extractProductIdFromUrn(targetUrn)
 
         let content = try container.decode(ContentConfig.self, forKey: .contentConfig)
         contentImageURL = content.imageURL
@@ -103,6 +111,7 @@ private extension BlazeCampaign {
     enum CodingKeys: String, CodingKey {
         case campaignId
         case name
+        case targetUrn
         case uiStatus
         case contentConfig
         case campaignStats
@@ -130,4 +139,16 @@ private extension BlazeCampaign {
     enum DecodingError: Error {
         case missingSiteID
     }
+
+    /// Extracts the product ID from the `target_urn` response.
+    /// The response looks like the following: `urn:wpcom:post:1:134`
+    /// The product ID is the last number following the colon in the response (`134`).
+    /// If the product ID cannot be found, zero will be returned, to ensure that the entire Campaign response is not rejected.
+    /// Product ID is currently used only for showing or hiding the Blaze button on product details, and its absence is not a
+    /// dealbreaker.
+    static func extractProductIdFromUrn(_ urn: String) -> Int64 {
+        let components = urn.split(separator: ":").compactMap { Int64($0) }
+        return components.last ?? 0
+    }
+
 }

--- a/Networking/Networking/Model/BlazeCampaign.swift
+++ b/Networking/Networking/Model/BlazeCampaign.swift
@@ -38,7 +38,7 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
 
     public init(siteID: Int64,
                 campaignID: Int64,
-                productID: Int64,
+                productID: Int64?,
                 name: String,
                 uiStatus: String,
                 contentImageURL: String?,

--- a/Networking/Networking/Model/BlazeCampaign.swift
+++ b/Networking/Networking/Model/BlazeCampaign.swift
@@ -147,8 +147,10 @@ private extension BlazeCampaign {
     /// Product ID is currently used only for showing or hiding the Blaze button on product details, and its absence is not a
     /// dealbreaker.
     static func extractProductIdFromUrn(_ urn: String) -> Int64 {
-        let components = urn.split(separator: ":").compactMap { Int64($0) }
-        return components.last ?? 0
+        let components = urn.split(separator: ":")
+        guard let lastComponent = components.last, let productId = Int64(lastComponent) else {
+            return 0
+        }
+        return productId
     }
-
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -164,7 +164,7 @@ extension Networking.BlazeCampaign {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
         campaignID: CopiableProp<Int64> = .copy,
-        productID: CopiableProp<Int64> = .copy,
+        productID: NullableCopiableProp<Int64> = .copy,
         name: CopiableProp<String> = .copy,
         uiStatus: CopiableProp<String> = .copy,
         contentImageURL: NullableCopiableProp<String> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -164,6 +164,7 @@ extension Networking.BlazeCampaign {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
         campaignID: CopiableProp<Int64> = .copy,
+        productID: CopiableProp<Int64> = .copy,
         name: CopiableProp<String> = .copy,
         uiStatus: CopiableProp<String> = .copy,
         contentImageURL: NullableCopiableProp<String> = .copy,
@@ -174,6 +175,7 @@ extension Networking.BlazeCampaign {
     ) -> Networking.BlazeCampaign {
         let siteID = siteID ?? self.siteID
         let campaignID = campaignID ?? self.campaignID
+        let productID = productID ?? self.productID
         let name = name ?? self.name
         let uiStatus = uiStatus ?? self.uiStatus
         let contentImageURL = contentImageURL ?? self.contentImageURL
@@ -185,6 +187,7 @@ extension Networking.BlazeCampaign {
         return Networking.BlazeCampaign(
             siteID: siteID,
             campaignID: campaignID,
+            productID: productID,
             name: name,
             uiStatus: uiStatus,
             contentImageURL: contentImageURL,

--- a/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
@@ -16,6 +16,7 @@ final class BlazeCampaignListMapperTests: XCTestCase {
         let item = try XCTUnwrap(campaigns.first)
         XCTAssertEqual(item.siteID, dummySiteID)
         XCTAssertEqual(item.campaignID, 34518)
+        XCTAssertEqual(item.productID, 134)
         XCTAssertEqual(item.name, "Fried-egg Bacon Bagel")
         XCTAssertEqual(item.uiStatus, "rejected")
         XCTAssertEqual(item.contentClickURL, "https://example.com/product/fried-egg-bacon-bagel/")

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -135,6 +135,7 @@ private extension BlazeCampaignItemView {
 struct BlazeCampaignItemView_Previews: PreviewProvider {
     static let campaign: BlazeCampaign = .init(siteID: 123,
                                                campaignID: 11,
+                                               productID: 33,
                                                name: "Fluffy bunny pouch",
                                                uiStatus: BlazeCampaign.Status.finished.rawValue,
                                                contentImageURL: nil,

--- a/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
@@ -23,7 +23,7 @@ extension Storage.BlazeCampaign: ReadOnlyConvertible {
     public func toReadOnly() -> BlazeCampaign {
         BlazeCampaign(siteID: siteID,
                       campaignID: campaignID,
-                      productID: 0, // TODO-11059: update storage
+                      productID: nil, // TODO-11059: update storage
                       name: name,
                       uiStatus: rawStatus,
                       contentImageURL: contentImageURL,

--- a/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
@@ -23,6 +23,7 @@ extension Storage.BlazeCampaign: ReadOnlyConvertible {
     public func toReadOnly() -> BlazeCampaign {
         BlazeCampaign(siteID: siteID,
                       campaignID: campaignID,
+                      productID: 0, // TODO-11059: update storage
                       name: name,
                       uiStatus: rawStatus,
                       contentImageURL: contentImageURL,


### PR DESCRIPTION
Fixes #11059
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the `productID` value into the `BlazeCampaign` model. The ID itself is extracted from the `target_urn` value in the response. Specifically, it's the last number in the response. If the response is `urn:wpcom:post:1:134`, then the value is `134`.

## Testing instructions
Just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
n/a
