### PR TITLE
[Fakes] Fix Fakes generation for Deposits-related models

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2153,6 +2153,132 @@ extension WCPayPaymentMethodType {
         .card
     }
 }
+extension Networking.WooPaymentsAccountDepositSummary {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsAccountDepositSummary {
+        .init(
+            depositsEnabled: .fake(),
+            depositsBlocked: .fake(),
+            depositsSchedule: .fake(),
+            defaultCurrency: .fake()
+        )
+    }
+}
+extension Networking.WooPaymentsBalance {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsBalance {
+        .init(
+            amount: .fake(),
+            currency: .fake(),
+            sourceTypes: .fake(),
+            depositsCount: .fake()
+        )
+    }
+}
+extension Networking.WooPaymentsCurrencyBalances {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsCurrencyBalances {
+        .init(
+            pending: .fake(),
+            available: .fake(),
+            instant: .fake()
+        )
+    }
+}
+extension Networking.WooPaymentsCurrencyDeposits {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsCurrencyDeposits {
+        .init(
+            lastPaid: .fake(),
+            nextScheduled: .fake(),
+            lastManualDeposits: .fake()
+        )
+    }
+}
+extension Networking.WooPaymentsDeposit {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsDeposit {
+        .init(
+            id: .fake(),
+            date: .fake(),
+            type: .fake(),
+            amount: .fake(),
+            status: .fake(),
+            bankAccount: .fake(),
+            currency: .fake(),
+            automatic: .fake(),
+            fee: .fake(),
+            feePercentage: .fake(),
+            created: .fake()
+        )
+    }
+}
+extension WooPaymentsDepositInterval {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WooPaymentsDepositInterval {
+        .daily
+    }
+}
+extension WooPaymentsDepositStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WooPaymentsDepositStatus {
+        .estimated
+    }
+}
+extension WooPaymentsDepositType {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WooPaymentsDepositType {
+        .withdrawal
+    }
+}
+extension Networking.WooPaymentsDepositsOverview {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsDepositsOverview {
+        .init(
+            deposit: .fake(),
+            balance: .fake(),
+            account: .fake()
+        )
+    }
+}
+extension Networking.WooPaymentsDepositsSchedule {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsDepositsSchedule {
+        .init(
+            delayDays: .fake(),
+            interval: .fake()
+        )
+    }
+}
+extension Networking.WooPaymentsManualDeposit {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsManualDeposit {
+        .init(
+            currency: .fake(),
+            date: .fake()
+        )
+    }
+}
+extension Networking.WooPaymentsSourceTypes {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooPaymentsSourceTypes {
+        .init(
+            card: .fake()
+        )
+    }
+}
 extension Networking.WordPressMedia {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2839,6 +2839,186 @@ extension Networking.WCPayCharge {
     }
 }
 
+extension Networking.WooPaymentsAccountDepositSummary {
+    public func copy(
+        depositsEnabled: CopiableProp<Bool> = .copy,
+        depositsBlocked: CopiableProp<Bool> = .copy,
+        depositsSchedule: CopiableProp<WooPaymentsDepositsSchedule> = .copy,
+        defaultCurrency: CopiableProp<String> = .copy
+    ) -> Networking.WooPaymentsAccountDepositSummary {
+        let depositsEnabled = depositsEnabled ?? self.depositsEnabled
+        let depositsBlocked = depositsBlocked ?? self.depositsBlocked
+        let depositsSchedule = depositsSchedule ?? self.depositsSchedule
+        let defaultCurrency = defaultCurrency ?? self.defaultCurrency
+
+        return Networking.WooPaymentsAccountDepositSummary(
+            depositsEnabled: depositsEnabled,
+            depositsBlocked: depositsBlocked,
+            depositsSchedule: depositsSchedule,
+            defaultCurrency: defaultCurrency
+        )
+    }
+}
+
+extension Networking.WooPaymentsBalance {
+    public func copy(
+        amount: CopiableProp<Int> = .copy,
+        currency: CopiableProp<String> = .copy,
+        sourceTypes: CopiableProp<WooPaymentsSourceTypes> = .copy,
+        depositsCount: NullableCopiableProp<Int> = .copy
+    ) -> Networking.WooPaymentsBalance {
+        let amount = amount ?? self.amount
+        let currency = currency ?? self.currency
+        let sourceTypes = sourceTypes ?? self.sourceTypes
+        let depositsCount = depositsCount ?? self.depositsCount
+
+        return Networking.WooPaymentsBalance(
+            amount: amount,
+            currency: currency,
+            sourceTypes: sourceTypes,
+            depositsCount: depositsCount
+        )
+    }
+}
+
+extension Networking.WooPaymentsCurrencyBalances {
+    public func copy(
+        pending: CopiableProp<[WooPaymentsBalance]> = .copy,
+        available: CopiableProp<[WooPaymentsBalance]> = .copy,
+        instant: CopiableProp<[WooPaymentsBalance]> = .copy
+    ) -> Networking.WooPaymentsCurrencyBalances {
+        let pending = pending ?? self.pending
+        let available = available ?? self.available
+        let instant = instant ?? self.instant
+
+        return Networking.WooPaymentsCurrencyBalances(
+            pending: pending,
+            available: available,
+            instant: instant
+        )
+    }
+}
+
+extension Networking.WooPaymentsCurrencyDeposits {
+    public func copy(
+        lastPaid: CopiableProp<[WooPaymentsDeposit]> = .copy,
+        nextScheduled: CopiableProp<[WooPaymentsDeposit]> = .copy,
+        lastManualDeposits: CopiableProp<[WooPaymentsManualDeposit]> = .copy
+    ) -> Networking.WooPaymentsCurrencyDeposits {
+        let lastPaid = lastPaid ?? self.lastPaid
+        let nextScheduled = nextScheduled ?? self.nextScheduled
+        let lastManualDeposits = lastManualDeposits ?? self.lastManualDeposits
+
+        return Networking.WooPaymentsCurrencyDeposits(
+            lastPaid: lastPaid,
+            nextScheduled: nextScheduled,
+            lastManualDeposits: lastManualDeposits
+        )
+    }
+}
+
+extension Networking.WooPaymentsDeposit {
+    public func copy(
+        id: CopiableProp<String> = .copy,
+        date: CopiableProp<Date> = .copy,
+        type: CopiableProp<WooPaymentsDepositType> = .copy,
+        amount: CopiableProp<Int> = .copy,
+        status: CopiableProp<WooPaymentsDepositStatus> = .copy,
+        bankAccount: NullableCopiableProp<String> = .copy,
+        currency: CopiableProp<String> = .copy,
+        automatic: CopiableProp<Bool> = .copy,
+        fee: CopiableProp<Int> = .copy,
+        feePercentage: CopiableProp<Int> = .copy,
+        created: CopiableProp<Int> = .copy
+    ) -> Networking.WooPaymentsDeposit {
+        let id = id ?? self.id
+        let date = date ?? self.date
+        let type = type ?? self.type
+        let amount = amount ?? self.amount
+        let status = status ?? self.status
+        let bankAccount = bankAccount ?? self.bankAccount
+        let currency = currency ?? self.currency
+        let automatic = automatic ?? self.automatic
+        let fee = fee ?? self.fee
+        let feePercentage = feePercentage ?? self.feePercentage
+        let created = created ?? self.created
+
+        return Networking.WooPaymentsDeposit(
+            id: id,
+            date: date,
+            type: type,
+            amount: amount,
+            status: status,
+            bankAccount: bankAccount,
+            currency: currency,
+            automatic: automatic,
+            fee: fee,
+            feePercentage: feePercentage,
+            created: created
+        )
+    }
+}
+
+extension Networking.WooPaymentsDepositsOverview {
+    public func copy(
+        deposit: CopiableProp<WooPaymentsCurrencyDeposits> = .copy,
+        balance: CopiableProp<WooPaymentsCurrencyBalances> = .copy,
+        account: CopiableProp<WooPaymentsAccountDepositSummary> = .copy
+    ) -> Networking.WooPaymentsDepositsOverview {
+        let deposit = deposit ?? self.deposit
+        let balance = balance ?? self.balance
+        let account = account ?? self.account
+
+        return Networking.WooPaymentsDepositsOverview(
+            deposit: deposit,
+            balance: balance,
+            account: account
+        )
+    }
+}
+
+extension Networking.WooPaymentsDepositsSchedule {
+    public func copy(
+        delayDays: CopiableProp<Int> = .copy,
+        interval: CopiableProp<WooPaymentsDepositInterval> = .copy
+    ) -> Networking.WooPaymentsDepositsSchedule {
+        let delayDays = delayDays ?? self.delayDays
+        let interval = interval ?? self.interval
+
+        return Networking.WooPaymentsDepositsSchedule(
+            delayDays: delayDays,
+            interval: interval
+        )
+    }
+}
+
+extension Networking.WooPaymentsManualDeposit {
+    public func copy(
+        currency: CopiableProp<String> = .copy,
+        date: CopiableProp<Date> = .copy
+    ) -> Networking.WooPaymentsManualDeposit {
+        let currency = currency ?? self.currency
+        let date = date ?? self.date
+
+        return Networking.WooPaymentsManualDeposit(
+            currency: currency,
+            date: date
+        )
+    }
+}
+
+extension Networking.WooPaymentsSourceTypes {
+    public func copy(
+        card: CopiableProp<Int> = .copy
+    ) -> Networking.WooPaymentsSourceTypes {
+        let card = card ?? self.card
+
+        return Networking.WooPaymentsSourceTypes(
+            card: card
+        )
+    }
+}
+
 extension Networking.WordPressMedia {
     public func copy(
         mediaID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
+++ b/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
@@ -5,12 +5,24 @@ public struct WooPaymentsDepositsOverview: Codable, GeneratedFakeable, Generated
     public let deposit: WooPaymentsCurrencyDeposits
     public let balance: WooPaymentsCurrencyBalances
     public let account: WooPaymentsAccountDepositSummary
+
+    public init(deposit: WooPaymentsCurrencyDeposits, balance: WooPaymentsCurrencyBalances, account: WooPaymentsAccountDepositSummary) {
+        self.deposit = deposit
+        self.balance = balance
+        self.account = account
+    }
 }
 
 public struct WooPaymentsCurrencyDeposits: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
     public let lastPaid: [WooPaymentsDeposit]
     public let nextScheduled: [WooPaymentsDeposit]
     public let lastManualDeposits: [WooPaymentsManualDeposit]
+
+    public init(lastPaid: [WooPaymentsDeposit], nextScheduled: [WooPaymentsDeposit], lastManualDeposits: [WooPaymentsManualDeposit]) {
+        self.lastPaid = lastPaid
+        self.nextScheduled = nextScheduled
+        self.lastManualDeposits = lastManualDeposits
+    }
 
     enum CodingKeys: String, CodingKey {
         case lastPaid = "last_paid"
@@ -32,6 +44,20 @@ public struct WooPaymentsDeposit: Codable, GeneratedFakeable, GeneratedCopiable,
     public let feePercentage: Int
     public let created: Int
 
+    public init(id: String, date: Date, type: WooPaymentsDepositType, amount: Int, status: WooPaymentsDepositStatus, bankAccount: String?, currency: String, automatic: Bool, fee: Int, feePercentage: Int, created: Int) {
+        self.id = id
+        self.date = date
+        self.type = type
+        self.amount = amount
+        self.status = status
+        self.bankAccount = bankAccount
+        self.currency = currency
+        self.automatic = automatic
+        self.fee = fee
+        self.feePercentage = feePercentage
+        self.created = created
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case date
@@ -50,6 +76,11 @@ public struct WooPaymentsDeposit: Codable, GeneratedFakeable, GeneratedCopiable,
 public struct WooPaymentsManualDeposit: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
     public let currency: String
     public let date: Date
+
+    public init(currency: String, date: Date) {
+        self.currency = currency
+        self.date = date
+    }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -76,7 +107,7 @@ public struct WooPaymentsManualDeposit: Codable, GeneratedFakeable, GeneratedCop
 /// originates from 
 // https://github.com/Automattic/woocommerce-payments-server/blob/899963c61d9ad1c1aa5306087b8bb7ea253e66a0/server/
 // wp-content/rest-api-plugins/endpoints/wcpay/class-deposits-controller.php#L753
-public enum WooPaymentsDepositType: String, Codable, Equatable {
+public enum WooPaymentsDepositType: String, Codable, Equatable, GeneratedFakeable, GeneratedCopiable {
     case withdrawal
     case deposit
 }
@@ -85,7 +116,7 @@ public enum WooPaymentsDepositType: String, Codable, Equatable {
 /// with additions in WooPayments e.g. 
 // https://github.com/Automattic/woocommerce-payments-server/blob/899963c61d9ad1c1aa5306087b8bb7ea253e66a0/
 // server/wp-content/rest-api-plugins/endpoints/wcpay/utils/class-deposit-utils.php#L141
-public enum WooPaymentsDepositStatus: String, Codable, Equatable {
+public enum WooPaymentsDepositStatus: String, Codable, Equatable, GeneratedFakeable, GeneratedCopiable {
     case estimated
     case pending
     case inTransit = "in_transit"
@@ -98,6 +129,12 @@ public struct WooPaymentsCurrencyBalances: Codable, GeneratedFakeable, Generated
     public let pending: [WooPaymentsBalance]
     public let available: [WooPaymentsBalance]
     public let instant: [WooPaymentsBalance]
+
+    public init(pending: [WooPaymentsBalance], available: [WooPaymentsBalance], instant: [WooPaymentsBalance]) {
+        self.pending = pending
+        self.available = available
+        self.instant = instant
+    }
 }
 
 public struct WooPaymentsBalance: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
@@ -105,6 +142,13 @@ public struct WooPaymentsBalance: Codable, GeneratedFakeable, GeneratedCopiable,
     public let currency: String
     public let sourceTypes: WooPaymentsSourceTypes
     public let depositsCount: Int?
+
+    public init(amount: Int, currency: String, sourceTypes: WooPaymentsSourceTypes, depositsCount: Int?) {
+        self.amount = amount
+        self.currency = currency
+        self.sourceTypes = sourceTypes
+        self.depositsCount = depositsCount
+    }
 
     public enum CodingKeys: String, CodingKey {
         case amount
@@ -117,6 +161,10 @@ public struct WooPaymentsBalance: Codable, GeneratedFakeable, GeneratedCopiable,
 public struct WooPaymentsSourceTypes: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
     public let card: Int
     // TODO: find out other possible source types, or remove
+
+    public init(card: Int) {
+        self.card = card
+    }
 }
 
 public struct WooPaymentsAccountDepositSummary: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
@@ -124,6 +172,13 @@ public struct WooPaymentsAccountDepositSummary: Codable, GeneratedFakeable, Gene
     public let depositsBlocked: Bool
     public let depositsSchedule: WooPaymentsDepositsSchedule
     public let defaultCurrency: String
+
+    public init(depositsEnabled: Bool, depositsBlocked: Bool, depositsSchedule: WooPaymentsDepositsSchedule, defaultCurrency: String) {
+        self.depositsEnabled = depositsEnabled
+        self.depositsBlocked = depositsBlocked
+        self.depositsSchedule = depositsSchedule
+        self.defaultCurrency = defaultCurrency
+    }
 
     public enum CodingKeys: String, CodingKey {
         case depositsEnabled = "deposits_enabled"
@@ -136,6 +191,11 @@ public struct WooPaymentsAccountDepositSummary: Codable, GeneratedFakeable, Gene
 public struct WooPaymentsDepositsSchedule: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
     public let delayDays: Int
     public let interval: WooPaymentsDepositInterval
+
+    public init(delayDays: Int, interval: WooPaymentsDepositInterval) {
+        self.delayDays = delayDays
+        self.interval = interval
+    }
 
     enum CodingKeys: String, CodingKey {
         case delayDays = "delay_days"
@@ -176,7 +236,7 @@ public struct WooPaymentsDepositsSchedule: Codable, GeneratedFakeable, Generated
 }
 
 /// originally from https://stripe.com/docs/api/accounts/object#account_object-settings-payouts-schedule-interval
-public enum WooPaymentsDepositInterval: Equatable {
+public enum WooPaymentsDepositInterval: Equatable, GeneratedFakeable, GeneratedCopiable {
     case daily
     case weekly(anchor: Weekday)
     case monthly(anchor: Int)

--- a/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
+++ b/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
@@ -6,7 +6,9 @@ public struct WooPaymentsDepositsOverview: Codable, GeneratedFakeable, Generated
     public let balance: WooPaymentsCurrencyBalances
     public let account: WooPaymentsAccountDepositSummary
 
-    public init(deposit: WooPaymentsCurrencyDeposits, balance: WooPaymentsCurrencyBalances, account: WooPaymentsAccountDepositSummary) {
+    public init(deposit: WooPaymentsCurrencyDeposits,
+                balance: WooPaymentsCurrencyBalances,
+                account: WooPaymentsAccountDepositSummary) {
         self.deposit = deposit
         self.balance = balance
         self.account = account
@@ -18,7 +20,9 @@ public struct WooPaymentsCurrencyDeposits: Codable, GeneratedFakeable, Generated
     public let nextScheduled: [WooPaymentsDeposit]
     public let lastManualDeposits: [WooPaymentsManualDeposit]
 
-    public init(lastPaid: [WooPaymentsDeposit], nextScheduled: [WooPaymentsDeposit], lastManualDeposits: [WooPaymentsManualDeposit]) {
+    public init(lastPaid: [WooPaymentsDeposit],
+                nextScheduled: [WooPaymentsDeposit],
+                lastManualDeposits: [WooPaymentsManualDeposit]) {
         self.lastPaid = lastPaid
         self.nextScheduled = nextScheduled
         self.lastManualDeposits = lastManualDeposits
@@ -44,7 +48,17 @@ public struct WooPaymentsDeposit: Codable, GeneratedFakeable, GeneratedCopiable,
     public let feePercentage: Int
     public let created: Int
 
-    public init(id: String, date: Date, type: WooPaymentsDepositType, amount: Int, status: WooPaymentsDepositStatus, bankAccount: String?, currency: String, automatic: Bool, fee: Int, feePercentage: Int, created: Int) {
+    public init(id: String,
+                date: Date,
+                type: WooPaymentsDepositType,
+                amount: Int,
+                status: WooPaymentsDepositStatus,
+                bankAccount: String?,
+                currency: String,
+                automatic: Bool,
+                fee: Int,
+                feePercentage: Int,
+                created: Int) {
         self.id = id
         self.date = date
         self.type = type
@@ -173,7 +187,10 @@ public struct WooPaymentsAccountDepositSummary: Codable, GeneratedFakeable, Gene
     public let depositsSchedule: WooPaymentsDepositsSchedule
     public let defaultCurrency: String
 
-    public init(depositsEnabled: Bool, depositsBlocked: Bool, depositsSchedule: WooPaymentsDepositsSchedule, defaultCurrency: String) {
+    public init(depositsEnabled: Bool,
+                depositsBlocked: Bool,
+                depositsSchedule: WooPaymentsDepositsSchedule,
+                defaultCurrency: String) {
         self.depositsEnabled = depositsEnabled
         self.depositsBlocked = depositsBlocked
         self.depositsSchedule = depositsSchedule


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I forgot to generate fakes when I added the Deposit views during the last HACK week. The lack of public init methods (other than `from: Decoder` variants) meant that fake generation showed errors and failed for others.

This PR adds the required init methods to fix fakes generation. They aren't used elsewhere, and these models are only used behind feature flags at the moment.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check `bundle exec rake generate` works without errors.

Check unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
