### PR TITLE
Blaze campaign view in Dashboard - Limit Core data fetch count

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -57,6 +57,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageBlazeCampaign.campaignID, ascending: false)
         let resultsController = ResultsController<StorageBlazeCampaign>(storageManager: storageManager,
                                                                         matching: predicate,
+                                                                        fetchLimit: 1,
                                                                         sortedBy: [sortDescriptorByID])
         return resultsController
     }()
@@ -66,6 +67,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         let predicate = NSPredicate(format: "siteID == %lld AND statusKey ==[c] %@ ", siteID, ProductStatus.published.rawValue)
         return ResultsController<StorageProduct>(storageManager: storageManager,
                                                  matching: predicate,
+                                                 fetchLimit: 1,
                                                  sortOrder: .dateDescending)
     }()
 

--- a/Yosemite/Yosemite/Tools/Products/ResultsController+SortProducts.swift
+++ b/Yosemite/Yosemite/Tools/Products/ResultsController+SortProducts.swift
@@ -5,11 +5,13 @@ extension ResultsController where T: StorageProduct {
     public convenience init(storageManager: StorageManagerType,
                             sectionNameKeyPath: String? = nil,
                             matching predicate: NSPredicate? = nil,
+                            fetchLimit: Int? = nil,
                             sortOrder: ProductsSortOrder) {
 
         self.init(storageManager: storageManager,
                   sectionNameKeyPath: sectionNameKeyPath,
                   matching: predicate,
+                  fetchLimit: fetchLimit,
                   sortedBy: sortOrder.sortDescriptors ?? [])
     }
 

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -43,6 +43,9 @@ public class ResultsController<T: ResultsControllerMutableType> {
         let request = NSFetchRequest<T>(entityName: T.entityName)
         request.predicate = predicate
         request.sortDescriptors = sortDescriptors
+        if let fetchLimit {
+            request.fetchLimit = fetchLimit
+        }
         return request
     }()
 
@@ -85,17 +88,22 @@ public class ResultsController<T: ResultsControllerMutableType> {
     ///
     public var onDidResetContent: (() -> Void)?
 
+    /// Limits the number of objects fetched from storage
+    ///
+    private let fetchLimit: Int?
 
     /// Designated Initializer.
     ///
     public init(viewStorage: StorageType,
                 sectionNameKeyPath: String? = nil,
                 matching predicate: NSPredicate? = nil,
+                fetchLimit: Int? = nil,
                 sortedBy descriptors: [NSSortDescriptor]) {
 
         self.viewStorage = viewStorage
         self.sectionNameKeyPath = sectionNameKeyPath
         self.predicate = predicate
+        self.fetchLimit = fetchLimit
         self.sortDescriptors = descriptors
 
         setupResultsController()
@@ -108,11 +116,13 @@ public class ResultsController<T: ResultsControllerMutableType> {
     public convenience init(storageManager: StorageManagerType,
                             sectionNameKeyPath: String? = nil,
                             matching predicate: NSPredicate? = nil,
+                            fetchLimit: Int? = nil,
                             sortedBy descriptors: [NSSortDescriptor]) {
 
         self.init(viewStorage: storageManager.viewStorage,
                   sectionNameKeyPath: sectionNameKeyPath,
                   matching: predicate,
+                  fetchLimit: fetchLimit,
                   sortedBy: descriptors)
     }
 

--- a/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -388,6 +388,43 @@ final class ResultsControllerTests: XCTestCase {
         // Then
         XCTAssertNil(readonlyAccount)
     }
+
+    // MARK: Fetch limit
+
+    func test_fetchLimit_fetches_the_specified_count() throws {
+        // Given
+        let _ = [
+            insertAccount(displayName: "A", username: "one"),
+            insertAccount(displayName: "B", username: "two"),
+            insertAccount(displayName: "C", username: "three"),
+        ]
+
+        let resultsController = ResultsController<Storage.Account>(viewStorage: viewStorage,
+                                                                   sectionNameKeyPath: #keyPath(Storage.Account.displayName),
+                                                                   fetchLimit: 1,
+                                                                   sortedBy: [sampleSortDescriptor])
+        try resultsController.performFetch()
+
+        // Then
+        XCTAssertEqual(resultsController.fetchedObjects.count, 1)
+    }
+
+    func test_all_matching_objects_are_fetched_when_fetchLimit_not_specified() throws {
+        // Given
+        let _ = [
+            insertAccount(displayName: "A", username: "one"),
+            insertAccount(displayName: "B", username: "two"),
+            insertAccount(displayName: "C", username: "three"),
+        ]
+
+        let resultsController = ResultsController<Storage.Account>(viewStorage: viewStorage,
+                                                                   sectionNameKeyPath: #keyPath(Storage.Account.displayName),
+                                                                   sortedBy: [sampleSortDescriptor])
+        try resultsController.performFetch()
+
+        // Then
+        XCTAssertEqual(resultsController.fetchedObjects.count, 3)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11064
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Why?

To resolve a core data related crash occurring in `BlazeCampaignDashboardViewModel`.

The crash occurs in the Dashboard screen's Blaze campaign view. We suspect it is because we are fetching too many items from Core data. 

Internal - p1698843107754349-slack-C03L1NF1EA3

What?

We can limit the number of Products and Blaze campaigns fetched for the Blaze view. The logic actually uses only one Product or BlazeCampaign.

How? 

- Add a way to specify `fetchLimit` in `ResultsController`
- Mention 1 as `fetchLimit` for both Product and BlazeCampaign `ResultsController`s in `BlazeCampaignDashboardViewModel`

## Testing instructions

Smoke test that Blaze view in Dashboard works as before. #10969

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.