### PR TITLE
[Bundle products in order form] Configuration screen polishes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
@@ -20,8 +20,31 @@ struct ConfigurableBundleProductView: View {
                             .dividerStyle()
                             .padding(.leading, Layout.defaultPadding)
                     }
-                    .background(Color(.listForeground(modal: false)))
+                    .renderedIf(viewModel.bundleItemViewModels.isNotEmpty)
+
+                    ForEach(viewModel.placeholderItemViewModels) { bundleItemViewModel in
+                        ConfigurableBundleItemView(viewModel: bundleItemViewModel)
+                        Divider()
+                            .dividerStyle()
+                            .padding(.leading, Layout.defaultPadding)
+                    }
+                    .redacted(reason: .placeholder)
+                    .shimmering()
+                    .renderedIf(viewModel.bundleItemViewModels.isEmpty && viewModel.errorMessage == nil)
+
+                    if let errorMessage = viewModel.errorMessage {
+                        Group {
+                            Text(errorMessage)
+                                .errorStyle()
+                            Button(Localization.retry) {
+                                viewModel.retry()
+                            }
+                            .buttonStyle(PrimaryButtonStyle())
+                        }
+                        .padding()
+                    }
                 }
+                .background(Color(.listForeground(modal: false)))
             }
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
@@ -71,6 +94,11 @@ private extension ConfigurableBundleProductView {
             "configureBundleProduct.done",
             value: "Done",
             comment: "Text for the done button in the bundle product configuration screen in the order form."
+        )
+        static let retry = NSLocalizedString(
+            "configureBundleProduct.retry",
+            value: "Retry",
+            comment: "Text for the retry button to reload bundled products in the bundle product configuration screen in the order form."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
@@ -29,7 +29,12 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
     @Published private(set) var isConfigureEnabled: Bool = true
 
     /// Closure invoked when the configure CTA is tapped to submit the configuration.
+    /// If there are no changes to the configuration, the closure is not invoked.
     let onConfigure: (_ configurations: [BundledProductConfiguration]) -> Void
+
+    /// Used to check if there are any outstanding changes to the configuration when submitting the form.
+    /// This is set when the `bundleItemViewModels` are set.
+    private var initialConfigurations: [BundledProductConfiguration] = []
 
     private let product: Product
     private let childItems: [OrderItem]
@@ -61,6 +66,9 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
     func configure() {
         let configurations: [BundledProductConfiguration] = bundleItemViewModels.compactMap {
             $0.toConfiguration
+        }
+        guard configurations != initialConfigurations else {
+            return
         }
         onConfigure(configurations)
     }
@@ -100,6 +108,7 @@ private extension ConfigurableBundleProductViewModel {
                         return .init(bundleItem: bundleItem, product: product, variableProductSettings: nil, existingOrderItem: existingOrderItem)
                 }
             }
+        initialConfigurations = bundleItemViewModels.compactMap { $0.toConfiguration }
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
@@ -28,6 +28,11 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
     // TODO: 10428 - only enable configure CTA when all bundle items are configured
     @Published private(set) var isConfigureEnabled: Bool = true
 
+    @Published private(set) var errorMessage: String?
+
+    /// View models for placeholder rows.
+    let placeholderItemViewModels: [ConfigurableBundleItemViewModel]
+
     /// Closure invoked when the configure CTA is tapped to submit the configuration.
     /// If there are no changes to the configuration, the closure is not invoked.
     let onConfigure: (_ configurations: [BundledProductConfiguration]) -> Void
@@ -53,6 +58,26 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
         self.childItems = childItems
         self.stores = stores
         self.onConfigure = onConfigure
+        // The content does not matter because the text in placeholder rows is redacted.
+        placeholderItemViewModels = [Int64](0..<3).map { _ in
+                .init(bundleItem: .init(bundledItemID: 0,
+                                        productID: 0,
+                                        menuOrder: 0,
+                                        title: "   ",
+                                        stockStatus: .inStock,
+                                        minQuantity: 0,
+                                        maxQuantity: nil,
+                                        defaultQuantity: 0,
+                                        isOptional: true,
+                                        overridesVariations: false,
+                                        allowedVariations: [],
+                                        overridesDefaultVariationAttributes: false,
+                                        defaultVariationAttributes: []),
+                      product: product,
+                      variableProductSettings: nil,
+                      existingOrderItem: nil)
+        }
+
         loadProductsAndCreateItemViewModels()
     }
 
@@ -72,18 +97,25 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
         }
         onConfigure(configurations)
     }
+
+    /// Invoked when the retry CTA is tapped.
+    func retry() {
+        loadProductsAndCreateItemViewModels()
+    }
 }
 
 private extension ConfigurableBundleProductViewModel {
     func loadProductsAndCreateItemViewModels() {
+        errorMessage = nil
+
         Task { @MainActor in
             do {
                 // When there is a long list of bundle items, products are loaded in a paginated way.
                 let products = try await loadProducts(from: product.bundledItems)
                 createItemViewModels(products: products)
             } catch {
-                // TODO: 10428 - handle error loading products for bundle items
-                DDLogError("⛔️ Error loading products for bundle product items in order form:  \(error)")
+                DDLogError("⛔️ Error loading products for bundle product items in order form: \(error)")
+                errorMessage = Localization.errorLoadingProducts
             }
         }
     }
@@ -144,5 +176,15 @@ private extension ConfigurableBundleProductViewModel {
                 continuation.resume(with: result)
             })
         }
+    }
+}
+
+private extension ConfigurableBundleProductViewModel {
+    enum Localization {
+        static let errorLoadingProducts = NSLocalizedString(
+            "configureBundleProductError.cannotLoadProducts",
+            value: "Cannot load the bundled products. Please try again.",
+            comment: "Error message when the products cannot be loaded in the bundle product configuration form."
+        )
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */; };
 		021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */; };
 		021A84E1257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021A84DF257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib */; };
+		021AC6662AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AC6652AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift */; };
 		021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */; };
 		021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */; };
 		021DD44D286A3A8D004F0468 /* UIViewController+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */; };
@@ -2653,6 +2654,7 @@
 		0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewController.swift; sourceTree = "<group>"; };
 		021A84DF257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundShippingLabelViewController.xib; sourceTree = "<group>"; };
+		021AC6652AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleProductViewModelTests.swift; sourceTree = "<group>"; };
 		021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductImageStatus+HelpersTests.swift"; sourceTree = "<group>"; };
 		021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHAssetImageLoader.swift; sourceTree = "<group>"; };
 		021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Navigation.swift"; sourceTree = "<group>"; };
@@ -5189,6 +5191,7 @@
 			children = (
 				02038C5E2AF21BC300CD36D9 /* ConfigurableBundleItemViewModelTests.swift */,
 				02038C602AF222D600CD36D9 /* ConfigurableVariableBundleAttributePickerViewModelTests.swift */,
+				021AC6652AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift */,
 			);
 			path = ProductBundles;
 			sourceTree = "<group>";
@@ -14158,6 +14161,7 @@
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				DE69C54F27BCB4B7000BB888 /* CouponRestrictionsViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,
+				021AC6662AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift in Sources */,
 				26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */,
 				D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */,
 				DE3877E4283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class ConfigurableBundleProductViewModelTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
+
+    func test_configure_invokes_onConfigure_if_configuration_is_changed() throws {
+        // Given
+        let product = Product.fake().copy(productID: 1, bundledItems: [
+            .fake().copy(productID: 2)
+        ])
+        let productsFromRetrieval = [1, 2].map { Product.fake().copy(productID: $0) }
+        mockProductsRetrieval(result: .success((products: productsFromRetrieval, hasNextPage: false)))
+
+        var configurationsFromOnConfigure: [BundledProductConfiguration] = []
+        let viewModel = ConfigurableBundleProductViewModel(product: product,
+                                                           childItems: [],
+                                                           stores: self.stores,
+                                                           onConfigure: { configurations in
+            configurationsFromOnConfigure = configurations
+        })
+
+        // The products are loaded async before the bundle item view models are set.
+        waitUntil {
+            viewModel.bundleItemViewModels.isNotEmpty
+        }
+
+        // When altering the bundle item
+        let bundleItemViewModel = try XCTUnwrap(viewModel.bundleItemViewModels.first)
+        bundleItemViewModel.quantity = 8
+
+        viewModel.configure()
+
+        waitUntil {
+            configurationsFromOnConfigure.isNotEmpty
+        }
+
+        // Then
+        let configurationFromOnConfigure = try XCTUnwrap(configurationsFromOnConfigure.first)
+        XCTAssertEqual(configurationFromOnConfigure.quantity, 8)
+    }
+
+    func test_configure_does_not_invoke_onConfigure_if_configuration_is_the_same() throws {
+        // Given
+        let product = Product.fake().copy(productID: 1, bundledItems: [
+            .fake().copy(productID: 2)
+        ])
+        let productsFromRetrieval = [1, 2].map { Product.fake().copy(productID: $0) }
+        mockProductsRetrieval(result: .success((products: productsFromRetrieval, hasNextPage: false)))
+
+        let viewModel = ConfigurableBundleProductViewModel(product: product,
+                                                           childItems: [],
+                                                           stores: stores,
+                                                           onConfigure: { configurations in
+            // Then
+            XCTFail("The configure closure should not be invoked")
+        })
+
+        // The products are loaded async before the bundle item view models are set.
+        waitUntil {
+            viewModel.bundleItemViewModels.isNotEmpty
+        }
+
+        // When
+        viewModel.configure()
+    }
+}
+
+private extension ConfigurableBundleProductViewModelTests {
+    func mockProductsRetrieval(result: Result<(products: [Product], hasNextPage: Bool), Error>) {
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+                case let .retrieveProducts(_, _, _, _, onCompletion):
+                    onCompletion(result)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10428 
⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/11058 to avoid merge conflicts
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The bundle configuration screen is missing 3 features:
- When loading bundled products, there is no placeholder UI and the screen is just blank --> this PR adds 3 placeholder rows similar to how we do in other screens in the app
- If loading bundled products fails, there is no error UI and the screen just stays blank --> this PR adds an error UI with an error message plus a Retry CTA
- When updating a bundle configuration and no changes are made, tapping Done still triggers an order remote sync --> this PR saves the initial configuration and checks if the updated configuration is the same as the initial value

Test cases were also added for `ConfigurableBundleProductViewModel`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items. **The store has an order with a bundle product with non-empty items.**

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and tap on a bundle product in the prerequisite --> some placeholder rows should be shown animated before the bundled products are loaded
- Tap `Close`
- Turn off the network to simulate the error scenario, or set a breakpoint in a proxy tool to simulate a failure on the products request
- Tap `Add Products` and tap on a bundle product in the prerequisite --> an error message should be shown with a Retry CTA
- Turn on the network or disable the proxy breakpoint
- Tap on `Retry` --> the bundled products should be loaded again
- Configure the bundle until it's valid
- Tap `Done` to save the bundle --> the bundle product should be added remotely with the configuration
- When the order is ready, tap `Create`
- Tap `Edit` to edit the order again
- Tap on the expand  🔽 CTA on the bundle product item, then tap `Configure` --> the bundled products should be loaded
- Tap `Done` without changing anything --> no order update API request should be made (no spinner in the order form)


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

placeholder state | error state
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/bfa009a4-056b-41ef-910a-362927cc0da8" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/6544dfc7-c13f-46ad-ac2c-4e88a2079512" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
