### PR TITLE
Account Creation: Revert to authenticator library login by default

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -104,6 +104,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productBundlesInOrderForm:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .customLoginUIForAccountCreation:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -217,4 +217,8 @@ public enum FeatureFlag: Int {
     /// Enables bundle product configuration support in order creation/editing.
     ///
     case productBundlesInOrderForm
+
+    /// Enables the custom login UI when user enters an existing email address during account creation.
+    ///
+    case customLoginUIForAccountCreation
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10590 
<!-- Id number of the GitHub issue this PR addresses. -->

## What
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new feature flag for the custom login UI used in account creation. This flag is enabled only for debug and alpha builds.

## Why
The work in #10590 requires much more effort and serious planning. The feature flag makes sure that the work-in-progress is not available in production builds until the feature is complete.

## How
- Added a new feature flag `customLoginUIForAccountCreation`.
- Check for the flag when handling existing email address during account creation.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app if needed.
- On the prologue screen, select Create a new store.
- Enter an email address associated to an existing WPCom account.
- If the feature flag is on, notice that the custom password login screen is displayed if the account is not passwordless - otherwise the magic link UI is displayed.
- If the feature flag is off, notice that the authenticator library UI is displayed, you have to confirm the email address before starting login.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Feature flag off:

https://github.com/woocommerce/woocommerce-ios/assets/5533851/168e754e-febc-4b24-80d7-4215a22c96a4

Feature flag on:

https://github.com/woocommerce/woocommerce-ios/assets/5533851/731cdcb2-b94a-4dfe-ae00-1095053d2ec7


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
