### PR TITLE
Remove `defaultStoreURL` from `SessionManager`

### DIFF
--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -37,16 +37,6 @@ public enum Credentials: Equatable {
         }
         return UUID(uuidString: username) != nil
     }
-
-    /// Returns true if the siteAddress is a placeholder.
-    ///
-    public func hasPlaceholderSiteAddress() -> Bool {
-        // Only WPCOM credentials will have placeholder `siteAddress`
-        guard case let .wpcom(_, _, siteAddress) = self else {
-            return false
-        }
-        return siteAddress == Constants.placeholderSiteAddress
-    }
 }
 
 private extension Credentials {

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -95,17 +95,6 @@ final class SessionManager: SessionManagerProtocol {
         }
     }
 
-    /// URL of the default store.
-    ///
-    var defaultStoreURL: String? {
-        switch defaultCredentials {
-        case .none:
-            return nil
-        case .some(let wrapped):
-            return wrapped.siteAddress
-        }
-    }
-
     /// Roles for the default Store Site.
     ///
     var defaultRoles: [User.Role] {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -54,7 +54,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
     }()
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultStoreURL ?? "",
+         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          userDefaults: UserDefaults = .standard,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -78,7 +78,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     private var visibilitySubscription: AnyCancellable?
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultStoreURL ?? "",
+         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -575,7 +575,7 @@ private extension DefaultStoresManager {
         }
 
         if siteID == WooConstants.placeholderStoreID,
-           let url = sessionManager.defaultStoreURL {
+           let url = sessionManager.defaultCredentials?.siteAddress {
             restoreSessionSite(with: url)
         } else {
             restoreSessionSiteAndSynchronizeIfNeeded(with: siteID)

--- a/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
+++ b/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
@@ -23,10 +23,6 @@ public protocol SessionManagerProtocol {
     ///
     var defaultStoreID: Int64? { get set }
 
-    /// URL of default store
-    ///
-    var defaultStoreURL: String? { get }
-
     /// Roles for the default Store Site.
     ///
     var defaultRoles: [User.Role] { get set }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11076 
<!-- Id number of the GitHub issue this PR addresses. -->

## What
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the redundant and misleading `defaultStoreURL` from `SessionManager`.

## Why
This property is only used when restoring session for users logging in without WPCom. It can be replaced with a simple check with the credentials. This check doesn't work if the logged in credentials are WPCom because multiple sites are supported and the credentials are not updated when the default site is switched.

## How
- Removed `defaultStoreURL` from `SessionManagerProtocol` and `SessionManager`.
- Replaced the use of `defaultStoreURL` (because #11074 has yet to be merge back to trunk).
- Replace the use of `defaultStoreURL` in `DefaultStoresManager` by checking directly with credentials.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in with a self-hosted site without Jetpack.
- Confirm that all logged-in features are still working properly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
