### PR TITLE
Blaze: Hide Blaze button on Product detail screen if there's existing active campaign for the product.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -55,7 +55,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
 
     private let product: EditableProductModel
     private let formType: ProductFormType
-    private let isEligibleForBlaze: Bool
+    private let canPromoteWithBlaze: Bool
     private let editable: Bool
     private let addOnsFeatureEnabled: Bool
     private let variationsPrice: VariationsPrice
@@ -74,7 +74,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     // TODO: Remove default parameter
     init(product: EditableProductModel,
          formType: ProductFormType,
-         isEligibleForBlaze: Bool = false,
+         canPromoteWithBlaze: Bool = false,
          addOnsFeatureEnabled: Bool = true,
          isLinkedProductsPromoEnabled: Bool = false,
          isBundledProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles),
@@ -84,7 +84,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          variationsPrice: VariationsPrice = .unknown) {
         self.product = product
         self.formType = formType
-        self.isEligibleForBlaze = isEligibleForBlaze
+        self.canPromoteWithBlaze = canPromoteWithBlaze
         self.editable = formType != .readonly
         self.addOnsFeatureEnabled = addOnsFeatureEnabled
         self.variationsPrice = variationsPrice
@@ -106,7 +106,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         && product.upsellIDs.isEmpty
         && product.crossSellIDs.isEmpty
 
-        let shouldShowPromoteWithBlaze = isEligibleForBlaze
+        let shouldShowPromoteWithBlaze = canPromoteWithBlaze
 
         let actions: [ProductFormEditAction?] = [
             shouldShowImagesRow ? .images(editable: editable): nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -296,8 +296,9 @@ extension ProductFormViewModel {
         return isSitePublic && formType != .add && productHasLinkToShare
     }
 
+    /// Merchants can promote a product with Blaze if product and site are eligible, and there's no existing Blaze campaign for the product.
     func canPromoteWithBlaze() -> Bool {
-        isEligibleForBlaze
+        isEligibleForBlaze && !hasActiveBlazeCampaign
     }
 
     func canDeleteProduct() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -66,6 +66,8 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private var isEligibleForBlaze: Bool = false
 
+    private var hasActiveBlazeCampaign: Bool = false
+
     /// Blaze campaign ResultsController.
     private lazy var blazeCampaignResultsController: ResultsController<StorageBlazeCampaign> = {
         let predicate = NSPredicate(format: "siteID == %lld", product.siteID)
@@ -730,10 +732,23 @@ private extension ProductFormViewModel {
 
     /// Performs initial fetch from storage and updates results.
     func configureResultsController() {
+        blazeCampaignResultsController.onDidChangeContent = { [weak self] in
+            self?.updateResults()
+
+        }
+        blazeCampaignResultsController.onDidResetContent = { [weak self] in
+            self?.updateResults()
+        }
+
         do {
             try blazeCampaignResultsController.performFetch()
+            updateResults()
         } catch {
             ServiceLocator.crashLogging.logError(error)
         }
+    }
+
+    func updateResults() {
+        hasActiveBlazeCampaign = false /* todo */
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -734,23 +734,23 @@ private extension ProductFormViewModel {
     /// Performs initial fetch from storage and updates results.
     func configureResultsController() {
         blazeCampaignResultsController.onDidChangeContent = { [weak self] in
-            self?.updateResults()
+            self?.updateBlazeCampaignResult()
 
         }
         blazeCampaignResultsController.onDidResetContent = { [weak self] in
-            self?.updateResults()
+            self?.updateBlazeCampaignResult()
         }
 
         do {
             try blazeCampaignResultsController.performFetch()
-            updateResults()
+            updateBlazeCampaignResult()
         } catch {
             ServiceLocator.crashLogging.logError(error)
         }
     }
 
-    func updateResults() {
-        hasActiveBlazeCampaign = checkBlazeCampaignForProduct()
+    func updateBlazeCampaignResult() {
+        hasActiveBlazeCampaign = hasBlazeCampaign()
     }
 }
 
@@ -762,7 +762,7 @@ private extension ProductFormViewModel {
     /// - approved,
     /// - scheduled, or
     /// - active.
-    func checkBlazeCampaignForProduct() -> Bool {
+    func hasBlazeCampaign() -> Bool {
         let campaigns = blazeCampaignResultsController.fetchedObjects
         return campaigns.contains(where: {
             ($0.productID == product.productID) &&

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -749,6 +749,7 @@ private extension ProductFormViewModel {
     }
 
     func updateResults() {
-        hasActiveBlazeCampaign = false /* todo */
+        let campaigns = blazeCampaignResultsController.fetchedObjects
+        hasActiveBlazeCampaign = campaigns.contains(where: { $0.productID == product.productID })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -705,12 +705,12 @@ private extension ProductFormViewModel {
         stores.dispatch(action)
     }
 
-    /// Recreates `actionsFactory` with the latest `product`, `formType`, `isEligibleForBlaze` and `isAddOnsFeatureEnabled` information.
+    /// Recreates `actionsFactory` with the latest `product`, `formType`, `canPromoteWithBlaze` and `isAddOnsFeatureEnabled` information.
     ///
     func updateActionsFactory() {
         actionsFactory = ProductFormActionsFactory(product: product,
                                                    formType: formType,
-                                                   isEligibleForBlaze: canPromoteWithBlaze(),
+                                                   canPromoteWithBlaze: canPromoteWithBlaze(),
                                                    addOnsFeatureEnabled: isAddOnsFeatureEnabled,
                                                    isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                                    variationsPrice: calculateVariationPriceState())

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -749,7 +749,23 @@ private extension ProductFormViewModel {
     }
 
     func updateResults() {
+        hasActiveBlazeCampaign = checkBlazeCampaignForProduct()
+    }
+}
+
+// MARK: Blaze
+//
+private extension ProductFormViewModel {
+    /// Check whether there is already an existing campaign for the current Product, that also has one of these statuses:
+    /// - created (in moderation),
+    /// - approved,
+    /// - scheduled, or
+    /// - active.
+    func checkBlazeCampaignForProduct() -> Bool {
         let campaigns = blazeCampaignResultsController.fetchedObjects
-        hasActiveBlazeCampaign = campaigns.contains(where: { $0.productID == product.productID })
+        return campaigns.contains(where: {
+            ($0.productID == product.productID) &&
+            ($0.status == .created || $0.status == .approved || $0.status == .scheduled || $0.status == .active)
+        })
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11068 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a functionality to hide the "Promote with Blaze" button when opening Product detail screen, if the particular product already has an active* Blaze campaign. "Active" here being defined as a campaign with one of these statuses:
- Created (or also known as in moderation),
- Approved,
- Scheduled, or
- Active

**Known issue**
The check for active Blaze campaign here is strictly done from Core Data value. Once a merchant creates a campaign from the Product form, and returns, the button will still be shown. This is because there is no sync happening. Only after the campaign list is updated elsewhere (from Dashboard or More menu), that the sync will happen.

A potential solution is to save info to Core Data during Blaze webview session, once the campaign is created (by checking the URL), but it is a bigger task and is not covered by this PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start with a site that's eligible for Blaze,
2. Go to a Product that's eligible for Blaze,
3. Use the "Promote with Blaze" button to create a new campaign.
4. Once it is created, exit the Blaze webview,
5. Go to more menu > Blaze,
6. Pull down to refresh and fetch. Ensure the created campaign is shown with "In moderation" status,
7. Go back to the Product from step 2,
8. Ensure that now the "Promote with Blaze" button is **not shown**,
9. Go to the Blaze backend and reject the campaign,
10. Go back to More Menu > Blaze and refresh to get the latest update,
11. Go back to the Product from step 2,
12. Ensure that now the "Promote with Blaze" button is **shown again**

