### PR TITLE
Merge 16.0 final into trunk

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -54,7 +54,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
     }()
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultStoreURL ?? "",
+         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          userDefaults: UserDefaults = .standard,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -76,7 +76,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     private var visibilitySubscription: AnyCancellable?
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultStoreURL ?? "",
+         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,

--- a/config/Version.Public.xcconfig
+++ b/config/Version.Public.xcconfig
@@ -1,7 +1,7 @@
 VERSION_SHORT=16.0
 
 // Public long version example: VERSION_LONG=1.2.0.0
-VERSION_LONG=16.0.0.1
+VERSION_LONG=16.0.0.2
 
 // Re-map our custom version values (used by release-toolkit) to the Xcode ones
 MARKETING_VERSION=$VERSION_SHORT


### PR DESCRIPTION
This PR merges the changes from the 16.0 finalization into `trunk`. Includes:
- Version bump
- Beta fix: https://github.com/woocommerce/woocommerce-ios/pull/11074
- The translation updates happened in the `16.0.0.1` build