### PR TITLE
[Order SKU Scanner] Fix a different product/variation can be returned from partial SKU match

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.2
 -----
-
+- [*] Order form: when adding a product/variation by scanning a barcode, only the product/variation with the exact SKU should be added to the order. [https://github.com/woocommerce/woocommerce-ios/pull/11089]
 
 16.1
 -----

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -390,7 +390,7 @@ private extension ProductStore {
                     return onCompletion(.failure(ProductLoadError.notFound))
                 }
 
-                guard let product = products.first(where: { $0.purchasable }) else {
+                guard let product = skuProducts.first(where: { $0.purchasable }) else {
                     return onCompletion(.failure(ProductLoadError.notPurchasable))
                 }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -41,6 +41,8 @@ final class MockProductsRemote {
 
     private var searchProductsResultsByQuery = [String: Result<[Product], Error>]()
 
+    private var searchProductsBySKUResultsBySKU = [String: Result<[Product], Error>]()
+
     /// The number of times that `loadProduct()` was invoked.
     private(set) var invocationCountOfLoadProduct: Int = 0
 
@@ -93,6 +95,12 @@ final class MockProductsRemote {
     ///
     func whenSearchingProducts(query: String, thenReturn result: Result<[Product], Error>) {
         searchProductsResultsByQuery[query] = result
+    }
+
+    /// Set the value passed to the `completion` block if `searchProductsBySKU()` is called.
+    ///
+    func whenSearchingProductsBySKU(sku: String, thenReturn result: Result<[Product], Error>) {
+        searchProductsBySKUResultsBySKU[sku] = result
     }
 }
 
@@ -205,7 +213,11 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                              pageNumber: Int,
                              pageSize: Int,
                              completion: @escaping (Result<[Product], Error>) -> Void) {
-        // no-op
+        if let result = searchProductsBySKUResultsBySKU[keyword] {
+            completion(result)
+        } else {
+            XCTFail("\(String(describing: self)) Could not find result for SKU \(keyword)")
+        }
     }
 
     func searchSku(for siteID: Int64, sku: String, completion: @escaping (Result<String, Error>) -> Void) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11088 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the order form, when adding a product by scanning a barcode, the app searches products by partial SKU. When there are multiple products/variations with an SKU that matches the exact SKU **or** contains the SKU, these products/variations can come back in an order where the first result isn't the one with the precise SKU. In this case, a different product/variation can be added to the order which is confusing to the merchant.

## How

The function currently filters the products by the exact SKU, but the filtered products variable wasn't used for the final product that is returned. This PR just updated to return the first purchasable product from the filtered products.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

First, I'd recommend reproducing the issue in `trunk`:

- Create a variable product if needed
- Create at least 2 purchasable variations for the variable product if needed
- Find a barcode
- Enter two SKUs for these two variations, where one is the barcode and the other contains the barcode (e.g. "111131" and "111131-dark")
- Go to the Orders tab
- Tap `+` to create an order
- Tap on the scan CTA to scan a barcode
- Scan the barcode --> notice the other variation is added to the order instead. If you can't reproduce this, try swapping the SKUs in the 2 variations so that the two variations come back in a different order. Then, repeat the steps above

After this PR, the issue should be fixed and the product/variation with the exact SKU should be added to the order.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
