### PR TITLE
[Subscriptions] Remove `readOnlySubscriptions` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -58,8 +58,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .compositeProducts:
             return true
-        case .readOnlySubscriptions:
-            return true
         case .productDescriptionAI:
             return true
         case .productDescriptionAIFromStoreOnboarding:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -127,10 +127,6 @@ public enum FeatureFlag: Int {
     ///
     case compositeProducts
 
-    /// Enables read-only support for the Subscriptions extension in product and order details
-    ///
-    case readOnlySubscriptions
-
     /// Enables generating product description using AI from product description editor.
     ///
     case productDescriptionAI

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1211,7 +1211,7 @@ extension OrderDetailsDataSource {
 
         let subscriptions: Section? = {
             // Subscriptions section is hidden if there are no subscriptions for the order.
-            guard orderSubscriptions.isNotEmpty && featureFlags.isFeatureFlagEnabled(.readOnlySubscriptions) else {
+            guard orderSubscriptions.isNotEmpty else {
                 return nil
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -627,14 +627,7 @@ extension OrderDetailsViewModel {
         stores.dispatch(action)
     }
 
-    func syncSubscriptions(isFeatureFlagEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlySubscriptions),
-                           onCompletion: ((Error?) -> ())? = nil) {
-        // Only sync subscriptions if the feature flag is enabled.
-        guard isFeatureFlagEnabled else {
-            onCompletion?(nil)
-            return
-        }
-
+    func syncSubscriptions(onCompletion: ((Error?) -> ())? = nil) {
         // If the plugin is not active, there is no point in continuing with a request that will fail.
         isPluginActive(SitePlugin.SupportedPlugin.WCSubscriptions) { [weak self] isActive in
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -68,7 +68,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     }
     private let isBundledProductsEnabled: Bool
     private let isCompositeProductsEnabled: Bool
-    private let isSubscriptionProductsEnabled: Bool
     private let isMinMaxQuantitiesEnabled: Bool
 
     // TODO: Remove default parameter
@@ -79,7 +78,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          isLinkedProductsPromoEnabled: Bool = false,
          isBundledProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles),
          isCompositeProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.compositeProducts),
-         isSubscriptionProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlySubscriptions),
          isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
          variationsPrice: VariationsPrice = .unknown) {
         self.product = product
@@ -91,7 +89,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.isLinkedProductsPromoEnabled = isLinkedProductsPromoEnabled
         self.isBundledProductsEnabled = isBundledProductsEnabled
         self.isCompositeProductsEnabled = isCompositeProductsEnabled
-        self.isSubscriptionProductsEnabled = isSubscriptionProductsEnabled
         self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
     }
 
@@ -152,7 +149,7 @@ private extension ProductFormActionsFactory {
         case .subscription:
             return allSettingsSectionActionsForSubscriptionProduct()
         case .variableSubscription:
-            return isSubscriptionProductsEnabled ? allSettingsSectionActionsForVariableSubscriptionProduct() : allSettingsSectionActionsForNonCoreProduct()
+            return allSettingsSectionActionsForVariableSubscriptionProduct()
         default:
             return allSettingsSectionActionsForNonCoreProduct()
         }
@@ -304,20 +301,11 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForSubscriptionProduct() -> [ProductFormEditAction] {
-        let subscriptionOrPriceRow: ProductFormEditAction? = {
-            if isSubscriptionProductsEnabled {
-                return .subscription(actionable: true)
-            } else if !product.regularPrice.isNilOrEmpty {
-                return .priceSettings(editable: false, hideSeparator: false)
-            } else {
-                return nil
-            }
-        }()
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
-            subscriptionOrPriceRow,
+            .subscription(actionable: true),
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
             shouldShowQuantityRulesRow ? .quantityRules : nil,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -10,7 +10,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSupportRequestEnabled: Bool
     private let isDashboardStoreOnboardingEnabled: Bool
     private let jetpackSetupWithApplicationPassword: Bool
-    private let isReadOnlySubscriptionsEnabled: Bool
     private let isProductDescriptionAIEnabled: Bool
     private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
@@ -33,7 +32,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSupportRequestEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
-         isReadOnlySubscriptionsEnabled: Bool = false,
          isProductDescriptionAIEnabled: Bool = false,
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
@@ -55,7 +53,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
-        self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
         self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
@@ -89,8 +86,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isDashboardStoreOnboardingEnabled
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
-        case .readOnlySubscriptions:
-            return isReadOnlySubscriptionsEnabled
         case .productDescriptionAI:
             return isProductDescriptionAIEnabled
         case .productDescriptionAIFromStoreOnboarding:

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -251,7 +251,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
                 }
             }
 
-            self.viewModel.syncSubscriptions(isFeatureFlagEnabled: true)
+            self.viewModel.syncSubscriptions()
         }
 
         // Then
@@ -283,7 +283,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
                 }
             }
 
-            self.viewModel.syncSubscriptions(isFeatureFlagEnabled: true)
+            self.viewModel.syncSubscriptions()
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -562,8 +562,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = MockOrders().makeOrder()
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                featureFlags: MockFeatureFlagService(isReadOnlySubscriptionsEnabled: true)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration
         )
 
         // When
@@ -579,8 +578,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = MockOrders().makeOrder()
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                featureFlags: MockFeatureFlagService(isReadOnlySubscriptionsEnabled: true)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration
         )
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
@@ -49,7 +49,6 @@ private extension ProductFormActionsFactory_ProductCreationTests {
                                    isLinkedProductsPromoEnabled: Bool = false,
                                    isBundledProductsEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
-                                   isSubscriptionProductsEnabled: Bool = false,
                                    isMinMaxQuantitiesEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
@@ -58,7 +57,6 @@ private extension ProductFormActionsFactory_ProductCreationTests {
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                       isBundledProductsEnabled: isBundledProductsEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
-                                      isSubscriptionProductsEnabled: isSubscriptionProductsEnabled,
                                       isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       variationsPrice: variationsPrice)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -584,36 +584,13 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_subscription_product_with_feature_flag_disabled() {
+    func test_view_model_for_subscription_product() {
         // Arrange
         let product = Fixtures.subscriptionProduct
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: false)
-
-        // Assert
-        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
-        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
-
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
-                                                                       .reviews,
-                                                                       .inventorySettings(editable: false),
-                                                                       .linkedProducts(editable: true),
-                                                                       .productType(editable: false)]
-        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
-
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
-        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
-    }
-
-    func test_view_model_for_subscription_product_with_feature_flag_enabled() {
-        // Arrange
-        let product = Fixtures.subscriptionProduct
-        let model = EditableProductModel(product: product)
-
-        // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: true)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -630,35 +607,13 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_variable_subscription_product_with_feature_flag_disabled() {
+    func test_view_model_for_variable_subscription_product_with_no_variations() {
         // Arrange
         let product = Fixtures.variableSubscriptionProduct
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: false)
-
-        // Assert
-        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
-        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
-
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.reviews,
-                                                                       .inventorySettings(editable: false),
-                                                                       .linkedProducts(editable: true),
-                                                                       .productType(editable: false)]
-        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
-
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
-        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
-    }
-
-    func test_view_model_for_variable_subscription_product_with_no_variations_and_feature_flag_enabled() {
-        // Arrange
-        let product = Fixtures.variableSubscriptionProduct
-        let model = EditableProductModel(product: product)
-
-        // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: true)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -675,13 +630,13 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_variable_subscription_product_with_variations_and_feature_flag_enabled() {
+    func test_view_model_for_variable_subscription_product_with_variations() {
         // Arrange
         let product = Fixtures.variableSubscriptionProduct.copy(attributes: [.fake().copy(variation: true)], variations: [123])
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: true)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -800,7 +755,6 @@ private extension ProductFormActionsFactoryTests {
                                    isLinkedProductsPromoEnabled: Bool = false,
                                    isBundledProductsEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
-                                   isSubscriptionProductsEnabled: Bool = false,
                                    isMinMaxQuantitiesEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
@@ -809,7 +763,6 @@ private extension ProductFormActionsFactoryTests {
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                       isBundledProductsEnabled: isBundledProductsEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
-                                      isSubscriptionProductsEnabled: isSubscriptionProductsEnabled,
                                       isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       variationsPrice: variationsPrice)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11091
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Removes `readOnlySubscriptions` feature flag before starting development work for Support subscriptions products #11090 project. 

## Testing instructions

Prerequisites
1. Install and activate the [Subscriptions extension](https://woocommerce.com/products/woocommerce-subscriptions/) on your store.
1. Create a new simple subscription product and a new variable subscription product (with at least one variation).

Steps
- Build and run the app.
- Go to the Products tab.
- Select a simple subscription product.
- Validate that the `Subscription` row is visible.
- Go back to the Products tab and select a variable subscription product.
- Select Variations to open the variation list.
- Select a variation to open variation details.
- Validate that the `Subscription` row is visible.

## Screenshots

| Subscription | Variable subscription |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-11-07 at 10 52 13](https://github.com/woocommerce/woocommerce-ios/assets/524475/d34604c4-6e04-4983-a81e-87a2280d702d) | ![Simulator Screenshot - iPhone 14 Pro - 2023-11-07 at 10 52 24](https://github.com/woocommerce/woocommerce-ios/assets/524475/dddc5771-0ba6-430d-b76d-deb64208a113) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.