### PR TITLE
[.github] Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,10 @@
 ---
 name: "\U0001F41E Bug report"
-about: Report a bug if something isn't working as expected in the WooCommerce iOS app.
+about: Report a bug if something isn't working as expected in the WooCommerce iOS
+  app.
+title: ''
+labels: 'type: bug'
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/Enhancement.md
@@ -1,6 +1,10 @@
 ---
 name: "✨ New Enhancement"
-about: "If you have an idea to improve an existing feature in the app please let us know or submit a Pull Request!"
+about: If you have an idea to improve an existing feature in the app please let us
+  know or submit a Pull Request!
+title: ''
+labels: 'type: enhancement'
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,10 @@
 ---
 name: "\U0001F680 Feature request"
-about: "Suggest a new feature \U0001F389 We'll consider building it if it receives sufficient interest! \U0001F44D"
+about: "Suggest a new feature \U0001F389 We'll consider building it if it receives
+  sufficient interest! \U0001F44D"
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Support.md
+++ b/.github/ISSUE_TEMPLATE/Support.md
@@ -2,6 +2,9 @@
 name: "❓ Support Question"
 about: "If you have a question \U0001F4AC please see our docs or use our forums, helpdesk,
   or Slack Community!"
+title: ''
+labels: 'type: question'
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/🏗-task.md
+++ b/.github/ISSUE_TEMPLATE/🏗-task.md
@@ -1,0 +1,10 @@
+---
+name: "\U0001F3D7 Task"
+about: An internally driven task.
+title: ''
+labels: 'type: task'
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/🚧-technical-debt.md
+++ b/.github/ISSUE_TEMPLATE/🚧-technical-debt.md
@@ -1,0 +1,10 @@
+---
+name: "\U0001F6A7 Technical Debt"
+about: Represents tech debt of the project.
+title: ''
+labels: 'type: technical debt'
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
### Description

This PR is a result of editing / extending the issues templates through [GH issue template editor](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). Some lines were changed by GH automatically (like removing `"` around strings), some were changed by me. What was changed by me:

1. `Bug` type of issue now contains `type: bug` label automatically.
2. `New Enhancement` type of issue now contains `type: enhancement` label automatically.
3. `Support` type of issue now contains `type: question` label automatically.
4. A new `Task` type of issue was added, with `type: task` default label.
5. A new `Technical Debt`  type of issue was added, with `type: technical debt` default label.

More context at p91TBi-aK9-p2#comment-11677

### To Test
- I see no ways to tests this other than going through the changes in the files.