### PR TITLE
[Universal Links] Add Universal Link support for woo.com

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.2
 -----
-
+- [*] Add support for Universal Links in the woo.com domain [https://github.com/woocommerce/woocommerce-ios/pull/11098]
 
 16.1
 -----

--- a/WooCommerce/Classes/JustInTimeMessages/UniversalLinkRouter+JustInTimeMessages.swift
+++ b/WooCommerce/Classes/JustInTimeMessages/UniversalLinkRouter+JustInTimeMessages.swift
@@ -32,6 +32,6 @@ private extension JustInTimeMessagesURLOpener {
     }
 
     enum Constants {
-        static let trustedDomains = ["woocommerce.com", "wordpress.com"]
+        static let trustedDomains = ["woo.com", "woocommerce.com", "wordpress.com"]
     }
 }

--- a/WooCommerce/Resources/Woo-Alpha.entitlements
+++ b/WooCommerce/Resources/Woo-Alpha.entitlements
@@ -8,6 +8,7 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:woocommerce.com</string>
+		<string>applinks:woo.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/WooCommerce/Resources/Woo-Debug.entitlements
+++ b/WooCommerce/Resources/Woo-Debug.entitlements
@@ -12,6 +12,7 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:woocommerce.com</string>
+		<string>applinks:woo.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/WooCommerce/Resources/Woo-Release.entitlements
+++ b/WooCommerce/Resources/Woo-Release.entitlements
@@ -12,6 +12,7 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:woocommerce.com</string>
+		<string>applinks:woo.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
@@ -86,7 +86,7 @@ final class UniversalLinkRouterTests: XCTestCase {
 
     func test_handle_when_there_no_routes_matching_then_bounces_url() {
         // Given
-        let url = URL(string: "woocommerce.com/mobile/a/nice/path")!
+        let url = URL(string: "woo.com/mobile/a/nice/path")!
 
         var routeOneWasCalled = false
         let routeOne = MockRoute(handledSubpaths: ["a/different/path"], performAction: { _, _ in
@@ -166,7 +166,7 @@ private extension UniversalLinkRouterTests {
     func makeUrlForTesting(subPath: String, queryItem: URLQueryItem? = nil, includeMobileSegment: Bool = true) -> URL? {
         var components = URLComponents()
             components.scheme = "https"
-            components.host = "woocommerce.com"
+            components.host = "woo.com"
         if includeMobileSegment {
             components.path = "/mobile/" + subPath
         } else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11096 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The move to Woo.com means that all our Universal Links need support adding for the new domain. The `apple-app-site-association` file is already correctly hosted, this adds support for the domain in the app only.

N.B. this doesn't address anything to do with existing links using woocommerce.com, which is covered under #11095, but this should not break them in the app either. A fix to the app-site-association file for that domain should still be sufficient to restore those.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Try Universal Links by adding URLs in Notes or another similar app on your phone, then tapping them. They should open the app.

URLs to check:

- [x] https://woo.com/mobile/
- [x] https://woo.com/mobile/payments : Payments menu
- [x] https://woo.com/mobile/payments/tap-to-pay : Set up Tap to Pay screen on supported devices/stores
- [x] https://woo.com/mobile/payments/collect-payment : Simple Payments flow
- [x] https://woo.com/mobile/orders/details?blog_id={StoreID}&order_id={OrderID} : Order Details screen for correct order

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/6ec4c6ab-c4b7-42f8-85bb-0b726049b23f

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
