### PR TITLE
[Blaze] `Site` JSON parsing - Fallback to default value while parsing `can_blaze` key

### DIFF
--- a/Networking/Networking/Mapper/SiteListMapper.swift
+++ b/Networking/Networking/Mapper/SiteListMapper.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Mapper: SiteList
 ///
-class SiteListMapper: Mapper {
+final class SiteListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [Site].
     ///

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -112,7 +112,7 @@ public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
         let adminURL = try optionsContainer.decode(String.self, forKey: .adminURL)
         let loginURL = try optionsContainer.decode(String.self, forKey: .loginURL)
         let frameNonce = try optionsContainer.decode(String.self, forKey: .frameNonce)
-        let canBlaze = try optionsContainer.decode(Bool.self, forKey: .canBlaze)
+        let canBlaze = optionsContainer.failsafeDecodeIfPresent(booleanForKey: .canBlaze) ?? false
         let isPublic = optionsContainer.failsafeDecodeIfPresent(booleanForKey: .isPublic) ?? false
 
         let planContainer = try siteContainer.nestedContainer(keyedBy: PlanInfo.self, forKey: .plan)

--- a/Networking/NetworkingTests/Mapper/SiteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteListMapperTests.swift
@@ -3,6 +3,15 @@ import XCTest
 
 final class SiteListMapperTests: XCTestCase {
 
+    func test_site_without_can_blaze_key_is_parsed_successfully() throws {
+        // Given
+        let sites = mapLoadSiteListResponse()
+
+        // Then
+        let second = try XCTUnwrap(sites[safe: 1])
+        XCTAssertFalse(second.canBlaze)
+    }
+
     /// `sites-malformed.json` contains a correct site and a site without options(malformed)
     ///
     func test_malformed_sites_are_evicted_from_site_list() throws {
@@ -24,6 +33,10 @@ private extension SiteListMapperTests {
         }
 
         return (try? SiteListMapper().map(response: response)) ?? []
+    }
+
+    func mapLoadSiteListResponse() -> [Site] {
+        mapSiteListData(from: "sites")
     }
 
     func mapLoadMalformedSiteListResponse() -> [Site] {

--- a/Networking/NetworkingTests/Responses/sites.json
+++ b/Networking/NetworkingTests/Responses/sites.json
@@ -281,7 +281,6 @@
         "is_automated_transfer": false,
         "is_wpcom_store": false,
         "woocommerce_is_active": false,
-        "can_blaze": false,
         "design_type": null,
         "site_goals": null,
         "jetpack_connection_active_plugins": [


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11094
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We expect the `can_blaze` to be present while trying to parse [Site](https://github.com/woocommerce/woocommerce-ios/blob/trunk/Networking/Networking/Model/Site.swift) model from JSON response.

For sites without blaze support, this `can_blaze` key is not present in the JSON response, and we end up with JSON decoding errors. 

This PR attempts to fix it by using `false` as default value for `canBlaze` property when `can_blaze` property is not present in `sites` response.

## Testing instructions
- Smoke test that you can load and switch sites. 
- CI passing is sufficient. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
