### PR TITLE
[Blaze] Stop tracking entry point event before showing Blaze view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -233,9 +233,17 @@ private extension BlazeCampaignDashboardViewModel {
     }
 
     func observeSectionVisibility() {
-        visibilitySubscription = $shouldShowInDashboard
+        visibilitySubscription = $state
+            .map { state in
+                switch state {
+                case .showCampaign, .showProduct:
+                    return true
+                default:
+                    return false
+                }
+            }
+            .filter { $0 }
             .removeDuplicates()
-            .filter { $0 == true }
             .sink { [weak self] _ in
                 self?.analytics.track(event: .Blaze.blazeEntryPointDisplayed(source: .myStoreSection))
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -702,6 +702,119 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         XCTAssertEqual(properties["source"] as? String, "intro_view")
     }
+
+    func test_blazeEntryPointDisplayed_tracked_if_blaze_campaign_available() async throws {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
+        let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  analytics: analytics,
+                                                  blazeEligibilityChecker: checker)
+
+        mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_entry_point_displayed"))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(eventProperties["source"] as? String, "my_store_section")
+    }
+
+    func test_blazeEntryPointDisplayed_tracked_if_published_product_available_and_blaze_campaign_not_available() async throws {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let fakeProduct = Product.fake().copy(siteID: sampleSiteID,
+                                              statusKey: (ProductStatus.published.rawValue))
+
+        let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  analytics: analytics,
+                                                  blazeEligibilityChecker: checker)
+
+        mockSynchronizeCampaigns()
+        mockSynchronizeProducts(insertProductToStorage: fakeProduct)
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_entry_point_displayed"))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(eventProperties["source"] as? String, "my_store_section")
+    }
+
+    func test_blazeEntryPointDisplayed_is_not_tracked_if_draft_product_available_and_blaze_campaign_not_available() async {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let fakeProduct = Product.fake().copy(siteID: sampleSiteID,
+                                              statusKey: (ProductStatus.draft.rawValue))
+
+        let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  analytics: analytics,
+                                                  blazeEligibilityChecker: checker)
+
+        mockSynchronizeCampaigns()
+        mockSynchronizeProducts(insertProductToStorage: fakeProduct)
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+    }
+
+    func test_blazeEntryPointDisplayed_is_not_tracked_if_no_blaze_campaign_no_product_available() async {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  analytics: analytics,
+                                                  blazeEligibilityChecker: checker)
+
+        mockSynchronizeCampaigns()
+        mockSynchronizeProducts()
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
+    }
+
+    func test_blazeEntryPointDisplayed_is_not_tracked_again_after_reload() async throws {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
+        let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  analytics: analytics,
+                                                  blazeEligibilityChecker: checker)
+
+        mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.filter { $0 == "blaze_entry_point_displayed" }.count == 1)
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.filter { $0 == "blaze_entry_point_displayed" }.count == 1)
+    }
 }
 
 private extension BlazeCampaignDashboardViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11107
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
#### What?
`blaze_entry_point_displayed` event is tracked from the Dashboard (My Store) screen when we show the Blaze view which has an option to Create a new Blaze campaign. 

We are wrongly tracking the event while trying to load the Blaze view. If there are no Blaze campaigns/published products available in a store we will not display the Blaze view. But we still track the `blaze_entry_point_displayed` event which is wrong.

#### Why?

We will be using this `blaze_entry_point_displayed` event to measure the success rate of the Blaze project. Fixing this will help us measure correct results.

I am opting for a beta fix as this is a data-related fix with a contained impact area. 

#### How?

Listen to the `state` property of the view model and track the event only for `showCampaign` and `showProduct` states.

## Testing instructions

With Blaze campaigns
- Create a JN store with Jetpack
- Create a product and publish it
- Create a Blaze campaign for the product 
    - If you have trouble creating Blaze campaigns, I can invite you to my store with a Blaze campaign. 
- Login into the app
- Once you reach the dashboard, validate that the following event is tracked
```
Tracked blaze_entry_point_displayed, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("site_url"): "<site_url>", AnyHashable("is_wpcom_store"): false, AnyHashable("source"): "my_store_section", AnyHashable("blog_id"): 123456, AnyHashable("plan"): "jetpack_free"]
```
- Pull down to refresh and validate that the event is not tracked again


With published products
- Create a JN store with Jetpack
- Create a product and publish it
- Login into the app
- Once you reach the dashboard, validate that the following event is tracked
```
Tracked blaze_entry_point_displayed, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("site_url"): "<site_url>", AnyHashable("is_wpcom_store"): false, AnyHashable("source"): "my_store_section", AnyHashable("blog_id"): 123456, AnyHashable("plan"): "jetpack_free"]
```
- Pull down to refresh and validate that the event is not tracked again

No Blaze campaigns and no published products
- Create a JN store with Jetpack
- Login into the app
- Once you reach the dashboard validate that `blaze_entry_point_displayed` is not tracked
- Pull down to refresh and validate that the event is still not tracked

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/524475/7643b32e-8c58-4cc5-80a4-af9324c1c0f5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
