### PR TITLE
[Subscription products] Add feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -84,6 +84,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customLoginUIForAccountCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .subscriptionProducts:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -175,4 +175,8 @@ public enum FeatureFlag: Int {
     /// Enables the custom login UI when user enters an existing email address during account creation.
     ///
     case customLoginUIForAccountCreation
+
+    /// Enables creating Subscription products
+    ///
+    case subscriptionProducts
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,6 +21,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let productCreationAI: Bool
     private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
+    private let subscriptionProducts: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -40,7 +41,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          betterCustomerSelectionInOrder: Bool = false,
          productCreationAI: Bool = false,
          productBundles: Bool = false,
-         productBundlesInOrderForm: Bool = false) {
+         productBundlesInOrderForm: Bool = false,
+         subscriptionProducts: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -60,6 +62,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.productCreationAI = productCreationAI
         self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
+        self.subscriptionProducts = subscriptionProducts
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -100,6 +103,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return productBundles
         case .productBundlesInOrderForm:
             return productBundlesInOrderForm
+        case .subscriptionProducts:
+            return subscriptionProducts
         default:
             return false
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11114 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Adds `subscriptionProducts` feature flag for subscription products feature development. 

## Testing instructions
CI passing is sufficient. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
