### PR TITLE
[Payments Menu] SwiftUI: basic view implementation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -25,7 +25,7 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
-         onboardingUseCase: CardPresentPaymentsOnboardingUseCase) {
+         onboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol) {
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
         cardReaderConnectionAnalyticsTracker = .init(configuration: configuration,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayViewModel.swift
@@ -20,14 +20,14 @@ class AboutTapToPayViewModel: ObservableObject {
 
     let formattedMinimumOperatingSystemVersionForTapToPay: String
 
-    let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
+    let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol
 
     let shouldAlwaysHideSetUpTapToPayButton: Bool
 
     init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
          cardReaderSupportDeterminer: CardReaderSupportDetermining? = nil,
-         cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase? = nil,
+         cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol? = nil,
          shouldAlwaysHideSetUpTapToPayButton: Bool = false) {
         self.siteID = siteID
         self.configuration = configuration

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -9,8 +9,6 @@ struct InPersonPaymentsLearnMore: View {
         self.viewModel = viewModel
     }
 
-    private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
-
     var body: some View {
         HStack(spacing: 16) {
             Image(uiImage: .infoOutlineImage)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -4,9 +4,12 @@ struct InPersonPaymentsLearnMore: View {
     @Environment(\.customOpenURL) var customOpenURL
 
     private let viewModel: LearnMoreViewModel
+    private let showInfoIcon: Bool
 
-    init(viewModel: LearnMoreViewModel = LearnMoreViewModel()) {
+    init(viewModel: LearnMoreViewModel = LearnMoreViewModel(),
+         showInfoIcon: Bool = true) {
         self.viewModel = viewModel
+        self.showInfoIcon = showInfoIcon
     }
 
     var body: some View {
@@ -15,6 +18,7 @@ struct InPersonPaymentsLearnMore: View {
                 .resizable()
                 .foregroundColor(Color(.neutral(.shade60)))
                 .frame(width: iconSize, height: iconSize)
+                .renderedIf(showInfoIcon)
             AttributedText(viewModel.learnMoreAttributedString)
         }
             .padding(.vertical, Constants.verticalPadding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenu.swift
@@ -145,13 +145,13 @@ private extension InPersonPaymentsMenu {
 
         static let purchaseCardReader = NSLocalizedString(
             "menu.payments.cardReader.purchase.row.title",
-            value: "Order card reader",
+            value: "Order Card Reader",
             comment: "Navigates to Card Reader purchase screen"
         )
 
         static let manageCardReader = NSLocalizedString(
             "menu.payments.cardReader.manage.row.title",
-            value: "Manage card reader",
+            value: "Manage Card Reader",
             comment: "Navigates to Card Reader management screen"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenu.swift
@@ -1,13 +1,256 @@
 import SwiftUI
 
 struct InPersonPaymentsMenu: View {
+    @ObservedObject private(set) var viewModel: InPersonPaymentsMenuViewModel
+    @State private var safariSheetURL: URL?
+
+    @State private var showingSimplePayments: Bool = false
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        List {
+            Section(Localization.paymentActionsSectionTitle) {
+                // Modal
+                PaymentsRow(image: Image(uiImage: .moneyIcon),
+                            title: Localization.collectPayment)
+                .onTapGesture {
+                    showingSimplePayments = true
+                }
+                .sheet(isPresented: $showingSimplePayments,
+                       onDismiss: {
+                    // log analytics, maybe prevent, better if we can defer to the SimplePaymentsVM
+                }) {
+                    NavigationView {
+                        // TODO: fix IPP/TTP payments from this route – needs a rootVC
+                        SimplePaymentsAmount(
+                            dismiss: {
+                                showingSimplePayments = false
+                            },
+                            viewModel: SimplePaymentsAmountViewModel(siteID: viewModel.siteID))
+                        .navigationBarTitleDisplayMode(.inline)
+                    }
+                }
+            }
+
+            Section(Localization.paymentSettingsSectionTitle) {
+                EmptyView()
+            }
+
+            Section(Localization.tapToPaySectionTitle) {
+                // Modal
+                NavigationLink(destination:
+                                PaymentSettingsFlowPresentingView(
+                                    viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)) {
+                    PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
+                                title: viewModel.setUpTryOutTapToPayRowTitle)
+                }
+
+                NavigationLink(destination: AboutTapToPayView(viewModel: viewModel.aboutTapToPayViewModel)) {
+                    PaymentsRow(image: Image(uiImage: .infoOutlineImage),
+                                title: Localization.aboutTapToPayOnIPhone)
+                }
+
+                // Modal
+                NavigationLink(destination: Survey(source: .tapToPayFirstPayment)) {
+                    PaymentsRow(image: Image(uiImage: .feedbackOutlineIcon.withRenderingMode(.alwaysTemplate)),
+                                title: Localization.tapToPayOnIPhoneFeedback)
+                }
+                .renderedIf(viewModel.shouldShowTapToPayFeedbackRow)
+            }
+            .renderedIf(viewModel.shouldShowTapToPaySection)
+
+            Section {
+                NavigationLink {
+                    AuthenticatedWebView(isPresented: .constant(true),
+                                         viewModel: viewModel.purchaseCardReaderWebViewModel)
+                } label: {
+                    PaymentsRow(image: Image(uiImage: .shoppingCartIcon),
+                                title: Localization.purchaseCardReader)
+                }
+
+                NavigationLink {
+                    PaymentSettingsFlowPresentingView(viewModelsAndViews: viewModel.manageCardReadersViewModelsAndViews)
+                } label: {
+                    PaymentsRow(image: Image(uiImage: .creditCardIcon),
+                                title: Localization.manageCardReader)
+                }
+                .disabled(viewModel.shouldDisableManageCardReaders)
+
+                NavigationLink {
+                    CardReaderManualsView()
+                } label: {
+                    PaymentsRow(image: Image(uiImage: .cardReaderManualIcon),
+                                title: Localization.cardReaderManuals)
+                }
+            } header: {
+                Text(Localization.cardReaderSectionTitle)
+            } footer: {
+                InPersonPaymentsLearnMore(viewModel: .inPersonPayments(source: .paymentsMenu),
+                                          showInfoIcon: false)
+                    .customOpenURL(binding: $safariSheetURL)
+            }
+            .renderedIf(viewModel.shouldShowCardReaderSection)
+        }
+        .safariSheet(url: $safariSheetURL)
+    }
+}
+
+struct PaymentsRow: View {
+    let image: Image
+    let title: String
+
+    var body: some View {
+        HStack {
+            image
+            Text(title)
+        }
+    }
+}
+
+private extension InPersonPaymentsMenu {
+    enum Localization {
+        static let cardReaderSectionTitle = NSLocalizedString(
+            "menu.payments.cardReader.section.title",
+            value: "Card readers",
+            comment: "Title for the section related to card readers inside In-Person Payments settings")
+
+        static let paymentOptionsSectionTitle = NSLocalizedString(
+            "menu.payments.paymentOptions.section.title",
+            value: "Payment options",
+            comment: "Title for the section related to payments inside In-Person Payments settings")
+
+        static let paymentActionsSectionTitle = NSLocalizedString(
+            "menu.payments.actions.section.title",
+            value: "Actions",
+            comment: "Title for the section related to actions inside In-Person Payments settings")
+
+        static let paymentSettingsSectionTitle = NSLocalizedString(
+            "menu.payments.paymentSettings.section.title",
+            value: "Settings",
+            comment: "Title for the section related to changing payment settings inside the In-Person Payments menu")
+
+        static let wooPaymentsDepositsSectionTitle = NSLocalizedString(
+            "menu.payments.wooPaymentsDeposits.section.title",
+            value: "Woo Payments Balance",
+            comment: "Title for the section related to Woo Payments Deposits/Balances.")
+
+        static let tapToPaySectionTitle = NSLocalizedString(
+            "menu.payments.tapToPay.section.title",
+            value: "Tap to Pay",
+            comment: "Title for the Tap to Pay section in the In-Person payments settings")
+
+        static let wooPaymentsDeposits = NSLocalizedString(
+            "menu.payments.wooPaymentsDeposits.row.title",
+            value: "Woo Payments Balance",
+            comment: "Title for the row related to Woo Payments Deposits/Balances.")
+
+        static let purchaseCardReader = NSLocalizedString(
+            "menu.payments.cardReader.purchase.row.title",
+            value: "Order card reader",
+            comment: "Navigates to Card Reader purchase screen"
+        )
+
+        static let manageCardReader = NSLocalizedString(
+            "menu.payments.cardReader.manage.row.title",
+            value: "Manage card reader",
+            comment: "Navigates to Card Reader management screen"
+        )
+
+        static let managePaymentGateways = NSLocalizedString(
+            "menu.payments.paymentGateway.manage.row.title",
+            value: "Payment Provider",
+            comment: "Navigates to Payment Gateway management screen"
+        )
+
+        static let toggleEnableCashOnDelivery = NSLocalizedString(
+            "menu.payments.payInPerson.toggle.row.title",
+            value: "Pay in Person",
+            comment: "Title for a switch on the In-Person Payments menu to enable Cash on Delivery"
+        )
+
+        static let toggleEnableCashOnDeliveryLearnMoreFormat = NSLocalizedString(
+            "menu.payments.payInPerson.learnMore.description",
+            value: "The Pay in Person checkout option lets you accept payments for website orders, on collection or delivery. %1$@",
+            comment: "A label prompting users to learn more about adding Pay in Person to their checkout. " +
+            "%1$@ is a placeholder that always replaced with \"Learn more\" string, " +
+            "which should be translated separately and considered part of this sentence.")
+
+        static let toggleEnableCashOnDeliveryLearnMoreLink = NSLocalizedString(
+            "menu.payments.payInPerson.learnMore.link",
+            value: "Learn more",
+            comment: "The \"Learn more\" string replaces the placeholder in a label prompting users to learn " +
+            "more about adding Pay in Person to their checkout. ")
+
+        static let cardReaderManuals = NSLocalizedString(
+            "menu.payments.cardReader.manuals.row.title",
+            value: "Card Reader Manuals",
+            comment: "Navigates to Card Reader Manuals screen"
+        )
+
+        static let collectPayment = NSLocalizedString(
+            "menu.payments.actions.collectPayment.row.title",
+            value: "Collect Payment",
+            comment: "Navigates to Collect a payment via the Simple Payment screen"
+        )
+
+        static let aboutTapToPayOnIPhone = NSLocalizedString(
+            "menu.payments.tapToPay.about.row.title",
+            value: "About Tap to Pay",
+            comment: "Navigates to the About Tap to Pay on iPhone screen, which explains the capabilities and limits " +
+            "of Tap to Pay on iPhone, relevant to the store territory.")
+
+        static let tapToPayOnIPhoneFeedback = NSLocalizedString(
+            "menu.payments.tapToPay.feedback.row.title",
+            value: "Share Feedback",
+            comment: "Navigates to a screen to share feedback about Tap to Pay on iPhone.")
+
+        static let inPersonPaymentsSetupNotFinishedNotice = NSLocalizedString(
+            "menu.payments.inPersonPayments.setup.incomplete.notice.title",
+            value: "In-Person Payments setup is incomplete.",
+            comment: "Shows a notice pointing out that the user didn't finish the In-Person Payments setup, so some functionalities are disabled."
+        )
+
+        static let inPersonPaymentsSetupNotFinishedNoticeButtonTitle = NSLocalizedString(
+            "menu.payments.inPersonPayments.setup.incomplete.notice.button.title",
+            value: "Continue setup",
+            comment: "Call to Action to finish the setup of In-Person Payments in the Menu"
+        )
+
+        static let done = NSLocalizedString(
+            "menu.payments.wooPaymentsDeposits.navigation.done.button.title",
+            value: "Done",
+            comment: "Title for a done button in the navigation bar")
+
+        static let inPersonPaymentsLearnMoreText = NSLocalizedString(
+            "menu.payments.inPersonPayments.learnMore.text",
+            value: "%1$@ about In‑Person Payments",
+            comment: """
+                     A label prompting users to learn more about In-Person Payments.
+                     The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                     If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
+                     %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                     which should be translated separately and considered part of this sentence.
+                     """
+        )
+
+        static let learnMoreLink = NSLocalizedString(
+            "menu.payments.inPersonPayments.learnMore.link",
+            value: "Learn more",
+            comment: """
+                     A label prompting users to learn more about card readers.
+                     This part is the link to the website, and forms part of a longer sentence which it should be considered a part of.
+                     """
+        )
     }
 }
 
 struct InPersonPaymentsMenu_Previews: PreviewProvider {
+    static let viewModel: InPersonPaymentsMenuViewModel = .init(
+        siteID: 0,
+        dependencies: .init(
+            cardPresentPaymentsConfiguration: .init(country: .US),
+            onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
+            cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: 0)))
     static var previews: some View {
-        InPersonPaymentsMenu()
+        InPersonPaymentsMenu(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -1,0 +1,89 @@
+import Foundation
+import SwiftUI
+import Yosemite
+import WooFoundation
+
+class InPersonPaymentsMenuViewModel: ObservableObject {
+    @Published private(set) var shouldShowTapToPaySection: Bool = true
+    @Published private(set) var shouldShowCardReaderSection: Bool = true
+    @Published private(set) var setUpTryOutTapToPayRowTitle: String = Localization.setUpTapToPayOnIPhoneRowTitle
+    @Published private(set) var shouldShowTapToPayFeedbackRow: Bool = true
+    @Published private(set) var shouldDisableManageCardReaders: Bool = false
+    var shouldAlwaysHideSetUpButtonOnAboutTapToPay: Bool = false
+
+    let siteID: Int64
+
+    struct Dependencies {
+        let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
+        let onboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol
+        let cardReaderSupportDeterminer: CardReaderSupportDetermining
+    }
+
+    let dependencies: Dependencies
+
+    init(siteID: Int64,
+         dependencies: Dependencies) {
+        self.siteID = siteID
+        self.dependencies = dependencies
+        updateOutputProperties()
+    }
+
+    func updateOutputProperties() {
+        Task {
+            await shouldAlwaysHideSetUpButtonOnAboutTapToPay = dependencies.cardReaderSupportDeterminer.hasPreviousTapToPayUsage()
+        }
+    }
+
+    var setUpTapToPayViewModelsAndViews: SetUpTapToPayViewModelsOrderedList {
+        SetUpTapToPayViewModelsOrderedList(
+            siteID: siteID,
+            configuration: dependencies.cardPresentPaymentsConfiguration,
+            onboardingUseCase: dependencies.onboardingUseCase)
+    }
+
+    var aboutTapToPayViewModel: AboutTapToPayViewModel {
+        AboutTapToPayViewModel(
+            siteID: siteID,
+            configuration: dependencies.cardPresentPaymentsConfiguration,
+            cardPresentPaymentsOnboardingUseCase: dependencies.onboardingUseCase,
+            shouldAlwaysHideSetUpTapToPayButton: shouldAlwaysHideSetUpButtonOnAboutTapToPay)
+    }
+
+    var manageCardReadersViewModelsAndViews: CardReaderSettingsViewModelsOrderedList {
+        CardReaderSettingsViewModelsOrderedList(
+            configuration: dependencies.cardPresentPaymentsConfiguration,
+            siteID: siteID)
+    }
+
+    var purchaseCardReaderWebViewModel: PurchaseCardReaderWebViewViewModel {
+        PurchaseCardReaderWebViewViewModel(
+            configuration: dependencies.cardPresentPaymentsConfiguration,
+            utmProvider: WooCommerceComUTMProvider(
+                campaign: Constants.utmCampaign,
+                source: Constants.utmSource,
+                content: nil,
+                siteID: siteID),
+            onDismiss: {})
+
+    }
+
+}
+
+private enum Constants {
+    static let utmCampaign = "payments_menu_item"
+    static let utmSource = "payments_menu"
+}
+
+private extension InPersonPaymentsMenuViewModel {
+    enum Localization {
+        static let setUpTapToPayOnIPhoneRowTitle = NSLocalizedString(
+            "Set Up Tap to Pay on iPhone",
+            comment: "Navigates to the Tap to Pay on iPhone set up flow. The full name is expected by Apple. " +
+            "The destination screen also allows for a test payment, after set up.")
+
+        static let tryOutTapToPayOnIPhoneRowTitle = NSLocalizedString(
+            "Try Out Tap to Pay on iPhone",
+            comment: "Navigates to the Tap to Pay on iPhone set up flow, after set up has been completed, when it " +
+            "primarily allows for a test payment. The full name is expected by Apple.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -167,7 +167,7 @@ struct HubMenu: View {
     @ViewBuilder
     private func inPersonPaymentsMenu() -> some View {
         if viewModel.swiftUIPaymentsMenuEnabled {
-            InPersonPaymentsMenu()
+            InPersonPaymentsMenu(viewModel: viewModel.inPersonPaymentsMenuViewModel)
         } else {
             LegacyInPersonPaymentsMenu(tapToPayBadgePromotionChecker: viewModel.tapToPayBadgePromotionChecker)
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -73,6 +73,15 @@ final class HubMenuViewModel: ObservableObject {
 
     let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
 
+    lazy var inPersonPaymentsMenuViewModel: InPersonPaymentsMenuViewModel = {
+        InPersonPaymentsMenuViewModel(
+            siteID: siteID,
+            dependencies: .init(
+                cardPresentPaymentsConfiguration: CardPresentConfigurationLoader().configuration,
+                onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
+                cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID)))
+    }()
+
     init(siteID: Int64,
          navigationController: UINavigationController? = nil,
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -48,20 +48,25 @@ struct AuthenticatedWebView: UIViewControllerRepresentable {
         }
     }
 
-    let url: URL
+    let viewModel: AuthenticatedWebViewModel
 
-    /// Optional URL or part of URL to trigger exit
-    ///
-    var urlToTriggerExit: String?
+    init(isPresented: Binding<Bool>,
+             viewModel: AuthenticatedWebViewModel) {
+            self._isPresented = isPresented
+            self.viewModel = viewModel
+        }
 
-    /// Callback that will be triggered if the destination url containts the `urlToTriggerExit`
-    ///
-    var exitTrigger: (() -> Void)?
-
-    func makeUIViewController(context: Context) -> AuthenticatedWebViewController {
-        let viewModel = DefaultAuthenticatedWebViewModel(initialURL: url,
+    init(isPresented: Binding<Bool>,
+             url: URL,
+             urlToTriggerExit: String? = nil,
+             exitTrigger: (() -> Void)? = nil) {
+            self._isPresented = isPresented
+            viewModel = DefaultAuthenticatedWebViewModel(initialURL: url,
                                                          urlToTriggerExit: urlToTriggerExit,
                                                          exitTrigger: exitTrigger)
+        }
+
+    func makeUIViewController(context: Context) -> AuthenticatedWebViewController {
         return AuthenticatedWebViewController(viewModel: viewModel)
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -718,6 +718,7 @@
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
+		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
 		20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* AboutTapToPayView.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
@@ -3269,6 +3270,7 @@
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
+		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* AboutTapToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayView.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
@@ -11058,11 +11060,12 @@
 				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* LegacyInPersonPaymentsMenuViewController.swift */,
-				20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */,
+				03EF250128C615A5006A033E /* LegacyInPersonPaymentsMenuViewModel.swift */,
 				209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */,
 				209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */,
 				203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */,
-				03EF250128C615A5006A033E /* LegacyInPersonPaymentsMenuViewModel.swift */,
+				20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */,
+				20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */,
 				03EF250528C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift */,
 				03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */,
 				E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */,
@@ -12938,6 +12941,7 @@
 				0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */,
 				45E9A6E424DAE1EA00A600E8 /* ProductReviewsViewController.swift in Sources */,
 				03E471C4293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift in Sources */,
+				20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */,
 				D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */,
 				DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */,
 				B5F8B7E02194759100DAB7E2 /* ReviewDetailsViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11103
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In order to make future changes and additions to the Payments Menu easier, we're converting it to SwiftUI.

This PR adds a basic, incomplete implementation of the menu. It is feature flagged, and won't be released until significant further work is done, so this should be reviewed as work in progress. Some parts are missing, some screens don't open in the way we intend, and others are not fully functional when opened from the new menu. I'll detail these below, but safe to say that this isn't a PR to go into lots of detailed testing on.

### Known Issues
- Simple Payments won't let you take a Card Reader or TTP payment (both need a UIKit VC at the moment. #11123)
- Set Up Tap to Pay and the Tap to Pay Feedback rows should open modal views, but push. (Issue: #11122)
- Manage Card Reader can always be accessed, even if you've not completed onboarding. (Issue: #11104)
- Onboarding tracks events are logged more frequently than expected (likely due to view model recreation. Issue: #11104)
- Pay in Person row isn't showing (addressed in #11121)
- Background onboarding isn't implemented (Issue: #11104)
- Deeplinks, Spotlight search, and App Intents are untested (Issue: #11100)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app from Xcode
2. Navigate to `Menu > Settings > Experimental Features`
3. Toggle `SwiftUI Payments Menu`
4. Navigate to `Menu > Payments`
5. Observe that the new menu is shown. Try some of the screens and check that broadly, it's a payments menu 😁 .

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/e28ab1e8-6062-4986-b7d1-7ca983bdc798


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
