### PR TITLE
Update Ruby Tooling Configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Metrics/MethodLength:
 
 Layout/LineLength:
   Max: 180
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never

--- a/Dangerfile
+++ b/Dangerfile
@@ -32,6 +32,6 @@ view_changes_need_screenshots.view_changes_need_screenshots
 pr_size_checker.check_diff_size
 
 # skip check for draft PRs and for WIP features unless the PR is against the main branch or release branch
-milestone_checker.check_milestone_due_date(days_before_due: 2) if !github.pr_draft? && (!wip_feature? || (release_branch? || main_branch?))
+milestone_checker.check_milestone_due_date(days_before_due: 2) unless github.pr_draft? || (wip_feature? && !(release_branch? || main_branch?))
 
 rubocop.lint(inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 gem 'cocoapods', '~> 1.14'
 gem 'cocoapods-catalyst-support', '~> 0.1'
 gem 'dotenv'
-gem 'fastlane', '~> 2'
+gem 'fastlane', '~> 2.216'
 gem 'fastlane-plugin-appcenter', '~> 2.0'
 gem 'fastlane-plugin-sentry', '~> 1.0'
 # This comment avoids typing to switch to a development version for testing.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Automattic/dangermattic
-  revision: 451932e8870ef3c52de0d8bea80edcfa3d879e53
+  revision: 06a54db4f546d20c0465e4d144049d061a2a1e20
   specs:
     danger-dangermattic (0.0.1)
       danger (~> 9.3)
@@ -336,7 +336,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (4.0.7)
-    racc (1.7.1)
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (12.3.3)
     rake-compiler (1.2.5)
@@ -351,8 +351,7 @@ GEM
     rexml (3.2.6)
     rmagick (4.3.0)
     rouge (2.0.7)
-    rubocop (1.57.1)
-      base64 (~> 0.1.1)
+    rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -363,7 +362,7 @@ GEM
       rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
+    rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ DEPENDENCIES
   cocoapods-catalyst-support (~> 0.1)
   danger-dangermattic!
   dotenv
-  fastlane (~> 2)
+  fastlane (~> 2.216)
   fastlane-plugin-appcenter (~> 2.0)
   fastlane-plugin-sentry (~> 1.0)
   fastlane-plugin-wpmreleasetoolkit (~> 9.1)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -215,7 +215,7 @@ platform :ios do
       extracted_notes_file_path: RELEASE_NOTES_PATH
     )
     ios_update_release_notes(
-      new_version:,
+      new_version: new_version,
       release_notes_file_path: RELEASE_NOTES_SOURCE_PATH
     )
 
@@ -1320,7 +1320,7 @@ def build_code_current
   # calculator can be used to calculate the next four-part version
   version = VERSION_FORMATTER.parse(VERSION_FILE.read_build_code(attribute_name: 'VERSION_LONG'))
   # Return the formatted build code
-  BUILD_CODE_FORMATTER.build_code(version:)
+  BUILD_CODE_FORMATTER.build_code(version: version)
 end
 
 # Returns the build code of the app for the code freeze. It is the release version name plus sets the build number to 0
@@ -1341,7 +1341,7 @@ end
 def build_code_hotfix(release_version:)
   version = VERSION_FORMATTER.parse(release_version)
   # Return the formatted build code
-  BUILD_CODE_FORMATTER.build_code(version:)
+  BUILD_CODE_FORMATTER.build_code(version: version)
 end
 
 # Returns the next build code of the app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -614,7 +614,7 @@ platform :ios do
     version = options[:beta_release] ? build_code_current : release_version_current
     create_release(
       repository: GITHUB_REPO,
-      version:,
+      version: version,
       release_notes_file_path: RELEASE_NOTES_PATH,
       release_assets: archive_zip_path.to_s,
       prerelease: options[:beta_release]
@@ -749,7 +749,7 @@ platform :ios do
       team_id: '299112',
       skip_binary_upload: true,
       screenshots_path: File.join(FASTLANE_DIR, 'promo_screenshots'),
-      skip_screenshots:,
+      skip_screenshots: skip_screenshots,
       overwrite_screenshots: true, # won't have effect if `skip_screenshots` is true
       phased_release: true,
       precheck_include_in_app_purchases: false,
@@ -801,9 +801,9 @@ platform :ios do
       scheme: SCREENSHOTS_SCHEME,
 
       localize_simulator: true,
-      languages:,
+      languages: languages,
 
-      devices:,
+      devices: devices,
 
       # Don't rebuild the app for every new locale / device type, and specify where to find the binaries
       test_without_building: true,
@@ -938,7 +938,7 @@ platform :ios do
 
     gp_downloadmetadata(
       project_url: GLOTPRESS_APP_STORE_METADATA_PROJECT_URL,
-      target_files:,
+      target_files: target_files,
       locales: locales_map,
       download_path: metadata_directory
     )
@@ -1085,8 +1085,8 @@ platform :ios do
       type: 'enterprise',
       team_id: get_required_env('INT_EXPORT_TEAM_ID'),
       app_identifier: ALPHA_BUNDLE_IDENTIFIERS,
-      readonly:,
-      api_key_path:
+      readonly: readonly,
+      api_key_path: api_key_path
     )
   end
 
@@ -1200,7 +1200,7 @@ lane :test_without_building do |options|
 
   UI.user_error!("Unable to find .xctestrun file at #{xctestrun_path}") unless !xctestrun_path.nil? && File.exist?(xctestrun_path)
 
-  inject_buildkite_analytics_environment(xctestrun_path:) if buildkite_ci?
+  inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
 
   # Only run UI tests in parallel.
   # At the time of writing with Xcode 14.3, we need to explicitly set this value despite using test plans that configure parallelism.
@@ -1264,7 +1264,7 @@ def trigger_buildkite_release_build(branch:, beta:)
   buildkite_trigger_build(
     buildkite_organization: 'automattic',
     buildkite_pipeline: 'woocommerce-ios',
-    branch:,
+    branch: branch,
     environment: { BETA_RELEASE: beta },
     pipeline_file: 'release-builds.yml'
   )


### PR DESCRIPTION
## Description

The main goal of this PR is to align the Ruby setup and standard syntax (preventing Ruby 3.1 new hash syntax, as discussed on paaHJt-5yi-p2) with other projects, mainly by configuring RuboCop with:
```yaml
Style/HashSyntax:
  EnforcedShorthandSyntax: never
```
And adjusting Ruby files accordingly.

I also took the chance to update `Dangermattic` to the latest version.


## Testing instructions
Make sure CI is green.
