### PR TITLE
Updated Sentry from `8.10.0` to `8.15.2`

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,12 +14,12 @@ PODS:
   - Kingfisher (7.6.2)
   - NSObject-SafeExpectations (0.0.6)
   - "NSURL+IDN (0.4)"
-  - Sentry (8.10.0):
-    - Sentry/Core (= 8.10.0)
-    - SentryPrivate (= 8.10.0)
-  - Sentry/Core (8.10.0):
-    - SentryPrivate (= 8.10.0)
-  - SentryPrivate (8.10.0)
+  - Sentry (8.15.2):
+    - Sentry/Core (= 8.15.2)
+    - SentryPrivate (= 8.15.2)
+  - Sentry/Core (8.15.2):
+    - SentryPrivate (= 8.15.2)
+  - SentryPrivate (8.15.2)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
   - StripeTerminal (2.23.2)
@@ -131,8 +131,8 @@ SPEC CHECKSUMS:
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
-  Sentry: 71cd4427146ac56eab6e70401ac7a24384c3d3b5
-  SentryPrivate: 9334613897c85a9e30f2c9d7a331af8aaa4fe71f
+  Sentry: 6f5742b4c47c17c9adcf265f6f328cf4a0ed1923
+  SentryPrivate: b2f7996f37781080f04a946eb4e377ff63c64195
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 77c47dcc178113ed85ad47540df92d61646877e3


### PR DESCRIPTION
This PR updates the Sentry pod from `8.10.0` to `8.15.2`. 

###  Testing instructions
This is good to go if CI is green. 

Once the App Center build is available, I can go in and verify that data is being correctly sent to Sentry.
