### PR TITLE
Merge beta 16.1.0.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -83,8 +83,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 7.2.0'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
+  pod 'WordPressAuthenticator', '~> 7.3'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.23.2)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
+  - WordPressAuthenticator (~> 7.3)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -99,6 +99,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressShared
     - WordPressUI
     - Wormholy
@@ -111,16 +112,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :branch: trunk
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 77c77d005b1a34f9c0dc656addc884e5eb6fd362
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -155,6 +146,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 1360bf824fbcac72f5d6aee318a2d79a4fbf79d6
+PODFILE CHECKSUM: 5e7ae933ba20024981cdc979c563bbb07d19ef17
 
 COCOAPODS: 1.14.0

--- a/config/Version.Public.xcconfig
+++ b/config/Version.Public.xcconfig
@@ -1,7 +1,7 @@
 VERSION_SHORT=16.1
 
 // Public long version example: VERSION_LONG=1.2.0.0
-VERSION_LONG=16.1.0.2
+VERSION_LONG=16.1.0.3
 
 // Re-map our custom version values (used by release-toolkit) to the Xcode ones
 MARKETING_VERSION=$VERSION_SHORT

--- a/config/Version.Public.xcconfig
+++ b/config/Version.Public.xcconfig
@@ -1,7 +1,7 @@
 VERSION_SHORT=16.1
 
 // Public long version example: VERSION_LONG=1.2.0.0
-VERSION_LONG=16.1.0.1
+VERSION_LONG=16.1.0.2
 
 // Re-map our custom version values (used by release-toolkit) to the Xcode ones
 MARKETING_VERSION=$VERSION_SHORT


### PR DESCRIPTION
- [x] Updates to the localization files (`.strings` and Fastlane metadata) automatically pulled for the new translations that have already been approved in GlotPress – No changes since previous beta 🤷‍♂️ 
- [x] Version update in `.xcconfig`
- [x] Diffs from the PRs that made it into this beta 👉 I committed the WordPressAuthenticator version bump directly in the interest of testing it's effectiveness via TestFlight.