### PR TITLE
Product Add/Edit: Update price row and screen to support subscription

### DIFF
--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -71,7 +71,7 @@ private extension ProductSubscription {
 
 /// Represents all possible subscription periods
 ///
-public enum SubscriptionPeriod: String, Codable, GeneratedFakeable {
+public enum SubscriptionPeriod: String, Decodable, GeneratedFakeable {
     case day
     case week
     case month

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -71,7 +71,7 @@ private extension ProductSubscription {
 
 /// Represents all possible subscription periods
 ///
-public enum SubscriptionPeriod: String, Decodable, GeneratedFakeable {
+public enum SubscriptionPeriod: String, Decodable, GeneratedFakeable, CaseIterable {
     case day
     case week
     case month

--- a/Networking/Networking/Model/Product/ProductType.swift
+++ b/Networking/Networking/Model/Product/ProductType.swift
@@ -85,11 +85,6 @@ extension ProductType: RawRepresentable {
             return payload // unable to localize at runtime.
         }
     }
-
-    /// Whether the current type is either simple or variable subscription.
-    public var isSubscriptionType: Bool {
-        self == .subscription || self == .variableSubscription
-    }
 }
 
 

--- a/Networking/Networking/Model/Product/ProductType.swift
+++ b/Networking/Networking/Model/Product/ProductType.swift
@@ -85,6 +85,11 @@ extension ProductType: RawRepresentable {
             return payload // unable to localize at runtime.
         }
     }
+
+    /// Whether the current type is either simple or variable subscription.
+    public var isSubscriptionType: Bool {
+        self == .subscription || self == .variableSubscription
+    }
 }
 
 

--- a/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
+++ b/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
@@ -1,5 +1,4 @@
 import Foundation
-import struct Yosemite.Product
 import enum Yosemite.SubscriptionPeriod
 
 extension ProductFormDataModel {

--- a/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
+++ b/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
@@ -1,5 +1,6 @@
 import Foundation
 import struct Yosemite.Product
+import enum Yosemite.SubscriptionPeriod
 
 extension ProductFormDataModel {
 
@@ -7,15 +8,18 @@ extension ProductFormDataModel {
     /// Returns nil if the product does not have subscription info.
     ///
     var subscriptionPeriodDescription: String? {
-        guard let subscription = subscription else {
-            return nil
-        }
+        subscription.map { String.formatSubscriptionPeriodDescription(period: $0.period, interval: $0.periodInterval) }
+    }
+}
+
+extension String {
+    static func formatSubscriptionPeriodDescription(period: SubscriptionPeriod, interval: String) -> String {
         let billingFrequency = {
-            switch subscription.periodInterval {
+            switch interval {
             case "1":
-                return subscription.period.descriptionSingular
+                return period.descriptionSingular
             default:
-                return "\(subscription.periodInterval) \(subscription.period.descriptionPlural)"
+                return "\(interval) \(period.descriptionPlural)"
             }
         }()
 
@@ -25,6 +29,6 @@ extension ProductFormDataModel {
             comment: "Description of the subscription period for a product. " +
             "Reads like: 'every 2 months'."
         )
-        return String.localizedStringWithFormat(subscriptionPeriodFormat, billingFrequency)
+        return localizedStringWithFormat(subscriptionPeriodFormat, billingFrequency)
     }
 }

--- a/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
+++ b/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
@@ -3,10 +3,10 @@ import struct Yosemite.Product
 
 extension ProductFormDataModel {
 
-    /// Formats subscription period info to readable text.
+    /// Returns the formatted subscription period info in readable text.
     /// Returns nil if the product does not have subscription info.
     ///
-    func subscriptionPeriodDescription() -> String? {
+    var subscriptionPeriodDescription: String? {
         guard let subscription = subscription else {
             return nil
         }

--- a/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
+++ b/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
@@ -1,0 +1,30 @@
+import Foundation
+import struct Yosemite.Product
+
+extension ProductFormDataModel {
+
+    /// Formats subscription period info to readable text.
+    /// Returns nil if the product does not have subscription info.
+    ///
+    func subscriptionPeriodDescription() -> String? {
+        guard let subscription = subscription else {
+            return nil
+        }
+        let billingFrequency = {
+            switch subscription.periodInterval {
+            case "1":
+                return subscription.period.descriptionSingular
+            default:
+                return "\(subscription.periodInterval) \(subscription.period.descriptionPlural)"
+            }
+        }()
+
+        let subscriptionPeriodFormat = NSLocalizedString(
+            "product.subscriptionPeriodFormat",
+            value: "every %1$@",
+            comment: "Description of the subscription price for a product, with the price " +
+            "and billing frequency. Reads like: 'every 2 months'."
+        )
+        return String.localizedStringWithFormat(subscriptionPeriodFormat, billingFrequency)
+    }
+}

--- a/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
+++ b/WooCommerce/Classes/Extensions/ProductFormDataModel+SubscriptionDescription.swift
@@ -20,10 +20,10 @@ extension ProductFormDataModel {
         }()
 
         let subscriptionPeriodFormat = NSLocalizedString(
-            "product.subscriptionPeriodFormat",
+            "productFormDataModel.subscriptionPeriodFormat",
             value: "every %1$@",
-            comment: "Description of the subscription price for a product, with the price " +
-            "and billing frequency. Reads like: 'every 2 months'."
+            comment: "Description of the subscription period for a product. " +
+            "Reads like: 'every 2 months'."
         )
         return String.localizedStringWithFormat(subscriptionPeriodFormat, billingFrequency)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -184,7 +184,15 @@ private extension DefaultProductFormTableViewModel {
         // Regular price and sale price are both available only when a sale price is set.
         if let regularPrice = product.regularPrice, regularPrice.isNotEmpty {
             let formattedRegularPrice = currencyFormatter.formatAmount(regularPrice, with: currency) ?? ""
-            priceDetails.append(String.localizedStringWithFormat(Localization.regularPriceFormat, formattedRegularPrice))
+            if let subscriptionPeriodDescription = product.subscriptionPeriodDescription {
+                priceDetails.append(String.localizedStringWithFormat(
+                    Localization.regularSubscriptionPriceFormat,
+                    formattedRegularPrice,
+                    subscriptionPeriodDescription
+                ))
+            } else {
+                priceDetails.append(String.localizedStringWithFormat(Localization.regularPriceFormat, formattedRegularPrice))
+            }
 
             if let salePrice = product.salePrice, salePrice.isNotEmpty {
                 let formattedSalePrice = currencyFormatter.formatAmount(salePrice, with: currency) ?? ""
@@ -673,6 +681,12 @@ private extension DefaultProductFormTableViewModel {
         // Price
         static let regularPriceFormat = NSLocalizedString("Regular price: %@",
                                                           comment: "Format of the regular price on the Price Settings row")
+        static let regularSubscriptionPriceFormat = NSLocalizedString(
+            "defaultProductFormTableViewModel.regularSubscriptionPriceFormat",
+            value: "Regular price: %1$@ %2$@",
+            comment: "Format of the regular price for a subscription product on the Price Settings row. " +
+            "Reads like: 'Regular price: $60.00 every 2 months'."
+        )
         static let salePriceFormat = NSLocalizedString("Sale price: %@",
                                                        comment: "Format of the sale price on the Price Settings row")
         static let saleDatesFormat = NSLocalizedString("Sale dates: %@",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -44,10 +44,15 @@ extension Product {
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        var value = currencyFormatter.formatAmount(salePrice ?? "", with: unit) ?? ""
-        value = value
-            .replacingOccurrences(of: unit, with: "")
-            .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
+        let value: String = {
+            guard let salePrice, salePrice.isNotEmpty else {
+                return ""
+            }
+            return (currencyFormatter.formatAmount(salePrice, with: unit) ?? "")
+                .replacingOccurrences(of: unit, with: "")
+                .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
+        }()
+
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -389,6 +389,7 @@ private extension ProductPriceSettingsViewController {
                                         onEditingEnd: { [weak self] in
             self?.refreshViewContent()
         }))
+        preselectSubscriptionPeriodPickerRows()
     }
 
     func configureSalePrice(cell: UnitInputTableViewCell) {
@@ -546,6 +547,31 @@ private extension ProductPriceSettingsViewController {
         let selectedPeriodRow = subscriptionPeriodPickerView.selectedRow(inComponent: SubscriptionPeriodPickerComponent.period.rawValue)
         viewModel.handleSubscriptionPeriodChange(interval: "\(selectedIntervalRow + 1)",
                                                  period: SubscriptionPeriod.allCases[selectedPeriodRow])
+    }
+
+    func preselectSubscriptionPeriodPickerRows() {
+        let intervalRowIndex: Int = {
+            guard let interval = viewModel.subscriptionPeriodInterval,
+                let intervalNumber = Int(interval) else {
+                return 0
+            }
+            return intervalNumber - 1
+        }()
+
+        let periodRowIndex: Int = {
+            guard let period = viewModel.subscriptionPeriod,
+                  let index = SubscriptionPeriod.allCases.firstIndex(of: period) else {
+                return 0
+            }
+            return index
+        }()
+
+        subscriptionPeriodPickerView.selectRow(intervalRowIndex,
+                                               inComponent: SubscriptionPeriodPickerComponent.interval.rawValue,
+                                               animated: false)
+        subscriptionPeriodPickerView.selectRow(periodRowIndex,
+                                               inComponent: SubscriptionPeriodPickerComponent.period.rawValue,
+                                               animated: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -343,8 +343,6 @@ private extension ProductPriceSettingsViewController {
             configureTaxClass(cell: cell)
         case let cell as TitleAndValueTableViewCell where row == .subscriptionPeriod:
             configureSubscriptionPeriod(cell: cell)
-        case let cell as TitleAndValueTableViewCell where row == .subscriptionPeriodInterval:
-            configureSubscriptionPeriodInterval(cell: cell)
         default:
             fatalError()
             break
@@ -361,11 +359,9 @@ private extension ProductPriceSettingsViewController {
     }
 
     func configureSubscriptionPeriod(cell: TitleAndValueTableViewCell) {
-        // TODO
-    }
-
-    func configureSubscriptionPeriodInterval(cell: TitleAndValueTableViewCell) {
-        // TODO
+        cell.updateUI(title: Localization.subscriptionPeriod,
+                      value: viewModel.subscriptionPeriod)
+        cell.accessoryType = .disclosureIndicator
     }
 
     func configureSalePrice(cell: UnitInputTableViewCell) {
@@ -484,7 +480,6 @@ extension ProductPriceSettingsViewController {
     enum Row: CaseIterable {
         case price
         case subscriptionPeriod
-        case subscriptionPeriodInterval
         case salePrice
 
         case scheduleSale
@@ -503,7 +498,7 @@ extension ProductPriceSettingsViewController {
                 return UnitInputTableViewCell.self
             case .scheduleSale:
                 return SwitchTableViewCell.self
-            case .scheduleSaleFrom, .scheduleSaleTo, .subscriptionPeriod, .subscriptionPeriodInterval:
+            case .scheduleSaleFrom, .scheduleSaleTo, .subscriptionPeriod:
                 return TitleAndValueTableViewCell.self
             case .datePickerSaleFrom, .datePickerSaleTo:
                 return DatePickerTableViewCell.self
@@ -522,4 +517,19 @@ extension ProductPriceSettingsViewController {
 
 private struct Constants {
     static let sectionHeight = CGFloat(44)
+}
+
+private extension ProductPriceSettingsViewController {
+    enum Localization {
+        static let subscriptionPeriod = NSLocalizedString(
+            "productPriceSettingsViewController.subscriptionPeriodRowTitle",
+            value: "Subscription period",
+            comment: "Title of the subscription period row on the Product Price screen"
+        )
+        static let subscriptionPeriodInterval = NSLocalizedString(
+            "productPriceSettingsViewController.subscriptionPeriodIntervalRowTitle",
+            value: "Subscription period interval",
+            comment: "Title of the subscription period interval row on the Product Price screen"
+        )
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -30,12 +30,14 @@ final class ProductPriceSettingsViewController: UIViewController {
     // Completion callback
     //
     typealias Completion = (_ regularPrice: String?,
-        _ salePrice: String?,
-        _ dateOnSaleStart: Date?,
-        _ dateOnSaleEnd: Date?,
-        _ taxStatus: ProductTaxStatus,
-        _ taxClass: TaxClass?,
-        _ hasUnsavedChanges: Bool) -> Void
+                            _ subscriptionPeriod: SubscriptionPeriod?,
+                            _ subscriptionPeriodInterval: String?,
+                            _ salePrice: String?,
+                            _ dateOnSaleStart: Date?,
+                            _ dateOnSaleEnd: Date?,
+                            _ taxStatus: ProductTaxStatus,
+                            _ taxClass: TaxClass?,
+                            _ hasUnsavedChanges: Bool) -> Void
     private let onCompletion: Completion
 
     private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
@@ -167,9 +169,8 @@ extension ProductPriceSettingsViewController {
 
     @objc private func completeUpdating() {
         viewModel.completeUpdating(
-            onCompletion: { [weak self] (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges) in
-                self?.onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges)
-            }, onError: { [weak self] error in
+            onCompletion: onCompletion,
+            onError: { [weak self] error in
                 switch error {
                 case .salePriceWithoutRegularPrice:
                     self?.displaySalePriceWithoutRegularPriceErrorNotice()
@@ -380,7 +381,7 @@ private extension ProductPriceSettingsViewController {
 
     func configureSubscriptionPeriod(cell: TitleAndTextFieldTableViewCell) {
         cell.configure(viewModel: .init(title: Localization.subscriptionPeriod,
-                                        text: viewModel.subscriptionPeriod,
+                                        text: viewModel.subscriptionPeriodDescription,
                                         placeholder: nil,
                                         textFieldAlignment: .trailing,
                                         inputView: subscriptionPeriodPickerView,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -53,9 +53,10 @@ final class ProductPriceSettingsViewController: UIViewController {
                                              size: .init(width: UIScreen.main.bounds.width,
                                                          height: Constants.subscriptionPeriodToolbarHeight)))
         let doneButton = UIBarButtonItem(title: Localization.subscriptionPeriodToolBarButton,
-                                         style: .plain,
+                                         style: .done,
                                          target: self,
                                          action: #selector(self.onSubscriptionPeriodUpdateDone))
+        doneButton.tintColor = .accent
         toolBar.setItems([.flexibleSpace(), doneButton], animated: false)
         return toolBar
     }()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -341,6 +341,10 @@ private extension ProductPriceSettingsViewController {
             configureTaxStatus(cell: cell)
         case let cell as TitleAndValueTableViewCell where row == .taxClass:
             configureTaxClass(cell: cell)
+        case let cell as TitleAndValueTableViewCell where row == .subscriptionPeriod:
+            configureSubscriptionPeriod(cell: cell)
+        case let cell as TitleAndValueTableViewCell where row == .subscriptionPeriodInterval:
+            configureSubscriptionPeriodInterval(cell: cell)
         default:
             fatalError()
             break
@@ -354,6 +358,14 @@ private extension ProductPriceSettingsViewController {
         }
         cell.selectionStyle = .none
         cell.configure(viewModel: cellViewModel)
+    }
+
+    func configureSubscriptionPeriod(cell: TitleAndValueTableViewCell) {
+        // TODO
+    }
+
+    func configureSubscriptionPeriodInterval(cell: TitleAndValueTableViewCell) {
+        // TODO
     }
 
     func configureSalePrice(cell: UnitInputTableViewCell) {
@@ -471,6 +483,8 @@ extension ProductPriceSettingsViewController {
 
     enum Row: CaseIterable {
         case price
+        case subscriptionPeriod
+        case subscriptionPeriodInterval
         case salePrice
 
         case scheduleSale
@@ -489,7 +503,7 @@ extension ProductPriceSettingsViewController {
                 return UnitInputTableViewCell.self
             case .scheduleSale:
                 return SwitchTableViewCell.self
-            case .scheduleSaleFrom, .scheduleSaleTo:
+            case .scheduleSaleFrom, .scheduleSaleTo, .subscriptionPeriod, .subscriptionPeriodInterval:
                 return TitleAndValueTableViewCell.self
             case .datePickerSaleFrom, .datePickerSaleTo:
                 return DatePickerTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -120,6 +120,7 @@ private extension ProductPriceSettingsViewController {
     func configureTableView() {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
+        tableView.keyboardDismissMode = .onDragWithAccessory
 
         registerTableViewHeaderSections()
         registerTableViewCells()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -387,7 +387,7 @@ private extension ProductPriceSettingsViewController {
         )
         self.subscriptionPeriodPickerUseCase = useCase
 
-        cell.configure(viewModel: .init(title: Localization.subscriptionPeriod,
+        cell.configure(viewModel: .init(title: Localization.billingInterval,
                                         text: viewModel.subscriptionPeriodDescription,
                                         placeholder: nil,
                                         textFieldAlignment: .trailing,
@@ -563,10 +563,10 @@ private struct Constants {
 
 private extension ProductPriceSettingsViewController {
     enum Localization {
-        static let subscriptionPeriod = NSLocalizedString(
-            "productPriceSettingsViewController.subscriptionIntervalRowTitle",
-            value: "Subscription period",
-            comment: "Title of the subscription interval row on the Product Price screen"
+        static let billingInterval = NSLocalizedString(
+            "productPriceSettingsViewController.billingIntervalRowTitle",
+            value: "Billing interval",
+            comment: "Title of the billing interval row on the Product Price screen"
         )
         static let subscriptionPeriodToolBarButton = NSLocalizedString(
             "productPriceSettingsViewController.subscriptionPeriodToolBarButton",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -169,7 +169,9 @@ extension ProductPriceSettingsViewController {
 
     @objc private func completeUpdating() {
         viewModel.completeUpdating(
-            onCompletion: onCompletion,
+            onCompletion: { [weak self] in
+                self?.onCompletion($0, $1, $2, $3, $4, $5, $6, $7, $8)
+            },
             onError: { [weak self] error in
                 switch error {
                 case .salePriceWithoutRegularPrice:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -130,7 +130,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
     var sections: [Section] {
         // Price section
         var priceRows: [Row] = [.price]
-        if product.productType.isSubscriptionType {
+        if product.subscription != nil {
             priceRows.append(contentsOf: [.subscriptionPeriod])
         }
         let priceSection = Section(title: Strings.priceSectionTitle, rows: priceRows)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -35,6 +35,7 @@ protocol ProductPriceSettingsActionHandler {
     func handleScheduleSaleChange(isEnabled: Bool)
     func handleSaleStartDateChange(_ date: Date)
     func handleSaleEndDateChange(_ date: Date?)
+    func handleSubscriptionPeriodChange(interval: String, period: SubscriptionPeriod)
 
     // Navigation actions
     func completeUpdating(onCompletion: ProductPriceSettingsViewController.Completion, onError: (ProductPriceSettingsError) -> Void)
@@ -235,6 +236,18 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
         }
     }
 
+    func handleSubscriptionPeriodChange(interval: String, period: SubscriptionPeriod) {
+        let billingFrequency = {
+            switch interval {
+            case "1":
+                return period.descriptionSingular
+            default:
+                return "\(interval) \(period.descriptionPlural)"
+            }
+        }()
+        subscriptionPeriod = String.localizedStringWithFormat(Strings.subscriptionPeriodFormat, billingFrequency)
+    }
+
     // MARK: - Navigation actions
 
     func completeUpdating(onCompletion: ProductPriceSettingsViewController.Completion, onError: (ProductPriceSettingsError) -> Void) {
@@ -262,7 +275,8 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
             dateOnSaleStart != originalDateOnSaleStart ||
             dateOnSaleEnd != product.dateOnSaleEnd ||
             taxStatus.rawValue != product.taxStatusKey ||
-            newTaxClass != originalTaxClass {
+            newTaxClass != originalTaxClass ||
+            subscriptionPeriod != product.subscriptionPeriodDescription {
             return true
         }
 
@@ -280,5 +294,11 @@ extension ProductPriceSettingsViewModel {
         )
         static let taxSectionTitle = NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings")
         static let standardTaxClassName = NSLocalizedString("Standard rate", comment: "The name of the default Tax Class in Product Price Settings")
+        static let subscriptionPeriodFormat = NSLocalizedString(
+            "productPriceSettingsViewModel.subscriptionPeriodFormat",
+            value: "every %1$@",
+            comment: "Description of the subscription period for a product. " +
+            "Reads like: 'every 2 months'."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -129,10 +129,13 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
 
     var sections: [Section] {
         // Price section
-        var priceRows: [Row] = [.price]
-        if product.subscription != nil {
-            priceRows.append(contentsOf: [.subscriptionPeriod])
-        }
+        let priceRows: [Row] = {
+            if product.subscription == nil {
+                return [.price]
+            }
+            return [.price, .subscriptionPeriod]
+        }()
+
         let priceSection = Section(title: Strings.priceSectionTitle, rows: priceRows)
 
         // Sales section

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -14,6 +14,9 @@ protocol ProductPriceSettingsViewModelOutput {
     var dateOnSaleEnd: Date? { get }
     var taxStatus: ProductTaxStatus { get }
     var taxClass: TaxClass? { get }
+
+    var subscriptionPeriod: SubscriptionPeriod? { get }
+    var subscriptionPeriodInterval: String? { get }
     var subscriptionPeriodDescription: String? { get }
 }
 
@@ -53,8 +56,8 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
     private(set) var salePrice: String?
 
     private(set) var subscriptionPeriodDescription: String?
-    private var subscriptionPeriod: SubscriptionPeriod?
-    private var subscriptionPeriodInterval: String?
+    private(set) var subscriptionPeriod: SubscriptionPeriod?
+    private(set) var subscriptionPeriodInterval: String?
 
     private(set) var dateOnSaleStart: Date?
     private(set) var dateOnSaleEnd: Date?

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -95,7 +95,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
 
         regularPrice = product.regularPrice
         salePrice = product.salePrice
-        subscriptionPeriod = product.subscriptionPeriodDescription()
+        subscriptionPeriod = product.subscriptionPeriodDescription
 
         // If the product sale start date is nil and the sale end date is not in the past, defaults the sale start date to today.
         if let saleEndDate = product.dateOnSaleEnd, product.dateOnSaleStart == nil &&

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -267,7 +267,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
             return
         }
 
-        onCompletion(regularPrice, 
+        onCompletion(regularPrice,
                      subscriptionPeriod,
                      subscriptionPeriodInterval,
                      salePrice,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -267,7 +267,15 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
             return
         }
 
-        onCompletion(regularPrice, subscriptionPeriod, subscriptionPeriodInterval, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges())
+        onCompletion(regularPrice, 
+                     subscriptionPeriod,
+                     subscriptionPeriodInterval, 
+                     salePrice,
+                     dateOnSaleStart,
+                     dateOnSaleEnd,
+                     taxStatus,
+                     taxClass,
+                     hasUnsavedChanges())
     }
 
     func hasUnsavedChanges() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -116,7 +116,11 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
 
     var sections: [Section] {
         // Price section
-        let priceSection = Section(title: Strings.priceSectionTitle, rows: [.price])
+        var priceRows: [Row] = [.price]
+        if product.productType.isSubscriptionType {
+            priceRows.append(contentsOf: [.subscriptionPeriod, .subscriptionPeriodInterval])
+        }
+        let priceSection = Section(title: Strings.priceSectionTitle, rows: priceRows)
 
         // Sales section
         var saleScheduleRows: [Row] = [.salePrice, .scheduleSale]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -269,7 +269,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
 
         onCompletion(regularPrice, 
                      subscriptionPeriod,
-                     subscriptionPeriodInterval, 
+                     subscriptionPeriodInterval,
                      salePrice,
                      dateOnSaleStart,
                      dateOnSaleEnd,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -14,7 +14,7 @@ protocol ProductPriceSettingsViewModelOutput {
     var dateOnSaleEnd: Date? { get }
     var taxStatus: ProductTaxStatus { get }
     var taxClass: TaxClass? { get }
-    var subscriptionPeriod: String? { get }
+    var subscriptionPeriodDescription: String? { get }
 }
 
 /// Handles actions related to the price settings data.
@@ -52,7 +52,9 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
     private(set) var regularPrice: String?
     private(set) var salePrice: String?
 
-    private(set) var subscriptionPeriod: String?
+    private(set) var subscriptionPeriodDescription: String?
+    private var subscriptionPeriod: SubscriptionPeriod?
+    private var subscriptionPeriodInterval: String?
 
     private(set) var dateOnSaleStart: Date?
     private(set) var dateOnSaleEnd: Date?
@@ -96,7 +98,10 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
 
         regularPrice = product.regularPrice
         salePrice = product.salePrice
-        subscriptionPeriod = product.subscriptionPeriodDescription
+
+        subscriptionPeriod = product.subscription?.period
+        subscriptionPeriodInterval = product.subscription?.periodInterval
+        subscriptionPeriodDescription = product.subscriptionPeriodDescription
 
         // If the product sale start date is nil and the sale end date is not in the past, defaults the sale start date to today.
         if let saleEndDate = product.dateOnSaleEnd, product.dateOnSaleStart == nil &&
@@ -245,7 +250,9 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
                 return "\(interval) \(period.descriptionPlural)"
             }
         }()
-        subscriptionPeriod = String.localizedStringWithFormat(Strings.subscriptionPeriodFormat, billingFrequency)
+        subscriptionPeriodDescription = String.localizedStringWithFormat(Strings.subscriptionPeriodFormat, billingFrequency)
+        subscriptionPeriod = period
+        subscriptionPeriodInterval = interval
     }
 
     // MARK: - Navigation actions
@@ -260,7 +267,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
             return
         }
 
-        onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges())
+        onCompletion(regularPrice, subscriptionPeriod, subscriptionPeriodInterval, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges())
     }
 
     func hasUnsavedChanges() -> Bool {
@@ -276,7 +283,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
             dateOnSaleEnd != product.dateOnSaleEnd ||
             taxStatus.rawValue != product.taxStatusKey ||
             newTaxClass != originalTaxClass ||
-            subscriptionPeriod != product.subscriptionPeriodDescription {
+            subscriptionPeriodDescription != product.subscriptionPeriodDescription {
             return true
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -14,6 +14,7 @@ protocol ProductPriceSettingsViewModelOutput {
     var dateOnSaleEnd: Date? { get }
     var taxStatus: ProductTaxStatus { get }
     var taxClass: TaxClass? { get }
+    var subscriptionPeriod: String? { get }
 }
 
 /// Handles actions related to the price settings data.
@@ -49,6 +50,8 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
     //
     private(set) var regularPrice: String?
     private(set) var salePrice: String?
+
+    private(set) var subscriptionPeriod: String?
 
     private(set) var dateOnSaleStart: Date?
     private(set) var dateOnSaleEnd: Date?
@@ -92,6 +95,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
 
         regularPrice = product.regularPrice
         salePrice = product.salePrice
+        subscriptionPeriod = product.subscriptionPeriodDescription()
 
         // If the product sale start date is nil and the sale end date is not in the past, defaults the sale start date to today.
         if let saleEndDate = product.dateOnSaleEnd, product.dateOnSaleStart == nil &&
@@ -118,7 +122,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
         // Price section
         var priceRows: [Row] = [.price]
         if product.productType.isSubscriptionType {
-            priceRows.append(contentsOf: [.subscriptionPeriod, .subscriptionPeriodInterval])
+            priceRows.append(contentsOf: [.subscriptionPeriod])
         }
         let priceSection = Section(title: Strings.priceSectionTitle, rows: priceRows)
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -245,15 +245,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     }
 
     func handleSubscriptionPeriodChange(interval: String, period: SubscriptionPeriod) {
-        let billingFrequency = {
-            switch interval {
-            case "1":
-                return period.descriptionSingular
-            default:
-                return "\(interval) \(period.descriptionPlural)"
-            }
-        }()
-        subscriptionPeriodDescription = String.localizedStringWithFormat(Strings.subscriptionPeriodFormat, billingFrequency)
+        subscriptionPeriodDescription = String.formatSubscriptionPeriodDescription(period: period, interval: interval)
         subscriptionPeriod = period
         subscriptionPeriodInterval = interval
     }
@@ -312,11 +304,5 @@ extension ProductPriceSettingsViewModel {
         )
         static let taxSectionTitle = NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings")
         static let standardTaxClassName = NSLocalizedString("Standard rate", comment: "The name of the default Tax Class in Product Price Settings")
-        static let subscriptionPeriodFormat = NSLocalizedString(
-            "productPriceSettingsViewModel.subscriptionPeriodFormat",
-            value: "every %1$@",
-            comment: "Description of the subscription period for a product. " +
-            "Reads like: 'every 2 months'."
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -116,10 +116,10 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
 
     var sections: [Section] {
         // Price section
-        let priceSection = Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice])
+        let priceSection = Section(title: Strings.priceSectionTitle, rows: [.price])
 
         // Sales section
-        var saleScheduleRows: [Row] = [.scheduleSale]
+        var saleScheduleRows: [Row] = [.salePrice, .scheduleSale]
         if dateOnSaleStart != nil || dateOnSaleEnd != nil {
             saleScheduleRows.append(contentsOf: [.scheduleSaleFrom])
             if datePickerSaleFromVisible {
@@ -133,7 +133,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
                 saleScheduleRows.append(.removeSaleTo)
             }
         }
-        let salesSection = Section(title: nil, rows: saleScheduleRows)
+        let salesSection = Section(title: Strings.saleSectionTitle, rows: saleScheduleRows)
 
         switch product {
         case is EditableProductModel:
@@ -265,6 +265,11 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
 extension ProductPriceSettingsViewModel {
     enum Strings {
         static let priceSectionTitle = NSLocalizedString("Price", comment: "Section header title for product price")
+        static let saleSectionTitle = NSLocalizedString(
+            "productPriceSettingsViewModel.saleSectionTitle",
+            value: "Sale",
+            comment: "Section header title for product sale price"
+        )
         static let taxSectionTitle = NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings")
         static let standardTaxClassName = NSLocalizedString("Standard rate", comment: "The name of the default Tax Class in Product Price Settings")
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductSubscriptionPeriodPickerUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductSubscriptionPeriodPickerUseCase.swift
@@ -11,12 +11,8 @@ final class ProductSubscriptionPeriodPickerUseCase: NSObject {
 
     typealias UpdateHandler = (_ period: SubscriptionPeriod, _ interval: String) -> Void
 
-    private(set) lazy var pickerView: UIPickerView = {
-        let pickerView = UIPickerView()
-        pickerView.dataSource = self
-        pickerView.delegate = self
-        return pickerView
-    }()
+    let pickerView: UIPickerView = .init()
+
     private let updateHandler: UpdateHandler
 
     init(initialPeriod: SubscriptionPeriod?,
@@ -24,27 +20,8 @@ final class ProductSubscriptionPeriodPickerUseCase: NSObject {
          updateHandler: @escaping UpdateHandler) {
         self.updateHandler = updateHandler
         super.init()
+        configurePickerView()
         preselectSubscriptionPeriodPickerRows(period: initialPeriod, interval: initialInterval)
-    }
-
-    func selectedRow(for component: Component) {
-        
-    }
-
-    func intervalRowIndexFor(interval: String?) -> Int {
-        guard let interval,
-            let intervalNumber = Int(interval) else {
-            return 0
-        }
-        return intervalNumber - 1
-    }
-
-    func periodRowIndex(for period: SubscriptionPeriod?) -> Int {
-        guard let period,
-              let index = SubscriptionPeriod.allCases.firstIndex(of: period) else {
-            return 0
-        }
-        return index
     }
 }
 
@@ -93,6 +70,12 @@ extension ProductSubscriptionPeriodPickerUseCase: UIPickerViewDataSource, UIPick
 // MARK: Helpers
 //
 private extension ProductSubscriptionPeriodPickerUseCase {
+
+    func configurePickerView() {
+        pickerView.dataSource = self
+        pickerView.delegate = self
+    }
+
     func preselectSubscriptionPeriodPickerRows(period: SubscriptionPeriod?, interval: String?) {
         let intervalRowIndex: Int = {
             guard let interval,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductSubscriptionPeriodPickerUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductSubscriptionPeriodPickerUseCase.swift
@@ -1,0 +1,136 @@
+import UIKit
+import enum Yosemite.SubscriptionPeriod
+
+/// Use case to handle product subscription period settings.
+///
+final class ProductSubscriptionPeriodPickerUseCase: NSObject {
+    enum Component: Int, CaseIterable {
+        case interval
+        case period
+    }
+
+    typealias UpdateHandler = (_ period: SubscriptionPeriod, _ interval: String) -> Void
+
+    private(set) lazy var pickerView: UIPickerView = {
+        let pickerView = UIPickerView()
+        pickerView.dataSource = self
+        pickerView.delegate = self
+        return pickerView
+    }()
+    private let updateHandler: UpdateHandler
+
+    init(initialPeriod: SubscriptionPeriod?,
+         initialInterval: String?,
+         updateHandler: @escaping UpdateHandler) {
+        self.updateHandler = updateHandler
+        super.init()
+        preselectSubscriptionPeriodPickerRows(period: initialPeriod, interval: initialInterval)
+    }
+
+    func selectedRow(for component: Component) {
+        
+    }
+
+    func intervalRowIndexFor(interval: String?) -> Int {
+        guard let interval,
+            let intervalNumber = Int(interval) else {
+            return 0
+        }
+        return intervalNumber - 1
+    }
+
+    func periodRowIndex(for period: SubscriptionPeriod?) -> Int {
+        guard let period,
+              let index = SubscriptionPeriod.allCases.firstIndex(of: period) else {
+            return 0
+        }
+        return index
+    }
+}
+
+// MARK: - UIPickerViewDataSource & UIPickerViewDelegate performance
+//
+extension ProductSubscriptionPeriodPickerUseCase: UIPickerViewDataSource, UIPickerViewDelegate {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        Component.allCases.count
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        switch component {
+        case Component.interval.rawValue:
+            return Constants.maximumSubscriptionPeriodInterval
+        case Component.period.rawValue:
+            return SubscriptionPeriod.allCases.count
+        default:
+            return 0
+        }
+    }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        switch component {
+        case Component.interval.rawValue:
+            return "\(row + 1)"
+        case Component.period.rawValue:
+            if pickerView.selectedRow(inComponent: Component.interval.rawValue) == 0 {
+                return SubscriptionPeriod.allCases[row].descriptionSingular
+            } else {
+                return SubscriptionPeriod.allCases[row].descriptionPlural
+            }
+        default:
+            return nil
+        }
+    }
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        if component == Component.interval.rawValue {
+            // reloads the period component to display the updated titles based on the interval.
+            pickerView.reloadComponent(Component.period.rawValue)
+        }
+        updateSubscriptionPeriodDescription()
+    }
+}
+
+// MARK: Helpers
+//
+private extension ProductSubscriptionPeriodPickerUseCase {
+    func preselectSubscriptionPeriodPickerRows(period: SubscriptionPeriod?, interval: String?) {
+        let intervalRowIndex: Int = {
+            guard let interval,
+                  let intervalNumber = Int(interval) else {
+                return 0
+            }
+            return intervalNumber - 1
+        }()
+
+        let periodRowIndex: Int = {
+            guard let period,
+                  let index = SubscriptionPeriod.allCases.firstIndex(of: period) else {
+                return 0
+            }
+            return index
+        }()
+
+        pickerView.selectRow(intervalRowIndex,
+                             inComponent: Component.interval.rawValue,
+                             animated: false)
+        pickerView.selectRow(periodRowIndex,
+                             inComponent: Component.period.rawValue,
+                             animated: false)
+    }
+
+    func updateSubscriptionPeriodDescription() {
+        let selectedIntervalRow = pickerView.selectedRow(inComponent: Component.interval.rawValue)
+        let selectedInterval = "\(selectedIntervalRow + 1)"
+
+        let selectedPeriodRow = pickerView.selectedRow(inComponent: Component.period.rawValue)
+        let selectedPeriod = SubscriptionPeriod.allCases[selectedPeriodRow]
+
+        updateHandler(selectedPeriod, selectedInterval)
+    }
+}
+
+private extension ProductSubscriptionPeriodPickerUseCase {
+    enum Constants {
+        static let maximumSubscriptionPeriodInterval = 6
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -306,7 +306,7 @@ private extension ProductFormActionsFactory {
         let editableSubscription = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionProducts)
 
         let actions: [ProductFormEditAction?] = [
-            editableSubscription ? .priceSettings(editable: true, hideSeparator: false) : .subscription(actionable: true),
+            editableSubscription ? .priceSettings(editable: editable, hideSeparator: false) : .subscription(actionable: true),
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
             shouldShowQuantityRulesRow ? .quantityRules : nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -303,9 +303,10 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForSubscriptionProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
+        let editableSubscription = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionProducts)
 
         let actions: [ProductFormEditAction?] = [
-            .subscription(actionable: true),
+            editableSubscription ? .priceSettings(editable: true, hideSeparator: false) : .subscription(actionable: true),
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
             shouldShowQuantityRulesRow ? .quantityRules : nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1359,8 +1359,10 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func editPriceSettings() {
         let priceSettingsViewController = ProductPriceSettingsViewController(product: product) { [weak self]
-            (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges) in
+            (regularPrice, subscriptionPeriod, subscriptionPeriodInterval, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges) in
             self?.onEditPriceSettingsCompletion(regularPrice: regularPrice,
+                                                subscriptionPeriod: subscriptionPeriod,
+                                                subscriptionPeriodInterval: subscriptionPeriodInterval,
                                                 salePrice: salePrice,
                                                 dateOnSaleStart: dateOnSaleStart,
                                                 dateOnSaleEnd: dateOnSaleEnd,
@@ -1372,6 +1374,8 @@ private extension ProductFormViewController {
     }
 
     func onEditPriceSettingsCompletion(regularPrice: String?,
+                                       subscriptionPeriod: SubscriptionPeriod?,
+                                       subscriptionPeriodInterval: String?,
                                        salePrice: String?,
                                        dateOnSaleStart: Date?,
                                        dateOnSaleEnd: Date?,
@@ -1388,6 +1392,8 @@ private extension ProductFormViewController {
         }
 
         viewModel.updatePriceSettings(regularPrice: regularPrice,
+                                      subscriptionPeriod: subscriptionPeriod,
+                                      subscriptionPeriodInterval: subscriptionPeriodInterval,
                                       salePrice: salePrice,
                                       dateOnSaleStart: dateOnSaleStart,
                                       dateOnSaleEnd: dateOnSaleEnd,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -326,17 +326,23 @@ extension ProductFormViewModel {
     }
 
     func updatePriceSettings(regularPrice: String?,
+                             subscriptionPeriod: SubscriptionPeriod?,
+                             subscriptionPeriodInterval: String?,
                              salePrice: String?,
                              dateOnSaleStart: Date?,
                              dateOnSaleEnd: Date?,
                              taxStatus: ProductTaxStatus,
                              taxClass: TaxClass?) {
+        let subscription = product.subscription?.copy(period: subscriptionPeriod, 
+                                                      periodInterval: subscriptionPeriodInterval,
+                                                      price: regularPrice)
         product = EditableProductModel(product: product.product.copy(dateOnSaleStart: dateOnSaleStart,
                                                                      dateOnSaleEnd: dateOnSaleEnd,
                                                                      regularPrice: regularPrice,
                                                                      salePrice: salePrice,
                                                                      taxStatusKey: taxStatus.rawValue,
-                                                                     taxClass: taxClass?.slug))
+                                                                     taxClass: taxClass?.slug,
+                                                                     subscription: subscription))
     }
 
     func updateProductType(productType: BottomSheetProductType) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -333,7 +333,7 @@ extension ProductFormViewModel {
                              dateOnSaleEnd: Date?,
                              taxStatus: ProductTaxStatus,
                              taxClass: TaxClass?) {
-        let subscription = product.subscription?.copy(period: subscriptionPeriod, 
+        let subscription = product.subscription?.copy(period: subscriptionPeriod,
                                                       periodInterval: subscriptionPeriodInterval,
                                                       price: regularPrice)
         product = EditableProductModel(product: product.product.copy(dateOnSaleStart: dateOnSaleStart,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -101,6 +101,8 @@ protocol ProductFormViewModelProtocol {
     func updateDescription(_ newDescription: String)
 
     func updatePriceSettings(regularPrice: String?,
+                             subscriptionPeriod: SubscriptionPeriod?,
+                             subscriptionPeriodInterval: String?,
                              salePrice: String?,
                              dateOnSaleStart: Date?,
                              dateOnSaleEnd: Date?,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -220,20 +220,29 @@ extension ProductVariationFormViewModel {
     }
 
     func updatePriceSettings(regularPrice: String?,
+                             subscriptionPeriod: SubscriptionPeriod?,
+                             subscriptionPeriodInterval: String?,
                              salePrice: String?,
                              dateOnSaleStart: Date?,
                              dateOnSaleEnd: Date?,
                              taxStatus: ProductTaxStatus,
                              taxClass: TaxClass?) {
-        productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(dateOnSaleStart: dateOnSaleStart,
-                                                                                                                  dateOnSaleEnd: dateOnSaleEnd,
-                                                                                                                  regularPrice: regularPrice,
-                                                                                                                  salePrice: salePrice,
-                                                                                                                  taxStatusKey: taxStatus.rawValue,
-                                                                                                                  taxClass: taxClass?.slug),
-                                                         allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU,
-                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
+        let subscription = productVariation.subscription?.copy(period: subscriptionPeriod,
+                                                               periodInterval: subscriptionPeriodInterval,
+                                                               price: regularPrice)
+        productVariation = EditableProductVariationModel(
+            productVariation: productVariation.productVariation.copy(
+                dateOnSaleStart: dateOnSaleStart,
+                dateOnSaleEnd: dateOnSaleEnd,
+                regularPrice: regularPrice,
+                salePrice: salePrice,
+                taxStatusKey: taxStatus.rawValue,
+                taxClass: taxClass?.slug,
+                subscription: subscription
+            ),
+            allAttributes: allAttributes,
+            parentProductSKU: parentProductSKU,
+            parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updateInventorySettings(sku: String?,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
@@ -10,7 +10,10 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         let state: State
         let keyboardType: UIKeyboardType
         let textFieldAlignment: TextFieldTextAlignment
+        let inputView: UIView?
+        let inputAccessoryView: UIView?
         let onTextChange: ((_ text: String?) -> Void)?
+        let onEditingEnd: (() -> Void)?
 
         enum State {
             case normal
@@ -23,14 +26,20 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
              state: State = .normal,
              keyboardType: UIKeyboardType = .default,
              textFieldAlignment: TextFieldTextAlignment,
-             onTextChange: ((_ text: String?) -> Void)?) {
+             inputView: UIView? = nil,
+             inputAccessoryView: UIView? = nil,
+             onTextChange: ((_ text: String?) -> Void)? = nil,
+             onEditingEnd: (() -> Void)? = nil) {
             self.title = title
             self.text = text
             self.placeholder = placeholder
             self.state = state
             self.keyboardType = keyboardType
             self.textFieldAlignment = textFieldAlignment
+            self.inputView = inputView
+            self.inputAccessoryView = inputAccessoryView
             self.onTextChange = onTextChange
+            self.onEditingEnd = onEditingEnd
         }
     }
 
@@ -39,6 +48,7 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
     @IBOutlet private weak var textField: UITextField!
 
     private var onTextChange: ((_ text: String?) -> Void)?
+    private var onEditingEnd: (() -> Void)?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -60,7 +70,10 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         textField.keyboardType = viewModel.keyboardType
         textField.textAlignment = viewModel.textFieldAlignment.toTextAlignment()
         textField.isEnabled = textFieldEnabled
+        textField.inputView = viewModel.inputView
+        textField.inputAccessoryView = viewModel.inputAccessoryView
         onTextChange = viewModel.onTextChange
+        onEditingEnd = viewModel.onEditingEnd
     }
 
     func textFieldBecomeFirstResponder() {
@@ -81,6 +94,7 @@ private extension TitleAndTextFieldTableViewCell {
         textField.applyBodyStyle()
         textField.borderStyle = .none
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
+        textField.addTarget(self, action: #selector(textFieldDidResignFirstResponder(textField:)), for: .editingDidEnd)
     }
 
     func configureContentStackView() {
@@ -106,6 +120,10 @@ private extension TitleAndTextFieldTableViewCell {
 private extension TitleAndTextFieldTableViewCell {
     @objc func textFieldDidChange(textField: UITextField) {
         onTextChange?(textField.text)
+    }
+
+    @objc func textFieldDidResignFirstResponder(textField: UITextField) {
+        onEditingEnd?()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2124,6 +2124,7 @@
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
 		DE157E152B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */; };
+		DE157E1A2B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE157E192B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift */; };
 		DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */; };
 		DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */; };
 		DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */; };
@@ -4698,6 +4699,7 @@
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
 		DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormDataModel+SubscriptionDescription.swift"; sourceTree = "<group>"; };
+		DE157E192B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscriptionPeriodPickerUseCase.swift; sourceTree = "<group>"; };
 		DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionList.swift; sourceTree = "<group>"; };
 		DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreRow.swift; sourceTree = "<group>"; };
 		DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetails.swift; sourceTree = "<group>"; };
@@ -7618,6 +7620,7 @@
 				45B9C64023A9139A007FC4C5 /* Product+PriceSettingsViewModels.swift */,
 				02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */,
 				09885C8627C6947A00910A62 /* ProductPriceSettingsValidator.swift */,
+				DE157E192B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift */,
 			);
 			path = "Edit Price";
 			sourceTree = "<group>";
@@ -12485,6 +12488,7 @@
 				CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */,
 				269B46622A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
+				DE157E1A2B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift in Sources */,
 				31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */,
 				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
 				02F3A6842A618CD7004CD2E8 /* WordPressMediaLibraryImagePickerCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2123,6 +2123,7 @@
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
+		DE157E152B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */; };
 		DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */; };
 		DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */; };
 		DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */; };
@@ -4696,6 +4697,7 @@
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
+		DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormDataModel+SubscriptionDescription.swift"; sourceTree = "<group>"; };
 		DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionList.swift; sourceTree = "<group>"; };
 		DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreRow.swift; sourceTree = "<group>"; };
 		DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetails.swift; sourceTree = "<group>"; };
@@ -9960,6 +9962,7 @@
 				DED974102AD8F05A00122EB4 /* URL+Identifiable.swift */,
 				022266B92AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift */,
 				864213012AE77C730036E5A6 /* UIImage+Resizing.swift */,
+				DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -13626,6 +13629,7 @@
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,
 				26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */,
+				DE157E152B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift in Sources */,
 				02279587237A50C900787C63 /* AztecHeaderFormatBarCommand.swift in Sources */,
 				025C006B2550DE4700FAC222 /* CodeScannerViewController.swift in Sources */,
 				09885C8727C6947A00910A62 /* ProductPriceSettingsValidator.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel+ProductVariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel+ProductVariationTests.swift
@@ -20,8 +20,8 @@ final class ProductPriceSettingsViewModel_ProductVariationTests: XCTestCase {
 
         // Assert
         let initialSections: [Section] = [
-            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale]),
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
         ]
         XCTAssertEqual(sections, initialSections)
     }
@@ -34,8 +34,9 @@ final class ProductPriceSettingsViewModel_ProductVariationTests: XCTestCase {
         let model = EditableProductVariationModel(productVariation: productVariation)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
 
@@ -47,8 +48,9 @@ final class ProductPriceSettingsViewModel_ProductVariationTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
-            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
         ])
         XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
     }
@@ -61,8 +63,9 @@ final class ProductPriceSettingsViewModel_ProductVariationTests: XCTestCase {
         let model = EditableProductVariationModel(productVariation: productVariation)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
 
@@ -71,8 +74,8 @@ final class ProductPriceSettingsViewModel_ProductVariationTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.sections, [
-            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
         ])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -479,7 +479,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _) in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             XCTAssertEqual(error, .salePriceWithoutRegularPrice)
@@ -503,7 +503,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _) in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             // Assert
@@ -523,7 +523,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Act
         let result = waitFor { promise in
-            viewModel.completeUpdating { _, _, _, _, _, _, _ in
+            viewModel.completeUpdating { (_, _, _, _, _, _, _, _, _) in
                 XCTFail("Completion block should not be called")
             } onError: { error in
                 promise(error)
@@ -547,7 +547,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (finalRegularPrice, finalSalePrice, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (finalRegularPrice, _, _, finalSalePrice, _, _, _, _, _) in
             expectation.fulfill()
 
             // Assert
@@ -660,6 +660,26 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         let initialSections: [Section] = [
             Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ]
+        XCTAssertEqual(sections, initialSections)
+    }
+
+    func test_price_section_includes_subscription_period_if_product_type_is_subscription() {
+        // Arrange
+        let saleStartDate: Date? = nil
+        let saleEndDate: Date? = nil
+        let product = Product.fake().copy(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate, productTypeKey: "subscription")
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductPriceSettingsViewModel(product: model)
+
+        // Act
+        let sections = viewModel.sections
+
+        // Assert
+        let initialSections: [Section] = [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .subscriptionPeriod]),
             Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -670,7 +670,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Arrange
         let saleStartDate: Date? = nil
         let saleEndDate: Date? = nil
-        let product = Product.fake().copy(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate, productTypeKey: "subscription")
+        let product = Product.fake().copy(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate, subscription: .fake())
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -695,7 +695,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
@@ -709,7 +710,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
         XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
@@ -724,7 +726,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
@@ -738,7 +741,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
         XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
@@ -753,7 +757,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
@@ -764,7 +769,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.sections, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
@@ -786,7 +792,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.sections, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
@@ -807,7 +814,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.sections, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+                    rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -695,7 +695,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
@@ -710,7 +710,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
@@ -726,7 +726,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
@@ -741,7 +741,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
@@ -757,7 +757,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
@@ -769,7 +769,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.sections, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
@@ -792,7 +792,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.sections, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
@@ -814,7 +814,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.sections, [
             Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
-            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, 
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle,
                     rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -659,8 +659,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(sections, initialSections)
@@ -674,8 +674,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
@@ -688,8 +688,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
         XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
@@ -703,8 +703,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
@@ -717,8 +717,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
         XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
@@ -732,8 +732,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
@@ -743,8 +743,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.sections, [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
@@ -765,8 +765,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.sections, [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
@@ -786,8 +786,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.sections, [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
-            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: Strings.priceSectionTitle, rows: [.price]),
+            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
@@ -796,6 +796,11 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 private extension ProductPriceSettingsViewModelTests {
     enum Strings {
         static let priceSectionTitle = NSLocalizedString("Price", comment: "Section header title for product price")
+        static let saleSectionTitle = NSLocalizedString(
+            "productPriceSettingsViewModel.saleSectionTitle",
+            value: "Sale",
+            comment: "Section header title for product sale price"
+        )
         static let taxSectionTitle = NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings")
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -659,9 +659,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(sections, initialSections)
     }
@@ -679,9 +679,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price, .subscriptionPeriod]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .subscriptionPeriod]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(sections, initialSections)
     }
@@ -694,9 +694,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
 
@@ -708,9 +708,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
         XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
     }
@@ -723,9 +723,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
 
@@ -737,9 +737,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(sectionsAfterTheFirstTap, [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
         XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
     }
@@ -752,9 +752,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
         let initialSections: [Section] = [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]
         XCTAssertEqual(viewModel.sections, initialSections)
 
@@ -763,9 +763,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.sections, [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
 
@@ -785,9 +785,9 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.sections, [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
 
@@ -806,24 +806,14 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.sections, [
-            Section(title: Strings.priceSectionTitle, rows: [.price]),
-            Section(title: Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
-            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
 }
 
 private extension ProductPriceSettingsViewModelTests {
-    enum Strings {
-        static let priceSectionTitle = NSLocalizedString("Price", comment: "Section header title for product price")
-        static let saleSectionTitle = NSLocalizedString(
-            "productPriceSettingsViewModel.saleSectionTitle",
-            value: "Sale",
-            comment: "Section header title for product sale price"
-        )
-        static let taxSectionTitle = NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings")
-    }
-
     func date(from dateString: String) -> Date? {
         DateFormatter.Defaults.dateTimeFormatter.date(from: dateString)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -57,6 +57,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         viewModel.updateShortDescription(product.shortDescription ?? "")
         viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
         viewModel.updatePriceSettings(regularPrice: product.regularPrice,
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
                                       salePrice: product.salePrice,
                                       dateOnSaleStart: product.dateOnSaleStart,
                                       dateOnSaleEnd: product.dateOnSaleEnd,
@@ -175,7 +177,14 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
 
     func testProductHasUnsavedChangesFromEditingPriceSettings() {
         // When
-        viewModel.updatePriceSettings(regularPrice: "999999", salePrice: "888888", dateOnSaleStart: nil, dateOnSaleEnd: nil, taxStatus: .none, taxClass: nil)
+        viewModel.updatePriceSettings(regularPrice: "999999",
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
+                                      salePrice: "888888",
+                                      dateOnSaleStart: nil,
+                                      dateOnSaleEnd: nil,
+                                      taxStatus: .none,
+                                      taxClass: nil)
 
         // Then
         XCTAssertTrue(viewModel.hasUnsavedChanges())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -19,7 +19,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        product = Product.fake()
+        let subscription = ProductSubscription.fake()
+        product = Product.fake().copy(subscription: subscription)
         model = EditableProductModel(product: product)
         mockProductImageUploader = MockProductImageUploader()
         productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
@@ -181,6 +182,21 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
                                       subscriptionPeriod: nil,
                                       subscriptionPeriodInterval: nil,
                                       salePrice: "888888",
+                                      dateOnSaleStart: nil,
+                                      dateOnSaleEnd: nil,
+                                      taxStatus: .none,
+                                      taxClass: nil)
+
+        // Then
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func test_product_has_unsaved_changes_from_editing_subscription_period_settings() {
+        // When
+        viewModel.updatePriceSettings(regularPrice: "",
+                                      subscriptionPeriod: .month,
+                                      subscriptionPeriodInterval: "1",
+                                      salePrice: "",
                                       dateOnSaleStart: nil,
                                       dateOnSaleEnd: nil,
                                       taxStatus: .none,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -45,8 +45,6 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let product = Product.fake()
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
-        let mockProductImageUploader = MockProductImageUploader()
-        let blazeEligibilityChecker = MockBlazeEligibilityChecker(isProductEligible: true)
         var isBlazeEligibilityUpdated: Bool? = nil
         let expectationForBlazeEligibility = self.expectation(description: "blazeEligibilityUpdateSubject is called")
         expectationForBlazeEligibility.expectedFulfillmentCount = 1

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -93,6 +93,8 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         viewModel.updateShortDescription(product.shortDescription ?? "")
         viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
         viewModel.updatePriceSettings(regularPrice: product.regularPrice,
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
                                       salePrice: product.salePrice,
                                       dateOnSaleStart: product.dateOnSaleStart,
                                       dateOnSaleEnd: product.dateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -91,8 +91,8 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         viewModel.updateShortDescription(product.shortDescription ?? "")
         viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
         viewModel.updatePriceSettings(regularPrice: product.regularPrice,
-                                      subscriptionPeriod: nil,
-                                      subscriptionPeriodInterval: nil,
+                                      subscriptionPeriod: product.subscription?.period,
+                                      subscriptionPeriodInterval: product.subscription?.periodInterval,
                                       salePrice: product.salePrice,
                                       dateOnSaleStart: product.dateOnSaleStart,
                                       dateOnSaleEnd: product.dateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -76,7 +76,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
 
     func testUpdatingPriceSettings() {
         // Arrange
-        let product = Product.fake()
+        let subscription = ProductSubscription.fake()
+        let product = Product.fake().copy(subscription: subscription)
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
@@ -90,9 +91,11 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let newDateOnSaleEnd = newDateOnSaleStart.addingTimeInterval(86400)
         let newTaxStatus = ProductTaxStatus.taxable
         let newTaxClass = TaxClass(siteID: product.siteID, name: "Reduced rate", slug: "reduced-rate")
+        let newSubscriptionPeriod = SubscriptionPeriod.month
+        let newSubscriptionInterval = "2"
         viewModel.updatePriceSettings(regularPrice: newRegularPrice,
-                                      subscriptionPeriod: nil,
-                                      subscriptionPeriodInterval: nil,
+                                      subscriptionPeriod: newSubscriptionPeriod,
+                                      subscriptionPeriodInterval: newSubscriptionInterval,
                                       salePrice: newSalePrice,
                                       dateOnSaleStart: newDateOnSaleStart,
                                       dateOnSaleEnd: newDateOnSaleEnd,
@@ -106,6 +109,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.dateOnSaleEnd, newDateOnSaleEnd)
         XCTAssertEqual(viewModel.productModel.taxStatusKey, newTaxStatus.rawValue)
         XCTAssertEqual(viewModel.productModel.taxClass, newTaxClass.slug)
+        XCTAssertEqual(viewModel.productModel.subscription?.period, newSubscriptionPeriod)
+        XCTAssertEqual(viewModel.productModel.subscription?.periodInterval, newSubscriptionInterval)
     }
 
     func testUpdatingInventorySettings() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -91,6 +91,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let newTaxStatus = ProductTaxStatus.taxable
         let newTaxClass = TaxClass(siteID: product.siteID, name: "Reduced rate", slug: "reduced-rate")
         viewModel.updatePriceSettings(regularPrice: newRegularPrice,
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
                                       salePrice: newSalePrice,
                                       dateOnSaleStart: newDateOnSaleStart,
                                       dateOnSaleEnd: newDateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -44,6 +44,8 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         viewModel.updateImages(model.images)
         viewModel.updateDescription(productVariation.description ?? "")
         viewModel.updatePriceSettings(regularPrice: productVariation.regularPrice,
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
                                       salePrice: productVariation.salePrice,
                                       dateOnSaleStart: productVariation.dateOnSaleStart,
                                       dateOnSaleEnd: productVariation.dateOnSaleEnd,
@@ -103,7 +105,14 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
 
     func test_product_variation_has_unsaved_changes_from_editing_price_settings() {
         // Action
-        viewModel.updatePriceSettings(regularPrice: "999999", salePrice: "888888", dateOnSaleStart: nil, dateOnSaleEnd: nil, taxStatus: .none, taxClass: nil)
+        viewModel.updatePriceSettings(regularPrice: "999999",
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
+                                      salePrice: "888888",
+                                      dateOnSaleStart: nil,
+                                      dateOnSaleEnd: nil,
+                                      taxStatus: .none,
+                                      taxClass: nil)
 
         // Assert
         XCTAssertTrue(viewModel.hasUnsavedChanges())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -118,6 +118,21 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
+    func test_product_variation_has_unsaved_changes_from_editing_subscription_period_settings() {
+        // Action
+        viewModel.updatePriceSettings(regularPrice: "",
+                                      subscriptionPeriod: .week,
+                                      subscriptionPeriodInterval: "3",
+                                      salePrice: "",
+                                      dateOnSaleStart: nil,
+                                      dateOnSaleEnd: nil,
+                                      taxStatus: .none,
+                                      taxClass: nil)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
     func test_product_variation_has_unsaved_changes_from_editing_inventory_settings() {
         // Action
         viewModel.updateInventorySettings(sku: "", manageStock: false, soldIndividually: nil, stockQuantity: 888888, backordersSetting: nil, stockStatus: nil)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -55,8 +55,8 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
         viewModel.updateImages(model.images)
         viewModel.updateDescription(productVariation.description ?? "")
         viewModel.updatePriceSettings(regularPrice: productVariation.regularPrice,
-                                      subscriptionPeriod: nil,
-                                      subscriptionPeriodInterval: nil,
+                                      subscriptionPeriod: productVariation.subscription?.period,
+                                      subscriptionPeriodInterval: productVariation.subscription?.periodInterval,
                                       salePrice: productVariation.salePrice,
                                       dateOnSaleStart: productVariation.dateOnSaleStart,
                                       dateOnSaleEnd: productVariation.dateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -55,6 +55,8 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
         viewModel.updateImages(model.images)
         viewModel.updateDescription(productVariation.description ?? "")
         viewModel.updatePriceSettings(regularPrice: productVariation.regularPrice,
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
                                       salePrice: productVariation.salePrice,
                                       dateOnSaleStart: productVariation.dateOnSaleStart,
                                       dateOnSaleEnd: productVariation.dateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -65,6 +65,8 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
         let newTaxStatus = ProductTaxStatus.taxable
         let newTaxClass = TaxClass(siteID: productVariation.siteID, name: "Reduced rate", slug: "reduced-rate")
         viewModel.updatePriceSettings(regularPrice: newRegularPrice,
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
                                       salePrice: newSalePrice,
                                       dateOnSaleStart: newDateOnSaleStart,
                                       dateOnSaleEnd: newDateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -52,7 +52,8 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
 
     func testUpdatingPriceSettings() {
         // Arrange
-        let productVariation = MockProductVariation().productVariation()
+        let subscription = ProductSubscription.fake().copy(period: .day, periodInterval: "1")
+        let productVariation = MockProductVariation().productVariation().copy(subscription: subscription)
         let model = EditableProductVariationModel(productVariation: productVariation)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductVariationFormViewModel(productVariation: model, productImageActionHandler: productImageActionHandler)
@@ -65,8 +66,8 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
         let newTaxStatus = ProductTaxStatus.taxable
         let newTaxClass = TaxClass(siteID: productVariation.siteID, name: "Reduced rate", slug: "reduced-rate")
         viewModel.updatePriceSettings(regularPrice: newRegularPrice,
-                                      subscriptionPeriod: nil,
-                                      subscriptionPeriodInterval: nil,
+                                      subscriptionPeriod: .month,
+                                      subscriptionPeriodInterval: "2",
                                       salePrice: newSalePrice,
                                       dateOnSaleStart: newDateOnSaleStart,
                                       dateOnSaleEnd: newDateOnSaleEnd,
@@ -80,6 +81,8 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.dateOnSaleEnd, newDateOnSaleEnd)
         XCTAssertEqual(viewModel.productModel.taxStatusKey, newTaxStatus.rawValue)
         XCTAssertEqual(viewModel.productModel.taxClass, newTaxClass.slug)
+        XCTAssertEqual(viewModel.productModel.subscription?.period, .month)
+        XCTAssertEqual(viewModel.productModel.subscription?.periodInterval, "2")
     }
 
     func testUpdatingInventorySettings() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11135 
<!-- Id number of the GitHub issue this PR addresses. -->

## What
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the support for updating the subscription period for simple subscription products. This setting is accessible through the price setting screen as discussed in p1699462947949809-slack-C03L1NF1EA3.

Due to the size of the changes, the subscription sign-up fee and more unit tests will be added in a separate PR.

## How
- Added a new row for the subscription period on the product price setting screen.
- Added a new extension for String and `ProductFormDataModel` to format subscription period. The format follows the read-only version instead of Core for simplicity.
- Created a separate use case for the picker view for subscription period and interval.
- Updated the `TitleAndTextFieldTableViewCell` to accept custom input view.
- Updated the subscription period row to display the new picker view for inputting the subscription period and interval.
- Updated the completion handler for price setting to include subscription period and interval.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `subscriptionProducts` to be able to edit subscription products.
- Create a simple subscription product for your test site on wp-admin if you haven't already.
- Build the app, log in to your test store and navigate to the Products tab.
- Select a simple subscription product.
- Notice that the price row is displayed in place of the read-only subscription row. It should state the subscription period, like "$10 every 2 weeks".
- Tap the price row, notice a few changes:
  - A new row for subscription period is displayed below the Regular Price row. 
  - The Sale Price row is displayed in the second section with the new name Sale.
  - Tap on the Subscription Period row, notice that a picker is displayed for you to select the interval and period. 
  - Tap on Done on the toolbar above the picker, the new period should be displayed correctly.
  - Tap on Done on the price settings screen and tap Save on the product form, the new period should be updated correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/4699750e-041b-4b60-90f3-9edea1f02a94" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.