### PR TITLE
Add unit tests for `AlamofireNetwork` to ensure errors are returned for unexpected status codes

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -41,6 +41,7 @@
 		025CA2C4238EBC4300B05C81 /* ProductShippingClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */; };
 		025CA2C6238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2C5238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift */; };
 		025CA2C8238F4FF400B05C81 /* product-shipping-classes-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */; };
+		025F9A252B020F1900B91F1D /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025F9A242B020F1900B91F1D /* MockURLProtocol.swift */; };
 		02616F8C292132800095BC00 /* SiteRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02616F8B292132800095BC00 /* SiteRemoteTests.swift */; };
 		02616F8F2921336C0095BC00 /* site-creation-domain-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 02616F8D2921336C0095BC00 /* site-creation-domain-error.json */; };
 		02616F902921336C0095BC00 /* site-creation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02616F8E2921336C0095BC00 /* site-creation-success.json */; };
@@ -119,6 +120,7 @@
 		02C43261298A55D100F14AEE /* validate-domain-contact-info-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C4325E298A55D100F14AEE /* validate-domain-contact-info-success.json */; };
 		02C54CC624D3E938007D658F /* product-variations-load-all-manage-stock-two-states.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */; };
 		02DD6492248A3EC00082523E /* product-external.json in Resources */ = {isa = PBXBuildFile; fileRef = 02DD6491248A3EC00082523E /* product-external.json */; };
+		02E2AF2F2AFD1C3A00EE6FE8 /* AlamofireNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E2AF2E2AFD1C3A00EE6FE8 /* AlamofireNetworkTests.swift */; };
 		02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */; };
 		02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */ = {isa = PBXBuildFile; fileRef = 02E7FFCE25621C7900C53030 /* shipping-label-print.json */; };
 		02EBCB3E2AA03D520019085B /* OrderItemProductAddOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBCB3D2AA03D520019085B /* OrderItemProductAddOn.swift */; };
@@ -1040,6 +1042,7 @@
 		025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassRemote.swift; sourceTree = "<group>"; };
 		025CA2C5238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassRemoteTests.swift; sourceTree = "<group>"; };
 		025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-all.json"; sourceTree = "<group>"; };
+		025F9A242B020F1900B91F1D /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		02616F8B292132800095BC00 /* SiteRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteRemoteTests.swift; sourceTree = "<group>"; };
 		02616F8D2921336C0095BC00 /* site-creation-domain-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-creation-domain-error.json"; sourceTree = "<group>"; };
 		02616F8E2921336C0095BC00 /* site-creation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-creation-success.json"; sourceTree = "<group>"; };
@@ -1118,6 +1121,7 @@
 		02C4325E298A55D100F14AEE /* validate-domain-contact-info-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "validate-domain-contact-info-success.json"; sourceTree = "<group>"; };
 		02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-load-all-manage-stock-two-states.json"; sourceTree = "<group>"; };
 		02DD6491248A3EC00082523E /* product-external.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-external.json"; sourceTree = "<group>"; };
+		02E2AF2E2AFD1C3A00EE6FE8 /* AlamofireNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireNetworkTests.swift; sourceTree = "<group>"; };
 		02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemoteTests.swift; sourceTree = "<group>"; };
 		02E7FFCE25621C7900C53030 /* shipping-label-print.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-print.json"; sourceTree = "<group>"; };
 		02EBCB3D2AA03D520019085B /* OrderItemProductAddOn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderItemProductAddOn.swift; sourceTree = "<group>"; };
@@ -2022,6 +2026,14 @@
 			path = Media;
 			sourceTree = "<group>";
 		};
+		025F9A232B020F0400B91F1D /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				025F9A242B020F1900B91F1D /* MockURLProtocol.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		02C2548225635BB500A04423 /* ShippingLabel */ = {
 			isa = PBXGroup;
 			children = (
@@ -2334,6 +2346,7 @@
 				B518663220A0A2E800037A38 /* Settings */,
 				B5C6FCC620A32E3100A4F8E4 /* Extensions */,
 				B5C6FCCB20A34B5E00A4F8E4 /* Mapper */,
+				025F9A232B020F0400B91F1D /* Mocks */,
 				B57B1E6521C9166F0046E764 /* Network */,
 				B518662820A09C5D00037A38 /* Remote */,
 				B519A3E82097A91800E2603A /* Requests */,
@@ -3054,6 +3067,7 @@
 				B57B1E6621C916850046E764 /* NetworkErrorTests.swift */,
 				DEFBA7552949D17300C35BA9 /* DefaultRequestAuthenticatorTests.swift */,
 				EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */,
+				02E2AF2E2AFD1C3A00EE6FE8 /* AlamofireNetworkTests.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -4386,6 +4400,7 @@
 				311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */,
 				2661547B242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift in Sources */,
 				4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */,
+				025F9A252B020F1900B91F1D /* MockURLProtocol.swift in Sources */,
 				45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
 				020D0C03291504DE00BB3DCE /* UnauthenticatedRequestTests.swift in Sources */,
@@ -4452,6 +4467,7 @@
 				453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */,
 				CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */,
 				2670C3FC270F4E06002FE931 /* SiteListMapperTests.swift in Sources */,
+				02E2AF2F2AFD1C3A00EE6FE8 /* AlamofireNetworkTests.swift in Sources */,
 				025CA2C6238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift in Sources */,
 				EE078D932AD2F1E500C1199E /* JWTokenMapperTests.swift in Sources */,
 				D800DA0A25EFEB9C001E13CE /* WCPayRemoteTests.swift in Sources */,

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -34,9 +34,12 @@ public class AlamofireNetwork: Network {
 
     /// Public Initializer
     ///
-    public required init(credentials: Credentials?) {
+    public required init(credentials: Credentials?, sessionManager: Alamofire.SessionManager? = nil) {
         self.requestConverter = RequestConverter(credentials: credentials)
         self.requestAuthenticator = RequestProcessor(requestAuthenticator: DefaultRequestAuthenticator(credentials: credentials))
+        if let sessionManager {
+            self.sessionManager = sessionManager
+        }
     }
 
     /// Executes the specified Network Request. Upon completion, the payload will be sent back to the caller as a Data instance.

--- a/Networking/NetworkingTests/Mocks/MockURLProtocol.swift
+++ b/Networking/NetworkingTests/Mocks/MockURLProtocol.swift
@@ -1,0 +1,73 @@
+import Alamofire
+import Networking
+import XCTest
+
+extension MockURLProtocol {
+    /// Stores the mocks for `URLRequest`s in memory to be used in `MockURLProtocol`.
+    final class Mocks {
+        private static var responsesByRequestURL: [String: (response: AnyCodable, statusCode: Int)] = [:]
+
+        /// Mocks the response of a given request.
+        static func mockResponse(_ response: AnyCodable, statusCode: Int, for request: URLRequest) {
+            guard let url = request.url?.absoluteString else {
+                return
+            }
+            responsesByRequestURL[url] = (response: response, statusCode: statusCode)
+        }
+
+        /// Returns the response for a request if it has been mocked.
+        static func response(for request: URLRequest) -> (response: Data?, statusCode: Int)? {
+            guard let url = request.url?.absoluteString,
+                  let response = responsesByRequestURL[url] else {
+                return nil
+            }
+
+            do {
+                let encoder = JSONEncoder()
+                let data = try encoder.encode(response.response)
+                return (response: data, statusCode: response.statusCode)
+            }
+            catch {
+                XCTFail("Couldn't convert response to Data: \(response)")
+                return (response: nil, statusCode: response.statusCode)
+            }
+        }
+    }
+}
+
+/// Allows mocking for the response of a `URLRequest` in Alamofire.
+final class MockURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        guard let headers = request.allHTTPHeaderFields else { return request }
+        do {
+            return try URLEncoding.default.encode(request, with: headers)
+        } catch {
+            return request
+        }
+    }
+
+    override func startLoading() {
+        defer {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        guard let url = request.url,
+              let response = Mocks.response(for: request) else {
+            return
+        }
+
+        guard let urlResponse = HTTPURLResponse(url: url, statusCode: response.statusCode, httpVersion: nil, headerFields: [:]) else {
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: urlResponse, cacheStoragePolicy: URLCache.StoragePolicy.notAllowed)
+
+        client?.urlProtocol(self, didLoad: response.response ?? .init())
+    }
+
+    override func stopLoading() {}
+}

--- a/Networking/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Networking/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -1,0 +1,85 @@
+import Alamofire
+import Combine
+import XCTest
+@testable import Networking
+
+/// AlamofireNetwork Tests
+///
+final class AlamofireNetworkTests: XCTestCase {
+    private var responseDataSubscription: AnyCancellable?
+
+    func test_responseData_completion_block_returns_NetworkError_unacceptableStatusCode_when_status_code_is_invalid() throws {
+        // Given
+        let request = JetpackRequest(wooApiVersion: .mark1,
+                                     method: .get,
+                                     siteID: 1,
+                                     path: "test")
+        let urlRequest = try XCTUnwrap(try? request.asURLRequest())
+        MockURLProtocol.Mocks.mockResponse(["error": "http_request_failed"], statusCode: 401, for: urlRequest)
+
+        // When
+        let network = AlamofireNetwork(credentials: nil, sessionManager: createSessionManagerWithMockURLProtocol())
+        let error = waitFor { promise in
+            network.responseData(for: request) { data, error in
+                promise(error)
+            }
+        }
+
+        // Then
+        let responseData = try JSONSerialization.data(withJSONObject: ["error": "http_request_failed"])
+        assertEqual(NetworkError.unacceptableStatusCode(statusCode: 401, response: responseData), error as? NetworkError)
+    }
+
+    func test_responseData_completion_result_returns_NetworkError_unacceptableStatusCode_when_status_code_is_invalid() throws {
+        // Given
+        let request = JetpackRequest(wooApiVersion: .mark1,
+                                     method: .get,
+                                     siteID: 1,
+                                     path: "test")
+        let urlRequest = try XCTUnwrap(try? request.asURLRequest())
+        MockURLProtocol.Mocks.mockResponse(["error": "http_request_failed"], statusCode: 500, for: urlRequest)
+
+        // When
+        let network = AlamofireNetwork(credentials: nil, sessionManager: createSessionManagerWithMockURLProtocol())
+        let result = waitFor { promise in
+            network.responseData(for: request) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let responseData = try JSONSerialization.data(withJSONObject: ["error": "http_request_failed"])
+        assertEqual(NetworkError.unacceptableStatusCode(statusCode: 500, response: responseData), result.failure as? NetworkError)
+    }
+
+    func test_responseDataPublisher_returns_NetworkError_unacceptableStatusCode_when_status_code_is_invalid() throws {
+        // Given
+        let request = JetpackRequest(wooApiVersion: .mark1,
+                                     method: .get,
+                                     siteID: 1,
+                                     path: "test")
+        let urlRequest = try XCTUnwrap(try? request.asURLRequest())
+        MockURLProtocol.Mocks.mockResponse(["error": "http_request_failed"], statusCode: 500, for: urlRequest)
+
+        // When
+        let network = AlamofireNetwork(credentials: nil, sessionManager: createSessionManagerWithMockURLProtocol())
+        let result = waitFor { promise in
+            self.responseDataSubscription = network.responseDataPublisher(for: request)
+                .sink { result in
+                    promise(result)
+                }
+        }
+
+        // Then
+        let responseData = try JSONSerialization.data(withJSONObject: ["error": "http_request_failed"])
+        assertEqual(NetworkError.unacceptableStatusCode(statusCode: 500, response: responseData), result.failure as? NetworkError)
+    }
+}
+
+private extension AlamofireNetworkTests {
+    func createSessionManagerWithMockURLProtocol() -> SessionManager {
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return SessionManager(configuration: configuration)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11109 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While debugging a surging JSON decoding error, we discovered that many decoding errors were from parsing an error response with a 40x/50x status code. This is because the `Alamofire`'s 2 response data functions skip the status code checking in `NetworkError` like in the original `responseData` with a legacy `(Data?, Error?)` callback. Thus, such responses are treated as success and parsed for each request's expected error format. When the error response doesn't follow the expected format (e.g. certain Blaze errors from Tumblr, and potentially some payment services), JSON decoding errors are returned instead of the underlying error response. https://github.com/woocommerce/woocommerce-ios/pull/11110 fixes this issue, and this PR adds unit tests for `AlamofireNetwork` since it wasn't straightforward to mock the response in Alamofire.

## How

Inspired by [the blog post](https://www.avanderlee.com/swift/mocking-alamofire-urlsession-requests/) and adapted from [some of the code](https://github.com/ksteigerwald/MockAlamofire) as a simpler way of mocking Alamofire, `MockURLProtocol` was added as a `URLProtocol` implementation to handle requests in Alamofire in unit tests. In order to mock the response (data & status code), static functions are available in `URLProtocol.Mocks` since `MockURLProtocol` can't be DI'ed. Then, `AlamofireNetworkTests` was added with a few test cases on the 3 response data functions to ensure 200 and 40x/50x status codes are handled as success/failure respectively.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The only app change is to add an optional `sessionManager` to `AlamofireNetwork`'s initializer for DI'ing the session manager with `MockURLProtocol`. The app functionality should remain the same. Please feel free to do a confidence check by launching the app in the logged-in state and making sure the app works as before (API requests work as before).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
