### PR TITLE
[Payments Menu] Fix card payments from new payment menu

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -5,8 +5,6 @@ struct InPersonPaymentsMenu: View {
 
     @State private var safariSheetURL: URL?
 
-    @State private var showingSimplePayments: Bool = false
-
     @State private var showingManagePaymentGateways: Bool = false
 
     var body: some View {
@@ -17,19 +15,13 @@ struct InPersonPaymentsMenu: View {
                     PaymentsRow(image: Image(uiImage: .moneyIcon),
                                 title: Localization.collectPayment)
                     .onTapGesture {
-                        showingSimplePayments = true
+                        viewModel.collectPaymentTapped()
                     }
-                    .sheet(isPresented: $showingSimplePayments,
-                           onDismiss: {
-                        // log analytics, maybe prevent, better if we can defer to the SimplePaymentsVM
-                    }) {
+                    .sheet(isPresented: $viewModel.presentCollectPayment) {
                         NavigationView {
-                            // TODO: fix IPP/TTP payments from this route – needs a rootVC
-                            SimplePaymentsAmount(
-                                dismiss: {
-                                    showingSimplePayments = false
-                                },
-                                viewModel: SimplePaymentsAmountViewModel(siteID: viewModel.siteID))
+                            SimplePaymentsAmountHosted(
+                                viewModel: SimplePaymentsAmountViewModel(siteID: viewModel.siteID),
+                                presentNoticePublisher: viewModel.simplePaymentsNoticePublisher)
                             .navigationBarTitleDisplayMode(.inline)
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -16,7 +16,11 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var shouldShowOnboarding: Bool = false
     @Published private(set) var shouldShowManagePaymentGatewaysRow: Bool = false
     @Published private(set) var activePaymentGatewayName: String?
+    @Published var presentCollectPayment: Bool = false
+
     var shouldAlwaysHideSetUpButtonOnAboutTapToPay: Bool = false
+
+    private(set) var simplePaymentsNoticePublisher: AnyPublisher<SimplePaymentsNotice, Never>
 
     let siteID: Int64
 
@@ -36,6 +40,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
          dependencies: Dependencies) {
         self.siteID = siteID
         self.dependencies = dependencies
+        self.simplePaymentsNoticePublisher = PassthroughSubject<SimplePaymentsNotice, Never>().eraseToAnyPublisher()
         observeOnboardingChanges()
         runCardPresentPaymentsOnboardingIfPossible()
         updateOutputProperties()
@@ -49,6 +54,12 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     func onAppear() {
         runCardPresentPaymentsOnboardingIfPossible()
+    }
+
+    func collectPaymentTapped() {
+        presentCollectPayment = true
+
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowStarted())
     }
 
     lazy var setUpTapToPayViewModelsAndViews: SetUpTapToPayViewModelsOrderedList = {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
@@ -27,7 +27,10 @@ struct PaymentsRow: View {
             } else {
                 Text(title)
             }
+
+            Spacer()
         }
+        .contentShape(Rectangle())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -54,7 +54,7 @@ final class SimplePaymentsAmountHostingController: UIHostingController<SimplePay
         super.viewDidLoad()
 
         // Needed to present IPP collect amount alerts, which are displayed in UIKit view controllers.
-        rootView.rootViewController = navigationController
+        rootView.rootViewController = navigationController ?? self
 
         // Set presentation delegate to track the user dismiss flow event
         if let navigationController = navigationController {
@@ -108,6 +108,24 @@ extension SimplePaymentsAmountHostingController: UIAdaptivePresentationControlle
         }
 
         viewController.present(actionSheet, animated: true)
+    }
+}
+
+// MARK: - SwiftUI compatibility
+/// It's obviously strange to use UIViewControllerRepresentable to present a UIHostingController containing a SwiftUI view.
+/// This is done because the CollectOrderPaymentUseCase and associated files use a UIViewController to show their UI.
+/// We should find a better way of doing this, but it's out of scope at the time of adding this (during Payments Menu rewrite.)
+struct SimplePaymentsAmountHosted: UIViewControllerRepresentable {
+    let viewModel: SimplePaymentsAmountViewModel
+    let presentNoticePublisher: AnyPublisher<SimplePaymentsNotice, Never>
+
+    func makeUIViewController(context: Context) -> some UIViewController {
+        SimplePaymentsAmountHostingController(
+            viewModel: viewModel,
+            presentNoticePublisher: presentNoticePublisher)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after: #11128 
Closes: #11123
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the Simple Payments flow when opened from the new Payments Menu (rewritten in SwiftUI.)

Before this PR, Card Reader and Tap to Pay Payments were not possible, because the connection and payment collection screens would not show.

This is because the CollectPaymentUseCase expects a UIViewController to be passed in, which it uses to present the UI for card payments. When presented from the SwiftUI Payments Menu, we didn't have that view controller any more.

Breaking the dependency of the payments code on UIViewController is beyond the scope of this project.

To continue to make progress, I've wrapped the `SimplePaymentsAmountHostingController` in a UIViewControllerRepresentable; that means we have:

`SimplePaymentsAmountHosted` SwiftUI wrapper for `SimplePaymentsAmountHostingController` UIKit wrapper for `SimplePaymentsAmount`.

It's annoying, but effective. We can improve it in future.

Additionally, this PR makes the whole `Collect Payment` row tappable, previously only the text was. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Navigate to `Menu > Settings > Experimental Features`
2. Toggle `SwiftUI Payments Menu`
3. Navigate to `Menu > Payments`
4. Tap `Collect Payment` in the whitespace on the right hand side of the row.
5. Go through the flow and take a Card Reader payment. Observe that you can complete it as expected, including connection to the reader.

Repeat steps 3-5 for a Tap to Pay payment.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/42eac55f-3237-4769-a723-d50778bb8ef1


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
