### PR TITLE
[Payments menu] Card Reader and Tap to Pay presentation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WooFoundation
 
 struct InPersonPaymentsMenu: View {
     @ObservedObject private(set) var viewModel: InPersonPaymentsMenuViewModel
@@ -36,23 +37,31 @@ struct InPersonPaymentsMenu: View {
                 }
 
                 Section(Localization.tapToPaySectionTitle) {
-                    // Modal
-                    NavigationLink(destination:
-                                    PaymentSettingsFlowPresentingView(
-                                        viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)) {
-                                            PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
-                                                        title: viewModel.setUpTryOutTapToPayRowTitle)
-                                        }
+                    PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
+                                title: viewModel.setUpTryOutTapToPayRowTitle)
+                    .onTapGesture {
+                        viewModel.setUpTryOutTapToPayTapped()
+                    }
+                    .sheet(isPresented: $viewModel.presentSetUpTryOutTapToPay) {
+                        PaymentSettingsFlowPresentingView(
+                            viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)
+                    }
 
-                    NavigationLink(destination: AboutTapToPayView(viewModel: viewModel.aboutTapToPayViewModel)) {
+                    NavigationLink {
+                        AboutTapToPayView(viewModel: viewModel.aboutTapToPayViewModel)
+                    } label: {
                         PaymentsRow(image: Image(uiImage: .infoOutlineImage),
                                     title: Localization.aboutTapToPayOnIPhone)
                     }
 
-                    // Modal
-                    NavigationLink(destination: Survey(source: .tapToPayFirstPayment)) {
-                        PaymentsRow(image: Image(uiImage: .feedbackOutlineIcon.withRenderingMode(.alwaysTemplate)),
-                                    title: Localization.tapToPayOnIPhoneFeedback)
+                    PaymentsRow(image: Image(uiImage: .feedbackOutlineIcon.withRenderingMode(.alwaysTemplate)),
+                                title: Localization.tapToPayOnIPhoneFeedback)
+                    .foregroundColor(Color(uiColor: .textLink))
+                    .onTapGesture {
+                        viewModel.tapToPayFeedbackTapped()
+                    }
+                    .sheet(isPresented: $viewModel.presentTapToPayFeedback) {
+                        Survey(source: .tapToPayFirstPayment)
                     }
                     .renderedIf(viewModel.shouldShowTapToPayFeedbackRow)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -18,7 +18,12 @@ struct InPersonPaymentsMenu: View {
                     .onTapGesture {
                         viewModel.collectPaymentTapped()
                     }
-                    .sheet(isPresented: $viewModel.presentCollectPayment) {
+                    .sheet(isPresented: $viewModel.presentCollectPayment,
+                           onDismiss: {
+                        Task { @MainActor in
+                            await viewModel.onAppear()
+                        }
+                    }) {
                         NavigationView {
                             SimplePaymentsAmountHosted(
                                 viewModel: SimplePaymentsAmountViewModel(siteID: viewModel.siteID),
@@ -42,9 +47,17 @@ struct InPersonPaymentsMenu: View {
                     .onTapGesture {
                         viewModel.setUpTryOutTapToPayTapped()
                     }
-                    .sheet(isPresented: $viewModel.presentSetUpTryOutTapToPay) {
-                        PaymentSettingsFlowPresentingView(
-                            viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)
+                    .sheet(isPresented: $viewModel.presentSetUpTryOutTapToPay,
+                           onDismiss: {
+                        Task { @MainActor in
+                            await viewModel.onAppear()
+                        }
+                    }) {
+                        NavigationView {
+                            PaymentSettingsFlowPresentingView(
+                                viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)
+                            .navigationBarHidden(true)
+                        }
                     }
 
                     NavigationLink {
@@ -127,7 +140,9 @@ struct InPersonPaymentsMenu: View {
                 PermanentNoticeView(notice: onboardingNotice)
             }
         }
-        .onAppear(perform: viewModel.onAppear)
+        .task {
+            await viewModel.onAppear()
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 ActivityIndicator(isAnimating: $viewModel.backgroundOnboardingInProgress,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -17,6 +17,8 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published private(set) var shouldShowManagePaymentGatewaysRow: Bool = false
     @Published private(set) var activePaymentGatewayName: String?
     @Published var presentCollectPayment: Bool = false
+    @Published var presentSetUpTryOutTapToPay: Bool = false
+    @Published var presentTapToPayFeedback: Bool = false
 
     var shouldAlwaysHideSetUpButtonOnAboutTapToPay: Bool = false
 
@@ -60,6 +62,14 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
         presentCollectPayment = true
 
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowStarted())
+    }
+
+    func setUpTryOutTapToPayTapped() {
+        presentSetUpTryOutTapToPay = true
+    }
+
+    func tapToPayFeedbackTapped() {
+        presentTapToPayFeedback = true
     }
 
     lazy var setUpTapToPayViewModelsAndViews: SetUpTapToPayViewModelsOrderedList = {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -50,7 +50,9 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     private func updateOutputProperties() {
         Task {
-            await shouldAlwaysHideSetUpButtonOnAboutTapToPay = dependencies.cardReaderSupportDeterminer.hasPreviousTapToPayUsage()
+            let tapToPayWasPreviouslyUsed = await dependencies.cardReaderSupportDeterminer.hasPreviousTapToPayUsage()
+            setUpTryOutTapToPayRowTitle = tapToPayWasPreviouslyUsed ? Localization.tryOutTapToPayOnIPhoneRowTitle : Localization.setUpTapToPayOnIPhoneRowTitle
+            shouldAlwaysHideSetUpButtonOnAboutTapToPay = tapToPayWasPreviouslyUsed
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -50,12 +50,15 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
         }
     }
 
+    @MainActor
     private func updateOutputProperties() async {
         await updateTapToPaySection()
     }
 
-    func onAppear() {
+    @MainActor
+    func onAppear() async {
         runCardPresentPaymentsOnboardingIfPossible()
+        await updateOutputProperties()
     }
 
     func collectPaymentTapped() {
@@ -188,6 +191,7 @@ private extension InPersonPaymentsMenuViewModel {
 // MARK: - Tap to Pay visibility
 
 private extension InPersonPaymentsMenuViewModel {
+    @MainActor
     private func updateTapToPaySection() async {
         let deviceSupportsTapToPay = await dependencies.cardReaderSupportDeterminer.deviceSupportsLocalMobileReader()
 
@@ -203,6 +207,7 @@ private extension InPersonPaymentsMenuViewModel {
         dependencies.cardPresentPaymentsConfiguration.supportedReaders.contains(.appleBuiltIn)
     }
 
+    @MainActor
     private func updateSetUpTryTapToPay() async {
         let tapToPayWasPreviouslyUsed = await dependencies.cardReaderSupportDeterminer.hasPreviousTapToPayUsage()
 
@@ -210,6 +215,7 @@ private extension InPersonPaymentsMenuViewModel {
         shouldAlwaysHideSetUpButtonOnAboutTapToPay = tapToPayWasPreviouslyUsed
     }
 
+    @MainActor
     private func updateTapToPayFeedbackRowVisibility() async {
         guard let firstTapToPayTransactionDate = await dependencies.cardReaderSupportDeterminer.firstTapToPayTransactionDate(),
               let thirtyDaysAgo = Calendar.current.date(byAdding: DateComponents(day: -30), to: Date()) else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -52,6 +52,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     @MainActor
     private func updateOutputProperties() async {
+        updateCardReadersSection()
         await updateTapToPaySection()
     }
 
@@ -185,6 +186,17 @@ private extension InPersonPaymentsMenuViewModel {
                 ServiceLocator.analytics.track(.paymentsMenuOnboardingErrorTapped)
                 self?.shouldShowOnboarding = true
             })
+    }
+}
+
+// MARK: - Card Reader visibility
+
+private extension InPersonPaymentsMenuViewModel {
+    private func updateCardReadersSection() {
+        shouldShowCardReaderSection = isEligibleForCardPresentPayments
+    }
+
+    var isEligibleForCardPresentPayments: Bool { dependencies.cardPresentPaymentsConfiguration.isSupportedCountry
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSupportDeterminer.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSupportDeterminer.swift
@@ -3,7 +3,6 @@ import Yosemite
 @testable import WooCommerce
 
 final class MockCardReaderSupportDeterminer: CardReaderSupportDetermining {
-
     var shouldReturnLocationIsAuthorized = false
     var locationIsAuthorized: Bool {
         return shouldReturnLocationIsAuthorized
@@ -28,4 +27,10 @@ final class MockCardReaderSupportDeterminer: CardReaderSupportDetermining {
     func deviceSupportsLocalMobileReader() async -> Bool {
         return shouldReturnDeviceSupportsLocalMobileReader
     }
+
+    var mockFirstTapToPayTransactionDate: Date? = nil
+    func firstTapToPayTransactionDate() async -> Date? {
+        mockFirstTapToPayTransactionDate
+    }
+
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after: #11140 
Closes: #11122 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Card Reader and Tap to Pay availability are dependent on country and device support. Additionally, we make changes to the views based on previous usage of Tap to Pay. This PR copies that logic over from the existing payments menu.

### Changes
- Only show Card Reader section when it's a supported country
- Only show TTP section when it's a supported country, running on a supported device
- Show `Set up TTP` before first transaction on this device, and `Try out TTP` afterwards
- Hide the `Set up TTP` button on the `About TTP` screen after the first transaction
- Show the TTP Feedback row after the first transaction on this device, for 30 days.
- Open the `Set up/Try out TTP` and `TTP Feedback` screens modally

### Known issues
Tap to Pay badging is not shown on the Set up Tap to Pay row, but is correctly cleared after that's done. #11142 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### TTP supporting devices/countries
1. Delete the app from your test iPhone
2. Launch the app from Xcode
3. Log in and switch to a WooPayments store in the US or UK
4. Navigate to `Menu > Settings > Experimental features` and turn on the new payments menu
5. Navigate to `Menu > Payments`
6. Observe that the `Card Reader` and `Tap to Pay` sections are shown
7. Observe that the `Tap to Pay` section does not include a Feedback row
8. Tap `About Tap to Pay` – observe that in the pushed screen, there's a Set up button.
9. Go back to the Payments Menu
10. Tap `Set up Tap to Pay on iPhone`. Observe that it opens modally.
11. Go through the flow and test payment.
12. Go back to the Payments Menu
13. Observe that there's a Feedback row added
14. Observe that the `Set up Tap to Pay on iPhone` item is now named `Try out Tap to Pay on iPhone`.
15. Tap Feedback; observe that it opens modally and the flow works.
16. Tap `About Tap to Pay` – observe that there's no longer a `Set up` button.

### Card payment only countries
1. Switch to a WooPayments store in Canada
2. Navigate to `Menu > Settings > Experimental features` and turn on the new payments menu
3. Navigate to `Menu > Payments`
4. Observe that the `Card Reader` section is shown, but the `Tap to Pay` section is not

### No IPP countries
1. Switch to a WooPayments store in any other country
2. Navigate to `Menu > Settings > Experimental features` and turn on the new payments menu
3. Navigate to `Menu > Payments`
4. Observe that the `Card Reader` section is shown, but the `Tap to Pay` section is not

### Unsupported devices
Using a phone running iOS 15, or any iPad:
1. Switch to a WooPayments store in the US or UK
2. Navigate to `Menu > Settings > Experimental features` and turn on the new payments menu
3. Navigate to `Menu > Payments`
4. Observe that the `Card Reader` section is shown, but the `Tap to Pay` section is not

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/cf1749e5-1df2-441c-ac00-16cb280dc103



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
