### PR TITLE
[Payments Menu] Refresh Pay in Person toggle when Payments Menu appears

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
@@ -89,6 +89,15 @@ final class InPersonPaymentsCashOnDeliveryToggleRowViewModel: ObservableObject {
                                                         sortedBy: [])
     }
 
+    func refreshState() {
+        guard let siteID = siteID else {
+            return
+        }
+
+        let action = PaymentGatewayAction.synchronizePaymentGateways(siteID: siteID) { _ in }
+        stores.dispatch(action)
+    }
+
     private func updateCashOnDeliveryEnabledState() {
         cashOnDeliveryEnabledState = cashOnDeliveryGateway?.enabled ?? false
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -52,6 +52,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     @MainActor
     private func updateOutputProperties() async {
+        payInPersonToggleViewModel.refreshState()
         updateCardReadersSection()
         await updateTapToPaySection()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after: #11141 
Closes: #11132
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, changes to the Pay in Person toggle wouldn’t be reflected in the app until the store was switched, or the app was relaunched.

This PR adds a refresh call whenever the menu appears, which means that any changes from outside the app are reflected in the Payments Menu the next time it’s opened.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app from Xcode
2. Navigate to `Menu > Settings > Experimental Features` and enable the New Payments Menu
3. Navigate to `Menu > Payments`
4. Observe the current state of the Pay in Person toggle
5. In your store's WP-Admin, go to `Payments > Settings > All Payment Methods` 
6. Turn off the toggle for `Cash on Delivery`, Click `Save changes`
7. Go back to the app, and go to another tab. Then tap back to the Menu tab, which will show the Payments Menu still.
8. Observe that after a second, the new value for the Pay in Person toggle is shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/aed5ad4b-3a7f-4842-8c5f-24bd54c722d3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
