### PR TITLE
[Payments Menu] Badge Set up TTP before first access

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -43,7 +43,8 @@ struct InPersonPaymentsMenu: View {
 
                 Section(Localization.tapToPaySectionTitle) {
                     PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
-                                title: viewModel.setUpTryOutTapToPayRowTitle)
+                                title: viewModel.setUpTryOutTapToPayRowTitle,
+                                badgeImage: viewModel.shouldBadgeTapToPayOnIPhone)
                     .onTapGesture {
                         viewModel.setUpTryOutTapToPayTapped()
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -10,6 +10,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published private(set) var shouldShowPaymentOptionsSection: Bool = false
     @Published private(set) var setUpTryOutTapToPayRowTitle: String = Localization.setUpTapToPayOnIPhoneRowTitle
     @Published private(set) var shouldShowTapToPayFeedbackRow: Bool = true
+    @Published private(set) var shouldBadgeTapToPayOnIPhone: Bool = false
     @Published private(set) var shouldDisableManageCardReaders: Bool = true
     @Published var backgroundOnboardingInProgress: Bool = false
     @Published private(set) var cardPresentPaymentsOnboardingNotice: PermanentNotice?
@@ -32,6 +33,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
         let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
         let onboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol
         let cardReaderSupportDeterminer: CardReaderSupportDetermining
+        let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker = TapToPayBadgePromotionChecker()
     }
 
     let dependencies: Dependencies
@@ -45,6 +47,11 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
         self.simplePaymentsNoticePublisher = PassthroughSubject<SimplePaymentsNotice, Never>().eraseToAnyPublisher()
         observeOnboardingChanges()
         runCardPresentPaymentsOnboardingIfPossible()
+
+        dependencies.tapToPayBadgePromotionChecker.$shouldShowTapToPayBadges
+            .share()
+            .assign(to: &$shouldBadgeTapToPayOnIPhone)
+
         Task { @MainActor in
             await updateOutputProperties()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
@@ -4,11 +4,13 @@ struct PaymentsRow: View {
     private let image: Image
     private let title: String
     private let subtitle: String?
+    private let badgeImage: Bool
 
-    init(image: Image, title: String, subtitle: String? = nil) {
+    init(image: Image, title: String, subtitle: String? = nil, badgeImage: Bool = false) {
         self.image = image
         self.title = title
         self.subtitle = subtitle
+        self.badgeImage = badgeImage
     }
 
     var body: some View {
@@ -17,6 +19,12 @@ struct PaymentsRow: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(maxWidth: Layout.imageSize, maxHeight: Layout.imageSize)
+                .overlay(alignment: .topTrailing, content: {
+                    Circle()
+                        .fill(Color.withColorStudio(name: .wooCommercePurple, shade: .shade50))
+                        .frame(width: Layout.dotSize, height: Layout.dotSize)
+                        .renderedIf(badgeImage)
+                })
 
             if let subtitle {
                 VStack(alignment: .leading, spacing: Layout.subtitleSpacing) {
@@ -38,6 +46,7 @@ private extension PaymentsRow {
     enum Layout {
         static let subtitleSpacing: CGFloat = 4.0
         static let imageSize: CGFloat = 24.0
+        static let dotSize: CGFloat = 7.0
     }
 }
 
@@ -45,7 +54,8 @@ struct PaymentsRow_Previews: PreviewProvider {
     static var previews: some View {
         PaymentsRow(image: Image(uiImage: .creditCardIcon),
                     title: "Payments Row",
-                    subtitle: "More details")
+                    subtitle: "More details",
+                    badgeImage: true)
         .previewLayout(.sizeThatFits)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Merge after: #11143 
Closes: #11142
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With the rewrite of the Payments Menu, we have a new `Set up Tap to Pay on iPhone` row, which should be badged on devices where merchants have not opened the TTP screen before.

The badges leading up to this (Menu tab, Payments item) were both working already, and the badge was correctly removed when Set up was opened.

This PR shows the badge itself on the new Payments menu.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Delete the app from your test phone
2. Launch the app from Xcode
3. Log in to a US or UK based WooPayments store
4. Navigate to `Menu > Settings > Experimental Features` and enable the New Payments Menu
5. Navigate to `Menu > Payments`
6. Observe that the `Set up Tap to Pay on iPhone` row's icon is badged.
7. Tap the row, then dismiss the flow which shows
8. Observe that the `Set up TTP` row is not badged any more.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


Uploading badge-tap-to-pay.mp4…


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
