### PR TITLE
[Payments menu] Accessibility testing and fixes

### DIFF
--- a/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticeView.swift
@@ -22,6 +22,7 @@ private struct PermanentNoticeContentView: View {
         HStack(alignment: .top, spacing: Layout.hStackSpacing) {
             Image(uiImage: .infoOutlineImage)
                 .foregroundColor(Color(.gray(.shade40)))
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Layout.vStackSpacing) {
                 Text(notice.message)
@@ -36,6 +37,7 @@ private struct PermanentNoticeContentView: View {
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .padding(Layout.hStackPadding)
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct InPersonPaymentsLearnMore: View {
     @Environment(\.customOpenURL) var customOpenURL
 
-    private let viewModel: LearnMoreViewModel
+    @ObservedObject private var viewModel: LearnMoreViewModel
     private let showInfoIcon: Bool
 
     init(viewModel: LearnMoreViewModel = LearnMoreViewModel(),
@@ -18,13 +18,22 @@ struct InPersonPaymentsLearnMore: View {
                 .resizable()
                 .foregroundColor(Color(.neutral(.shade60)))
                 .frame(width: iconSize, height: iconSize)
+                .accessibilityHidden(true)
                 .renderedIf(showInfoIcon)
             AttributedText(viewModel.learnMoreAttributedString)
         }
-        .accessibilityAddTraits(.isButton)
+        .accessibilityHint(viewModel.learnMoreAttributedString.string)
+        .accessibilityAction(named: Localization.toggleEnableCashOnDeliveryLearnMoreAccessibilityAction) {
+            viewModel.learnMoreTapped()
+        }
         .onTapGesture {
             viewModel.learnMoreTapped()
-            customOpenURL?(viewModel.url)
+        }
+        .task(id: viewModel.showLearnMoreWebViewURL) {
+            guard let url = viewModel.showLearnMoreWebViewURL else {
+                return
+            }
+            customOpenURL?(url)
         }
     }
 
@@ -37,5 +46,17 @@ struct InPersonPaymentsLearnMore_Previews: PreviewProvider {
     static var previews: some View {
         InPersonPaymentsLearnMore()
             .padding()
+    }
+}
+
+
+
+extension InPersonPaymentsLearnMore {
+    enum Localization {
+        static let toggleEnableCashOnDeliveryLearnMoreAccessibilityAction = NSLocalizedString(
+            "menu.payments.payInPerson.learnMore.link.accessibilityAction",
+            value: "Learn more",
+            comment: "Title for the accessibility action to open the learn more screen, showing information " +
+            "about adding Pay in Person to their checkout.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -21,6 +21,7 @@ struct InPersonPaymentsLearnMore: View {
                 .renderedIf(showInfoIcon)
             AttributedText(viewModel.learnMoreAttributedString)
         }
+        .accessibilityAddTraits(.isButton)
         .onTapGesture {
             viewModel.learnMoreTapped()
             customOpenURL?(viewModel.url)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
@@ -1,7 +1,8 @@
 import Foundation
 import UIKit
+import SwiftUI
 
-struct LearnMoreViewModel {
+class LearnMoreViewModel: ObservableObject {
 
     static let learnMoreURL = URL(string: "woocommerce://in-person-payments/learn-more")!
 
@@ -9,6 +10,8 @@ struct LearnMoreViewModel {
     let linkText: String
     let formatText: String
     let tappedAnalyticEvent: WooAnalyticsEvent?
+
+    @Published var showLearnMoreWebViewURL: URL?
 
     init(url: URL = learnMoreURL,
          linkText: String = Localization.learnMoreLink,
@@ -38,6 +41,8 @@ struct LearnMoreViewModel {
     }
 
     func learnMoreTapped() {
+        showLearnMoreWebViewURL = url
+
         guard let tappedAnalyticEvent = tappedAnalyticEvent else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -12,7 +12,6 @@ struct InPersonPaymentsMenu: View {
         VStack {
             List {
                 Section(Localization.paymentActionsSectionTitle) {
-                    // Modal
                     PaymentsRow(image: Image(uiImage: .moneyIcon),
                                 title: Localization.collectPayment)
                     .onTapGesture {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
@@ -25,6 +25,7 @@ struct PaymentsRow: View {
                         .frame(width: Layout.dotSize, height: Layout.dotSize)
                         .renderedIf(badgeImage)
                 })
+                .accessibilityHidden(true)
 
             if let subtitle {
                 VStack(alignment: .leading, spacing: Layout.subtitleSpacing) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsToggleRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsToggleRow.swift
@@ -22,15 +22,20 @@ struct PaymentsToggleRow: View {
     }
 
     var body: some View {
-        Toggle(isOn: $toggleState) {
-            HStack(alignment: .top) {
-                image
+        HStack(alignment: .top) {
+            image
+                .accessibilityHidden(true)
+            HStack {
                 VStack(alignment: .leading, spacing: Layout.narrowSpacing) {
                     Text(title)
                     InPersonPaymentsLearnMore(viewModel: toggleRowViewModel.learnMoreViewModel,
                                               showInfoIcon: false)
                 }
+                .layoutPriority(1)
+                Toggle(isOn: $toggleState) {}
+                    .accessibilityAddTraits(toggleState == true ? .isSelected : [])
             }
+            .accessibilityElement(children: .combine)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11104
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With the rewrite of the Payments Menu, we need to ensure that the screen is still accessible.

Having tested with VoiceOver, this PR fixes various issues I found:

- [x] Decorative icons are no longer announced
- [x] Learn more links are accessible (using accessibility actions, on the Pay in Person toggle)
- [x] The background onboarding notice is announced as one item

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. Launch the app from Xcode
2. Log in to a US or UK based WooPayments store
3. Navigate to `Menu > Settings > Experimental Features` and enable the New Payments Menu
4. Navigate to `Menu > Payments`
5. Turn on VoiceOver
6. Interact with the screen and ensure you can access and understand the state of all elements.

## Screenshots (Sound On)
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/8e216ed9-dccf-4c40-8510-55afb0c70635


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
