### PR TITLE
[Payments Menu] Fix Learn More links from onboarding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -25,15 +25,11 @@ struct InPersonPaymentsLearnMore: View {
         .accessibilityHint(viewModel.learnMoreAttributedString.string)
         .accessibilityAction(named: Localization.toggleEnableCashOnDeliveryLearnMoreAccessibilityAction) {
             viewModel.learnMoreTapped()
+            customOpenURL?(viewModel.url)
         }
         .onTapGesture {
             viewModel.learnMoreTapped()
-        }
-        .task(id: viewModel.showLearnMoreWebViewURL) {
-            guard let url = viewModel.showLearnMoreWebViewURL else {
-                return
-            }
-            customOpenURL?(url)
+            customOpenURL?(viewModel.url)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
@@ -11,8 +11,6 @@ class LearnMoreViewModel: ObservableObject {
     let formatText: String
     let tappedAnalyticEvent: WooAnalyticsEvent?
 
-    @Published var showLearnMoreWebViewURL: URL?
-
     init(url: URL = learnMoreURL,
          linkText: String = Localization.learnMoreLink,
          formatText: String = Localization.learnMoreText,
@@ -41,8 +39,6 @@ class LearnMoreViewModel: ObservableObject {
     }
 
     func learnMoreTapped() {
-        showLearnMoreWebViewURL = url
-
         guard let tappedAnalyticEvent = tappedAnalyticEvent else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -4,8 +4,6 @@ import WooFoundation
 struct InPersonPaymentsMenu: View {
     @ObservedObject private(set) var viewModel: InPersonPaymentsMenuViewModel
 
-    @State private var safariSheetURL: URL?
-
     @State private var showingManagePaymentGateways: Bool = false
 
     var body: some View {
@@ -37,7 +35,7 @@ struct InPersonPaymentsMenu: View {
                         image: Image(uiImage: .creditCardIcon),
                         title: Localization.toggleEnableCashOnDelivery,
                         toggleRowViewModel: viewModel.payInPersonToggleViewModel)
-                    .customOpenURL(binding: $safariSheetURL)
+                    .customOpenURL(binding: $viewModel.safariSheetURL)
                 }
 
                 Section(Localization.tapToPaySectionTitle) {
@@ -108,7 +106,7 @@ struct InPersonPaymentsMenu: View {
                 } footer: {
                     InPersonPaymentsLearnMore(viewModel: .inPersonPayments(source: .paymentsMenu),
                                               showInfoIcon: false)
-                    .customOpenURL(binding: $safariSheetURL)
+                    .customOpenURL(binding: $viewModel.safariSheetURL)
                 }
                 .renderedIf(viewModel.shouldShowCardReaderSection)
 
@@ -128,7 +126,7 @@ struct InPersonPaymentsMenu: View {
                 }
                 .renderedIf(viewModel.shouldShowPaymentOptionsSection)
             }
-            .safariSheet(url: $safariSheetURL)
+            .safariSheet(url: $viewModel.safariSheetURL)
 
             NavigationLink(isActive: $viewModel.shouldShowOnboarding) {
                 InPersonPaymentsView(viewModel: viewModel.onboardingViewModel)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -20,6 +20,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var presentCollectPayment: Bool = false
     @Published var presentSetUpTryOutTapToPay: Bool = false
     @Published var presentTapToPayFeedback: Bool = false
+    @Published var safariSheetURL: URL? = nil
 
     var shouldAlwaysHideSetUpButtonOnAboutTapToPay: Bool = false
 
@@ -117,7 +118,11 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     }()
 
     lazy var onboardingViewModel: InPersonPaymentsViewModel = {
-        InPersonPaymentsViewModel(useCase: dependencies.onboardingUseCase)
+        let onboardingViewModel = InPersonPaymentsViewModel(useCase: dependencies.onboardingUseCase)
+        onboardingViewModel.showURL = { [weak self] url in
+            self?.safariSheetURL = url
+        }
+        return onboardingViewModel
     }()
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after: #11145
Closes: #11131
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the Learn More links from onboarding screens didn't all work properly.

Those on onboarding screens opened from background onboarding didn't open anything, and those on in-line onboarding screens during payments could not be dismissed effectively (as they would repeatedly pop up again.)

This PR fixes both those issues.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. Delete the app from your test phone
2. Launch the app from Xcode
3. Log in to a US or UK based WooPayments store with Cash on Delivery disabled
4. Navigate to `Menu > Settings > Experimental Features` and enable the New Payments Menu
5. Navigate to `Menu > Payments`
6. Observe that the background onboarding banner shows
7. Tap `Continue Setup`
8. Select a payment gateway if needed
9. Tap `Learn More` on the onboarding screen – observe that the web view opens
10. Go back to the payments menu and tap `Collect Payment`
11. Go through the flow to take a TTP or Card reader payment
12. Tap `Learn More` on the onboarding screen that shows up
13. Observe that the web view opens, and that you can dismiss it afterwards.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/7b62eaaa-bd05-4afd-888c-e15121de4620



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
