### PR TITLE
Take one test down from 5s to 0.1s

### DIFF
--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -73,5 +73,8 @@ public enum ShippingLabelAction: Action {
                                destinationAddress: ShippingLabelAddress,
                                packages: [ShippingLabelPackagePurchase],
                                emailCustomerReceipt: Bool,
-                               completion: (Result<[ShippingLabel], Error>) -> Void)
+                               completion: (Result<[ShippingLabel], Error>) -> Void,
+                               backendProcessingDelay: TimeInterval = 2.0,
+                               pollingDelay: TimeInterval = 1.0,
+                               pollingMaximumRetries: Int64 = 3)
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -66,13 +66,16 @@ public final class ShippingLabelStore: Store {
             synchronizeShippingLabelAccountSettings(siteID: siteID, completion: completion)
         case .updateShippingLabelAccountSettings(let siteID, let settings, let completion):
             updateShippingLabelAccountSettings(siteID: siteID, settings: settings, completion: completion)
-        case .purchaseShippingLabel(let siteID, let orderID, let originAddress, let destinationAddress, let packages, let emailCustomerReceipt, let completion):
+        case .purchaseShippingLabel(let siteID, let orderID, let originAddress, let destinationAddress, let packages, let emailCustomerReceipt, let completion, let backendProcessingDelay, let pollingDelay, let pollingMaximumRetries):
             purchaseShippingLabel(siteID: siteID,
                                   orderID: orderID,
                                   originAddress: originAddress,
                                   destinationAddress: destinationAddress,
                                   packages: packages,
                                   emailCustomerReceipt: emailCustomerReceipt,
+                                  backendProcessingDelay: backendProcessingDelay,
+                                  pollingDelay: pollingDelay,
+                                  pollingMaximumRetries: pollingMaximumRetries,
                                   completion: completion)
         }
     }
@@ -230,6 +233,9 @@ private extension ShippingLabelStore {
                                destinationAddress: ShippingLabelAddress,
                                packages: [ShippingLabelPackagePurchase],
                                emailCustomerReceipt: Bool,
+                               backendProcessingDelay: TimeInterval,
+                               pollingDelay: TimeInterval,
+                               pollingMaximumRetries: Int64,
                                completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
         var labelPurchaseIDs: [Int64] = []
 
@@ -247,14 +253,13 @@ private extension ShippingLabelStore {
                     labelPurchaseIDs.append(label.shippingLabelID)
                 }
 
-                // Wait for 2 seconds (give the backend time to process the purchase)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                // Wait to give the backend time to process the purchase
+                DispatchQueue.main.asyncAfter(deadline: .now() + backendProcessingDelay) { [weak self] in
                     guard let self = self else { return }
 
                     // Poll the status of the label purchases from the response above
-                    // with a delay of 1 second each time, with a maximum of 3 retries for failed requests.
-                    self.pollLabelStatus(withDelayInSeconds: 1.0,
-                                         maxErrorRetries: 3,
+                    self.pollLabelStatus(withDelayInSeconds: pollingDelay,
+                                         maxErrorRetries: pollingMaximumRetries,
                                          siteID: siteID,
                                          orderID: orderID,
                                          labelIDs: labelPurchaseIDs,

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -66,7 +66,18 @@ public final class ShippingLabelStore: Store {
             synchronizeShippingLabelAccountSettings(siteID: siteID, completion: completion)
         case .updateShippingLabelAccountSettings(let siteID, let settings, let completion):
             updateShippingLabelAccountSettings(siteID: siteID, settings: settings, completion: completion)
-        case .purchaseShippingLabel(let siteID, let orderID, let originAddress, let destinationAddress, let packages, let emailCustomerReceipt, let completion, let backendProcessingDelay, let pollingDelay, let pollingMaximumRetries):
+        case .purchaseShippingLabel(
+            let siteID,
+            let orderID,
+            let originAddress,
+            let destinationAddress,
+            let packages,
+            let emailCustomerReceipt,
+            let completion,
+            let backendProcessingDelay,
+            let pollingDelay,
+            let pollingMaximumRetries
+        ):
             purchaseShippingLabel(siteID: siteID,
                                   orderID: orderID,
                                   originAddress: originAddress,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -6,6 +6,10 @@ import XCTest
 /// Mock for `ShippingLabelRemote`.
 ///
 final class MockShippingLabelRemote {
+
+    private(set) var purchaseShippingLabelCalled = false
+    private(set) var checkLabelStatusCallsCount = 0
+
     private struct LoadAllResultKey: Hashable {
         let siteID: Int64
         let orderID: Int64
@@ -356,6 +360,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
             let key = PurchaseShippingLabelResultKey(siteID: siteID)
             if let result = self.purchaseShippingLabelResults[key] {
+                self.purchaseShippingLabelCalled = true
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")
@@ -372,6 +377,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
             let key = CheckLabelStatusResultKey(siteID: siteID)
             if let result = self.checkLabelStatusResults[key] {
+                self.checkLabelStatusCallsCount += 1
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -852,10 +852,12 @@ final class ShippingLabelStoreTests: XCTestCase {
                                                                // Here just for reference.
                                                                pollingMaximumRetries: 3)
 
-        // We want to test that purchaseShippingLabel does not call its completion ("return") with an error for the entire duration of the polling it makes under the hood when the status is progress.
-        // So, let's set an inverted expectation: Let's validate that the result will never be an error.
+        // We want to test that purchaseShippingLabel does not call its completion ("return") with 
+        // an error for the entire duration of the polling it makes under the hood when the status
+        // is progress. So, let's set an inverted expectation: Let's validate that the result will
+        // never be an error.
         let exp = expectation(
-            for: NSPredicate(block: { _,_ in
+            for: NSPredicate(block: { _, _ in
                 switch purchaseResult {
                 case .failure: return true
                 default: return false

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -874,6 +874,13 @@ final class ShippingLabelStoreTests: XCTestCase {
         // - and there is no maximum retry count for the progress state
         // any timeout longer that 3s plus a few decimal places for buffer would have been okay.
         wait(for: [exp], timeout: 6.0)
+
+        // To ensure we didn't get a false positive, with the test simply waiting for 6 seconds but
+        // nothing happening in the SUT, let's inspect the remote test double to ensure that both
+        // the purchase labels and the check status API calls were made. For the status, let's also
+        // verify more that one was made, to ensure that it polled upon a "in progress" status.
+        XCTAssertTrue(remote.purchaseShippingLabelCalled)
+        XCTAssertGreaterThan(remote.checkLabelStatusCallsCount, 1)
     }
 }
 


### PR DESCRIPTION
**Before** (`trunk` 0975f5d70729c908e244376483ef465c10783436)

![progress](https://github.com/woocommerce/woocommerce-ios/assets/1218433/93c0b138-4147-472a-bbff-f779222ecfce)


**After**
<img width="1021" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/1218433/5839eb85-e88c-4c8d-ab0f-7b79be91cb8d">

## Description
A good guideline for writing unit tests is that they should be [FIRST: Fast, Isolated, Repeatable, Self-Verifying, and Timely](https://medium.com/pragmatic-programmers/unit-tests-are-first-fast-isolated-repeatable-self-verifying-and-timely-a83e8070698e) (this used to be on a site other than Medium, but I couldn't find the original)

Let's focus on the first item. Fast. 

How fast should they be? As always, it depends. But 5 _seconds_ for _one_ test is most definitely not fast.

The reason `test_purchaseShippingLabel_does_not_return_error_if_purchase_remains_in_progress()` takes this long is a mix of source code architecture and test strategy. Basically, `ShippingLabelStore` has a series of delays internally to account for backend processing times.  Addressing the architecture is beyond the scope of this PR and, to be honest, I haven't done my homework to be able to confidently suggest a solid alternative.

Regardless, there's a lot we can do to make the test itself faster.

The refactor in this PR use my long time favorite technique of dependency injection to go from 5s to 0.1s.

The dependencies being injected, in this instance, are the configuration for how long the `ShippingLabelStore` delays should be.

The approach I took was incremental, see commits list:

1. Refactor the code to read delay and retry times from default value in function parameter. No test changes.
2. Use inverted expectation in the test, to make it clearer to read and ready to go faster.
3. Improve the test to ensure that we don't get false positive (see inline comments)
4. Finally, override the default delay values to make the test run faster.

## Testing instructions
If CI is green, we're good.

## Where to go from here?

- The same approach could be used for the other slow test in the test case. The cost should be lower than investigating architectural changes, at least for someone with no context like me.
- I'll address the Hound comments before merging. Some of them are due to the method parameter indentation. I decided not to change that to reduce the noise in the PR. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.
