### PR TITLE
Subscription Products: Add sign-up fee to the price row and screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -194,6 +194,11 @@ private extension DefaultProductFormTableViewModel {
                 priceDetails.append(String.localizedStringWithFormat(Localization.regularPriceFormat, formattedRegularPrice))
             }
 
+            if let signupFee = product.subscription?.signUpFee, signupFee.isNotEmpty {
+                let formattedFee = currencyFormatter.formatAmount(signupFee, with: currency) ?? ""
+                priceDetails.append(String.localizedStringWithFormat(Localization.subscriptionSignupFeeFormat, formattedFee))
+            }
+
             if let salePrice = product.salePrice, salePrice.isNotEmpty {
                 let formattedSalePrice = currencyFormatter.formatAmount(salePrice, with: currency) ?? ""
                 priceDetails.append(String.localizedStringWithFormat(Localization.salePriceFormat, formattedSalePrice))
@@ -686,6 +691,12 @@ private extension DefaultProductFormTableViewModel {
             value: "Regular price: %1$@ %2$@",
             comment: "Format of the regular price for a subscription product on the Price Settings row. " +
             "Reads like: 'Regular price: $60.00 every 2 months'."
+        )
+        static let subscriptionSignupFeeFormat = NSLocalizedString(
+            "defaultProductFormTableViewModel.subscriptionSignupFeeFormat",
+            value: "Sign-up fee: %1$@",
+            comment: "Format of the sign-up fee for a subscription product on the Price Settings row. " +
+            "Reads like: 'Sign-up fee: $0.99'."
         )
         static let salePriceFormat = NSLocalizedString("Sale price: %@",
                                                        comment: "Format of the sale price on the Price Settings row")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -194,8 +194,9 @@ private extension DefaultProductFormTableViewModel {
                 priceDetails.append(String.localizedStringWithFormat(Localization.regularPriceFormat, formattedRegularPrice))
             }
 
-            if let signupFee = product.subscription?.signUpFee, signupFee.isNotEmpty {
-                let formattedFee = currencyFormatter.formatAmount(signupFee, with: currency) ?? ""
+            if let signupFee = product.subscription?.signUpFee,
+               signupFee.isNotEmpty,
+               let formattedFee = currencyFormatter.formatAmount(signupFee, with: currency) {
                 priceDetails.append(String.localizedStringWithFormat(Localization.subscriptionSignupFeeFormat, formattedFee))
             }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -13,22 +13,22 @@ extension Product {
     static func createRegularPriceViewModel(regularPrice: String?,
                                             using currencySettings: CurrencySettings,
                                             onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
-        let title = NSLocalizedString("Price", comment: "Title of the cell in Product Price Settings > Price")
-
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
-        var value = currencyFormatter.formatAmount(regularPrice ?? "", with: unit) ?? ""
-        value = value
-            .replacingOccurrences(of: unit, with: "")
-            .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
-        return UnitInputViewModel(title: title,
+        let value: String = {
+            guard let regularPrice, regularPrice.isNotEmpty else {
+                return ""
+            }
+            return currencyFormatter.formatAmount(regularPrice, with: unit) ?? ""
+                .replacingOccurrences(of: unit, with: "")
+                .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
+        }()
+        return UnitInputViewModel(title: Localization.regularPriceTitle,
                                   unit: unit,
                                   value: value,
                                   placeholder: placeholder,
-                                  accessibilityHint: NSLocalizedString(
-                                  "The price for this product. Editable.",
-                                  comment: "VoiceOver accessibility hint, informing the user that the cell shows the price information for this product."),
+                                  accessibilityHint: Localization.regularPriceAccessibilityHint,
                                   unitPosition: currencySettings.currencyUnitPosition,
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
@@ -39,8 +39,6 @@ extension Product {
     static func createSalePriceViewModel(salePrice: String?,
                                          using currencySettings: CurrencySettings,
                                          onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
-        let title = NSLocalizedString("Sale price", comment: "Title of the cell in Product Price Settings > Sale price")
-
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
@@ -53,18 +51,75 @@ extension Product {
                 .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
         }()
 
-        return UnitInputViewModel(title: title,
+        return UnitInputViewModel(title: Localization.salePriceTitle,
                                   unit: unit,
                                   value: value,
                                   placeholder: placeholder,
-                                  accessibilityHint: NSLocalizedString(
-                                  "The sale price for this product. Editable.",
-                                  comment: "VoiceOver accessibility hint, informing the user that the cell shows the sale price information for this product."),
+                                  accessibilityHint: Localization.salePriceAccessibility,
                                   unitPosition: currencySettings.currencyUnitPosition,
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .primary,
                                   onInputChange: onInputChange)
+    }
+
+    static func createSubscriptionSignupFeeViewModel(fee: String?,
+                                                     using currencySettings: CurrencySettings,
+                                                     onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+        let currencyCode = ServiceLocator.currencySettings.currencyCode
+        let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
+        let value: String = {
+            guard let fee, fee.isNotEmpty else {
+                return ""
+            }
+            return currencyFormatter.formatAmount(fee, with: unit) ?? ""
+                .replacingOccurrences(of: unit, with: "")
+                .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
+        }()
+        return UnitInputViewModel(title: Localization.signupFeeTitle,
+                                  unit: unit,
+                                  value: value,
+                                  placeholder: placeholder,
+                                  accessibilityHint: Localization.signupFeeAccessibilityHint,
+                                  unitPosition: currencySettings.currencyUnitPosition,
+                                  keyboardType: .decimalPad,
+                                  inputFormatter: PriceInputFormatter(),
+                                  style: .primary,
+                                  onInputChange: onInputChange)
+    }
+
+    private enum Localization {
+        static let regularPriceTitle = NSLocalizedString(
+            "productPriceSettingsViewModel.regularPriceTitle",
+            value: "Price",
+            comment: "Title of the cell in Product Price Settings > Price"
+        )
+        static let regularPriceAccessibilityHint = NSLocalizedString(
+            "productPriceSettingsViewModel.regularPriceAccessibilityHint",
+            value: "The price for this product. Editable.",
+            comment: "VoiceOver accessibility hint, informing the user that the cell shows the price information for this product."
+        )
+        static let salePriceTitle = NSLocalizedString(
+            "productPriceSettingsViewModel.salePriceTitle",
+            value: "Sale price",
+            comment: "Title of the cell in Product Price Settings > Sale price"
+        )
+        static let salePriceAccessibility = NSLocalizedString(
+            "productPriceSettingsViewModel.salePriceAccessibilityHint",
+            value: "The sale price for this product. Editable.",
+            comment: "VoiceOver accessibility hint, informing the user that the cell shows the sale price information for this product."
+        )
+        static let signupFeeTitle = NSLocalizedString(
+            "productPriceSettingsViewModel.signupFeeTitle",
+            value: "Sign-up Fee",
+            comment: "Title of the cell in Product Price Settings > Sign-up Fee"
+        )
+        static let signupFeeAccessibilityHint = NSLocalizedString(
+            "productPriceSettingsViewModel.signupFeeAccessibilityHint",
+            value: "The subscription sign-up fee for this product. Editable.",
+            comment: "VoiceOver accessibility hint, informing the user that the cell shows the subscription sign-up fee for this product."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -20,7 +20,7 @@ extension Product {
             guard let regularPrice, regularPrice.isNotEmpty else {
                 return ""
             }
-            return currencyFormatter.formatAmount(regularPrice, with: unit) ?? ""
+            return (currencyFormatter.formatAmount(regularPrice, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
         }()
@@ -73,7 +73,7 @@ extension Product {
             guard let fee, fee.isNotEmpty else {
                 return ""
             }
-            return currencyFormatter.formatAmount(fee, with: unit) ?? ""
+            return (currencyFormatter.formatAmount(fee, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
         }()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -78,6 +78,7 @@ extension Product {
                 .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
         }()
         return UnitInputViewModel(title: Localization.signupFeeTitle,
+                                  subtitle: Localization.signupFeeSubtitle,
                                   unit: unit,
                                   value: value,
                                   placeholder: placeholder,
@@ -114,6 +115,12 @@ extension Product {
             "productPriceSettingsViewModel.signupFeeTitle",
             value: "Sign-up Fee",
             comment: "Title of the cell in Product Price Settings > Sign-up Fee"
+        )
+        static let signupFeeSubtitle = NSLocalizedString(
+            "productPriceSettingsViewModel.signupFeeSubtitle",
+            value: "Optionally include an amount to be charged at the outset of the subscription. " +
+            "The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.",
+            comment: "Subtitle of the cell in Product Price Settings > Sign-up Fee"
         )
         static let signupFeeAccessibilityHint = NSLocalizedString(
             "productPriceSettingsViewModel.signupFeeAccessibilityHint",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -32,6 +32,7 @@ final class ProductPriceSettingsViewController: UIViewController {
     typealias Completion = (_ regularPrice: String?,
                             _ subscriptionPeriod: SubscriptionPeriod?,
                             _ subscriptionPeriodInterval: String?,
+                            _ subscriptionSignupFee: String?,
                             _ salePrice: String?,
                             _ dateOnSaleStart: Date?,
                             _ dateOnSaleEnd: Date?,
@@ -166,7 +167,7 @@ extension ProductPriceSettingsViewController {
     @objc private func completeUpdating() {
         viewModel.completeUpdating(
             onCompletion: { [weak self] in
-                self?.onCompletion($0, $1, $2, $3, $4, $5, $6, $7, $8)
+                self?.onCompletion($0, $1, $2, $3, $4, $5, $6, $7, $8, $9)
             },
             onError: { [weak self] error in
                 switch error {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -401,7 +401,11 @@ private extension ProductPriceSettingsViewController {
     }
 
     func configureSubscriptionSignupFee(cell: UnitInputTableViewCell) {
-        // TODO
+        let cellViewModel = Product.createSubscriptionSignupFeeViewModel(fee: viewModel.subscriptionSignupFee, using: ServiceLocator.currencySettings) { [weak self] fee in
+            self?.viewModel.handleSubscriptionSignupFeeChange(fee)
+        }
+        cell.selectionStyle = .none
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureSalePrice(cell: UnitInputTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -402,7 +402,10 @@ private extension ProductPriceSettingsViewController {
     }
 
     func configureSubscriptionSignupFee(cell: UnitInputTableViewCell) {
-        let cellViewModel = Product.createSubscriptionSignupFeeViewModel(fee: viewModel.subscriptionSignupFee, using: ServiceLocator.currencySettings) { [weak self] fee in
+        let cellViewModel = Product.createSubscriptionSignupFeeViewModel(
+            fee: viewModel.subscriptionSignupFee,
+            using: ServiceLocator.currencySettings
+        ) { [weak self] fee in
             self?.viewModel.handleSubscriptionSignupFeeChange(fee)
         }
         cell.selectionStyle = .none

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -362,6 +362,8 @@ private extension ProductPriceSettingsViewController {
             configureTaxClass(cell: cell)
         case let cell as TitleAndTextFieldTableViewCell where row == .subscriptionPeriod:
             configureSubscriptionPeriod(cell: cell)
+        case let cell as UnitInputTableViewCell where row == .subscriptionSignupFee:
+            configureSubscriptionSignupFee(cell: cell)
         default:
             fatalError()
             break
@@ -396,6 +398,10 @@ private extension ProductPriceSettingsViewController {
                                         onEditingEnd: { [weak self] in
             self?.refreshViewContent()
         }))
+    }
+
+    func configureSubscriptionSignupFee(cell: UnitInputTableViewCell) {
+        // TODO
     }
 
     func configureSalePrice(cell: UnitInputTableViewCell) {
@@ -519,6 +525,7 @@ extension ProductPriceSettingsViewController {
     enum Row: CaseIterable {
         case price
         case subscriptionPeriod
+        case subscriptionSignupFee
         case salePrice
 
         case scheduleSale
@@ -533,7 +540,7 @@ extension ProductPriceSettingsViewController {
 
         fileprivate var type: UITableViewCell.Type {
             switch self {
-            case .price, .salePrice:
+            case .price, .salePrice, .subscriptionSignupFee:
                 return UnitInputTableViewCell.self
             case .scheduleSale:
                 return SwitchTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -18,6 +18,7 @@ protocol ProductPriceSettingsViewModelOutput {
     var subscriptionPeriod: SubscriptionPeriod? { get }
     var subscriptionPeriodInterval: String? { get }
     var subscriptionPeriodDescription: String? { get }
+    var subscriptionSignupFee: String? { get }
 }
 
 /// Handles actions related to the price settings data.
@@ -39,6 +40,7 @@ protocol ProductPriceSettingsActionHandler {
     func handleSaleStartDateChange(_ date: Date)
     func handleSaleEndDateChange(_ date: Date?)
     func handleSubscriptionPeriodChange(interval: String, period: SubscriptionPeriod)
+    func handleSubscriptionSignupFeeChange(_ fee: String?)
 
     // Navigation actions
     func completeUpdating(onCompletion: ProductPriceSettingsViewController.Completion, onError: (ProductPriceSettingsError) -> Void)
@@ -58,6 +60,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
     private(set) var subscriptionPeriodDescription: String?
     private(set) var subscriptionPeriod: SubscriptionPeriod?
     private(set) var subscriptionPeriodInterval: String?
+    private(set) var subscriptionSignupFee: String?
 
     private(set) var dateOnSaleStart: Date?
     private(set) var dateOnSaleEnd: Date?
@@ -105,6 +108,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
         subscriptionPeriod = product.subscription?.period
         subscriptionPeriodInterval = product.subscription?.periodInterval
         subscriptionPeriodDescription = product.subscriptionPeriodDescription
+        subscriptionSignupFee = product.subscription?.signUpFee
 
         // If the product sale start date is nil and the sale end date is not in the past, defaults the sale start date to today.
         if let saleEndDate = product.dateOnSaleEnd, product.dateOnSaleStart == nil &&
@@ -250,6 +254,9 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
         subscriptionPeriodInterval = interval
     }
 
+    func handleSubscriptionSignupFeeChange(_ fee: String?) {
+        self.subscriptionSignupFee = fee
+    }
     // MARK: - Navigation actions
 
     func completeUpdating(onCompletion: ProductPriceSettingsViewController.Completion, onError: (ProductPriceSettingsError) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -272,6 +272,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
         onCompletion(regularPrice,
                      subscriptionPeriod,
                      subscriptionPeriodInterval,
+                     subscriptionSignupFee,
                      salePrice,
                      dateOnSaleStart,
                      dateOnSaleEnd,
@@ -293,7 +294,8 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
             dateOnSaleEnd != product.dateOnSaleEnd ||
             taxStatus.rawValue != product.taxStatusKey ||
             newTaxClass != originalTaxClass ||
-            subscriptionPeriodDescription != product.subscriptionPeriodDescription {
+            subscriptionPeriodDescription != product.subscriptionPeriodDescription ||
+            priceSettingsValidator.getDecimalPrice(subscriptionSignupFee) != priceSettingsValidator.getDecimalPrice(product.subscription?.signUpFee) {
             return true
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -131,7 +131,7 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
         // Price section
         var priceRows: [Row] = [.price]
         if product.productType.isSubscriptionType {
-            priceRows.append(contentsOf: [.subscriptionPeriod])
+            priceRows.append(contentsOf: [.subscriptionPeriod, .subscriptionSignupFee])
         }
         let priceSection = Section(title: Strings.priceSectionTitle, rows: priceRows)
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1358,17 +1358,17 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func editPriceSettings() {
-        let priceSettingsViewController = ProductPriceSettingsViewController(product: product) { [weak self]
-            (regularPrice, subscriptionPeriod, subscriptionPeriodInterval, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges) in
-            self?.onEditPriceSettingsCompletion(regularPrice: regularPrice,
-                                                subscriptionPeriod: subscriptionPeriod,
-                                                subscriptionPeriodInterval: subscriptionPeriodInterval,
-                                                salePrice: salePrice,
-                                                dateOnSaleStart: dateOnSaleStart,
-                                                dateOnSaleEnd: dateOnSaleEnd,
-                                                taxStatus: taxStatus,
-                                                taxClass: taxClass,
-                                                hasUnsavedChanges: hasUnsavedChanges)
+        let priceSettingsViewController = ProductPriceSettingsViewController(product: product) { [weak self] in
+            self?.onEditPriceSettingsCompletion(regularPrice: $0,
+                                                subscriptionPeriod: $1,
+                                                subscriptionPeriodInterval: $2,
+                                                subscriptionSignupFee: $3,
+                                                salePrice: $4,
+                                                dateOnSaleStart: $5,
+                                                dateOnSaleEnd: $6,
+                                                taxStatus: $7,
+                                                taxClass: $8,
+                                                hasUnsavedChanges: $9)
         }
         navigationController?.pushViewController(priceSettingsViewController, animated: true)
     }
@@ -1376,6 +1376,7 @@ private extension ProductFormViewController {
     func onEditPriceSettingsCompletion(regularPrice: String?,
                                        subscriptionPeriod: SubscriptionPeriod?,
                                        subscriptionPeriodInterval: String?,
+                                       subscriptionSignupFee: String?,
                                        salePrice: String?,
                                        dateOnSaleStart: Date?,
                                        dateOnSaleEnd: Date?,
@@ -1394,6 +1395,7 @@ private extension ProductFormViewController {
         viewModel.updatePriceSettings(regularPrice: regularPrice,
                                       subscriptionPeriod: subscriptionPeriod,
                                       subscriptionPeriodInterval: subscriptionPeriodInterval,
+                                      subscriptionSignupFee: subscriptionSignupFee,
                                       salePrice: salePrice,
                                       dateOnSaleStart: dateOnSaleStart,
                                       dateOnSaleEnd: dateOnSaleEnd,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -328,6 +328,7 @@ extension ProductFormViewModel {
     func updatePriceSettings(regularPrice: String?,
                              subscriptionPeriod: SubscriptionPeriod?,
                              subscriptionPeriodInterval: String?,
+                             subscriptionSignupFee: String?,
                              salePrice: String?,
                              dateOnSaleStart: Date?,
                              dateOnSaleEnd: Date?,
@@ -335,7 +336,8 @@ extension ProductFormViewModel {
                              taxClass: TaxClass?) {
         let subscription = product.subscription?.copy(period: subscriptionPeriod,
                                                       periodInterval: subscriptionPeriodInterval,
-                                                      price: regularPrice)
+                                                      price: regularPrice,
+                                                      signUpFee: subscriptionSignupFee)
         product = EditableProductModel(product: product.product.copy(dateOnSaleStart: dateOnSaleStart,
                                                                      dateOnSaleEnd: dateOnSaleEnd,
                                                                      regularPrice: regularPrice,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -103,6 +103,7 @@ protocol ProductFormViewModelProtocol {
     func updatePriceSettings(regularPrice: String?,
                              subscriptionPeriod: SubscriptionPeriod?,
                              subscriptionPeriodInterval: String?,
+                             subscriptionSignupFee: String?,
                              salePrice: String?,
                              dateOnSaleStart: Date?,
                              dateOnSaleEnd: Date?,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -222,6 +222,7 @@ extension ProductVariationFormViewModel {
     func updatePriceSettings(regularPrice: String?,
                              subscriptionPeriod: SubscriptionPeriod?,
                              subscriptionPeriodInterval: String?,
+                             subscriptionSignupFee: String?,
                              salePrice: String?,
                              dateOnSaleStart: Date?,
                              dateOnSaleEnd: Date?,
@@ -229,7 +230,8 @@ extension ProductVariationFormViewModel {
                              taxClass: TaxClass?) {
         let subscription = productVariation.subscription?.copy(period: subscriptionPeriod,
                                                                periodInterval: subscriptionPeriodInterval,
-                                                               price: regularPrice)
+                                                               price: regularPrice,
+                                                               signUpFee: subscriptionSignupFee)
         productVariation = EditableProductVariationModel(
             productVariation: productVariation.productVariation.copy(
                 dateOnSaleStart: dateOnSaleStart,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -17,6 +17,7 @@ struct UnitInputViewModel {
     }
 
     let title: String
+    var subtitle: String? = nil
     let unit: String
     let value: String?
     let placeholder: String?
@@ -35,7 +36,9 @@ final class UnitInputTableViewCell: UITableViewCell {
     @IBOutlet private weak var inputAndUnitStackView: UIStackView!
     @IBOutlet private weak var inputTextField: UITextField!
     @IBOutlet private weak var unitLabel: UILabel!
-    @IBOutlet private weak var inputAndUnitStackViewTotitleLabel: NSLayoutConstraint!
+    @IBOutlet private weak var inputAndUnitStackViewToTitleLabel: NSLayoutConstraint!
+    @IBOutlet private weak var subtitleLabel: UILabel!
+    @IBOutlet private weak var subtitleLabelToInputAndUnitStackView: NSLayoutConstraint!
 
     private var inputFormatter: UnitInputFormatter?
     private var onInputChange: ((_ input: String?) -> Void)?
@@ -45,6 +48,7 @@ final class UnitInputTableViewCell: UITableViewCell {
 
         configureSelectionStyle()
         configureTitleLabel()
+        configureSubtitleLabel()
         configureInputAndUnitStackView()
         configureInputTextField()
         configureUnitLabel()
@@ -54,6 +58,8 @@ final class UnitInputTableViewCell: UITableViewCell {
 
     func configure(viewModel: UnitInputViewModel) {
         titleLabel.text = viewModel.title
+        subtitleLabel.text = viewModel.subtitle
+        subtitleLabelToInputAndUnitStackView.constant = viewModel.subtitle == nil ? 0 : Constants.subtitleLabelToInputAndUnitStackViewSpacing
         unitLabel.text = viewModel.unit
         unitLabel.isHidden = viewModel.unit.isEmpty
         inputTextField.text = viewModel.value
@@ -107,6 +113,11 @@ private extension UnitInputTableViewCell {
         titleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
+    func configureSubtitleLabel() {
+        subtitleLabel.applyFootnoteStyle()
+        subtitleLabel.numberOfLines = 0
+    }
+
     func configureInputAndUnitStackView() {
         inputAndUnitStackView.spacing = Constants.stackViewSpacing
         inputAndUnitStackView.distribution = .fill
@@ -126,12 +137,12 @@ private extension UnitInputTableViewCell {
     private func configureStyle(_ style: UnitInputViewModel.Style) {
 
         if style == .primary {
-            inputAndUnitStackViewTotitleLabel.constant = Constants.inputAndUnitStackViewTotitleLabelSpacing
+            inputAndUnitStackViewToTitleLabel.constant = Constants.inputAndUnitStackViewToTitleLabelSpacing
             inputTextField.setContentHuggingPriority(.required, for: .horizontal)
         } else {
             // In secondary style we have no title do we need to remove the extra space between
             // the title and the stackView
-            inputAndUnitStackViewTotitleLabel.constant = 0.0
+            inputAndUnitStackViewToTitleLabel.constant = 0.0
             // If the title label has higher hugging priority then this textfield will stretch take all the free space
             inputTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
         }
@@ -191,7 +202,8 @@ private extension UnitInputTableViewCell {
 private extension UnitInputTableViewCell {
     enum Constants {
         static let stackViewSpacing: CGFloat = 6
-        static let inputAndUnitStackViewTotitleLabelSpacing: CGFloat = 16
+        static let inputAndUnitStackViewToTitleLabelSpacing: CGFloat = 16
+        static let subtitleLabelToInputAndUnitStackViewSpacing: CGFloat = 8
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.xib
@@ -1,64 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="UnitInputTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="77" id="KGk-i7-Jjw" customClass="UnitInputTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="77"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="77"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="USm-hW-Nqm">
-                        <rect key="frame" x="16" y="16" width="41.5" height="12"/>
+                        <rect key="frame" x="16" y="14" width="41.5" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ob4-NO-lKK">
-                        <rect key="frame" x="73.5" y="11" width="230.5" height="22"/>
+                        <rect key="frame" x="73.5" y="11" width="230.5" height="26.5"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Egc-4I-j1K">
-                                <rect key="frame" x="0.0" y="0.0" width="189" height="22"/>
+                                <rect key="frame" x="0.0" y="0.0" width="189" height="26.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zeq-2u-wuX">
-                                <rect key="frame" x="189" y="0.0" width="41.5" height="22"/>
+                                <rect key="frame" x="189" y="0.0" width="41.5" height="26.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                     </stackView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbl-vr-5y8">
+                        <rect key="frame" x="16" y="45.5" width="288" height="20.5"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
                     <constraint firstItem="Ob4-NO-lKK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="11" id="1SP-Ip-tgf"/>
-                    <constraint firstItem="USm-hW-Nqm" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="94h-Pu-yw9"/>
+                    <constraint firstItem="USm-hW-Nqm" firstAttribute="centerY" secondItem="Ob4-NO-lKK" secondAttribute="centerY" id="ARP-Nc-hmT"/>
                     <constraint firstAttribute="trailingMargin" secondItem="Ob4-NO-lKK" secondAttribute="trailing" id="Cgk-BX-4Tt"/>
-                    <constraint firstAttribute="bottom" secondItem="Ob4-NO-lKK" secondAttribute="bottom" constant="11" id="L3s-mF-7Se"/>
+                    <constraint firstItem="Dbl-vr-5y8" firstAttribute="top" secondItem="Ob4-NO-lKK" secondAttribute="bottom" constant="8" id="Hve-2K-mZS"/>
                     <constraint firstItem="USm-hW-Nqm" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="NaZ-l9-qgY"/>
-                    <constraint firstAttribute="bottom" secondItem="USm-hW-Nqm" secondAttribute="bottom" constant="16" id="jA4-Ga-8ge"/>
+                    <constraint firstAttribute="bottom" secondItem="Dbl-vr-5y8" secondAttribute="bottom" constant="11" id="clw-cl-zlD"/>
+                    <constraint firstItem="Dbl-vr-5y8" firstAttribute="leading" secondItem="USm-hW-Nqm" secondAttribute="leading" id="cqC-w9-MBg"/>
                     <constraint firstItem="Ob4-NO-lKK" firstAttribute="leading" secondItem="USm-hW-Nqm" secondAttribute="trailing" constant="16" id="ohO-Vo-Z9g"/>
+                    <constraint firstItem="Dbl-vr-5y8" firstAttribute="trailing" secondItem="Ob4-NO-lKK" secondAttribute="trailing" id="zZb-pW-mZ0"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="inputAndUnitStackView" destination="Ob4-NO-lKK" id="ENb-Cm-KUp"/>
-                <outlet property="inputAndUnitStackViewTotitleLabel" destination="ohO-Vo-Z9g" id="hD7-mw-hCx"/>
+                <outlet property="inputAndUnitStackViewToTitleLabel" destination="ohO-Vo-Z9g" id="9lo-kO-sjJ"/>
                 <outlet property="inputTextField" destination="Egc-4I-j1K" id="ABz-lR-XQG"/>
+                <outlet property="subtitleLabel" destination="Dbl-vr-5y8" id="zjR-s0-0PR"/>
+                <outlet property="subtitleLabelToInputAndUnitStackView" destination="Hve-2K-mZS" id="JwC-cj-8Ar"/>
                 <outlet property="titleLabel" destination="USm-hW-Nqm" id="z1x-su-ObU"/>
                 <outlet property="unitLabel" destination="Zeq-2u-wuX" id="GWc-C1-ftr"/>
             </connections>
-            <point key="canvasLocation" x="139" y="125"/>
+            <point key="canvasLocation" x="137.68115942028987" y="135.60267857142856"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2287,6 +2287,7 @@
 		DED9740B2AD7D09E00122EB4 /* BlazeCampaignListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED9740A2AD7D09E00122EB4 /* BlazeCampaignListView.swift */; };
 		DED9740D2AD7D27000122EB4 /* BlazeCampaignListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED9740C2AD7D27000122EB4 /* BlazeCampaignListViewModel.swift */; };
 		DED974112AD8F05A00122EB4 /* URL+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED974102AD8F05A00122EB4 /* URL+Identifiable.swift */; };
+		DEDA8D972B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D962B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4862,6 +4863,7 @@
 		DED9740A2AD7D09E00122EB4 /* BlazeCampaignListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListView.swift; sourceTree = "<group>"; };
 		DED9740C2AD7D27000122EB4 /* BlazeCampaignListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListViewModel.swift; sourceTree = "<group>"; };
 		DED974102AD8F05A00122EB4 /* URL+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Identifiable.swift"; sourceTree = "<group>"; };
+		DEDA8D962B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscriptionPeriodPickerUseCaseTests.swift; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -6224,6 +6226,7 @@
 				09BE3A8F27C921980070B69D /* Bulk Edit Price */,
 				02153210242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift */,
 				02BAB02024D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift */,
+				DEDA8D962B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift */,
 				09EA565127C8235200407D40 /* ProductPriceSettingsValidatorTests.swift */,
 			);
 			path = "Edit Price";
@@ -14109,6 +14112,7 @@
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				2667BFE92530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift in Sources */,
 				D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */,
+				DEDA8D972B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift in Sources */,
 				02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */,
 				31F635DC273AF0B100E14F10 /* VersionHelpersTests.swift in Sources */,
 				EE6F08682A721DCB00AA9B88 /* FreeTrialSurveyCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel+ProductVariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel+ProductVariationTests.swift
@@ -26,6 +26,29 @@ final class ProductPriceSettingsViewModel_ProductVariationTests: XCTestCase {
         XCTAssertEqual(sections, initialSections)
     }
 
+    func test_price_section_contains_subscription_rows_if_variation_is_subscription_type() {
+        // Arrange
+        let saleStartDate: Date? = nil
+        let saleEndDate: Date? = nil
+        let productVariation = MockProductVariation().productVariation().copy(
+            dateOnSaleStart: saleStartDate,
+            dateOnSaleEnd: saleEndDate,
+            subscription: .fake()
+        )
+        let model = EditableProductVariationModel(productVariation: productVariation)
+        let viewModel = ProductPriceSettingsViewModel(product: model)
+
+        // Act
+        let sections = viewModel.sections
+
+        // Assert
+        let initialSections: [Section] = [
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .subscriptionPeriod, .subscriptionSignupFee]),
+            Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
+        ]
+        XCTAssertEqual(sections, initialSections)
+    }
+
     func testTappingScheduleSaleToRowTogglesPickerRowInSalesSection() {
         // Arrange
         let saleStartDate: Date? = nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -670,7 +670,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Arrange
         let saleStartDate: Date? = nil
         let saleEndDate: Date? = nil
-        let product = Product.fake().copy(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate, productTypeKey: "subscription")
+        let product = Product.fake().copy(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate, subscription: .fake())
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -666,7 +666,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(sections, initialSections)
     }
 
-    func test_price_section_includes_subscription_period_if_product_type_is_subscription() {
+    func test_price_section_includes_subscription_rows_if_product_type_is_subscription() {
         // Arrange
         let saleStartDate: Date? = nil
         let saleEndDate: Date? = nil
@@ -679,7 +679,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Assert
         let initialSections: [Section] = [
-            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .subscriptionPeriod]),
+            Section(title: ProductPriceSettingsViewModel.Strings.priceSectionTitle, rows: [.price, .subscriptionPeriod, .subscriptionSignupFee]),
             Section(title: ProductPriceSettingsViewModel.Strings.saleSectionTitle, rows: [.salePrice, .scheduleSale]),
             Section(title: ProductPriceSettingsViewModel.Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -479,7 +479,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _, _) in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             XCTAssertEqual(error, .salePriceWithoutRegularPrice)
@@ -503,7 +503,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _, _) in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             // Assert
@@ -523,7 +523,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Act
         let result = waitFor { promise in
-            viewModel.completeUpdating { (_, _, _, _, _, _, _, _, _) in
+            viewModel.completeUpdating { (_, _, _, _, _, _, _, _, _, _) in
                 XCTFail("Completion block should not be called")
             } onError: { error in
                 promise(error)
@@ -547,7 +547,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (finalRegularPrice, _, _, finalSalePrice, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (finalRegularPrice, _, _, _, finalSalePrice, _, _, _, _, _) in
             expectation.fulfill()
 
             // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductSubscriptionPeriodPickerUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductSubscriptionPeriodPickerUseCaseTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import WooCommerce
+import enum Yosemite.SubscriptionPeriod
+
+final class ProductSubscriptionPeriodPickerUseCaseTests: XCTestCase {
+
+    func test_numberOfComponents_in_pickerView_is_correct() {
+        // Given
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: nil, initialInterval: nil, updateHandler: { _, _ in })
+        let pickerView = useCase.pickerView
+
+        // When
+        let number = useCase.numberOfComponents(in: pickerView)
+
+        // Then
+        XCTAssertEqual(number, 2)
+    }
+
+    func test_numberOfRows_in_first_component_is_correct() {
+        // Given
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: nil, initialInterval: nil, updateHandler: { _, _ in })
+        let pickerView = useCase.pickerView
+
+        // When
+        let number = useCase.pickerView(pickerView, numberOfRowsInComponent: 0)
+
+        // Then
+        XCTAssertEqual(number, 6)
+    }
+
+    func test_numberOfRows_in_second_component_is_correct() {
+        // Given
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: nil, initialInterval: nil, updateHandler: { _, _ in })
+        let pickerView = useCase.pickerView
+
+        // When
+        let number = useCase.pickerView(pickerView, numberOfRowsInComponent: 1)
+
+        // Then
+        XCTAssertEqual(number, 4)
+    }
+
+    func test_titleForRow_in_first_component_is_correct() {
+        // Given
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: nil, initialInterval: nil, updateHandler: { _, _ in })
+        let pickerView = useCase.pickerView
+
+        // When
+        let title = useCase.pickerView(pickerView, titleForRow: 1, forComponent: 0)
+
+        // Then
+        XCTAssertEqual(title, "2")
+    }
+
+    func test_titleForRow_in_second_component_is_correct_when_first_row_in_first_component_is_selected() {
+        // Given
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: nil, initialInterval: nil, updateHandler: { _, _ in })
+        let pickerView = useCase.pickerView
+
+        // When
+        pickerView.selectRow(0, inComponent: 0, animated: false)
+        let title = useCase.pickerView(pickerView, titleForRow: 1, forComponent: 1)
+
+        // Then
+        XCTAssertEqual(title, SubscriptionPeriod.allCases[1].descriptionSingular)
+    }
+
+    func test_titleForRow_in_second_component_is_correct_when_first_row_in_first_component_is_not_selected() {
+        // Given
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: nil, initialInterval: nil, updateHandler: { _, _ in })
+        let pickerView = useCase.pickerView
+
+        // When
+        pickerView.selectRow(2, inComponent: 0, animated: false)
+        let title = useCase.pickerView(pickerView, titleForRow: 1, forComponent: 1)
+
+        // Then
+        XCTAssertEqual(title, SubscriptionPeriod.allCases[1].descriptionPlural)
+    }
+
+    func test_pickerView_is_updated_with_initial_selected_rows() {
+        // Given
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: .month, initialInterval: "2", updateHandler: { _, _ in })
+        let pickerView = useCase.pickerView
+
+        // When
+        let intervalRowIndex = pickerView.selectedRow(inComponent: 0)
+        let periodRowIndex = pickerView.selectedRow(inComponent: 1)
+
+        // Then
+        XCTAssertEqual(intervalRowIndex, 1)
+        XCTAssertEqual(periodRowIndex, SubscriptionPeriod.allCases.firstIndex(of: .month))
+    }
+
+    func test_updateHandler_is_triggered_correctly_upon_selecting_any_row() {
+        // Given
+        var selectedPeriod: SubscriptionPeriod?
+        var selectedInterval: String?
+        let useCase = ProductSubscriptionPeriodPickerUseCase(initialPeriod: nil, initialInterval: nil, updateHandler: { period, interval in
+            selectedPeriod = period
+            selectedInterval = interval
+        })
+        let pickerView = useCase.pickerView
+
+        // When
+        // simulates user's tap - calling this programmatically doesn't trigger the delegate method.
+        pickerView.selectRow(1, inComponent: 0, animated: false)
+        useCase.pickerView(pickerView, didSelectRow: 1, inComponent: 0)
+
+        // Then
+        XCTAssertEqual(selectedPeriod, .day)
+        XCTAssertEqual(selectedInterval, "2")
+
+        // When
+        // simulates user's tap - calling this programmatically doesn't trigger the delegate method.
+        pickerView.selectRow(2, inComponent: 1, animated: false)
+        useCase.pickerView(pickerView, didSelectRow: 2, inComponent: 1)
+
+        // Then
+        XCTAssertEqual(selectedPeriod, .month)
+        XCTAssertEqual(selectedInterval, "2")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -58,8 +58,9 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         viewModel.updateShortDescription(product.shortDescription ?? "")
         viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
         viewModel.updatePriceSettings(regularPrice: product.regularPrice,
-                                      subscriptionPeriod: nil,
-                                      subscriptionPeriodInterval: nil,
+                                      subscriptionPeriod: product.subscription?.period,
+                                      subscriptionPeriodInterval: product.subscription?.periodInterval,
+                                      subscriptionSignupFee: product.subscription?.signUpFee,
                                       salePrice: product.salePrice,
                                       dateOnSaleStart: product.dateOnSaleStart,
                                       dateOnSaleEnd: product.dateOnSaleEnd,
@@ -181,6 +182,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         viewModel.updatePriceSettings(regularPrice: "999999",
                                       subscriptionPeriod: nil,
                                       subscriptionPeriodInterval: nil,
+                                      subscriptionSignupFee: nil,
                                       salePrice: "888888",
                                       dateOnSaleStart: nil,
                                       dateOnSaleEnd: nil,
@@ -196,6 +198,23 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         viewModel.updatePriceSettings(regularPrice: "",
                                       subscriptionPeriod: .month,
                                       subscriptionPeriodInterval: "1",
+                                      subscriptionSignupFee: nil,
+                                      salePrice: "",
+                                      dateOnSaleStart: nil,
+                                      dateOnSaleEnd: nil,
+                                      taxStatus: .none,
+                                      taxClass: nil)
+
+        // Then
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func test_product_has_unsaved_changes_from_editing_subscription_signup_fee() {
+        // When
+        viewModel.updatePriceSettings(regularPrice: "",
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
+                                      subscriptionSignupFee: "0.99",
                                       salePrice: "",
                                       dateOnSaleStart: nil,
                                       dateOnSaleEnd: nil,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -93,6 +93,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         viewModel.updatePriceSettings(regularPrice: product.regularPrice,
                                       subscriptionPeriod: product.subscription?.period,
                                       subscriptionPeriodInterval: product.subscription?.periodInterval,
+                                      subscriptionSignupFee: product.subscription?.signUpFee,
                                       salePrice: product.salePrice,
                                       dateOnSaleStart: product.dateOnSaleStart,
                                       dateOnSaleEnd: product.dateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -93,9 +93,11 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let newTaxClass = TaxClass(siteID: product.siteID, name: "Reduced rate", slug: "reduced-rate")
         let newSubscriptionPeriod = SubscriptionPeriod.month
         let newSubscriptionInterval = "2"
+        let newSubscriptionSignupFee = "0.99"
         viewModel.updatePriceSettings(regularPrice: newRegularPrice,
                                       subscriptionPeriod: newSubscriptionPeriod,
                                       subscriptionPeriodInterval: newSubscriptionInterval,
+                                      subscriptionSignupFee: newSubscriptionSignupFee,
                                       salePrice: newSalePrice,
                                       dateOnSaleStart: newDateOnSaleStart,
                                       dateOnSaleEnd: newDateOnSaleEnd,
@@ -111,6 +113,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.taxClass, newTaxClass.slug)
         XCTAssertEqual(viewModel.productModel.subscription?.period, newSubscriptionPeriod)
         XCTAssertEqual(viewModel.productModel.subscription?.periodInterval, newSubscriptionInterval)
+        XCTAssertEqual(viewModel.productModel.subscription?.signUpFee, newSubscriptionSignupFee)
     }
 
     func testUpdatingInventorySettings() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -44,8 +44,9 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         viewModel.updateImages(model.images)
         viewModel.updateDescription(productVariation.description ?? "")
         viewModel.updatePriceSettings(regularPrice: productVariation.regularPrice,
-                                      subscriptionPeriod: nil,
-                                      subscriptionPeriodInterval: nil,
+                                      subscriptionPeriod: productVariation.subscription?.period,
+                                      subscriptionPeriodInterval: productVariation.subscription?.periodInterval,
+                                      subscriptionSignupFee: productVariation.subscription?.signUpFee,
                                       salePrice: productVariation.salePrice,
                                       dateOnSaleStart: productVariation.dateOnSaleStart,
                                       dateOnSaleEnd: productVariation.dateOnSaleEnd,
@@ -108,6 +109,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         viewModel.updatePriceSettings(regularPrice: "999999",
                                       subscriptionPeriod: nil,
                                       subscriptionPeriodInterval: nil,
+                                      subscriptionSignupFee: nil,
                                       salePrice: "888888",
                                       dateOnSaleStart: nil,
                                       dateOnSaleEnd: nil,
@@ -123,6 +125,23 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         viewModel.updatePriceSettings(regularPrice: "",
                                       subscriptionPeriod: .week,
                                       subscriptionPeriodInterval: "3",
+                                      subscriptionSignupFee: nil,
+                                      salePrice: "",
+                                      dateOnSaleStart: nil,
+                                      dateOnSaleEnd: nil,
+                                      taxStatus: .none,
+                                      taxClass: nil)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func test_product_variation_has_unsaved_changes_from_editing_subscription_signup_fee() {
+        // Action
+        viewModel.updatePriceSettings(regularPrice: "",
+                                      subscriptionPeriod: nil,
+                                      subscriptionPeriodInterval: nil,
+                                      subscriptionSignupFee: "0.99",
                                       salePrice: "",
                                       dateOnSaleStart: nil,
                                       dateOnSaleEnd: nil,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -57,6 +57,7 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
         viewModel.updatePriceSettings(regularPrice: productVariation.regularPrice,
                                       subscriptionPeriod: productVariation.subscription?.period,
                                       subscriptionPeriodInterval: productVariation.subscription?.periodInterval,
+                                      subscriptionSignupFee: productVariation.subscription?.signUpFee,
                                       salePrice: productVariation.salePrice,
                                       dateOnSaleStart: productVariation.dateOnSaleStart,
                                       dateOnSaleEnd: productVariation.dateOnSaleEnd,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -68,6 +68,7 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
         viewModel.updatePriceSettings(regularPrice: newRegularPrice,
                                       subscriptionPeriod: .month,
                                       subscriptionPeriodInterval: "2",
+                                      subscriptionSignupFee: "0.99",
                                       salePrice: newSalePrice,
                                       dateOnSaleStart: newDateOnSaleStart,
                                       dateOnSaleEnd: newDateOnSaleEnd,
@@ -83,6 +84,7 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.taxClass, newTaxClass.slug)
         XCTAssertEqual(viewModel.productModel.subscription?.period, .month)
         XCTAssertEqual(viewModel.productModel.subscription?.periodInterval, "2")
+        XCTAssertEqual(viewModel.productModel.subscription?.signUpFee, "0.99")
     }
 
     func testUpdatingInventorySettings() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11135 
<!-- Id number of the GitHub issue this PR addresses. -->

## What
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the sign-up fee row for subscription products on the price settings screen. The price row in the product form has also been updated to display the sign-up fee if it's available.

## How
- Displayed the sign-up fee information in the price row in the product form if it's available.
- Added a new row type and showed it on the price settings screen for subscription products.
- Updated logic to include sign-up fee when checking for changes on the price settings screen.
- Handled sign-up fee updates on the price settings screen.
- Updated the callback closure for the price settings screen to include sign-up fee.
- Updated unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `subscriptionProducts` to be able to edit subscription products.
- Create a simple subscription product for your test site on wp-admin if you haven't already.
- Build the app, log in to your test store and navigate to the Products tab.
- Select a simple subscription product.
- If the product has a sign-up fee, the fee should be displayed on the price row of the product form.
- Tap the price row, notice a few changes:
  - A new row for subscription sign-up fee is displayed below the subscription period row. 
  - Change the sign-up fee, tap on Done on the price settings screen, and tap Save on the product form. The new fee should be updated correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/e31d68d5-66f3-43b6-b7a9-9d6bde4957bf



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
