### PR TITLE
[Custom Amounts M4] Add percentage to custom amounts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.3
 -----
-
+- [*] Orders: users can now calculate a custom amount based on the order total percentage. [https://github.com/woocommerce/woocommerce-ios/pull/11154]
 
 16.2
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -459,6 +459,7 @@ public enum WooAnalyticsStat: String {
     // MARK: Custom amounts
     case addCustomAmountDoneButtonTapped = "add_custom_amount_done_tapped"
     case addCustomAmountNameAdded = "add_custom_amount_name_added"
+    case addCustomAmountPercentageAdded = "add_custom_amount_percentage_added"
 
     // MARK: Order Tax Educational Dialog
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -28,6 +28,9 @@ struct AddCustomAmountView: View {
                             .foregroundColor(Color(.textSubtle))
                             .multilineTextAlignment(.center)
 
+                        InputField(placeholder: Localization.percentagePlaceholder,
+                                   text: $viewModel.percentage)
+
                         Spacer()
 
                         Button(viewModel.doneButtonTitle) {
@@ -56,8 +59,35 @@ struct AddCustomAmountView: View {
 }
 
 private extension AddCustomAmountView {
+    struct InputField: View {
+        let placeholder: String
+        @Binding var text: String
+
+        var body: some View {
+            TextField(placeholder, text: $text)
+            .keyboardType(.numbersAndPunctuation)
+            .padding(EdgeInsets(top: 0, leading: Layout.inputFieldInnerVerticalPadding, bottom: 0, trailing: Layout.inputFieldInnerVerticalPadding))
+            .frame(maxWidth: .infinity, minHeight: Layout.inputFieldHeight, maxHeight: Layout.inputFieldHeight)
+            .overlay {
+                RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
+                    .inset(by: Layout.inputFieldOverlayInset)
+                    .stroke(Color(uiColor: .wooCommercePurple(.shade50)), lineWidth: Layout.borderLineWidth)
+            }
+            .cornerRadius(Layout.frameCornerRadius)
+            .padding()
+        }
+    }
+}
+
+private extension AddCustomAmountView {
     enum Layout {
         static let mainVerticalSpacing: CGFloat = 8
+        static let rowHeight: CGFloat = 44
+        static let frameCornerRadius: CGFloat = 4
+        static let borderLineWidth: CGFloat = 1
+        static let inputFieldOverlayInset: CGFloat = 0.25
+        static let inputFieldHeight: CGFloat = 48
+        static let inputFieldInnerVerticalPadding: CGFloat = 8
     }
 }
 
@@ -68,6 +98,9 @@ private extension AddCustomAmountView {
         static let navigationTitle = NSLocalizedString("Custom Amount", comment: "Navigation title on the add custom amount view in orders.")
         static let navigationCancelButtonTitle = NSLocalizedString("Cancel",
                                                                 comment: "Cancel button title on the navigation bar on the add custom amount view in orders.")
+        static let percentagePlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.input",
+                                                             value: "Enter Percentage",
+                                                             comment: "Placeholder for entering an custom amount through a percentage")
     }
 
     enum AccessibilityIdentifiers {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -34,7 +34,7 @@ struct AddCustomAmountView: View {
                             }
                         }
                         .padding(.bottom, Layout.mainVerticalSpacing)
-                        .renderedIf(viewModel.showPercentageInput)
+                        .renderedIf(viewModel.shouldShowPercentageInput)
 
                         Text(Localization.nameTitle)
                             .font(.title3)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -20,7 +20,7 @@ struct AddCustomAmountView: View {
                         FormattableAmountTextField(viewModel: viewModel.formattableAmountTextFieldViewModel)
 
                         VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
-                            Text(Localization.percentageInputTitle + " " + viewModel.baseAmountForPercentageString)
+                            Text(String.localizedStringWithFormat(Localization.percentageInputTitle, viewModel.baseAmountForPercentageString))
                                 .font(.subheadline)
                                 .foregroundColor(Color(.textSubtle))
 
@@ -113,7 +113,7 @@ private extension AddCustomAmountView {
         static let navigationCancelButtonTitle = NSLocalizedString("Cancel",
                                                                 comment: "Cancel button title on the navigation bar on the add custom amount view in orders.")
         static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
-                                                             value: "Or enter percentage of the order total",
+                                                             value: "Or enter percentage of the order total (%1$@)",
                                                              comment: "Title for entering an custom amount through a percentage")
         static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
                                                              value: "Enter percentage",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -19,6 +19,23 @@ struct AddCustomAmountView: View {
 
                         FormattableAmountTextField(viewModel: viewModel.formattableAmountTextFieldViewModel)
 
+                        VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
+                            Text(Localization.percentageInputTitle + " " + viewModel.baseAmountForPercentageString)
+                                .font(.subheadline)
+                                .foregroundColor(Color(.textSubtle))
+
+                            HStack(spacing: Layout.inputFieldVerticalSpacing) {
+                                InputField(placeholder: Localization.percentageInputPlaceholder,
+                                           text: $viewModel.percentage)
+
+                                Text("%")
+                                    .font(.title3)
+                                    .foregroundColor(Color(.textSubtle))
+                            }
+                        }
+                        .padding(.bottom, Layout.mainVerticalSpacing)
+                        .renderedIf(viewModel.showPercentageInput)
+
                         Text(Localization.nameTitle)
                             .font(.title3)
                             .foregroundColor(Color(.textSubtle))
@@ -27,9 +44,6 @@ struct AddCustomAmountView: View {
                             .secondaryTitleStyle()
                             .foregroundColor(Color(.textSubtle))
                             .multilineTextAlignment(.center)
-
-                        InputField(placeholder: Localization.percentagePlaceholder,
-                                   text: $viewModel.percentage)
 
                         Spacer()
 
@@ -65,7 +79,7 @@ private extension AddCustomAmountView {
 
         var body: some View {
             TextField(placeholder, text: $text)
-            .keyboardType(.numbersAndPunctuation)
+            .keyboardType(.decimalPad)
             .padding(EdgeInsets(top: 0, leading: Layout.inputFieldInnerVerticalPadding, bottom: 0, trailing: Layout.inputFieldInnerVerticalPadding))
             .frame(maxWidth: .infinity, minHeight: Layout.inputFieldHeight, maxHeight: Layout.inputFieldHeight)
             .overlay {
@@ -74,7 +88,6 @@ private extension AddCustomAmountView {
                     .stroke(Color(uiColor: .wooCommercePurple(.shade50)), lineWidth: Layout.borderLineWidth)
             }
             .cornerRadius(Layout.frameCornerRadius)
-            .padding()
         }
     }
 }
@@ -86,8 +99,9 @@ private extension AddCustomAmountView {
         static let frameCornerRadius: CGFloat = 4
         static let borderLineWidth: CGFloat = 1
         static let inputFieldOverlayInset: CGFloat = 0.25
-        static let inputFieldHeight: CGFloat = 48
+        static let inputFieldHeight: CGFloat = 44
         static let inputFieldInnerVerticalPadding: CGFloat = 8
+        static let inputFieldVerticalSpacing: CGFloat = 8
     }
 }
 
@@ -98,8 +112,11 @@ private extension AddCustomAmountView {
         static let navigationTitle = NSLocalizedString("Custom Amount", comment: "Navigation title on the add custom amount view in orders.")
         static let navigationCancelButtonTitle = NSLocalizedString("Cancel",
                                                                 comment: "Cancel button title on the navigation bar on the add custom amount view in orders.")
-        static let percentagePlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.input",
-                                                             value: "Enter Percentage",
+        static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
+                                                             value: "Or enter percentage of the order total",
+                                                             comment: "Title for entering an custom amount through a percentage")
+        static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
+                                                             value: "Enter percentage",
                                                              comment: "Placeholder for entering an custom amount through a percentage")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -36,7 +36,14 @@ final class AddCustomAmountViewModel: ObservableObject {
         self.baseAmountForPercentage = baseAmountForPercentage
         self.onCustomAmountEntered = onCustomAmountEntered
         listenToAmountChanges()
+
+        formattableAmountTextFieldViewModel.onResetAmountWithNewValue = { [weak self] in
+            self?.updateFormattableAmountWithNextPercentageChange = false
+            self?.percentage = ""
+        }
     }
+
+    var updateFormattableAmountWithNextPercentageChange = true
 
     /// Variable that holds the name of the custom amount.
     ///
@@ -44,6 +51,11 @@ final class AddCustomAmountViewModel: ObservableObject {
     @Published var percentage = "" {
         didSet {
             guard oldValue != percentage else { return }
+
+            guard updateFormattableAmountWithNextPercentageChange else {
+                updateFormattableAmountWithNextPercentageChange = true
+                return
+            }
 
             guard percentage.isNotEmpty else { return formattableAmountTextFieldViewModel.reset() }
 
@@ -76,14 +88,6 @@ final class AddCustomAmountViewModel: ObservableObject {
         onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName, feeID)
     }
 
-    func reset() {
-        name = ""
-        baseAmountForPercentage = 0
-        feeID = nil
-        shouldDisableDoneButton = true
-
-        formattableAmountTextFieldViewModel.reset()
-    }
 
     func preset(with fee: OrderFeeLine) {
         name = fee.name ?? Localization.customAmountPlaceholder

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -38,12 +38,9 @@ final class AddCustomAmountViewModel: ObservableObject {
         listenToAmountChanges()
 
         formattableAmountTextFieldViewModel.onWillResetAmountWithNewValue = { [weak self] in
-            self?.updateFormattableAmountWithNextPercentageChange = false
             self?.percentage = ""
         }
     }
-
-    var updateFormattableAmountWithNextPercentageChange = true
 
     /// Variable that holds the name of the custom amount.
     ///
@@ -51,11 +48,6 @@ final class AddCustomAmountViewModel: ObservableObject {
     @Published var percentage = "" {
         didSet {
             guard oldValue != percentage else { return }
-
-            guard updateFormattableAmountWithNextPercentageChange else {
-                updateFormattableAmountWithNextPercentageChange = true
-                return
-            }
 
             guard percentage.isNotEmpty else { return formattableAmountTextFieldViewModel.reset() }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -14,11 +14,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
 
     var baseAmountForPercentageString: String {
-        guard let baseAmountForPercentageString = currencyFormatter.formatAmount(baseAmountForPercentage) else {
-            return ""
-        }
-
-        return "(\(baseAmountForPercentageString))"
+        currencyFormatter.formatAmount(baseAmountForPercentage) ?? ""
     }
 
     var showPercentageInput: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -24,6 +24,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     /// Variable that holds the name of the custom amount.
     ///
     @Published var name = ""
+    @Published var percentage = ""
     @Published private(set) var shouldDisableDoneButton: Bool = true
     private var feeID: Int64? = nil
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -13,6 +13,18 @@ final class AddCustomAmountViewModel: ObservableObject {
     private let analytics: Analytics
     private let currencyFormatter: CurrencyFormatter
 
+    var baseAmountForPercentageString: String {
+        guard let baseAmountForPercentageString = currencyFormatter.formatAmount(baseAmountForPercentage) else {
+            return ""
+        }
+
+        return "(\(baseAmountForPercentageString))"
+    }
+
+    var showPercentageInput: Bool {
+        baseAmountForPercentage > 0
+    }
+
     init(baseAmountForPercentage: Decimal,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
@@ -31,11 +43,13 @@ final class AddCustomAmountViewModel: ObservableObject {
     @Published var name = ""
     @Published var percentage = "" {
         didSet {
-            guard let decimalInput = currencyFormatter.convertToDecimal(percentage) else {
-                return
-            }
+            guard oldValue != percentage else { return }
 
-            formattableAmountTextFieldViewModel.amount = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
+            guard percentage.isNotEmpty else { return formattableAmountTextFieldViewModel.reset() }
+
+            guard let decimalInput = currencyFormatter.convertToDecimal(percentage) else { return }
+
+            formattableAmountTextFieldViewModel.presetAmount("\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -14,7 +14,11 @@ final class AddCustomAmountViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
 
     var baseAmountForPercentageString: String {
-        currencyFormatter.formatAmount(baseAmountForPercentage) ?? ""
+        guard let baseAmountForPercentageString = currencyFormatter.formatAmount(baseAmountForPercentage) else {
+            return ""
+        }
+
+        return "(\(baseAmountForPercentageString))"
     }
 
     var shouldShowPercentageInput: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -14,11 +14,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
 
     var baseAmountForPercentageString: String {
-        guard let baseAmountForPercentageString = currencyFormatter.formatAmount(baseAmountForPercentage) else {
-            return ""
-        }
-
-        return "(\(baseAmountForPercentageString))"
+        currencyFormatter.formatAmount(baseAmountForPercentage) ?? ""
     }
 
     var shouldShowPercentageInput: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -70,11 +70,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     }
 
     func doneButtonPressed() {
-        if name.isNotEmpty {
-            analytics.track(.addCustomAmountNameAdded)
-        }
-
-        analytics.track(.addCustomAmountDoneButtonTapped)
+        trackEventsOnDoneButtonPressed()
 
         let customAmountName = name.isNotEmpty ? name : customAmountPlaceholder
         onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName, feeID)
@@ -93,6 +89,18 @@ private extension AddCustomAmountViewModel {
         formattableAmountTextFieldViewModel.$amount.map { _ in
             !self.formattableAmountTextFieldViewModel.amountIsValid
         }.assign(to: &$shouldDisableDoneButton)
+    }
+
+    func trackEventsOnDoneButtonPressed() {
+        if name.isNotEmpty {
+            analytics.track(.addCustomAmountNameAdded)
+        }
+
+        if percentage.isNotEmpty {
+            analytics.track(.addCustomAmountPercentageAdded)
+        }
+
+        analytics.track(.addCustomAmountDoneButtonTapped)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -17,7 +17,7 @@ final class AddCustomAmountViewModel: ObservableObject {
         currencyFormatter.formatAmount(baseAmountForPercentage) ?? ""
     }
 
-    var showPercentageInput: Bool {
+    var shouldShowPercentageInput: Bool {
         baseAmountForPercentage > 0
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -51,9 +51,7 @@ final class AddCustomAmountViewModel: ObservableObject {
 
             guard percentage.isNotEmpty else { return formattableAmountTextFieldViewModel.reset() }
 
-            guard let decimalInput = currencyFormatter.convertToDecimal(percentage) else { return }
-
-            formattableAmountTextFieldViewModel.presetAmount("\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)")
+            presetAmountBasedOnPercentage(percentage)
         }
     }
 
@@ -101,6 +99,12 @@ private extension AddCustomAmountViewModel {
         }
 
         analytics.track(.addCustomAmountDoneButtonTapped)
+    }
+
+    func presetAmountBasedOnPercentage(_ percentage: String) {
+        guard let decimalInput = currencyFormatter.convertToDecimal(percentage) else { return }
+
+        formattableAmountTextFieldViewModel.presetAmount("\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -8,7 +8,7 @@ typealias CustomAmountEntered = (_ amount: String, _ name: String, _ feeID: Int6
 
 final class AddCustomAmountViewModel: ObservableObject {
     let formattableAmountTextFieldViewModel: FormattableAmountTextFieldViewModel
-    var baseAmountForPercentage: Decimal
+    private var baseAmountForPercentage: Decimal
     private let onCustomAmountEntered: CustomAmountEntered
     private let analytics: Analytics
     private let currencyFormatter: CurrencyFormatter
@@ -25,7 +25,7 @@ final class AddCustomAmountViewModel: ObservableObject {
         baseAmountForPercentage > 0
     }
 
-    init(baseAmountForPercentage: Decimal,
+    init(baseAmountForPercentage: Decimal = 0,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          analytics: Analytics = ServiceLocator.analytics,
@@ -37,7 +37,7 @@ final class AddCustomAmountViewModel: ObservableObject {
         self.onCustomAmountEntered = onCustomAmountEntered
         listenToAmountChanges()
 
-        formattableAmountTextFieldViewModel.onResetAmountWithNewValue = { [weak self] in
+        formattableAmountTextFieldViewModel.onWillResetAmountWithNewValue = { [weak self] in
             self?.updateFormattableAmountWithNextPercentageChange = false
             self?.percentage = ""
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -24,8 +24,9 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
     }
 
     /// When true, the amount will be reset with the new input instead of appending.
-    /// This is useful when we want to edit the amount with a new one, otherwise we would be appending non visible decimals.
-    /// 
+    /// This is useful when we want to edit the amount with a new one from a source different than the view,
+    /// otherwise we would be appending non visible decimals on the next time we edit it.
+    ///
     private var resetAmountWithNewValue = false
 
     var amountIsValid: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -15,6 +15,7 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
 
             if resetAmountWithNewValue,
                 let newInput = amount.last {
+                onResetAmountWithNewValue?()
                 amount = String(newInput)
                 resetAmountWithNewValue = false
             }
@@ -48,6 +49,8 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
     var amountTextColor: UIColor {
         amount.isEmpty ? .textSubtle : .text
     }
+
+    var onResetAmountWithNewValue: (() -> Void)?
 
     init(locale: Locale = Locale.autoupdatingCurrent,
         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -15,7 +15,7 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
 
             if resetAmountWithNewValue,
                 let newInput = amount.last {
-                onResetAmountWithNewValue?()
+                onWillResetAmountWithNewValue?()
                 amount = String(newInput)
                 resetAmountWithNewValue = false
             }
@@ -50,7 +50,7 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
         amount.isEmpty ? .textSubtle : .text
     }
 
-    var onResetAmountWithNewValue: (() -> Void)?
+    var onWillResetAmountWithNewValue: (() -> Void)?
 
     init(locale: Locale = Locale.autoupdatingCurrent,
         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -50,10 +50,10 @@ struct OrderCustomAmountsSection: View {
         }
         .padding()
         .background(Color(.listForeground(modal: true)))
-        .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
+        .sheet(isPresented: $showAddCustomAmount, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
         })
-        .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
+        .sheet(isPresented: $viewModel.showEditCustomAmount, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -50,10 +50,10 @@ struct OrderCustomAmountsSection: View {
         }
         .padding()
         .background(Color(.listForeground(modal: true)))
-        .sheet(isPresented: $showAddCustomAmount, content: {
+        .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
         })
-        .sheet(isPresented: $viewModel.showEditCustomAmount, content: {
+        .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -197,7 +197,7 @@ final class EditableOrderViewModel: ObservableObject {
     var addCustomAmountViewModel: AddCustomAmountViewModel {
         let orderTotals = OrderTotalsCalculator(for: orderSynchronizer.order, using: self.currencyFormatter)
 
-        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
+        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: orderTotals.orderTotal as Decimal,
                                         onCustomAmountEntered: { [weak self] amount, name, feeID in
             if let feeID = feeID {
                 self?.updateFee(with: feeID, total: amount, name: name)
@@ -806,6 +806,10 @@ final class EditableOrderViewModel: ObservableObject {
         forgetTaxRate()
     }
 
+    func onDismissAddCustomAmountView() {
+        editingFee = nil
+    }
+
     func onAddCustomAmountButtonTapped() {
         analytics.track(.orderCreationAddCustomAmountTapped)
     }
@@ -908,7 +912,6 @@ extension EditableOrderViewModel {
         let shippingMethodTotal: String
 
         let shouldShowTotalCustomAmounts: Bool
-        let feesBaseAmountForPercentage: Decimal
         let customAmountsTotal: String
 
         let taxesTotal: String
@@ -956,7 +959,6 @@ extension EditableOrderViewModel {
              shippingMethodTitle: String = "",
              shippingMethodTotal: String = "",
              shouldShowTotalCustomAmounts: Bool = false,
-             feesBaseAmountForPercentage: Decimal = 0,
              customAmountsTotal: String = "0",
              taxesTotal: String = "0",
              orderTotal: String = "0",
@@ -994,7 +996,6 @@ extension EditableOrderViewModel {
             self.shippingMethodTitle = shippingMethodTitle
             self.shippingMethodTotal = currencyFormatter.formatAmount(shippingMethodTotal) ?? "0.00"
             self.shouldShowTotalCustomAmounts = shouldShowTotalCustomAmounts
-            self.feesBaseAmountForPercentage = feesBaseAmountForPercentage
             self.customAmountsTotal = currencyFormatter.formatAmount(customAmountsTotal) ?? "0.00"
             self.taxesTotal = currencyFormatter.formatAmount(taxesTotal) ?? "0.00"
             self.orderTotal = currencyFormatter.formatAmount(orderTotal) ?? "0.00"
@@ -1416,7 +1417,6 @@ private extension EditableOrderViewModel {
                                             shippingMethodTitle: shippingMethodTitle,
                                             shippingMethodTotal: order.shippingLines.first?.total ?? "0",
                                             shouldShowTotalCustomAmounts: order.fees.filter { $0.name != nil }.isNotEmpty,
-                                            feesBaseAmountForPercentage: orderTotals.feesBaseAmountForPercentage as Decimal,
                                             customAmountsTotal: orderTotals.feesTotal.stringValue,
                                             taxesTotal: order.totalTax.isNotEmpty ? order.totalTax : "0",
                                             orderTotal: order.total.isNotEmpty ? order.total : "0",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1272,21 +1272,21 @@ private extension EditableOrderViewModel {
                 guard let self = self else { return [] }
                 return fees.compactMap { fee in
                     guard !fee.isDeleted else { return nil }
-                
+
                     let orderTotals = OrderTotalsCalculator(for: self.orderSynchronizer.order, using: self.currencyFormatter)
                     return CustomAmountRowViewModel(id: fee.feeID,
-                                             name: fee.name ?? Localization.customAmountDefaultName,
-                                             total: self.currencyFormatter.formatAmount(fee.total) ?? "",
-                                             onRemoveCustomAmount: {
-                                                self.analytics.track(.orderCreationRemoveCustomAmountTapped)
-                                                self.removeFee(fee)
-                                             },
-                                             onEditCustomAmount: {
-                                                self.analytics.track(.orderCreationEditCustomAmountTapped)
-                                                self.editingFee = fee
-                                                self.showEditCustomAmount = true
-                                             })
-                    }
+                                                    name: fee.name ?? Localization.customAmountDefaultName,
+                                                    total: self.currencyFormatter.formatAmount(fee.total) ?? "",
+                                                    onRemoveCustomAmount: {
+                        self.analytics.track(.orderCreationRemoveCustomAmountTapped)
+                        self.removeFee(fee)
+                    },
+                                                    onEditCustomAmount: {
+                        self.analytics.track(.orderCreationEditCustomAmountTapped)
+                        self.editingFee = fee
+                        self.showEditCustomAmount = true
+                    })
+                }
             }
             .assign(to: &$customAmountRows)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1272,7 +1272,7 @@ private extension EditableOrderViewModel {
                 guard let self = self else { return [] }
                 return fees.compactMap { fee in
                     guard !fee.isDeleted else { return nil }
-                    
+                
                     let orderTotals = OrderTotalsCalculator(for: self.orderSynchronizer.order, using: self.currencyFormatter)
                     return CustomAmountRowViewModel(id: fee.feeID,
                                              name: fee.name ?? Localization.customAmountDefaultName,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1273,7 +1273,6 @@ private extension EditableOrderViewModel {
                 return fees.compactMap { fee in
                     guard !fee.isDeleted else { return nil }
 
-                    let orderTotals = OrderTotalsCalculator(for: self.orderSynchronizer.order, using: self.currencyFormatter)
                     return CustomAmountRowViewModel(id: fee.feeID,
                                                     name: fee.name ?? Localization.customAmountDefaultName,
                                                     total: self.currencyFormatter.formatAmount(fee.total) ?? "",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculator.swift
@@ -34,12 +34,6 @@ final class OrderTotalsCalculator {
             .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
     }
 
-    /// Base amount used to calculate percentage-based fees for an order.
-    ///
-    var feesBaseAmountForPercentage: NSDecimalNumber {
-        itemsTotal.adding(shippingTotal).adding(taxesTotal)
-    }
-
     /// Total value of all fee lines on an order.
     ///
     var feesTotal: NSDecimalNumber {
@@ -60,6 +54,12 @@ final class OrderTotalsCalculator {
         return itemsTotal.subtracting(itemsDiscountedTotal)
     }
 
+    /// Order total
+    /// 
+    var orderTotal: NSDecimalNumber {
+        itemsTotal.adding(shippingTotal).adding(feesTotal).adding(taxesTotal).subtracting(discountTotal)
+    }
+
     init(for order: Order, using currencyFormatter: CurrencyFormatter) {
         self.order = order
         self.currencyFormatter = currencyFormatter
@@ -68,7 +68,6 @@ final class OrderTotalsCalculator {
     /// Returns a copy of the order with a new, locally calculated order total.
     ///
     func updateOrderTotal() -> Order {
-        let orderTotal = itemsTotal.adding(shippingTotal).adding(feesTotal).adding(taxesTotal).subtracting(discountTotal)
         return order.copy(total: orderTotal.stringValue)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -119,20 +119,20 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertNotNil(analytics.receivedEvents.first(where: { $0 == WooAnalyticsStat.addCustomAmountNameAdded.rawValue }))
     }
 
-    func test_showPercentageInput_when_baseAmountForPercentage_is_zero_then_returns_false() {
+    func test_shouldShowPercentageInput_when_baseAmountForPercentage_is_zero_then_returns_false() {
         // When
         let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 0, onCustomAmountEntered: {_, _, _ in })
 
         // Then
-        XCTAssertFalse(viewModel.showPercentageInput)
+        XCTAssertFalse(viewModel.shouldShowPercentageInput)
     }
 
-    func test_showPercentageInput_when_baseAmountForPercentage_is_bigger_than_zero_then_returns_true() {
+    func test_shouldShowPercentageInput_when_baseAmountForPercentage_is_bigger_than_zero_then_returns_true() {
         // When
         let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 1, onCustomAmountEntered: {_, _, _ in })
 
         // Then
-        XCTAssertTrue(viewModel.showPercentageInput)
+        XCTAssertTrue(viewModel.shouldShowPercentageInput)
     }
 
     func test_percentage_then_updates_amount() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -134,6 +134,14 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldShowPercentageInput)
     }
 
+    func test_shouldShowPercentageInput_when_baseAmountForPercentage_is_negative_then_returns_false() {
+        // When
+        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: -1, onCustomAmountEntered: {_, _, _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowPercentageInput)
+    }
+
     func test_percentage_then_updates_amount() {
         // Given
         let baseAmountForPercentage = 200

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -2,7 +2,6 @@
 @testable import Yosemite
 import XCTest
 import Fakes
-import WooFoundation
 
 final class AddCustomAmountViewModelTests: XCTestCase {
     func test_shouldDisableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -2,6 +2,7 @@
 @testable import Yosemite
 import XCTest
 import Fakes
+import WooFoundation
 
 final class AddCustomAmountViewModelTests: XCTestCase {
     func test_shouldDisableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {
@@ -91,20 +92,6 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertEqual(passedFeeID, feeID)
     }
 
-    func test_reset_then_reset_values() {
-        // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
-        viewModel.preset(with: OrderFeeLine.fake().copy(feeID: 1234, name: "test", total: "10"))
-
-        // When
-        viewModel.reset()
-
-        // Then
-        XCTAssertTrue(viewModel.formattableAmountTextFieldViewModel.amount.isEmpty)
-        XCTAssertTrue(viewModel.name.isEmpty)
-        XCTAssertTrue(viewModel.shouldDisableDoneButton)
-    }
-
     func test_doneButtonPressed_when_name_is_empty_then_it_tracks_only_done_event() {
         // Given
         let analytics = MockAnalyticsProvider()
@@ -130,5 +117,35 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analytics.receivedEvents.first(where: { $0 == WooAnalyticsStat.addCustomAmountNameAdded.rawValue }))
+    }
+
+    func test_showPercentageInput_when_baseAmountForPercentage_is_zero_then_returns_false() {
+        // When
+        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 0, onCustomAmountEntered: {_, _, _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.showPercentageInput)
+    }
+
+    func test_showPercentageInput_when_baseAmountForPercentage_is_bigger_than_zero_then_returns_true() {
+        // When
+        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 1, onCustomAmountEntered: {_, _, _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.showPercentageInput)
+    }
+
+    func test_percentage_then_updates_amount() {
+        // Given
+        let baseAmountForPercentage = 200
+        let percentage = 25
+
+        // When
+        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: Decimal(baseAmountForPercentage),
+                                                 onCustomAmountEntered: {_, _, _ in })
+        viewModel.percentage = "\(percentage)"
+
+        // Then
+        XCTAssertEqual(viewModel.formattableAmountTextFieldViewModel.amount, "\(baseAmountForPercentage / 100 * percentage)")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -436,8 +436,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         let customAmountName = "Test"
 
         // When
-        viewModel.addCustomAmountViewModel.name = customAmountName
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel
+        addCustomAmountViewModel.name = customAmountName
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Then
         XCTAssertTrue(viewModel.customAmountRows.contains(where: { $0.name == customAmountName }))
@@ -501,15 +502,16 @@ final class EditableOrderViewModelTests: XCTestCase {
         let newFeeName = "Test 2"
 
         // When
-        viewModel.addCustomAmountViewModel.name = "Test"
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel
+        addCustomAmountViewModel.name = "Test"
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Check previous condition
         XCTAssertEqual(viewModel.customAmountRows.count, 1)
 
-        viewModel.addCustomAmountViewModel.preset(with: OrderFeeLine.fake().copy(feeID: viewModel.customAmountRows.first?.id ?? 0))
-        viewModel.addCustomAmountViewModel.name = newFeeName
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        addCustomAmountViewModel.preset(with: OrderFeeLine.fake().copy(feeID: viewModel.customAmountRows.first?.id ?? 0))
+        addCustomAmountViewModel.name = newFeeName
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Then
         XCTAssertEqual(viewModel.customAmountRows.first?.name, newFeeName)
@@ -813,8 +815,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         productSelectorViewModel.completeMultipleSelection()
-        viewModel.addCustomAmountViewModel.formattableAmountTextFieldViewModel.amount = "10"
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel
+        addCustomAmountViewModel.formattableAmountTextFieldViewModel.amount = "10"
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Then
         XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowTotalCustomAmounts)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -789,7 +789,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£10.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£18.50")
-        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 18.50)
 
         // When
         viewModel.saveShippingLine(nil)
@@ -799,7 +798,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£0.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
-        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
 
     func test_payment_when_custom_amount_is_added_then_section_is_updated() {
@@ -823,7 +821,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.customAmountsTotal, "£10.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£18.50")
-        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
 
     func test_payment_section_is_updated_when_coupon_line_updated() throws {
@@ -881,7 +878,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "-£5.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£3.50")
-        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 3.50)
 
         // When
         viewModel.saveShippingLine(nil)
@@ -891,7 +887,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.shippingTotal, "£0.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
-        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 8.50)
     }
 
     func test_payment_section_loading_indicator_is_enabled_while_order_syncs() {
@@ -961,7 +956,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
         XCTAssertEqual(viewModel.paymentDataViewModel.taxesTotal, "$2.50")
-        XCTAssertEqual(viewModel.paymentDataViewModel.feesBaseAmountForPercentage, 2.50)
 
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
@@ -38,12 +38,11 @@ class OrderTotalsCalculatorTests: XCTestCase {
         let firstFeeTotal = 2
         let secondFeeTotal = 8
         
-        
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let order = Order.fake().copy(shippingTotal: String(shippingTotal),
                                       totalTax: String(taxTotal),
-                                      items: [OrderItem.fake().copy(subtotal: "2.00", 
+                                      items: [OrderItem.fake().copy(subtotal: "2.00",
                                                                     total: String(firstItemTotal)),
                                               OrderItem.fake().copy(subtotal: "8.00", total: String(secondItemTotal))],
                                       fees: [OrderFeeLine.fake().copy(total: String(firstFeeTotal)), OrderFeeLine.fake().copy(total: String(secondFeeTotal))])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
@@ -31,18 +31,29 @@ class OrderTotalsCalculatorTests: XCTestCase {
     }
 
     func test_orderTotal_includes_expected_totals() {
+        let shippingTotal = 5
+        let taxTotal = 3
+        let firstItemTotal = 1
+        let secondItemTotal = 8
+        let firstFeeTotal = 2
+        let secondFeeTotal = 8
+
+
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        let order = Order.fake().copy(shippingTotal: "5.00",
-                                      totalTax: "3.00",
-                                      items: [OrderItem.fake().copy(subtotal: "2.00", total: "1.00"), OrderItem.fake().copy(subtotal: "8.00", total: "8.00")],
-                                      fees: [OrderFeeLine.fake().copy(total: "2.00"), OrderFeeLine.fake().copy(total: "8.00")])
+        let order = Order.fake().copy(shippingTotal: String(shippingTotal),
+                                      totalTax: String(taxTotal),
+                                      items: [OrderItem.fake().copy(subtotal: "2.00", 
+                                                                    total: String(firstItemTotal)),
+                                              OrderItem.fake().copy(subtotal: "8.00", total: String(secondItemTotal))],
+                                      fees: [OrderFeeLine.fake().copy(total: String(firstFeeTotal)), OrderFeeLine.fake().copy(total: String(secondFeeTotal))])
 
         // When
         let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
 
         // Then
-        XCTAssertEqual(orderTotalsCalculator.orderTotal, 27)
+        let expectedTotal = shippingTotal + taxTotal + firstItemTotal + secondItemTotal + firstFeeTotal + secondFeeTotal
+        XCTAssertEqual(orderTotalsCalculator.orderTotal, NSDecimalNumber(decimal: Decimal(expectedTotal)))
     }
 
     func test_updateOrderTotal_returns_order_with_expected_total() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
@@ -37,8 +37,8 @@ class OrderTotalsCalculatorTests: XCTestCase {
         let secondItemTotal = 8
         let firstFeeTotal = 2
         let secondFeeTotal = 8
-
-
+        
+        
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let order = Order.fake().copy(shippingTotal: String(shippingTotal),
@@ -47,10 +47,10 @@ class OrderTotalsCalculatorTests: XCTestCase {
                                                                     total: String(firstItemTotal)),
                                               OrderItem.fake().copy(subtotal: "8.00", total: String(secondItemTotal))],
                                       fees: [OrderFeeLine.fake().copy(total: String(firstFeeTotal)), OrderFeeLine.fake().copy(total: String(secondFeeTotal))])
-
+        
         // When
         let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
-
+        
         // Then
         let expectedTotal = shippingTotal + taxTotal + firstItemTotal + secondItemTotal + firstFeeTotal + secondFeeTotal
         XCTAssertEqual(orderTotalsCalculator.orderTotal, NSDecimalNumber(decimal: Decimal(expectedTotal)))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/OrderTotalsCalculatorTests.swift
@@ -30,19 +30,19 @@ class OrderTotalsCalculatorTests: XCTestCase {
         XCTAssertEqual(orderTotalsCalculator.feesTotal, 10)
     }
 
-    func test_feesBaseAmountForPercentage_includes_expected_totals() {
+    func test_orderTotal_includes_expected_totals() {
         // Given
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let order = Order.fake().copy(shippingTotal: "5.00",
                                       totalTax: "3.00",
-                                      items: [OrderItem.fake().copy(subtotal: "2.00"), OrderItem.fake().copy(subtotal: "8.00")],
+                                      items: [OrderItem.fake().copy(subtotal: "2.00", total: "1.00"), OrderItem.fake().copy(subtotal: "8.00", total: "8.00")],
                                       fees: [OrderFeeLine.fake().copy(total: "2.00"), OrderFeeLine.fake().copy(total: "8.00")])
 
         // When
         let orderTotalsCalculator = OrderTotalsCalculator(for: order, using: currencyFormatter)
 
         // Then
-        XCTAssertEqual(orderTotalsCalculator.feesBaseAmountForPercentage, 18)
+        XCTAssertEqual(orderTotalsCalculator.orderTotal, 27)
     }
 
     func test_updateOrderTotal_returns_order_with_expected_total() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11139 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After receiving some user feedback, we restore here the option of adding a custom amount (fee) via an order total percentage.

Unlike before, we consider fees part of the total when calculating percentages. The reason behind this is twofold, we want to make them real elements of an order and thus a user might want to include them when calculating percentages, and want to simplify the implementation by just taking the order total.

Apart from that, we remove with this PR the code relevant to passing the total for calculating the percentage in the previous logic.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Orders
2. Tap on + to create a new order
3. Add a product
4. Tap on Add Custom Amount
5. See that we can enter a percentage of the order total. See that we enter a percentage, and the amount is updated.
6. When tapping in Done, the custom amount is created with the percentage based amount. The event is tracked:
`🔵 Tracked add_custom_amount_percentage_added, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 214354650, AnyHashable("plan"): "business-bundle", AnyHashable("site_url"): "https://americanwootester.wpcomstaging.com", AnyHashable("was_ecommerce_trial"): false]`
7. See that you can edit the custom amount. As explained before, the order total contains now the added custom amount. If you want to re-calculate the percentage of the order total without that custom amount, the user will have to delete the custom amount first.

- See also that when the order is empty and you tap on Add Custom Amount, there's no percentage input field, as there's no order total yet.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1864060/6ed2ea39-75ae-4ea9-b19c-1e0ac65d4455




---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
