### PR TITLE
[Custom Amounts M4] Taxability

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 16.3
 -----
 - [*] Orders: users can now calculate a custom amount based on the order total percentage. [https://github.com/woocommerce/woocommerce-ios/pull/11154]
+- [*] Orders: users can now decide whether their custom amounts are taxable or not. [https://github.com/woocommerce/woocommerce-ios/pull/11156]
 
 16.2
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -534,6 +534,7 @@ extension WooAnalyticsEvent {
             static let couponsCount = "coupons_count"
             static let type = "type"
             static let usesGiftCard = "use_gift_card"
+            static let taxStatus = "tax_status"
         }
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
@@ -653,12 +654,12 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderFeeAdd(flow: Flow) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderFeeAdd, properties: [Keys.flow: flow.rawValue])
+        static func orderFeeAdd(flow: Flow, taxStatus: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderFeeAdd, properties: [Keys.flow: flow.rawValue, Keys.taxStatus: taxStatus])
         }
 
-        static func orderFeeUpdate(flow: Flow) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderFeeUpdate, properties: [Keys.flow: flow.rawValue])
+        static func orderFeeUpdate(flow: Flow, taxStatus: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderFeeUpdate, properties: [Keys.flow: flow.rawValue, Keys.taxStatus: taxStatus])
         }
 
         static func orderFeeRemove(flow: Flow) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -36,6 +36,11 @@ struct AddCustomAmountView: View {
                         .padding(.bottom, Layout.mainVerticalSpacing)
                         .renderedIf(viewModel.showPercentageInput)
 
+                        Toggle(Localization.chargeTaxesToggleTitle, isOn: $viewModel.isTaxable)
+                            .font(.title3)
+                            .foregroundColor(Color(.textSubtle))
+                            .padding(.bottom, Layout.mainVerticalSpacing)
+
                         Text(Localization.nameTitle)
                             .font(.title3)
                             .foregroundColor(Color(.textSubtle))
@@ -118,6 +123,9 @@ private extension AddCustomAmountView {
         static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
                                                              value: "Enter percentage",
                                                              comment: "Placeholder for entering an custom amount through a percentage")
+        static let chargeTaxesToggleTitle = NSLocalizedString("addCustomAmountView.chargeTaxesToggle.title",
+                                                             value: "Charge Taxes",
+                                                             comment: "Title for the charge taxes toggle in the custom amounts screen.")
     }
 
     enum AccessibilityIdentifiers {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -4,7 +4,7 @@ import UIKit
 import SwiftUI
 import Yosemite
 
-typealias CustomAmountEntered = (_ amount: String, _ name: String, _ feeID: Int64?) -> Void
+typealias CustomAmountEntered = (_ amount: String, _ name: String, _ feeID: Int64?, _ isTaxable: Bool) -> Void
 
 final class AddCustomAmountViewModel: ObservableObject {
     let formattableAmountTextFieldViewModel: FormattableAmountTextFieldViewModel
@@ -58,6 +58,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     }
 
     @Published private(set) var shouldDisableDoneButton: Bool = true
+    @Published var isTaxable: Bool = true
     private var feeID: Int64? = nil
 
     var customAmountPlaceholder: String {
@@ -73,7 +74,7 @@ final class AddCustomAmountViewModel: ObservableObject {
         trackEventsOnDoneButtonPressed()
 
         let customAmountName = name.isNotEmpty ? name : customAmountPlaceholder
-        onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName, feeID)
+        onCustomAmountEntered(formattableAmountTextFieldViewModel.amount, customAmountName, feeID, isTaxable)
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1864,7 +1864,7 @@ private extension EditableOrderViewModel {
     func addFee(with total: String, name: String? = nil, taxStatus: OrderFeeTaxStatus) {
         let feeLine = OrderFactory.newOrderFee(total: total, name: name, taxStatus: taxStatus)
         orderSynchronizer.addFee.send(feeLine)
-        analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: flow.analyticsFlow))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderFeeAdd(flow: flow.analyticsFlow, taxStatus: taxStatus.rawValue))
     }
 
     func updateFee(with id: Int64, total: String, name: String? = nil, taxStatus: OrderFeeTaxStatus) {
@@ -1874,7 +1874,7 @@ private extension EditableOrderViewModel {
 
         let updatedFee = updatingFee.copy(name: name, taxStatus: taxStatus, total: total)
         orderSynchronizer.updateFee.send(updatedFee)
-        analytics.track(event: WooAnalyticsEvent.Orders.orderFeeUpdate(flow: flow.analyticsFlow))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderFeeUpdate(flow: flow.analyticsFlow, taxStatus: taxStatus.rawValue))
     }
 
     func removeFee(_ fee: OrderFeeLine) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -7,7 +7,7 @@ import WooFoundation
 final class AddCustomAmountViewModelTests: XCTestCase {
     func test_shouldDisableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {
         // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _, _ in })
 
         // When
         viewModel.formattableAmountTextFieldViewModel.amount = "$0"
@@ -18,7 +18,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
     func test_shouldDisableDoneButton_when_there_is_no_amount_then_disables_done_button() {
         // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _ in })
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _, _ in })
 
         // When
         viewModel.formattableAmountTextFieldViewModel.amount = ""
@@ -30,7 +30,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
     func test_doneButtonPressed_when_there_is_no_name_then_passes_placeholder() {
         // Given
         var passedName: String?
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _ in
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _, _ in
             passedName = name
         })
 
@@ -41,21 +41,39 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertEqual(passedName, "Custom amount")
     }
 
-    func test_doneButtonPressed_then_passes_amount_and_name() {
+    func test_doneButtonPressed_then_isTaxable_is_true_by_default() {
+        // Given
+        var passedIsTaxable: Bool?
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { _, _, _, isTaxable in
+            passedIsTaxable = isTaxable
+        })
+
+        // When
+        viewModel.doneButtonPressed()
+
+        // Then
+        XCTAssertTrue(passedIsTaxable ?? false)
+    }
+
+    func test_doneButtonPressed_then_passes_amount_name_and_taxability() {
         // Given
         let amount = "23"
         let name = "Custom amount name"
+        let isTaxable = false
 
         var passedName: String?
         var passedAmount: String?
+        var passedIsTaxable: Bool?
 
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _ in
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _, isTaxable in
             passedAmount = amount
             passedName = name
+            passedIsTaxable = isTaxable
         })
 
         viewModel.formattableAmountTextFieldViewModel.amount = amount
         viewModel.name = name
+        viewModel.isTaxable = isTaxable
 
         // When
         viewModel.doneButtonPressed()
@@ -63,6 +81,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(passedName, name)
         XCTAssertEqual(passedAmount, amount)
+        XCTAssertEqual(passedIsTaxable, isTaxable)
     }
 
     func test_doneButtonPressed_when_a_fee_is_preset_then_passes_its_data() {
@@ -75,7 +94,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         var passedAmount: String?
         var passedFeeID: Int64?
 
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, feeID in
+        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, feeID, _ in
             passedAmount = amount
             passedName = name
             passedFeeID = feeID
@@ -97,7 +116,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
 
         // When
-        let viewModel = AddCustomAmountViewModel(analytics: WooAnalytics(analyticsProvider: analytics), onCustomAmountEntered: {_, _, _ in })
+        let viewModel = AddCustomAmountViewModel(analytics: WooAnalytics(analyticsProvider: analytics), onCustomAmountEntered: {_, _, _, _ in })
         viewModel.name = ""
         viewModel.doneButtonPressed()
 
@@ -111,7 +130,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
 
         // When
-        let viewModel = AddCustomAmountViewModel(analytics: WooAnalytics(analyticsProvider: analytics), onCustomAmountEntered: {_, _, _ in })
+        let viewModel = AddCustomAmountViewModel(analytics: WooAnalytics(analyticsProvider: analytics), onCustomAmountEntered: {_, _, _, _ in })
         viewModel.name = "test"
         viewModel.doneButtonPressed()
 
@@ -121,7 +140,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
     func test_showPercentageInput_when_baseAmountForPercentage_is_zero_then_returns_false() {
         // When
-        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 0, onCustomAmountEntered: {_, _, _ in })
+        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 0, onCustomAmountEntered: {_, _, _, _ in })
 
         // Then
         XCTAssertFalse(viewModel.showPercentageInput)
@@ -129,7 +148,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
     func test_showPercentageInput_when_baseAmountForPercentage_is_bigger_than_zero_then_returns_true() {
         // When
-        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 1, onCustomAmountEntered: {_, _, _ in })
+        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 1, onCustomAmountEntered: {_, _, _, _ in })
 
         // Then
         XCTAssertTrue(viewModel.showPercentageInput)
@@ -142,7 +161,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
         // When
         let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: Decimal(baseAmountForPercentage),
-                                                 onCustomAmountEntered: {_, _, _ in })
+                                                 onCustomAmountEntered: {_, _, _, _ in })
         viewModel.percentage = "\(percentage)"
 
         // Then

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -62,11 +62,11 @@ public enum OrderFactory {
 
     /// Creates a fee line suitable to be used within a new order.
     ///
-    public static func newOrderFee(total: String, name: String? = nil) -> OrderFeeLine {
+    public static func newOrderFee(total: String, name: String? = nil, taxStatus: OrderFeeTaxStatus = .taxable) -> OrderFeeLine {
         OrderFeeLine(feeID: 0,
                      name: name ?? "Fee",
                      taxClass: "",
-                     taxStatus: .taxable,
+                     taxStatus: taxStatus,
                      total: total,
                      totalTax: "",
                      taxes: [],


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11155 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the option to make the custom amounts taxable or not.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
With your store setup to add taxes automatically:

1. Go to Orders
2. Tap on + to add a new order
3. Tap on + Add Custom Amount
4. See that the Charge Taxes toggle appears enabled by default. Leave it like that, and add a custom amount.
5. See that taxes are added to the order regarding the custom amount.
6. Tap again on + Add Custom Amount
7. This time disable adding taxes to the custom amount. Add a custom amount.
8. See that no taxes are added to the custom amount

Check also that the tax status is added to the tracked event:

`🔵 Tracked order_fee_add, properties: [AnyHashable("plan"): "business-bundle", AnyHashable("was_ecommerce_trial"): false, **AnyHashable("tax_status"): "taxable",** AnyHashable("flow"): "creation", AnyHashable("site_url"): "https://americanwootester.wpcomstaging.com", AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 214354650]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/0e983305-5047-40a3-8829-734e0b582b96

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
