### PR TITLE
[Bundle products in order form] Allow adding a new valid bundle without changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
@@ -96,7 +96,8 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
         let configurations: [BundledProductConfiguration] = bundleItemViewModels.compactMap {
             $0.toConfiguration
         }
-        guard configurations != initialConfigurations else {
+        let isNewBundle = childItems.isEmpty
+        guard configurations != initialConfigurations || isNewBundle else {
             return
         }
         onConfigure(configurations)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
@@ -101,7 +101,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         XCTAssertEqual(configurationFromOnConfigure.quantity, 8)
     }
 
-    func test_configure_does_not_invoke_onConfigure_if_configuration_is_the_same() throws {
+    func test_configure_does_not_invoke_onConfigure_if_configuration_is_the_same_when_bundle_is_not_new() throws {
         // Given
         let product = Product.fake().copy(productID: 1, bundledItems: [
             .fake().copy(productID: 2)
@@ -110,7 +110,8 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         mockProductsRetrieval(result: .success((products: productsFromRetrieval, hasNextPage: false)))
 
         let viewModel = ConfigurableBundleProductViewModel(product: product,
-                                                           childItems: [],
+                                                           // The bundle is not new when there are non-empty child items.
+                                                           childItems: [.fake()],
                                                            stores: stores,
                                                            onConfigure: { configurations in
             // Then
@@ -124,6 +125,37 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
 
         // When
         viewModel.configure()
+    }
+
+    func test_configure_invokes_onConfigure_if_configuration_is_the_same_when_bundle_is_new() throws {
+        // Given
+        let product = Product.fake().copy(productID: 1, bundledItems: [
+            .fake().copy(productID: 2, minQuantity: 2, maxQuantity: 8, defaultQuantity: 6)
+        ])
+        let productsFromRetrieval = [1, 2].map { Product.fake().copy(productID: $0) }
+        mockProductsRetrieval(result: .success((products: productsFromRetrieval, hasNextPage: false)))
+
+        var configurationsFromOnConfigure: [BundledProductConfiguration] = []
+        let viewModel = ConfigurableBundleProductViewModel(product: product,
+                                                           // The bundle is new when there are no child items.
+                                                           childItems: [],
+                                                           stores: stores,
+                                                           onConfigure: { configurations in
+            // Then
+            configurationsFromOnConfigure = configurations
+        })
+
+        // The products are loaded async before the bundle item view models are set.
+        waitUntil {
+            viewModel.bundleItemViewModels.isNotEmpty
+        }
+
+        // When
+        viewModel.configure()
+
+        // Then the quantity is the default quantity
+        let configurationFromOnConfigure = try XCTUnwrap(configurationsFromOnConfigure.first)
+        XCTAssertEqual(configurationFromOnConfigure.quantity, 6)
     }
 
     // MARK: - Analytics


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11157

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously in the bundle configuration form, there was a check on the Done action to skip adding a new bundle product if no changes are made. The original goal for this check is to avoid a remote order sync on **an existing bundle**, but it also disables adding **a new bundle** with the default valid configuration (no changes made). This PR fixes this case so that the unsaved changes check is only made for existing bundles (with child order items).

## How

Test cases were updated/added that failed in the first place. Then, in `ConfigurableBundleProductViewModel.configure`, the logic was updated so that it doesn't early return for a new bundle when there are no outstanding changes on the configuration.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items and all items are **simple products** (so that no variation needs to be selected).

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products`, search for the bundle product in the prerequisite if needed
- Tap on the bundle product in the prerequisite
- In the configuration form, tap `Done` without making any changes --> the form should be dismissed and the bundle with the default valid configuration should be added. before this PR, the form is dismissed but the bundle product isn't added

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/6f2beeb7-fb71-41fb-ade3-67bd72c0bf1a



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.