### PR TITLE
[Bundle products in order form] Validate with bundle min/max size rules - Networking and Yosemite layer changes

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -925,6 +925,8 @@ extension Networking.Product {
             isSampleItem: .fake(),
             bundleStockStatus: .fake(),
             bundleStockQuantity: .fake(),
+            bundleMinSize: .fake(),
+            bundleMaxSize: .fake(),
             bundledItems: .fake(),
             compositeComponents: .fake(),
             subscription: .fake(),

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1254,6 +1254,8 @@ extension Networking.Product {
         isSampleItem: CopiableProp<Bool> = .copy,
         bundleStockStatus: NullableCopiableProp<ProductStockStatus> = .copy,
         bundleStockQuantity: NullableCopiableProp<Int64> = .copy,
+        bundleMinSize: NullableCopiableProp<Decimal> = .copy,
+        bundleMaxSize: NullableCopiableProp<Decimal> = .copy,
         bundledItems: CopiableProp<[ProductBundleItem]> = .copy,
         compositeComponents: CopiableProp<[ProductCompositeComponent]> = .copy,
         subscription: NullableCopiableProp<ProductSubscription> = .copy,
@@ -1328,6 +1330,8 @@ extension Networking.Product {
         let isSampleItem = isSampleItem ?? self.isSampleItem
         let bundleStockStatus = bundleStockStatus ?? self.bundleStockStatus
         let bundleStockQuantity = bundleStockQuantity ?? self.bundleStockQuantity
+        let bundleMinSize = bundleMinSize ?? self.bundleMinSize
+        let bundleMaxSize = bundleMaxSize ?? self.bundleMaxSize
         let bundledItems = bundledItems ?? self.bundledItems
         let compositeComponents = compositeComponents ?? self.compositeComponents
         let subscription = subscription ?? self.subscription
@@ -1403,6 +1407,8 @@ extension Networking.Product {
             isSampleItem: isSampleItem,
             bundleStockStatus: bundleStockStatus,
             bundleStockQuantity: bundleStockQuantity,
+            bundleMinSize: bundleMinSize,
+            bundleMaxSize: bundleMaxSize,
             bundledItems: bundledItems,
             compositeComponents: compositeComponents,
             subscription: subscription,

--- a/Networking/Networking/Model/Product/AIProduct.swift
+++ b/Networking/Networking/Model/Product/AIProduct.swift
@@ -189,6 +189,8 @@ public extension Product {
                   isSampleItem: false,
                   bundleStockStatus: nil,
                   bundleStockQuantity: nil,
+                  bundleMinSize: nil,
+                  bundleMaxSize: nil,
                   bundledItems: [],
                   compositeComponents: [],
                   subscription: nil,

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -96,6 +96,12 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     /// Quantity of bundles left in stock, taking bundled product quantity requirements into account. Applicable for bundle-type products only.
     public let bundleStockQuantity: Int64?
 
+    /// Optional min bundle size (total number of bundle items) used in bundle configuration. Applicable for bundle-type products only.
+    public let bundleMinSize: Decimal?
+
+    /// Optional max bundle size (total number of bundle items) used in bundle configuration. Applicable for bundle-type products only.
+    public let bundleMaxSize: Decimal?
+
     /// List of bundled item data contained in this product.
     public let bundledItems: [ProductBundleItem]
 
@@ -242,6 +248,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 isSampleItem: Bool,
                 bundleStockStatus: ProductStockStatus?,
                 bundleStockQuantity: Int64?,
+                bundleMinSize: Decimal?,
+                bundleMaxSize: Decimal?,
                 bundledItems: [ProductBundleItem],
                 compositeComponents: [ProductCompositeComponent],
                 subscription: ProductSubscription?,
@@ -315,6 +323,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         self.isSampleItem = isSampleItem
         self.bundleStockStatus = bundleStockStatus
         self.bundleStockQuantity = bundleStockQuantity
+        self.bundleMinSize = bundleMinSize
+        self.bundleMaxSize = bundleMaxSize
         self.bundledItems = bundledItems
         self.compositeComponents = compositeComponents
         self.subscription = subscription
@@ -518,6 +528,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let bundleStockStatus = container.failsafeDecodeIfPresent(ProductStockStatus.self, forKey: .bundleStockStatus)
         // When the bundle stock quantity is not set for a product bundle, the API returns an empty string and the value will be `nil`.
         let bundleStockQuantity = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleStockQuantity)
+        let bundleMinSize = container.failsafeDecodeIfPresent(decimalForKey: .bundleMinSize)
+        let bundleMaxSize = container.failsafeDecodeIfPresent(decimalForKey: .bundleMaxSize)
         let bundledItems = try container.decodeIfPresent([ProductBundleItem].self, forKey: .bundledItems) ?? []
 
         // Composite Product properties
@@ -603,6 +615,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                   isSampleItem: isSampleItem,
                   bundleStockStatus: bundleStockStatus,
                   bundleStockQuantity: bundleStockQuantity,
+                  bundleMinSize: bundleMinSize,
+                  bundleMaxSize: bundleMaxSize,
                   bundledItems: bundledItems,
                   compositeComponents: compositeComponents,
                   subscription: subscription,
@@ -811,6 +825,8 @@ private extension Product {
 
         case bundleStockStatus              = "bundle_stock_status"
         case bundleStockQuantity            = "bundle_stock_quantity"
+        case bundleMinSize                  = "bundle_min_size"
+        case bundleMaxSize                  = "bundle_max_size"
         case bundledItems                   = "bundled_items"
 
         case compositeComponents    = "composite_components"

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -321,6 +321,8 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(product.bundleStockStatus, .insufficientStock)
         XCTAssertEqual(product.bundleStockQuantity, 0)
         XCTAssertEqual(product.bundledItems.count, 3)
+        XCTAssertEqual(product.bundleMinSize, 3)
+        XCTAssertNil(product.bundleMaxSize)
 
         // Check parsed ProductBundleItem properties
         XCTAssertEqual(bundledItem.bundledItemID, 6)

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -44,7 +44,7 @@ final class ProductsRemoteTests: XCTestCase {
         }
 
         // Then
-        let expectedProduct = Product(siteID: sampleSiteID,
+        let expectedProduct = Product.fake().copy(siteID: sampleSiteID,
                                       productID: 3007,
                                       name: "Product",
                                       slug: "product",
@@ -157,7 +157,7 @@ final class ProductsRemoteTests: XCTestCase {
         }
 
         // Then
-        let expectedProduct = Product(siteID: sampleSiteID,
+        let expectedProduct = Product.fake().copy(siteID: sampleSiteID,
                                       productID: 3007,
                                       name: "Product",
                                       slug: "product",
@@ -717,7 +717,7 @@ final class ProductsRemoteTests: XCTestCase {
 private extension ProductsRemoteTests {
 
     func sampleProduct() -> Product {
-        return Product(siteID: sampleSiteID,
+        Product.fake().copy(siteID: sampleSiteID,
                        productID: sampleProductID,
                        name: "Book the Green Room",
                        slug: "book-the-green-room",

--- a/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
@@ -71,6 +71,8 @@ extension Product {
                 isSampleItem: false,
                 bundleStockStatus: nil,
                 bundleStockQuantity: nil,
+                bundleMinSize: nil,
+                bundleMaxSize: nil,
                 bundledItems: [],
                 compositeComponents: [],
                 subscription: nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -98,6 +98,8 @@ private extension ProductFactory {
                 isSampleItem: false,
                 bundleStockStatus: nil,
                 bundleStockQuantity: nil,
+                bundleMinSize: nil,
+                bundleMaxSize: nil,
                 bundledItems: [],
                 compositeComponents: [],
                 subscription: nil,

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -51,7 +51,7 @@ final class MockReviews {
 extension MockReviews {
     func product(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? self.siteID
-        return Product(siteID: testSiteID,
+        return Product.fake().copy(siteID: testSiteID,
                        productID: productID,
                        name: productName,
                        slug: "book-the-green-room",
@@ -207,7 +207,7 @@ extension MockReviews {
     func sampleProductMutated(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? self.siteID
 
-        return Product(siteID: testSiteID,
+        return Product.fake().copy(siteID: testSiteID,
                        productID: productID,
                        name: productName,
                        slug: "book-the-green-room",
@@ -343,7 +343,7 @@ extension MockReviews {
 
     func sampleVariationTypeProduct(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? self.siteID
-        return Product(siteID: testSiteID,
+        return Product.fake().copy(siteID: testSiteID,
                        productID: sampleVariationTypeProductID,
                        name: "Paper Airplane - Black, Long",
                        slug: "paper-airplane-3",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -102,7 +102,7 @@ private extension Product_ProductFormTests {
     }
 
     func sampleProduct(description: String? = "", shortDescription: String? = "", categories: [ProductCategory] = []) -> Product {
-        return Product(siteID: sampleSiteID,
+        Product.fake().copy(siteID: sampleSiteID,
                        productID: 177,
                        name: "Book the Green Room",
                        slug: "book-the-green-room",

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -314,6 +314,8 @@ extension MockObjectGraph {
             isSampleItem: false,
             bundleStockStatus: nil,
             bundleStockQuantity: nil,
+            bundleMinSize: nil,
+            bundleMaxSize: nil,
             bundledItems: [],
             compositeComponents: [],
             subscription: nil,

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -83,6 +83,8 @@ extension Storage.Product: ReadOnlyConvertible {
         backordered = product.backordered
         bundleStockQuantity = product.bundleStockQuantity as? NSNumber
         bundleStockStatus = product.bundleStockStatus?.rawValue
+        bundleMinSize = product.bundleMinSize as? NSDecimalNumber
+        bundleMaxSize = product.bundleMaxSize as? NSDecimalNumber
         minAllowedQuantity = product.minAllowedQuantity
         maxAllowedQuantity = product.maxAllowedQuantity
         groupOfQuantity = product.groupOfQuantity
@@ -181,6 +183,8 @@ extension Storage.Product: ReadOnlyConvertible {
                        isSampleItem: isSampleItem,
                        bundleStockStatus: productBundleStockStatus,
                        bundleStockQuantity: bundleStockQuantity as? Int64,
+                       bundleMinSize: bundleMinSize?.decimalValue,
+                       bundleMaxSize: bundleMaxSize?.decimalValue,
                        bundledItems: bundledItemsArray.map { $0.toReadOnly() },
                        compositeComponents: compositeComponentsArray.map { $0.toReadOnly() },
                        subscription: subscription?.toReadOnly(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11159 
⚠️ Please review https://github.com/woocommerce/woocommerce-ios/pull/11161 first
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In previous development, I missed two bundle rules for validation - bundle min/max size (the total number of bundle items). These two values are in the product's `bundle_min_size` and `bundle_max_size` fields in the API. After the schema updates in https://github.com/woocommerce/woocommerce-ios/pull/11161, this PR includes the Networking and Yosemite layer changes to persist the values from the API response.

<img width="939" alt="Screenshot 2023-11-15 at 4 24 47 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/587687e9-1c2e-4a24-b059-c39482facef3">

## How

### Networking layer

Added `bundleMinSize` and `bundleMaxSize` Decimal properties to `Product`, which are parsed from the response's `bundle_min_size` and `bundle_max_size` fields respectively. These values are optional, the value is an empty string when the bundle size rule is not set for the bundle product.

A few diffs are required due to the new properties in `Product` in the app layer and unit tests.

### Yosemite layer

In `Product+ReadOnlyConvertible`, the bundle size rules are persisted and retrieved between the network and storage layers.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient, as the new properties aren't used in the app.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
