### PR TITLE
[Payments Menu] Enable showSupport from Pay in Person info

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -20,8 +20,8 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
         hidesBottomBarWhenPushed = true
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         createZendeskIdentity()
     }
 
@@ -268,4 +268,16 @@ struct SupportFormProvider: PreviewProvider {
             ]))
         }
     }
+}
+
+struct HostedSupportForm: UIViewControllerRepresentable {
+    typealias UIViewControllerType = SupportFormHostingController
+
+    let viewModel: SupportFormViewModel
+
+    func makeUIViewController(context: Context) -> SupportFormHostingController {
+        SupportFormHostingController(viewModel: viewModel)
+    }
+
+    func updateUIViewController(_ uiViewController: SupportFormHostingController, context: Context) { }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -135,6 +135,10 @@ struct InPersonPaymentsMenu: View {
 
             if let onboardingNotice = viewModel.cardPresentPaymentsOnboardingNotice {
                 PermanentNoticeView(notice: onboardingNotice)
+                LazyNavigationLink(destination: HostedSupportForm(viewModel: .init()),
+                                   isActive: $viewModel.presentSupport) {
+                    EmptyView()
+                }
             }
         }
         .task {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -21,6 +21,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var presentSetUpTryOutTapToPay: Bool = false
     @Published var presentTapToPayFeedback: Bool = false
     @Published var safariSheetURL: URL? = nil
+    @Published var presentSupport: Bool = false
 
     var shouldAlwaysHideSetUpButtonOnAboutTapToPay: Bool = false
 
@@ -129,6 +130,9 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
         let onboardingViewModel = InPersonPaymentsViewModel(useCase: onboardingUseCase)
         onboardingViewModel.showURL = { [weak self] url in
             self?.safariSheetURL = url
+        }
+        onboardingViewModel.showSupport = { [weak self] in
+            self?.presentSupport = true
         }
         return onboardingViewModel
     }()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11146
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

During the Payments Menu rewrite we realised that the Contact Support link on the Pay in Person onboarding screen had stopped working.

This PR re-introduces that functionality

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Turn off Pay in Person on your test store (`Menu > Payments > Pay in Person toggle`)
2. Delete the app from your phone
3. Launch the app from Xcode
4. Navigate to `Menu > Settings > Experimental Features` and turn on `New Payments Menu`
5. Navigate to the Payments menu
6. When the background onboarding notice shows, tap `Continue Setup`
7. Complete any prompts to get you to the `Enable Pay in Person` prompt
8. Tap `Contact us`
9. Observe that the Support screen is pushed, and you're prompted to set a name and email (don't set it yet)
10. Navigate to `Menu > Settings > Help and Support > Contact Support`
11. Observe that the Support screen is pushed and you're still prompted to set a name and email.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/b8f11e55-de8a-454b-9b0c-2cbcdeaa8993



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
