### PR TITLE
Fix missing login tags when creating support tickets

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -109,9 +109,6 @@ class AuthenticationManager: Authentication {
     /// Handles an Authentication URL Callback. Returns *true* on success.
     ///
     func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
-        let source = options[.sourceApplication] as? String
-        let annotation = options[.annotation]
-
         if WordPressAuthenticator.shared.isWordPressAuthUrl(url) {
             return WordPressAuthenticator.shared.handleWordPressAuthUrl(url,
                                                                         rootViewController: rootViewController)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -443,13 +443,13 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     func presentSupport(from sourceViewController: UIViewController, screen: CustomHelpCenterContent.Screen) {
         let customHelpCenterContent = CustomHelpCenterContent(screen: screen,
                                                               flow: AuthenticatorAnalyticsTracker.shared.state.lastFlow)
-        presentSupport(from: sourceViewController, customHelpCenterContent: customHelpCenterContent)
+        presentHelpAndSupport(from: sourceViewController, customHelpCenterContent: customHelpCenterContent, sourceTag: nil)
     }
 
     /// Presents the Support Interface from a given ViewController, with a specified SourceTag.
     ///
     func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
-        presentSupport(from: sourceViewController)
+        presentHelpAndSupport(from: sourceViewController, sourceTag: sourceTag)
     }
 
     /// Presents the Support Interface from a given ViewController.
@@ -465,17 +465,17 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                         lastStep: AuthenticatorAnalyticsTracker.Step,
                         lastFlow: AuthenticatorAnalyticsTracker.Flow) {
         guard let customHelpCenterContent = CustomHelpCenterContent(step: lastStep, flow: lastFlow) else {
-            presentSupport(from: sourceViewController)
+            presentSupport(from: sourceViewController, sourceTag: sourceTag)
             return
         }
 
-        presentSupport(from: sourceViewController, customHelpCenterContent: customHelpCenterContent)
+        presentHelpAndSupport(from: sourceViewController, customHelpCenterContent: customHelpCenterContent, sourceTag: sourceTag)
     }
 
     /// Presents the Support new request, from a given ViewController, with a specified SourceTag.
     ///
     func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
-        let supportForm = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag.name))
+        let supportForm = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag.origin))
         supportForm.show(from: sourceViewController)
     }
 
@@ -912,8 +912,9 @@ private extension AuthenticationManager {
 // MARK: - Help and support helpers
 private extension AuthenticationManager {
 
-    func presentSupport(from sourceViewController: UIViewController,
-                        customHelpCenterContent: CustomHelpCenterContent? = nil) {
+    func presentHelpAndSupport(from sourceViewController: UIViewController,
+                               customHelpCenterContent: CustomHelpCenterContent? = nil,
+                               sourceTag: WordPressSupportSourceTag?) {
         let identifier = HelpAndSupportViewController.classNameWithoutNamespaces
         let supportViewController = UIStoryboard.dashboard.instantiateViewController(identifier: identifier,
                                                                                      creator: { coder -> HelpAndSupportViewController? in
@@ -924,7 +925,7 @@ private extension AuthenticationManager {
                 return nil
             }
 
-            return HelpAndSupportViewController(customHelpCenterContent: customHelpCenterContent, coder: coder)
+            return HelpAndSupportViewController(customHelpCenterContent: customHelpCenterContent, sourceTag: sourceTag?.origin, coder: coder)
         })
         supportViewController.displaysDismissAction = true
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -61,13 +61,19 @@ final class HelpAndSupportViewController: UIViewController {
     ///
     private let customHelpCenterContent: CustomHelpCenterContent?
 
-    init?(customHelpCenterContent: CustomHelpCenterContent, coder: NSCoder) {
+    /// Source tag from where this request was originated.
+    ///
+    private let sourceTag: String?
+
+    init?(customHelpCenterContent: CustomHelpCenterContent, sourceTag: String? = nil, coder: NSCoder) {
         self.customHelpCenterContent = customHelpCenterContent
+        self.sourceTag = sourceTag
         super.init(coder: coder)
     }
 
     required init?(coder: NSCoder) {
         self.customHelpCenterContent = nil
+        self.sourceTag = nil
         super.init(coder: coder)
     }
 
@@ -306,7 +312,7 @@ private extension HelpAndSupportViewController {
     /// Contact Support action
     ///
     func contactSupportWasPressed() {
-        let viewController = SupportFormHostingController(viewModel: .init())
+        let viewController = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag))
         viewController.show(from: self)
     }
 


### PR DESCRIPTION
Closes: #10939

# Why 

It was reported that login origin tags were not being set creating support request tickets. 

This seemed to have happened when we added the "Help Center" screen which is an intermediary screen between the CTA action and the support form screen.

This PR fixes this issue by passing the provided "sourceTag" from the Auth library through the `HelpAndSupportViewController` to then reach the `SupportForm`.

# Screenshots

<img width="919" alt="Screenshot 2023-11-15 at 2 19 17 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/f88056c8-8a86-40b8-8581-4f978b7b9150">

# Testing Steps

- Create a support ticket while trying to log in into the app.
- Look for that support ticket on zendesk
- See that the support ticket contains a tag with the format `origin:{login-screen}`

PS: Please make sure to close the ticket after you have created it. You may need to set yourself as light-agent first.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
