### PR TITLE
[Bundle products in order form] Validate with bundle min/max size rules

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
@@ -30,9 +30,9 @@ struct ConfigurableBundleProductView: View {
                     }
                     .redacted(reason: .placeholder)
                     .shimmering()
-                    .renderedIf(viewModel.bundleItemViewModels.isEmpty && viewModel.errorMessage == nil)
+                    .renderedIf(viewModel.bundleItemViewModels.isEmpty && viewModel.loadProductsErrorMessage == nil)
 
-                    if let errorMessage = viewModel.errorMessage {
+                    if let errorMessage = viewModel.loadProductsErrorMessage {
                         Group {
                             Text(errorMessage)
                                 .errorStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
@@ -14,6 +14,26 @@ struct ConfigurableBundleProductView: View {
         NavigationView {
             ScrollView {
                 VStack(spacing: Layout.noSpacing) {
+                    if let validationErrorMessage = viewModel.validationErrorMessage {
+                        Group {
+                            Text(validationErrorMessage)
+                                .errorStyle()
+                        }
+                        .padding()
+                    }
+
+                    if let loadProductsErrorMessage = viewModel.loadProductsErrorMessage {
+                        Group {
+                            Text(loadProductsErrorMessage)
+                                .errorStyle()
+                            Button(Localization.retry) {
+                                viewModel.retry()
+                            }
+                            .buttonStyle(PrimaryButtonStyle())
+                        }
+                        .padding()
+                    }
+
                     ForEach(viewModel.bundleItemViewModels) { bundleItemViewModel in
                         ConfigurableBundleItemView(viewModel: bundleItemViewModel)
                         Divider()
@@ -31,18 +51,6 @@ struct ConfigurableBundleProductView: View {
                     .redacted(reason: .placeholder)
                     .shimmering()
                     .renderedIf(viewModel.bundleItemViewModels.isEmpty && viewModel.loadProductsErrorMessage == nil)
-
-                    if let errorMessage = viewModel.loadProductsErrorMessage {
-                        Group {
-                            Text(errorMessage)
-                                .errorStyle()
-                            Button(Localization.retry) {
-                                viewModel.retry()
-                            }
-                            .buttonStyle(PrimaryButtonStyle())
-                        }
-                        .padding()
-                    }
                 }
                 .background(Color(.listForeground(modal: false)))
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
@@ -28,7 +28,7 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
     // TODO: 10428 - only enable configure CTA when all bundle items are configured
     @Published private(set) var isConfigureEnabled: Bool = true
 
-    @Published private(set) var errorMessage: String?
+    @Published private(set) var loadProductsErrorMessage: String?
 
     /// View models for placeholder rows.
     let placeholderItemViewModels: [ConfigurableBundleItemViewModel]
@@ -111,7 +111,7 @@ final class ConfigurableBundleProductViewModel: ObservableObject, Identifiable {
 
 private extension ConfigurableBundleProductViewModel {
     func loadProductsAndCreateItemViewModels() {
-        errorMessage = nil
+        loadProductsErrorMessage = nil
 
         Task { @MainActor in
             do {
@@ -120,7 +120,7 @@ private extension ConfigurableBundleProductViewModel {
                 createItemViewModels(products: products)
             } catch {
                 DDLogError("⛔️ Error loading products for bundle product items in order form: \(error)")
-                errorMessage = Localization.errorLoadingProducts
+                loadProductsErrorMessage = Localization.errorLoadingProducts
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
@@ -36,7 +36,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.errorMessage != nil
+            viewModel.loadProductsErrorMessage != nil
         }
     }
 
@@ -53,7 +53,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
                                                            stores: stores,
                                                            onConfigure: { _ in })
         waitUntil {
-            viewModel.errorMessage != nil
+            viewModel.loadProductsErrorMessage != nil
         }
         let productsFromRetrieval = [1, 2].map { Product.fake().copy(productID: $0) }
         mockProductsRetrieval(result: .success((products: productsFromRetrieval, hasNextPage: false)))
@@ -61,7 +61,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.errorMessage == nil
+            viewModel.loadProductsErrorMessage == nil
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11159
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In previous development, I missed two bundle rules for validation - bundle min/max size (the total number of bundle items) as in the screenshot below. This PR adds a validation check on the bundle size, and displays an error message based on the optional min/max rules.

<img width="939" alt="Screenshot 2023-11-15 at 4 24 47 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/587687e9-1c2e-4a24-b059-c39482facef3">

## How

The previous `ConfigurableBundleProductViewModel.errorMessage` was renamed to `ConfigurableBundleProductViewModel.loadProductsErrorMessage`, and a new error message `validationErrorMessage` was added.

When validating the bundle, it first checks the bundle size if there are any rules on the min/max size. If an error occurs, `validationErrorMessage` is set based on the optional min/max bundle size values. The logic is a bit complicated because we have to also consider pluralization and different combinations of the min/max bundle sizes.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/), and also a bundle product with non-empty items.

### Bundle size is smaller than the minimum

- In wp-admin, update the bundle product in the prerequisite to have a `Min bundle size` without a `Max bundle size` - set it to a value so that it's possible for the minimum quantity of bundle items to reach a size smaller than this value
- In the app, go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product
- In the Configure form, update the item quantity if needed so that the total bundle size is smaller than the minimum
- Tap `Done` --> a validation error should be shown that mentions the minimum bundle size
- Update the item quantity so that it's not smaller than the minimum
- Tap `Done` --> the bundle should be added

### Bundle size is greater than the maximum

- In wp-admin, update the bundle product in the prerequisite to have a `Max bundle size` without a `Min bundle size` - set it to a value so that it's possible for the maximum quantity of bundle items to reach a size greater than this value
- In the app, go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product
- In the Configure form, update the item quantity if needed so that the total bundle size is greater than the maximum
- Tap `Done` --> a validation error should be shown that mentions the max bundle size
- Update the item quantity so that it's not greater than the maximum
- Tap `Done` --> the bundle should be added

### Bundle size is not within range

- In wp-admin, update the bundle product in the prerequisite to have a `Max bundle size` and a `Min bundle size` - set it to values so that it's possible for the minimum/maximum quantity of bundle items to go in and out of range
- In the app, go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product
- In the Configure form, update the item quantity if needed so that the total bundle size goes out of range
- Tap `Done` --> a validation error should be shown that mentions the min & max bundle size
- Update the item quantity so that the bundle size is within range
- Tap `Done` --> the bundle should be added

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

min/max range | min/max are the same | min only | max only
-- | -- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/7798b451-fbd8-4cdf-82a0-56f186fda6ef" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/236eded1-5492-4225-91ac-ac08c8ebf0db" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/929ca28d-19e4-407c-9466-7bb2d1db3954" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/9f16b2fd-5823-446f-8fb5-1dc7f6c5a55f" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
