### PR TITLE
[Custom Amounts M4] Hide tax rate row

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -318,9 +318,19 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     @Published var configurableProductViewModel: ConfigurableBundleProductViewModel? = nil
 
+    /// Whether the user tan select a new tax rate.
+    /// The User can change the tax rate by changing the customer address if:
+    ///
+    /// 1-. The 'Tax based on' setting is based on shipping or billing addresses.
+    /// 2-. The initial stored tax rate finished applying.
+    ///
+    private var canChangeTaxRate = false
+
     /// Whether it should show the tax rate selector
     ///
-    @Published private(set) var shouldShowNewTaxRateSection: Bool = false
+    var shouldShowNewTaxRateSection: Bool {
+        (orderSynchronizer.order.items.isNotEmpty || orderSynchronizer.order.fees.isNotEmpty) && canChangeTaxRate
+    }
 
     /// Keeps track of selected/unselected Products, if any
     ///
@@ -1523,8 +1533,7 @@ private extension EditableOrderViewModel {
                             await self.applySelectedStoredTaxRateIfAny()
                         }
 
-                        // Show the tax rate section once we know if any stored tax rate applies, as it can change the text
-                        self.shouldShowNewTaxRateSection = true
+                        self.canChangeTaxRate = true
                     }
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -318,7 +318,7 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     @Published var configurableProductViewModel: ConfigurableBundleProductViewModel? = nil
 
-    /// Whether the user tan select a new tax rate.
+    /// Whether the user can select a new tax rate.
     /// The User can change the tax rate by changing the customer address if:
     ///
     /// 1-. The 'Tax based on' setting is based on shipping or billing addresses.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11180
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we hide the "Set up tax rate" row until there are items or custom amounts in the order.  With this, we want to keep the initial state of the new order screen as simple as possible.

See the testing instructions for exact cases.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Tax based on Customer Shipping/Billing Address

Go to `wp-admin/admin.php?page=wc-settings&tab=tax` and ensure that the _Calculate tax based on_ setting is one of the above.

1. Go Orders
2. Tap on + to create a new order
3. See that the Set up new tax rate row is hidden
4. Add a product
5. See that the Set up new tax rate row is shown

Repeat with custom amount

https://github.com/woocommerce/woocommerce-ios/assets/1864060/1fc6911f-a835-4497-ac08-22373994a146

### Tax based on Shop Address

Go to `wp-admin/admin.php?page=wc-settings&tab=tax` and ensure that the _Calculate tax based on_ setting is _Shop Base Address_. Save changes

1. Go Orders
2. Tap on + to create a new order
3. See that the Set up new tax rate row is hidden
4. Add a product
5. See that the Set up new tax rate row is still hidden

Repeat with custom amount

https://github.com/woocommerce/woocommerce-ios/assets/1864060/e8d3866c-1ed1-4fe0-8616-2787159032f3

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
