### PR TITLE
[Bundle products in order form] Fix: updating the bundle product quantity doesn’t update the children’s quantity

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1653,6 +1653,7 @@ private extension EditableOrderViewModel {
     /// If the referenced product can't be found, `nil` is returned.
     ///
     private func createUpdateProductInput(item: OrderItem,
+                                          childItems: [OrderItem] = [],
                                           quantity: Decimal,
                                           discount: Decimal? = nil,
                                           bundleConfiguration: [BundledProductConfiguration] = []) -> OrderSyncProductInput? {
@@ -1672,6 +1673,40 @@ private extension EditableOrderViewModel {
         guard let product = product else {
             DDLogError("⛔️ Product with ID: \(item.productID) not found.")
             return nil
+        }
+
+        // When updating a bundle product's quantity while there are no bundle configuration updates from the configuration form,
+        // the bundle configuration needs to be populated in order for the quantity of child order items to be updated.
+        // The bundle configuration is deduced from the product's bundle items, existing child order items, and the bundle order item itself.
+        if case let .product(productValue) = product,
+            productValue.productType == .bundle && item.quantity != quantity && bundleConfiguration.isEmpty {
+            let bundleConfiguration: [BundledProductConfiguration] = productValue.bundledItems
+                .compactMap { bundleItem -> BundledProductConfiguration? in
+                    guard let existingOrderItem = childItems.first(where: { $0.productID == bundleItem.productID }) else {
+                        return nil
+                    }
+                    let attributes = existingOrderItem.attributes
+                        .map { ProductVariationAttribute(id: $0.metaID, name: $0.name, option: $0.value) }
+                    let productOrVariation: BundledProductConfiguration.ProductOrVariation = existingOrderItem.variationID == 0 ?
+                        .product(id: existingOrderItem.productID): .variation(productID: existingOrderItem.productID,
+                                                                              variationID: existingOrderItem.variationID,
+                                                                              attributes: attributes)
+                    // The quantity per bundle: as a buggy behavior in Pe5pgL-3Vd-p2#quantity-of-bundle-child-order-items, the child item quantity
+                    // can either by multiplied by the bundle quantity or not. To encounter for the edge case, the quantity is only divided by
+                    // the bundle quantity if the child item has at least the same quantity as the bundle.
+                    let quantity = existingOrderItem.quantity >= item.quantity ?
+                    existingOrderItem.quantity * 1.0 / item.quantity: existingOrderItem.quantity
+                    return .init(bundledItemID: bundleItem.bundledItemID,
+                                 productOrVariation: productOrVariation,
+                                 quantity: quantity,
+                                 isOptionalAndSelected: bundleItem.isOptional ? true: nil)
+                }
+            return OrderSyncProductInput(id: item.itemID,
+                                         product: product,
+                                         quantity: quantity,
+                                         discount: discount ?? currentDiscount(on: item),
+                                         baseSubtotal: baseSubtotal(on: item),
+                                         bundleConfiguration: bundleConfiguration)
         }
 
         // Return a new input with the new quantity but with the same item id to properly reference the update.
@@ -1764,8 +1799,14 @@ private extension EditableOrderViewModel {
             // Observe changes to the product quantity
             productRowViewModel.$quantity
                 .dropFirst() // Omit the default/initial quantity to prevent a double trigger.
+                // The quantity can be incremented/decremented quickly, and the order sync can be blocking (e.g. with bundle configuration).
+                // To avoid the UI being blocked for each quantity update, a debounce is added to wait for the final quantity
+                // within a 0.5 time frame.
+                .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
                 .sink { [weak self] newQuantity in
-                    guard let self = self, let newInput = self.createUpdateProductInput(item: item, quantity: newQuantity) else {
+                    guard let self else { return }
+                    let childItems = items.filter { $0.parent == item.itemID }
+                    guard let newInput = self.createUpdateProductInput(item: item, childItems: childItems, quantity: newQuantity) else {
                         return
                     }
                     self.orderSynchronizer.setProduct.send(newInput)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -359,8 +359,8 @@ private extension RemoteOrderSynchronizer {
                 $0.orderID != .zero
             }
             .handleEvents(receiveOutput: { order in
-                // Set a `blocking` state if the order contains new lines
-                self.state = .syncing(blocking: order.containsLocalLines())
+                // Set a `blocking` state if the order contains new lines or bundle configurations.
+                self.state = .syncing(blocking: order.containsLocalLines() || order.containsBundleConfigurations())
             })
             .debounce(for: 1.0, scheduler: DispatchQueue.main) // Group & wait for 1.0 since the last signal was emitted.
             .map { [weak self] order -> AnyPublisher<Order, Never> in // Allow multiple requests, once per update request.
@@ -556,5 +556,11 @@ private extension Order {
             return item.copy(itemID: .zero, subtotal: "", total: "")
         }
         return copy(items: sanitizedItems)
+    }
+
+    /// Returns true if the order contains any items with bundle configuration updates.
+    ///
+    func containsBundleConfigurations() -> Bool {
+        items.map { $0.bundleConfiguration.isNotEmpty }.contains(true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -19,7 +19,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager = MockStorageManager()
         viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                            stores: stores,
-                                           storageManager: storageManager)
+                                           storageManager: storageManager,
+                                           quantityDebounceDuration: 0)
     }
 
     // MARK: - Initialization
@@ -321,6 +322,59 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product.productID }))
+    }
+
+    func test_bundle_order_item_with_child_items_includes_bundle_configuration_when_quantity_is_incremented() throws {
+        // Given
+        let bundledProduct = Product.fake().copy(siteID: sampleSiteID, productID: 665, productTypeKey: ProductType.simple.rawValue)
+        let bundleItem = ProductBundleItem.fake().copy(bundledItemID: 1, productID: bundledProduct.productID)
+        let bundleProduct = Product.fake().copy(siteID: sampleSiteID,
+                                                productID: 600,
+                                                productTypeKey: ProductType.bundle.rawValue,
+                                                bundledItems: [
+                                                    bundleItem
+                                                ])
+        // Inserts necessary objects to storage.
+        storageManager.insertSampleProduct(readOnlyProduct: bundledProduct)
+        let storageBundleProduct = storageManager.insertSampleProduct(readOnlyProduct: bundleProduct)
+        storageManager.insert(bundleItem, for: storageBundleProduct)
+
+        let order = Order.fake().copy(siteID: sampleSiteID, orderID: sampleOrderID, items: [
+            // Bundle order item
+            .fake().copy(itemID: 1, productID: bundleProduct.productID, quantity: 2),
+            // Bundled child order item
+            .fake().copy(itemID: 2, productID: bundledProduct.productID, quantity: 6, parent: 1),
+        ])
+        viewModel = .init(siteID: sampleSiteID,
+                          flow: .editing(initialOrder: order),
+                          stores: stores,
+                          storageManager: storageManager,
+                          quantityDebounceDuration: 0)
+
+        waitUntil {
+            self.viewModel.productRows.count == 2
+        }
+
+        let orderToUpdate: Order = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, _, _, onCompletion):
+                    promise(order)
+                    onCompletion(.success(.fake()))
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+
+            // When
+            self.viewModel.productRows[0].incrementQuantity()
+        }
+
+        // Then
+        let bundleOrderItemToUpdate = try XCTUnwrap(orderToUpdate.items.first)
+        XCTAssertEqual(bundleOrderItemToUpdate.bundleConfiguration, [
+            .init(bundledItemID: 1, productID: 665, quantity: 3, isOptionalAndSelected: nil, variationID: nil, variationAttributes: nil)
+        ])
     }
 
     func test_selectOrderItem_selects_expected_order_item() throws {
@@ -749,7 +803,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
-                                               currencySettings: currencySettings)
+                                               currencySettings: currencySettings,
+                                               quantityDebounceDuration: 0)
         let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
 
         // When & Then
@@ -760,6 +815,11 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // When & Then
         viewModel.productRows[0].incrementQuantity()
+
+        // Debounce makes the quantity update async even though the duration is 0.
+        waitUntil {
+            viewModel.paymentDataViewModel.itemsTotal != "£8.50"
+        }
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£17.00")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£17.00")
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11177 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR aims to provide a workaround for a buggy behavior in the extension where updating the bundle quantity doesn't multiply the quantity of the child bundled order items until the order is updated with a bundle configuration (more details in Pe5pgL-3Vd-p2#quantity-of-bundle-child-order-items). When the quantity is changed for a bundle order item, the workaround adds a bundle configuration to the bundle order item in the order remote sync so that the child items can also have their quantity updated. The drawback of this workaround is if the order has other items than the bundle, then the bundle & its child items are moved to the last of the item list, this is the behavior wherever the bundle is updated. Android also implemented this workaround (issue 3 in pe5pgL-3Ze-p2#comment-3231).

## How

Personally I find this workaround quite hacky, but I haven't thought of a better way - any suggestions are welcome. I tried adding test cases for the changes since this is a special case.

The main changes are in two places:

- `RemoteOrderSynchronizer`: if any of the order items contain a bundle configuration, the syncing becomes blocking and the UI is disabled. This is to address the scenario when the order remote update is triggered again before the bundle is settled, and the bundle can be broken from this because the quantity of the parent/child items' is set async at different time
- `EditableOrderViewModel`: when the quantity is updated, `createUpdateProductInput` is called to create a product input for order update. This is where the workaround is - if the updated item is a bundle product & has child items & quantity is changed & no bundle configuration updates from the configuration form, bundle configuration is added to the order item. The bundle configuration is based on the bundle's bundled items & existing child items, as there's no other way to know the latest bundle configuration (there's actually a `_stamp` field in the order item metadata, but we aren't using metadata for this project as this metadata isn't documented)
  - A 0.5s debounce is also added to the quantity update handling now that the bundle quantity update is blocking from the changes in `RemoteOrderSynchronizer`. Otherwise, if the merchant wants to increment/decrement by more than 1, they have to wait for each quantity update

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite
- Configure the bundle if needed and tap `Done` --> the bundle should be added to the order with the child items
- Tap to expand the bundle order item
- Increment the bundle by more than 1 quickly --> the UI should look in the syncing and blocking state after a bit. After the order is synced, the quantity of the child items should be multiplied by the bundle quantity
- Tap `Create`
- Tap `Edit`
- Tap to expand the bundle order item
- Decrement the bundle by 1 --> after the order is synced, the quantity of the child items should be updated accordingly

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1945542/22908366-4631-48b1-b5d3-045d65b92261



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.