### PR TITLE
Fix regression issue in error parsing

### DIFF
--- a/Networking/Networking/Network/NetworkError.swift
+++ b/Networking/Networking/Network/NetworkError.swift
@@ -22,6 +22,7 @@ public enum NetworkError: Error, Equatable {
     /// Error for REST API requests with invalid cookie nonce
     case invalidCookieNonce
 
+    /// Response data accompanied the error if available
     var response: Data? {
         switch self {
         case .notFound(let response):

--- a/Networking/Networking/Network/NetworkError.swift
+++ b/Networking/Networking/Network/NetworkError.swift
@@ -21,6 +21,19 @@ public enum NetworkError: Error, Equatable {
 
     /// Error for REST API requests with invalid cookie nonce
     case invalidCookieNonce
+
+    var response: Data? {
+        switch self {
+        case .notFound(let response):
+            return response
+        case .timeout(let response):
+            return response
+        case .unacceptableStatusCode(_, let response):
+            return response
+        case .invalidURL, .invalidCookieNonce:
+            return nil
+        }
+    }
 }
 
 

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -301,8 +301,7 @@ private extension Remote {
         /// We will to attempt to validate the response using `ResponseDataValidator`
         /// if the error status code is unacceptable
         ///
-        guard case let .unacceptableStatusCode(_, response) = networkError,
-              let response else {
+        guard let response = networkError.response else {
             return networkError
         }
 

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -298,8 +298,8 @@ private extension Remote {
             return error
         }
 
-        /// We will to attempt to validate the response using `ResponseDataValidator`
-        /// if the error status code is unacceptable
+        /// We will to attempt to validate the error using `ResponseDataValidator`
+        /// if the error has accompanied response data.
         ///
         guard let response = networkError.response else {
             return networkError


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11192 
<!-- Id number of the GitHub issue this PR addresses. -->

## What
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a regression test in the way we parse errors that contain response data.

## Why
We have recently added new changes to how errors are parsed to catch responses from REST API requests. We are currently mapping [only](https://github.com/woocommerce/woocommerce-ios/blob/f2fadd1cba3a36dab415697339c01692f06b687d/Networking/Networking/Remote/Remote.swift#L304) `unacceptableStatusCode` errors, while there are other cases of `NetworkError` that contain response data.

## How
- Added an extension for `NetworkError` to get the accompanied response data if available.
- Updated `mapNetworkError` to get response from `NetworkError` and attempt mapping with the validator if possible.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a new free trial site on the app.
- When the store creation is done, notice that the banner `We couldn't load your data` is not displayed on the My Store screen even though requests to the `stats/` endpoints fail with 404 error (message "This blog does not have the Stats module enabled"). 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/d08433e4-0088-412d-ba53-6b45e19a3574" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
