### PR TITLE
[Bundle products in order form] Configure form: fix variation not selectable when the variable product is not in the first page of API response in the product selector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -530,6 +530,7 @@ final class EditableOrderViewModel: ObservableObject {
             siteID: siteID,
             selectedItemIDs: selectedProductsAndVariationsIDs,
             purchasableItemsOnly: true,
+            shouldDeleteStoredProductsOnFirstPage: false,
             storageManager: storageManager,
             stores: stores,
             toggleAllVariationsOnSelection: false,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -184,6 +184,8 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     private let purchasableItemsOnly: Bool
 
+    private let shouldDeleteStoredProductsOnFirstPage: Bool
+
     /// Closure to be invoked when "Clear Selection" is called.
     ///
     private let onAllSelectionsCleared: (() -> Void)?
@@ -199,6 +201,7 @@ final class ProductSelectorViewModel: ObservableObject {
     init(siteID: Int64,
          selectedItemIDs: [Int64] = [],
          purchasableItemsOnly: Bool = false,
+         shouldDeleteStoredProductsOnFirstPage: Bool = true,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
@@ -223,6 +226,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.selectedItemsIDs = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
+        self.shouldDeleteStoredProductsOnFirstPage = shouldDeleteStoredProductsOnFirstPage
         self.onAllSelectionsCleared = onAllSelectionsCleared
         self.onSelectedVariationsCleared = onSelectedVariationsCleared
         self.onCloseButtonTapped = onCloseButtonTapped
@@ -374,7 +378,7 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
                                                        productType: filtersSubject.value.promotableProductType?.productType,
                                                        productCategory: filtersSubject.value.productCategory,
                                                        sortOrder: .nameAscending,
-                                                       shouldDeleteStoredProductsOnFirstPage: true) { [weak self] result in
+                                                       shouldDeleteStoredProductsOnFirstPage: shouldDeleteStoredProductsOnFirstPage) { [weak self] result in
             guard let self = self else { return }
 
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -135,9 +135,8 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     @Published private(set) var syncStatus: SyncStatus?
 
-    /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
-    ///
-    private let syncingCoordinator = SyncingCoordinator()
+    /// Supports infinite scroll: keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
+    private let paginationTracker: PaginationTracker
 
     /// Tracks if the infinite scroll indicator should be displayed
     ///
@@ -208,6 +207,8 @@ final class ProductSelectorViewModel: ObservableObject {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          toggleAllVariationsOnSelection: Bool = true,
          topProductsProvider: ProductSelectorTopProductsProviderProtocol? = nil,
+         pageFirstIndex: Int = PaginationTracker.Defaults.pageFirstIndex,
+         pageSize: Int = PaginationTracker.Defaults.pageSize,
          onProductSelectionStateChanged: ((Product) -> Void)? = nil,
          onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
@@ -227,6 +228,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.selectedItemsIDs = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
         self.shouldDeleteStoredProductsOnFirstPage = shouldDeleteStoredProductsOnFirstPage
+        self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex, pageSize: pageSize)
         self.onAllSelectionsCleared = onAllSelectionsCleared
         self.onSelectedVariationsCleared = onSelectedVariationsCleared
         self.onCloseButtonTapped = onCloseButtonTapped
@@ -236,7 +238,7 @@ final class ProductSelectorViewModel: ObservableObject {
         topProductsFromCachedOrders = topProductsProvider?.provideTopProducts(siteID: siteID) ?? .empty
         tracker.viewModel = self
 
-        configureSyncingCoordinator()
+        configurePaginationTracker()
         refreshDataAndSync()
         configureFirstPageLoad()
         synchronizeProductFilterSearch()
@@ -353,11 +355,11 @@ final class ProductSelectorViewModel: ObservableObject {
     }
 }
 
-// MARK: - SyncingCoordinatorDelegate & Sync Methods
-extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
+// MARK: - PaginationTrackerDelegate conformance
+extension ProductSelectorViewModel: PaginationTrackerDelegate {
     /// Sync products from remote.
     ///
-    func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)?) {
+    func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: SyncCompletion?) {
         transitionToSyncingState(pageNumber: pageNumber)
 
         if searchTerm.isNotEmpty {
@@ -369,7 +371,7 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
 
     /// Sync all products from remote.
     ///
-    private func syncProducts(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)?) {
+    private func syncProducts(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: SyncCompletion?) {
         let action = ProductAction.synchronizeProducts(siteID: siteID,
                                                        pageNumber: pageNumber,
                                                        pageSize: pageSize,
@@ -392,14 +394,14 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
             }
 
             self.transitionToResultsUpdatedState()
-            onCompletion?(result.isSuccess)
+            onCompletion?(result)
         }
         stores.dispatch(action)
     }
 
     /// Sync products matching a given keyword.
     ///
-    private func searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+    private func searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: SyncCompletion?) {
         searchProductsInCacheIfPossible(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize)
 
         let action = ProductAction.searchProducts(siteID: siteID,
@@ -429,7 +431,7 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
             }
 
             self.transitionToResultsUpdatedState()
-            onCompletion?(result.isSuccess)
+            onCompletion?(result)
         }
 
         stores.dispatch(action)
@@ -461,14 +463,13 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
     /// Sync first page of products from remote if needed.
     ///
     func syncFirstPage() {
-        syncingCoordinator.synchronizeFirstPage()
+        paginationTracker.syncFirstPage()
     }
 
     /// Sync next page of products from remote.
     ///
     func syncNextPage() {
-        let lastIndex = productsResultsController.numberOfObjects - 1
-                syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: lastIndex)
+        paginationTracker.ensureNextPageIsSynced()
     }
 
     /// Updates the selected filters for the product list
@@ -605,10 +606,10 @@ private extension ProductSelectorViewModel {
         }
     }
 
-    /// Setup: Syncing Coordinator
+    /// Setup: Pagination Tracker
     ///
-    func configureSyncingCoordinator() {
-        syncingCoordinator.delegate = self
+    func configurePaginationTracker() {
+        paginationTracker.delegate = self
     }
 
     /// Performs initial sync on first page load
@@ -641,7 +642,7 @@ private extension ProductSelectorViewModel {
                 self.updateFilterButtonTitle(with: filtersSubject)
                 self.updatePredicate(searchTerm: searchTerm, filters: filtersSubject, productSearchFilter: productSearchFilter)
                 self.reloadData()
-                self.syncingCoordinator.resynchronize()
+                self.paginationTracker.resync()
             }.store(in: &subscriptions)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -195,7 +195,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
             case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 let product = Product.fake().copy(siteID: self.sampleSiteID, purchasable: true)
                 self.insert(product, withSearchTerm: "shirt")
-                onCompletion(.success(()))
+                onCompletion(.success(false))
                 expectation.fulfill()
             case .searchProductsInCache:
                 break
@@ -226,7 +226,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
                 remoteRequestSearchFilter = filter
                 self.insert(skuFilterProduct, withSearchTerm: "shirt", filterKey: "sku")
                 self.insert(allFilterProduct, withSearchTerm: "shirt", filterKey: "all")
-                onCompletion(.success(()))
+                onCompletion(.success(false))
                 expectation.fulfill()
             case .searchProductsInCache:
                 break
@@ -256,7 +256,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
             switch action {
             case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 self.insert(skuFilterVariation, withSearchTerm: "shirt", filterKey: "sku")
-                onCompletion(.success(()))
+                onCompletion(.success(false))
                 expectation.fulfill()
             case .searchProductsInCache:
                 break
@@ -339,7 +339,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
             switch action {
             case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 self.insert(shirt, withSearchTerm: "shirt")
-                onCompletion(.success(()))
+                onCompletion(.success(false))
                 expectation.fulfill()
             case .searchProductsInCache:
                 break
@@ -391,7 +391,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
             switch action {
             case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 self.insert(product.copy(name: "T-shirt"), withSearchTerm: "shirt")
-                onCompletion(.success(()))
+                onCompletion(.success(false))
             case let .synchronizeProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(.success(true))
                 expectation.fulfill()
@@ -1069,7 +1069,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
                 filteredProductType = productType
                 filteredProductStatus = productStatus
                 filteredProductCategory = category
-                onCompletion(.success(Void()))
+                onCompletion(.success(false))
             default:
                 XCTFail("Received unsupported action: \(action)")
             }
@@ -1255,7 +1255,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
             case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 let product = Product.fake().copy(siteID: self.sampleSiteID, purchasable: true)
                 self.insert(product, withSearchTerm: "shirt")
-                onCompletion(.success(()))
+                onCompletion(.success(false))
                 expectation.fulfill()
             case .searchProductsInCache:
                 break
@@ -1356,6 +1356,64 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         assertEqual(bundleProduct, productToConfigure)
+    }
+
+    // MARK: - Pagination
+
+    func test_it_syncs_the_second_page_after_searching_and_selecting_a_product_not_in_the_first_page() {
+        // Given
+        var searchProductsPages = [Int]()
+        var synchronizeProductsPages = [Int]()
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+                case let .searchProducts(_, _, _, pageNumber, _, _, _, _, _, _, onCompletion):
+                    searchProductsPages.append(pageNumber)
+                    let product = Product.fake().copy(siteID: self.sampleSiteID, productID: 3, purchasable: true)
+                    self.insert(product, withSearchTerm: "shirt")
+                    // No next page from the search.
+                    onCompletion(.success(false))
+                case let .synchronizeProducts(_, pageNumber, _, _, _, _, _, _, _, _, onCompletion):
+                    synchronizeProductsPages.append(pageNumber)
+                    let hasNextPage = pageNumber < 2
+                    onCompletion(.success(hasNextPage))
+                case .searchProductsInCache:
+                    break
+                default:
+                    XCTFail("Unsupported Action")
+            }
+        }
+
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, storageManager: storageManager, stores: stores)
+        viewModel.onLoadTrigger.send(())
+
+        XCTAssertEqual(synchronizeProductsPages, [1])
+        XCTAssertEqual(searchProductsPages, [])
+
+        // When
+        viewModel.searchTerm = "shirt"
+
+        waitUntil {
+            searchProductsPages.isNotEmpty
+        }
+
+        viewModel.changeSelectionStateForProduct(with: 3)
+
+        XCTAssertEqual(synchronizeProductsPages, [1])
+        XCTAssertEqual(searchProductsPages, [1])
+
+        viewModel.searchTerm = ""
+
+        waitUntil {
+            synchronizeProductsPages == [1, 1]
+        }
+
+        XCTAssertEqual(searchProductsPages, [1])
+
+        viewModel.syncNextPage()
+
+        // Then
+        XCTAssertEqual(synchronizeProductsPages, [1, 1, 2])
+        XCTAssertEqual(searchProductsPages, [1])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
@@ -98,7 +98,7 @@ final class ProductSearchUICommandTests: XCTestCase {
                 return XCTFail("Unexpected action: \(action)")
             }
             invocationCount += 1
-            onCompletion(.success(()))
+            onCompletion(.success(false))
         }
 
         // When
@@ -138,7 +138,7 @@ final class ProductSearchUICommandTests: XCTestCase {
                 return XCTFail("Unexpected action: \(action)")
             }
             invocationCount += 1
-            onCompletion(.success(()))
+            onCompletion(.success(false))
         }
 
         // When
@@ -162,7 +162,7 @@ final class ProductSearchUICommandTests: XCTestCase {
             guard case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion) = action else {
                 return XCTFail("Unexpected action: \(action)")
             }
-            onCompletion(.success(()))
+            onCompletion(.success(false))
         }
 
         // When

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -24,6 +24,8 @@ public enum ProductAction: Action {
 
     /// Searches products that contain a given keyword.
     ///
+    /// - Parameter onCompletion: called when sync completes, returns an error or a boolean that indicates whether there might be more products from search.
+    ///
     case searchProducts(siteID: Int64,
                         keyword: String,
                         filter: ProductSearchFilter = .all,
@@ -34,7 +36,7 @@ public enum ProductAction: Action {
                         productType: ProductType? = nil,
                         productCategory: ProductCategory? = nil,
                         excludedProductIDs: [Int64] = [],
-                        onCompletion: (Result<Void, Error>) -> Void)
+                        onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Synchronizes the Products matching the specified criteria.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -188,7 +188,7 @@ private extension ProductStore {
                         productType: ProductType?,
                         productCategory: ProductCategory?,
                         excludedProductIDs: [Int64],
-                        onCompletion: @escaping (Result<Void, Error>) -> Void) {
+                        onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         switch filter {
         case .all:
             remote.searchProducts(for: siteID,
@@ -203,6 +203,7 @@ private extension ProductStore {
                 self?.handleSearchResults(siteID: siteID,
                                           keyword: keyword,
                                           filter: filter,
+                                          pageSize: pageSize,
                                           result: result,
                                           onCompletion: onCompletion)
             }
@@ -214,6 +215,7 @@ private extension ProductStore {
                 self?.handleSearchResults(siteID: siteID,
                                           keyword: keyword,
                                           filter: filter,
+                                          pageSize: pageSize,
                                           result: result,
                                           onCompletion: onCompletion)
             }
@@ -232,6 +234,7 @@ private extension ProductStore {
         handleSearchResults(siteID: siteID,
                             keyword: keyword,
                             filter: .all,
+                            pageSize: pageSize,
                             result: Result.success(results.prefix(pageSize).map { $0.toReadOnly() }),
                             onCompletion: { _ in onCompletion(!results.isEmpty) })
     }
@@ -1091,15 +1094,17 @@ private extension ProductStore {
     func handleSearchResults(siteID: Int64,
                              keyword: String,
                              filter: ProductSearchFilter,
+                             pageSize: Int,
                              result: Result<[Product], Error>,
-                             onCompletion: @escaping (Result<Void, Error>) -> Void) {
+                             onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         switch result {
         case .success(let products):
             upsertSearchResultsInBackground(siteID: siteID,
                                             keyword: keyword,
                                             filter: filter,
                                             readOnlyProducts: products) {
-                onCompletion(.success(()))
+                let hasNextPage = products.count == pageSize
+                onCompletion(.success(hasNextPage))
             }
         case .failure(let error):
             onCompletion(.failure(error))

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -990,7 +990,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let keyword = "photo"
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Bool, Error> = waitFor { promise in
             let action = ProductAction.searchProducts(siteID: self.sampleSiteID,
                                                       keyword: keyword,
                                                       pageNumber: self.defaultPageNumber,
@@ -1018,7 +1018,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let keyword = "hiii"
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Bool, Error> = waitFor { promise in
             let action = ProductAction.searchProducts(siteID: self.sampleSiteID,
                                                       keyword: keyword,
                                                       pageNumber: self.defaultPageNumber,
@@ -1151,7 +1151,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let keyword = "hiii"
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Bool, Error> = waitFor { promise in
             let nestedAction = ProductAction.searchProducts(siteID: self.sampleSiteID,
                                                             keyword: keyword,
                                                             pageNumber: self.defaultPageNumber,

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1215,6 +1215,63 @@ final class ProductStoreTests: XCTestCase {
         assertEqual(filteredProductCategory, remote.searchProductWithProductCategory)
     }
 
+    func test_searchProducts_sets_hasNextPage_to_true_if_product_count_is_the_same_as_pageSize() throws {
+        // Given
+        let remote = MockProductsRemote()
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "woo"
+        let pageSize = 5
+        remote.whenSearchingProducts(query: keyword, thenReturn: .success(Array(repeating: Product.fake(), count: pageSize)))
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(ProductAction.searchProducts(siteID: self.sampleSiteID,
+                                                            keyword: keyword,
+                                                            pageNumber: self.defaultPageNumber,
+                                                            pageSize: pageSize,
+                                                            onCompletion: { result in
+                                                                promise(result)
+                                                            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+
+        let hasNextPage = try XCTUnwrap(result.get())
+        XCTAssertTrue(hasNextPage)
+    }
+
+    func test_searchProducts_sets_hasNextPage_to_false_if_product_count_is_smaller_than_pageSize() throws {
+        // Given
+        let remote = MockProductsRemote()
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "woo"
+        let pageSize = 5
+        remote.whenSearchingProducts(query: keyword, thenReturn: .success(Array(repeating: Product.fake(), count: pageSize - 1)))
+
+        // When
+
+        let result = waitFor { promise in
+            store.onAction(ProductAction.searchProducts(siteID: self.sampleSiteID,
+                                                            keyword: keyword,
+                                                            pageNumber: self.defaultPageNumber,
+                                                            pageSize: pageSize,
+                                                            onCompletion: { result in
+                                                                promise(result)
+                                                            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+
+        let hasNextPage = try XCTUnwrap(result.get())
+        XCTAssertFalse(hasNextPage)
+    }
+
     // MARK: - ProductAction.updateProduct
 
     /// Verifies that `ProductAction.updateProduct` returns the expected `Product`.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Short-term fix for #11198
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Thanks to @rachelmcr's discovery of a bug https://github.com/woocommerce/woocommerce-ios/pull/11186#pullrequestreview-1736581081 where the variation for a variable bundle item cannot be selected, some underlying issues are uncovered. The reason for the variation not being selectable is because when selecting a variation in the variation selector, it reloads the storage products and [expects the variable product object from storage](https://github.com/woocommerce/woocommerce-ios/blob/c32e2cb50705ac348e6b1237526694bac4a9327f/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift#L179) to pass to the callback.

Why is the variable product gone from storage even though it was just fetched from the Configure form?

When inspecting the API calls during the bundle configuration, I noticed that there were many API requests from syncing products that originated from `ProductSelectorViewModel.synchronizeProductFilterSearch` from its initializer. It looks like SwiftUI redraws the product selector view when the Configure form is presented, which [triggers the view model to be created and initialized again](https://github.com/woocommerce/woocommerce-ios/blob/c32e2cb50705ac348e6b1237526694bac4a9327f/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/OrderForm.swift#L498) with the products sync API request. Because the product selector currently deletes all products when syncing and upserting the first page of 25 products, if the variable product isn't part of the first page, it gets deleted after the products sync.

## How

The ultimate fix would be to prevent the product selector view model from being recreated whenever the view is redrawn. However, I tried this and there are a few things broken - the sheet can't be dismissed, and the "# Product Selected" isn't updated. We probably relied on the recreation of the view model for some view updates. While it might take more changes to fix everything, a short-term fix is to disable deleting all products when syncing the first page of products.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with 1 variable item where the **variable product is not the first 25 products in the product selector in the app**. 

- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite
- Tap `Select variation` for the variable item
- Tap any of the variation in the list --> before this PR, the variation can't be selected. now the variation should be selectable and it navigates back to the variation form

Since this change affects the product selector, please also do a confidence check on the selector:

- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products`
- Search for some products, scroll to the bottom, change the filters --> the pagination should work as before

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.