### PR TITLE
[Custom Amounts M4] Refunds

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
@@ -75,7 +75,7 @@ private extension RefundCustomAmountsDetailsTableViewCell {
         static let subtotalTitle = NSLocalizedString(
             "Subtotal", comment: "Title on the refund screen that lists the fees subtotal cost")
         static let totalTitle = NSLocalizedString("refundIssue.customAmounts.totalTitle",
-                                                  value:"Custom Amounts Refund",
+                                                  value: "Custom Amounts Refund",
                                                   comment: "Title on the refund screen that lists the custom amounts total cost")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class RefundFeesDetailsTableViewCell: UITableViewCell {
+final class RefundCustomAmountsDetailsTableViewCell: UITableViewCell {
     /// Displays `Subtotal` title
     ///
     @IBOutlet private var subtotalTitleLabel: UILabel!
@@ -33,7 +33,7 @@ final class RefundFeesDetailsTableViewCell: UITableViewCell {
 
 // MARK: View Styles Configuration
 
-private extension RefundFeesDetailsTableViewCell {
+private extension RefundCustomAmountsDetailsTableViewCell {
     func applyCellStyles() {
         applyDefaultBackgroundStyle()
         applyLabelsStyles()
@@ -55,11 +55,11 @@ private extension RefundFeesDetailsTableViewCell {
 
 // MARK: ViewModel Rendering
 
-extension RefundFeesDetailsTableViewCell {
+extension RefundCustomAmountsDetailsTableViewCell {
 
     /// Configure cell with the provided view model
     ///
-    func configure(with viewModel: RefundFeesDetailsViewModel) {
+    func configure(with viewModel: RefundCustomAmountsDetailsViewModel) {
         taxPriceLabel.text = viewModel.feesTaxes
         subtotalPriceLabel.text = viewModel.feesSubtotal
         totalPriceLabel.text = viewModel.feesTotal
@@ -68,13 +68,13 @@ extension RefundFeesDetailsTableViewCell {
 
 // MARK: Constants
 
-private extension RefundFeesDetailsTableViewCell {
+private extension RefundCustomAmountsDetailsTableViewCell {
     enum Localization {
         static let taxTitle = NSLocalizedString(
             "Tax", comment: "Title on the refunds screen that lists the fees tax cost")
         static let subtotalTitle = NSLocalizedString(
             "Subtotal", comment: "Title on the refund screen that lists the fees subtotal cost")
         static let totalTitle = NSLocalizedString(
-            "Fees Refund", comment: "Title on the refund screen that lists the fees total cost")
+            "Custom Amounts Refund", comment: "Title on the refund screen that lists the custom amounts total cost")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
@@ -74,7 +74,8 @@ private extension RefundCustomAmountsDetailsTableViewCell {
             "Tax", comment: "Title on the refunds screen that lists the fees tax cost")
         static let subtotalTitle = NSLocalizedString(
             "Subtotal", comment: "Title on the refund screen that lists the fees subtotal cost")
-        static let totalTitle = NSLocalizedString(
-            "Custom Amounts Refund", comment: "Title on the refund screen that lists the custom amounts total cost")
+        static let totalTitle = NSLocalizedString("refundIssue.customAmounts.totalTitle",
+                                                  value:"Custom Amounts Refund",
+                                                  comment: "Title on the refund screen that lists the custom amounts total cost")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.swift
@@ -74,7 +74,7 @@ private extension RefundCustomAmountsDetailsTableViewCell {
             "Tax", comment: "Title on the refunds screen that lists the fees tax cost")
         static let subtotalTitle = NSLocalizedString(
             "Subtotal", comment: "Title on the refund screen that lists the fees subtotal cost")
-        static let totalTitle = NSLocalizedString("refundIssue.customAmounts.totalTitle",
+        static let totalTitle = NSLocalizedString("refundCustomAmountsDetails.totalTitle",
                                                   value: "Custom Amounts Refund",
                                                   comment: "Title on the refund screen that lists the custom amounts total cost")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsTableViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="122" id="LHT-3r-b8Y" customClass="RefundFeesDetailsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="122" id="LHT-3r-b8Y" customClass="RefundCustomAmountsDetailsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="130"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LHT-3r-b8Y" id="zS1-ic-Kd0">

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundCustomAmountsDetailsViewModel.swift
@@ -4,15 +4,15 @@ import WooFoundation
 
 /// Represents fees details for an order to be refunded. Meant to be rendered by `RefundFeesDetailsTableViewCell`
 ///
-struct RefundFeesDetailsViewModel {
+struct RefundCustomAmountsDetailsViewModel {
     let feesTaxes: String
     let feesSubtotal: String
     let feesTotal: String
 }
 
 // MARK: Convenience Initializers
-extension RefundFeesDetailsViewModel {
-    /// Creates a `RefundFeesDetailsViewModel` based on a `[OrderFeeLine]`
+extension RefundCustomAmountsDetailsViewModel {
+    /// Creates a `RefundCustomAmountsDetailsViewModel` based on a `[OrderFeeLine]`
     ///
     init(fees: [OrderFeeLine], currency: String, currencySettings: CurrencySettings) {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -115,7 +115,7 @@ private extension IssueRefundViewController {
     }
 
     func feesSwitchChanged() {
-        viewModel.toggleRefundFees()
+        viewModel.toggleRefundCustomAmounts()
     }
 
     func quantityButtonPressed(sender: UITableViewCell) {
@@ -154,7 +154,7 @@ private extension IssueRefundViewController {
         tableView.registerNib(for: RefundItemTableViewCell.self)
         tableView.registerNib(for: RefundProductsTotalTableViewCell.self)
         tableView.registerNib(for: RefundShippingDetailsTableViewCell.self)
-        tableView.registerNib(for: RefundFeesDetailsTableViewCell.self)
+        tableView.registerNib(for: RefundCustomAmountsDetailsTableViewCell.self)
         tableView.registerNib(for: SwitchTableViewCell.self)
         tableView.registerNib(for: ImageAndTitleAndTextTableViewCell.self)
     }
@@ -248,7 +248,7 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
             let cell = tableView.dequeueReusableCell(RefundShippingDetailsTableViewCell.self, for: indexPath)
             cell.configure(with: viewModel)
             return cell
-        case let viewModel as IssueRefundViewModel.FeesSwitchViewModel:
+        case let viewModel as IssueRefundViewModel.CustomAmountsSwitchViewModel:
             let cell = tableView.dequeueReusableCell(SwitchTableViewCell.self, for: indexPath)
             cell.title = viewModel.title
             cell.isOn = viewModel.isOn
@@ -256,8 +256,8 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
                 self?.feesSwitchChanged()
             }
             return cell
-        case let viewModel as RefundFeesDetailsViewModel:
-            let cell = tableView.dequeueReusableCell(RefundFeesDetailsTableViewCell.self, for: indexPath)
+        case let viewModel as RefundCustomAmountsDetailsViewModel:
+            let cell = tableView.dequeueReusableCell(RefundCustomAmountsDetailsTableViewCell.self, for: indexPath)
             cell.configure(with: viewModel)
             return cell
         case let viewModel as ImageAndTitleAndTextTableViewCell.ViewModel:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -32,7 +32,7 @@ final class IssueRefundViewModel {
 
         /// Bool indicating if custom amounts will be refunded
         ///
-        var shouldRefundCustomAmounts: Bool = false
+        var shouldRefundCustomAmounts: Bool = true
 
         ///  Holds the quantity of items to refund
         ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -332,8 +332,9 @@ private extension IssueRefundViewModel {
 extension IssueRefundViewModel {
     enum Localization {
         static let refundShippingTitle = NSLocalizedString("Refund Shipping", comment: "Title of the switch in the IssueRefund screen to refund shipping")
-        static let refundCustomAmountsTitle = NSLocalizedString(
-            "Refund Custom Amounts", comment: "Title of the switch in the IssueRefund screen to refund customAmounts")
+        static let refundCustomAmountsTitle = NSLocalizedString("refundIssue.customAmounts.title",
+                                                                value: "Refund Custom Amounts",
+                                                                comment: "Title of the switch in the IssueRefund screen to refund customAmounts")
         static let itemSingular = NSLocalizedString("1 item selected", comment: "Title of the label indicating that there is 1 item to refund.")
         static let itemsPlural = NSLocalizedString("%d items selected", comment: "Title of the label indicating that there are multiple items to refund.")
     }
@@ -522,7 +523,7 @@ extension IssueRefundViewModel {
     }
 
     private func isAnyCustomAmountAvailableForRefund() -> Bool {
-        // Return false if there are no customAmounts left to be refunded.
+        // Return false if there are no custom amounts left to be refunded.
         return state.order.fees.isNotEmpty
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -336,9 +336,6 @@ extension IssueRefundViewModel {
             "Refund Custom Amounts", comment: "Title of the switch in the IssueRefund screen to refund customAmounts")
         static let itemSingular = NSLocalizedString("1 item selected", comment: "Title of the label indicating that there is 1 item to refund.")
         static let itemsPlural = NSLocalizedString("%d items selected", comment: "Title of the label indicating that there are multiple items to refund.")
-        static let unsupportedCustomAmountsRefund = NSLocalizedString(
-            "You can refund customAmounts in your store admin",
-            comment: "Shown in Refunds screen. Refunding customAmounts are currently not supported.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -30,9 +30,9 @@ final class IssueRefundViewModel {
         ///
         var shouldRefundShipping: Bool = false
 
-        /// Bool indicating if fees will be refunded
+        /// Bool indicating if custom amounts will be refunded
         ///
-        var shouldRefundFees: Bool = false
+        var shouldRefundCustomAmounts: Bool = false
 
         ///  Holds the quantity of items to refund
         ///
@@ -167,7 +167,7 @@ final class IssueRefundViewModel {
                                                               charge: self.state.charge,
                                                               amount: "\(self.calculateRefundTotal())",
                                                               refundsShipping: self.state.shouldRefundShipping,
-                                                              refundsFees: self.state.shouldRefundFees,
+                                                              refundsFees: self.state.shouldRefundCustomAmounts,
                                                               items: self.state.refundQuantityStore.refundableItems(),
                                                               paymentGateway: self.paymentGateway,
                                                               paymentGatewayAccount: paymentGatewayAccount)
@@ -188,8 +188,8 @@ extension IssueRefundViewModel {
         trackShippingSwitchChanged()
     }
 
-    func toggleRefundFees() {
-        state.shouldRefundFees.toggle()
+    func toggleRefundCustomAmounts() {
+        state.shouldRefundCustomAmounts.toggle()
     }
 
     /// Returns the number of items available for refund for the provided item index.
@@ -326,13 +326,13 @@ private extension IssueRefundViewModel {
 extension IssueRefundViewModel {
     enum Localization {
         static let refundShippingTitle = NSLocalizedString("Refund Shipping", comment: "Title of the switch in the IssueRefund screen to refund shipping")
-        static let refundFeesTitle = NSLocalizedString(
-            "Refund Fees", comment: "Title of the switch in the IssueRefund screen to refund fees")
+        static let refundCustomAmountsTitle = NSLocalizedString(
+            "Refund Custom Amounts", comment: "Title of the switch in the IssueRefund screen to refund customAmounts")
         static let itemSingular = NSLocalizedString("1 item selected", comment: "Title of the label indicating that there is 1 item to refund.")
         static let itemsPlural = NSLocalizedString("%d items selected", comment: "Title of the label indicating that there are multiple items to refund.")
-        static let unsupportedFeesRefund = NSLocalizedString(
-            "You can refund fees in your store admin",
-            comment: "Shown in Refunds screen. Refunding fees are currently not supported.")
+        static let unsupportedCustomAmountsRefund = NSLocalizedString(
+            "You can refund customAmounts in your store admin",
+            comment: "Shown in Refunds screen. Refunding customAmounts are currently not supported.")
     }
 }
 
@@ -354,8 +354,8 @@ extension IssueRefundViewModel {
         let isOn: Bool
     }
 
-    /// ViewModel that represents the fees switch row.
-    struct FeesSwitchViewModel: IssueRefundRow {
+    /// ViewModel that represents the customAmounts switch row.
+    struct CustomAmountsSwitchViewModel: IssueRefundRow {
         let title: String
         let isOn: Bool
     }
@@ -366,7 +366,7 @@ extension IssueRefundViewModel {
         [
             createItemsToRefundSection(),
             createShippingSection(),
-            createFeesSection()
+            createCustomAmountsSection()
         ].compactMap { $0 }
     }
 
@@ -415,19 +415,19 @@ extension IssueRefundViewModel {
         return Section(rows: [switchRow, detailsRow])
     }
 
-    private func createFeesSection() -> Section? {
-        guard isAnyFeeAvailableForRefund() else {
+    private func createCustomAmountsSection() -> Section? {
+        guard isAnyCustomAmountAvailableForRefund() else {
             return nil
         }
 
-        let switchRow = FeesSwitchViewModel(title: Localization.refundFeesTitle, isOn: state.shouldRefundFees)
-        guard state.shouldRefundFees else {
+        let switchRow = CustomAmountsSwitchViewModel(title: Localization.refundCustomAmountsTitle, isOn: state.shouldRefundCustomAmounts)
+        guard state.shouldRefundCustomAmounts else {
             return Section(rows: [switchRow])
         }
 
-        let detailsRow = RefundFeesDetailsViewModel(fees: state.order.fees,
-                                                    currency: state.order.currency,
-                                                    currencySettings: state.currencySettings)
+        let detailsRow = RefundCustomAmountsDetailsViewModel(fees: state.order.fees,
+                                                             currency: state.order.currency,
+                                                             currencySettings: state.currencySettings)
 
         return Section(rows: [switchRow, detailsRow])
     }
@@ -454,8 +454,8 @@ extension IssueRefundViewModel {
             refundsTotal += RefundShippingCalculationUseCase(shippingLine: shippingLine, currencyFormatter: formatter).calculateRefundValue()
         }
 
-        // If fees are enabled, sum the refund value to the total
-        if state.shouldRefundFees {
+        // If customAmounts are enabled, sum the refund value to the total
+        if state.shouldRefundCustomAmounts {
             refundsTotal += RefundFeesCalculationUseCase(fees: state.order.fees, currencyFormatter: formatter).calculateRefundValues().total
         }
 
@@ -489,7 +489,7 @@ extension IssueRefundViewModel {
             return false
         }
 
-        return state.refundQuantityStore.count() > 0 || state.shouldRefundShipping || state.shouldRefundFees
+        return state.refundQuantityStore.count() > 0 || state.shouldRefundShipping || state.shouldRefundCustomAmounts
     }
 
     /// Calculates whether the "select all" button should be visible or not.
@@ -518,8 +518,8 @@ extension IssueRefundViewModel {
         return state.refunds.first { $0.shippingLines?.isNotEmpty ?? false } != nil
     }
 
-    private func isAnyFeeAvailableForRefund() -> Bool {
-        // Return false if there are no fees left to be refunded.
+    private func isAnyCustomAmountAvailableForRefund() -> Bool {
+        // Return false if there are no customAmounts left to be refunded.
         return state.order.fees.isNotEmpty
     }
 }
@@ -539,7 +539,7 @@ extension RefundProductsTotalViewModel: IssueRefundRow {}
 
 extension RefundShippingDetailsViewModel: IssueRefundRow {}
 
-extension RefundFeesDetailsViewModel: IssueRefundRow {}
+extension RefundCustomAmountsDetailsViewModel: IssueRefundRow {}
 
 extension ImageAndTitleAndTextTableViewCell.ViewModel: IssueRefundRow {}
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -32,7 +32,7 @@ final class IssueRefundViewModel {
 
         /// Bool indicating if custom amounts will be refunded
         ///
-        var shouldRefundCustomAmounts: Bool = true
+        var shouldRefundCustomAmounts: Bool
 
         ///  Holds the quantity of items to refund
         ///
@@ -147,7 +147,13 @@ final class IssueRefundViewModel {
         self.stores = stores
         self.storage = storage
         let items = refundableOrderItemsDeterminer.determineRefundableOrderItems(from: order, with: refunds)
-        state = State(order: order, refunds: refunds, itemsToRefund: items, currencySettings: currencySettings, charge: nil)
+        let thereIsOnlyCustomAmountsToRefund = items.isEmpty && order.fees.isNotEmpty
+        state = State(order: order,
+                      refunds: refunds,
+                      itemsToRefund: items,
+                      currencySettings: currencySettings,
+                      shouldRefundCustomAmounts: thereIsOnlyCustomAmountsToRefund,
+                      charge: nil)
         sections = createSections()
         title = calculateTitle()
         isNextButtonEnabled = calculateNextButtonEnableState()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -147,12 +147,11 @@ final class IssueRefundViewModel {
         self.stores = stores
         self.storage = storage
         let items = refundableOrderItemsDeterminer.determineRefundableOrderItems(from: order, with: refunds)
-        let thereIsOnlyCustomAmountsToRefund = items.isEmpty && order.fees.isNotEmpty
         state = State(order: order,
                       refunds: refunds,
                       itemsToRefund: items,
                       currencySettings: currencySettings,
-                      shouldRefundCustomAmounts: thereIsOnlyCustomAmountsToRefund,
+                      shouldRefundCustomAmounts: refundableOrderItemsDeterminer.shouldRefundCustomAmountsByDefault(from: order),
                       charge: nil)
         sections = createSections()
         title = calculateTitle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/OrderRefundsOptionsDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/OrderRefundsOptionsDeterminer.swift
@@ -25,6 +25,15 @@ protocol OrderRefundsOptionsDeterminerProtocol {
     /// - Returns: A boolean indicating whether there is still something to be refunded from that order
     ///
     func isAnythingToRefund(from order: Order, with refunds: [Refund], currencyFormatter: CurrencyFormatter) -> Bool
+
+    /// Determines whether refunding custom amounts should be enabled by default.
+    ///
+    /// - Parameters:
+    ///   - order: the order to be analyzed
+    ///
+    /// - Returns: A boolean indicating whether custom amounts should be refunded by default
+    ///
+    func shouldRefundCustomAmountsByDefault(from order: Order) -> Bool
 }
 
 final class OrderRefundsOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol {
@@ -71,5 +80,11 @@ final class OrderRefundsOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol
             // Return the item with the updated quantity to refund
             return RefundableOrderItem(item: item, quantity: quantityLeftToRefund)
         }
+    }
+
+    func shouldRefundCustomAmountsByDefault(from order: Order) -> Bool {
+        let thereIsOnlyCustomAmountsToRefund = order.items.isEmpty && order.fees.isNotEmpty
+
+        return thereIsOnlyCustomAmountsToRefund
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1660,9 +1660,9 @@
 		B6C838DE28793B3A003AB786 /* OrderCustomFieldsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C838DD28793B3A003AB786 /* OrderCustomFieldsViewModel.swift */; };
 		B6D2468C2A0ED4C400B79B9C /* EUCustomsScenarioValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D2468B2A0ED4C400B79B9C /* EUCustomsScenarioValidatorTests.swift */; };
 		B6E7DB64293A7C390049B001 /* AnalyticsHubYesterdayRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E7DB63293A7C390049B001 /* AnalyticsHubYesterdayRangeData.swift */; };
-		B6E851F3276320C70041D1BA /* RefundFeesDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E851F2276320C70041D1BA /* RefundFeesDetailsViewModel.swift */; };
-		B6E851F5276330200041D1BA /* RefundFeesDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */; };
-		B6E851F7276331110041D1BA /* RefundFeesDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */; };
+		B6E851F3276320C70041D1BA /* RefundCustomAmountsDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E851F2276320C70041D1BA /* RefundCustomAmountsDetailsViewModel.swift */; };
+		B6E851F5276330200041D1BA /* RefundCustomAmountsDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E851F4276330200041D1BA /* RefundCustomAmountsDetailsTableViewCell.swift */; };
+		B6E851F7276331110041D1BA /* RefundCustomAmountsDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6E851F6276331110041D1BA /* RefundCustomAmountsDetailsTableViewCell.xib */; };
 		B6F379682937836700718561 /* AnalyticsHubTimeRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F379672937836700718561 /* AnalyticsHubTimeRange.swift */; };
 		B6F3796A29378B3900718561 /* AnalyticsHubMonthToDateRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3796929378B3900718561 /* AnalyticsHubMonthToDateRangeData.swift */; };
 		B6F3796C293794A000718561 /* AnalyticsHubYearToDateRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3796B293794A000718561 /* AnalyticsHubYearToDateRangeData.swift */; };
@@ -4230,9 +4230,9 @@
 		B6C838DD28793B3A003AB786 /* OrderCustomFieldsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomFieldsViewModel.swift; sourceTree = "<group>"; };
 		B6D2468B2A0ED4C400B79B9C /* EUCustomsScenarioValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EUCustomsScenarioValidatorTests.swift; sourceTree = "<group>"; };
 		B6E7DB63293A7C390049B001 /* AnalyticsHubYesterdayRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubYesterdayRangeData.swift; sourceTree = "<group>"; };
-		B6E851F2276320C70041D1BA /* RefundFeesDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsViewModel.swift; sourceTree = "<group>"; };
-		B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsTableViewCell.swift; sourceTree = "<group>"; };
-		B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundFeesDetailsTableViewCell.xib; sourceTree = "<group>"; };
+		B6E851F2276320C70041D1BA /* RefundCustomAmountsDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCustomAmountsDetailsViewModel.swift; sourceTree = "<group>"; };
+		B6E851F4276330200041D1BA /* RefundCustomAmountsDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCustomAmountsDetailsTableViewCell.swift; sourceTree = "<group>"; };
+		B6E851F6276331110041D1BA /* RefundCustomAmountsDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundCustomAmountsDetailsTableViewCell.xib; sourceTree = "<group>"; };
 		B6F379672937836700718561 /* AnalyticsHubTimeRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRange.swift; sourceTree = "<group>"; };
 		B6F3796929378B3900718561 /* AnalyticsHubMonthToDateRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubMonthToDateRangeData.swift; sourceTree = "<group>"; };
 		B6F3796B293794A000718561 /* AnalyticsHubYearToDateRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubYearToDateRangeData.swift; sourceTree = "<group>"; };
@@ -7130,9 +7130,9 @@
 				260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */,
 				26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */,
 				26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */,
-				B6E851F2276320C70041D1BA /* RefundFeesDetailsViewModel.swift */,
-				B6E851F4276330200041D1BA /* RefundFeesDetailsTableViewCell.swift */,
-				B6E851F6276331110041D1BA /* RefundFeesDetailsTableViewCell.xib */,
+				B6E851F2276320C70041D1BA /* RefundCustomAmountsDetailsViewModel.swift */,
+				B6E851F4276330200041D1BA /* RefundCustomAmountsDetailsTableViewCell.swift */,
+				B6E851F6276331110041D1BA /* RefundCustomAmountsDetailsTableViewCell.xib */,
 				0379C51827BFE23400A7E284 /* RefundConfirmationCardDetailsCell.xib */,
 				0379C51A27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift */,
 			);
@@ -11944,7 +11944,7 @@
 				3F587021281B9494004F7556 /* LaunchScreen.storyboard in Resources */,
 				027D4A8E2526FD1800108626 /* SettingsViewController.xib in Resources */,
 				0373A12B2A1D1E4D00731236 /* BadgedLeftImageTableViewCell.xib in Resources */,
-				B6E851F7276331110041D1BA /* RefundFeesDetailsTableViewCell.xib in Resources */,
+				B6E851F7276331110041D1BA /* RefundCustomAmountsDetailsTableViewCell.xib in Resources */,
 				7441EBCA226A71AA008BF83D /* TitleBodyTableViewCell.xib in Resources */,
 				740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */,
 				57CFCD2A2488496F003F51EC /* PrimarySectionHeaderView.xib in Resources */,
@@ -12659,7 +12659,7 @@
 				CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */,
 				DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */,
 				683421642ACE9391009021D7 /* ProductDiscountView.swift in Sources */,
-				B6E851F3276320C70041D1BA /* RefundFeesDetailsViewModel.swift in Sources */,
+				B6E851F3276320C70041D1BA /* RefundCustomAmountsDetailsViewModel.swift in Sources */,
 				024DF31F23743045006658FE /* Header+AztecFormatting.swift in Sources */,
 				AE7C957B27C3D5DA007E8E12 /* FeeOrDiscountLineDetails.swift in Sources */,
 				B5A8F8AD20B88D9900D211DE /* LoginPrologueViewController.swift in Sources */,
@@ -13124,7 +13124,7 @@
 				3142663F2645E2AB00500598 /* PaymentSettingsFlowViewModelPresenter.swift in Sources */,
 				DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */,
 				AEC95D412774C5AE001571F5 /* AddressFormViewModelProtocol.swift in Sources */,
-				B6E851F5276330200041D1BA /* RefundFeesDetailsTableViewCell.swift in Sources */,
+				B6E851F5276330200041D1BA /* RefundCustomAmountsDetailsTableViewCell.swift in Sources */,
 				028E1F702833DD0A001F8829 /* DashboardViewModel.swift in Sources */,
 				2602A63D27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift in Sources */,
 				CCFBBCFA29C4C85F0081B595 /* ComponentSettingsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderRefundsOptionsDeterminer.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderRefundsOptionsDeterminer.swift
@@ -6,10 +6,13 @@ import WooFoundation
 struct MockOrderRefundsOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol {
     private let determineRefundableOrderItems: [RefundableOrderItem]
     private let isAnythingToRefund: Bool
+    private let shouldRefundCustomAmountsByDefault: Bool
 
-    init(determineRefundableOrderItems: [RefundableOrderItem] = [], isAnythingToRefund: Bool = false) {
+    init(determineRefundableOrderItems: [RefundableOrderItem] = [], isAnythingToRefund: Bool = false,
+        shouldRefundCustomAmountsByDefault: Bool = false) {
         self.determineRefundableOrderItems = determineRefundableOrderItems
         self.isAnythingToRefund = isAnythingToRefund
+        self.shouldRefundCustomAmountsByDefault = shouldRefundCustomAmountsByDefault
     }
 
     func determineRefundableOrderItems(from order: Order, with refunds: [Refund]) -> [RefundableOrderItem] {
@@ -18,5 +21,9 @@ struct MockOrderRefundsOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol 
 
     func isAnythingToRefund(from order: Order, with refunds: [Refund], currencyFormatter: CurrencyFormatter) -> Bool {
         isAnythingToRefund
+    }
+
+    func shouldRefundCustomAmountsByDefault(from order: Order) -> Bool {
+        shouldRefundCustomAmountsByDefault
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -443,7 +443,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: false)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, 
+        let viewModel = IssueRefundViewModel(order: order,
                                              refunds: [],
                                              currencySettings: currencySettings,
                                              refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
@@ -462,7 +462,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: true)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, 
+        let viewModel = IssueRefundViewModel(order: order,
                                              refunds: [],
                                              currencySettings: currencySettings,
                                              refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
@@ -514,7 +514,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: false)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, 
+        let viewModel = IssueRefundViewModel(order: order,
                                              refunds: [],
                                              currencySettings: currencySettings,
                                              refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
@@ -533,7 +533,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: true)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, 
+        let viewModel = IssueRefundViewModel(order: order,
                                              refunds: [],
                                              currencySettings: currencySettings,
                                              refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
@@ -755,8 +755,8 @@ final class IssueRefundViewModelTests: XCTestCase {
 
 private extension MockOrderItem {
     static func sampleItemWithCalculatedTotal(itemID: Int64,
-                                    quantity: Decimal,
-                                    price: NSDecimalNumber) -> OrderItem {
+                                              quantity: Decimal,
+                                              price: NSDecimalNumber) -> OrderItem {
         let currencySettings = CurrencySettings()
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -443,7 +443,10 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: false)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
+        let viewModel = IssueRefundViewModel(order: order, 
+                                             refunds: [],
+                                             currencySettings: currencySettings,
+                                             refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonEnabled)
@@ -459,7 +462,10 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: true)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
+        let viewModel = IssueRefundViewModel(order: order, 
+                                             refunds: [],
+                                             currencySettings: currencySettings,
+                                             refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertTrue(viewModel.isNextButtonEnabled)
@@ -508,7 +514,10 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: false)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
+        let viewModel = IssueRefundViewModel(order: order, 
+                                             refunds: [],
+                                             currencySettings: currencySettings,
+                                             refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertFalse(viewModel.hasUnsavedChanges)
@@ -524,7 +533,10 @@ final class IssueRefundViewModelTests: XCTestCase {
         let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: true)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
+        let viewModel = IssueRefundViewModel(order: order, 
+                                             refunds: [],
+                                             currencySettings: currencySettings,
+                                             refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertTrue(viewModel.hasUnsavedChanges)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -153,23 +153,6 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.quantityAvailableForRefundForItemAtIndex(3), nil)
     }
 
-    func test_viewModel_does_not_have_unsupported_fees_tooltip_row_if_the_order_has_no_fees() {
-        // Given
-        let currencySettings = CurrencySettings()
-        let order = Order.fake()
-
-        // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
-
-        // Then
-        let rows = viewModel.sections.flatMap { $0.rows }
-        XCTAssertFalse(rows.isEmpty)
-
-        let unsupportedFeesTooltipRow = rows.compactMap { $0 as? ImageAndTitleAndTextTableViewCell.ViewModel }
-            .first { $0.title == IssueRefundViewModel.Localization.unsupportedCustomAmountsRefund }
-        XCTAssertNil(unsupportedFeesTooltipRow)
-    }
-
     func test_viewModel_returns_0_current_refund_quantity_for_a_clean_order() {
         // Given
         let currencySettings = CurrencySettings()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -166,7 +166,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertFalse(rows.isEmpty)
 
         let unsupportedFeesTooltipRow = rows.compactMap { $0 as? ImageAndTitleAndTextTableViewCell.ViewModel }
-            .first { $0.title == IssueRefundViewModel.Localization.unsupportedFeesRefund }
+            .first { $0.title == IssueRefundViewModel.Localization.unsupportedCustomAmountsRefund }
         XCTAssertNil(unsupportedFeesTooltipRow)
     }
 
@@ -450,13 +450,13 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.title, "$12.49")
     }
 
-    func test_viewModel_starts_with_next_button_disabled() {
+    func test_isNextButtonEnabled_when_there_are_no_custom_amounts_at_start_then_return_false() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
-        let order = MockOrders().makeOrder(items: items)
+        let order = MockOrders().makeOrder(items: items, fees: [])
 
         // When
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
@@ -465,13 +465,40 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isNextButtonEnabled)
     }
 
+    func test_isNextButtonEnabled_when_there_are_custom_amounts_and_items_at_start_then_return_false() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+        ]
+        let order = MockOrders().makeOrder(items: items, fees: [OrderFeeLine.fake()])
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        XCTAssertFalse(viewModel.isNextButtonEnabled)
+    }
+
+    func test_isNextButtonEnabled_when_there_are_custom_amounts_but_no_items_at_start_then_return_true() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder(items: [], fees: [OrderFeeLine.fake()])
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        XCTAssertTrue(viewModel.isNextButtonEnabled)
+    }
+
     func test_viewModel_next_button_gets_enabled_after_selecting_items() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
-        let order = MockOrders().makeOrder(items: items)
+        let order = MockOrders().makeOrder(items: items, fees: [])
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
 
         // When
@@ -487,7 +514,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
-        let order = MockOrders().makeOrder(items: items)
+        let order = MockOrders().makeOrder(items: items, fees: [])
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
         viewModel.selectAllOrderItems()
 
@@ -498,19 +525,31 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isNextButtonEnabled)
     }
 
-    func test_viewModel_starts_with_no_unsaved_changes() {
+    func test_hasUnsavedChanges_when_there_are_custom_amounts_and_items_at_start_then_return_false() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
-        let order = MockOrders().makeOrder(items: items)
+        let order = MockOrders().makeOrder(items: items, fees: [OrderFeeLine.fake()])
 
         // When
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
 
         // Then
         XCTAssertFalse(viewModel.hasUnsavedChanges)
+    }
+
+    func test_hasUnsavedChanges_when_there_are_custom_amounts_but_no_items_at_start_then_return_true() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder(items: [], fees: [OrderFeeLine.fake()])
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        XCTAssertTrue(viewModel.hasUnsavedChanges)
     }
 
     func test_viewModel_unsaved_changes_states_becomes_true_after_selecting_items() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -433,43 +433,33 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.title, "$12.49")
     }
 
-    func test_isNextButtonEnabled_when_there_are_no_custom_amounts_at_start_then_return_false() {
+    func test_isNextButtonEnabled_when_shouldRefundCustomAmountsByDefault_is_false_then_returns_false() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
         let order = MockOrders().makeOrder(items: items, fees: [])
+        let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: false)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertFalse(viewModel.isNextButtonEnabled)
     }
 
-    func test_isNextButtonEnabled_when_there_are_custom_amounts_and_items_at_start_then_return_false() {
+    func test_isNextButtonEnabled_when_shouldRefundCustomAmountsByDefault_is_true_then_returns_true() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
-        let order = MockOrders().makeOrder(items: items, fees: [OrderFeeLine.fake()])
+        let order = MockOrders().makeOrder(items: items, fees: [])
+        let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: true)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
-
-        // Then
-        XCTAssertFalse(viewModel.isNextButtonEnabled)
-    }
-
-    func test_isNextButtonEnabled_when_there_are_custom_amounts_but_no_items_at_start_then_return_true() {
-        // Given
-        let currencySettings = CurrencySettings()
-        let order = MockOrders().makeOrder(items: [], fees: [OrderFeeLine.fake()])
-
-        // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertTrue(viewModel.isNextButtonEnabled)
@@ -508,28 +498,33 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isNextButtonEnabled)
     }
 
-    func test_hasUnsavedChanges_when_there_are_custom_amounts_and_items_at_start_then_return_false() {
+    func test_hasUnsavedChanges_when_shouldRefundCustomAmountsByDefault_is_false_then_returns_false() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [
             MockOrderItem.sampleItem(itemID: 1, quantity: 3),
         ]
-        let order = MockOrders().makeOrder(items: items, fees: [OrderFeeLine.fake()])
+        let order = MockOrders().makeOrder(items: items, fees: [])
+        let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: false)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertFalse(viewModel.hasUnsavedChanges)
     }
 
-    func test_hasUnsavedChanges_when_there_are_custom_amounts_but_no_items_at_start_then_return_true() {
+    func test_hasUnsavedChanges_when_shouldRefundCustomAmountsByDefault_is_true_then_returns_true() {
         // Given
         let currencySettings = CurrencySettings()
-        let order = MockOrders().makeOrder(items: [], fees: [OrderFeeLine.fake()])
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+        ]
+        let order = MockOrders().makeOrder(items: items, fees: [])
+        let refundableOrderItemsDeterminer = MockOrderRefundsOptionsDeterminer(shouldRefundCustomAmountsByDefault: true)
 
         // When
-        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, refundableOrderItemsDeterminer: refundableOrderItemsDeterminer)
 
         // Then
         XCTAssertTrue(viewModel.hasUnsavedChanges)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/OrderRefundsOptionsDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/OrderRefundsOptionsDeterminerTests.swift
@@ -143,4 +143,43 @@ final class OrderRefundsOptionsDeterminerTests: XCTestCase {
         // Then
         XCTAssertEqual(result, expectedResult)
     }
+
+    func shouldRefundCustomAmountsByDefault_when_the_order_has_only_items_return_false() {
+        // Given
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+        ]
+        let order = MockOrders().makeOrder(items: items, fees: [])
+
+        // When
+        let result = sut.shouldRefundCustomAmountsByDefault(from: order)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func shouldRefundCustomAmountsByDefault_when_the_order_has_items_and_custom_amounts_return_false() {
+        // Given
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+        ]
+        let order = MockOrders().makeOrder(items: items, fees: [OrderFeeLine.fake()])
+
+        // When
+        let result = sut.shouldRefundCustomAmountsByDefault(from: order)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func shouldRefundCustomAmountsByDefault_when_the_order_has_only_custom_amounts_return_false() {
+        // Given
+        let order = MockOrders().makeOrder(items: [], fees: [OrderFeeLine.fake()])
+
+        // When
+        let result = sut.shouldRefundCustomAmountsByDefault(from: order)
+
+        // Then
+        XCTAssertTrue(result)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundFeesDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundFeesDetailsViewModelTests.swift
@@ -15,7 +15,7 @@ final class RefundFeesDetailsViewModelTests: XCTestCase {
         let currencySettings = CurrencySettings()
 
         // When
-        let viewModel = RefundFeesDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
+        let viewModel = RefundCustomAmountsDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.feesSubtotal, "$104.19")
@@ -30,7 +30,7 @@ final class RefundFeesDetailsViewModelTests: XCTestCase {
         let currencySettings = CurrencySettings()
 
         // When
-        let viewModel = RefundFeesDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
+        let viewModel = RefundCustomAmountsDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.feesTaxes, "$11.19")
@@ -45,7 +45,7 @@ final class RefundFeesDetailsViewModelTests: XCTestCase {
         let currencySettings = CurrencySettings()
 
         // When
-        let viewModel = RefundFeesDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
+        let viewModel = RefundCustomAmountsDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.feesTotal, "$46.84")
@@ -61,7 +61,7 @@ final class RefundFeesDetailsViewModelTests: XCTestCase {
         let currencySettings = CurrencySettings()
 
         // When
-        let viewModel = RefundFeesDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
+        let viewModel = RefundCustomAmountsDetailsViewModel(fees: feeLines, currency: "USD", currencySettings: currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.feesTaxes, "$11.20")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11196
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we address everything related to custom amounts and refunds:

- Refactor code to use custom amounts instead of fees. We set the line between the view model (we use custom amounts)  and model (we keep using fees), to differentiate between the user-facing wording and the backend, including the model, consistent with the rest of Woo's existing nomenclature.
- Make the custom amounts refundable by default if we only have custom amounts (no items). The reason behind is that if the user wants to refund an order with just a custom amount e.g. Simple Payments, we can assume that they want to refund the custom amount/fee. If they have products and custom amounts, they might want to choose what to refund. Starting with nothing to refund might make it easier for them.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

We need to prepare three type or **completed** orders:

1. Only with items
2. Only with custom amounts
3. With both items and custom amounts

Go to refund each of these screens. Please check that:

1. When only with items, they're not enabled to refund by default
2. Only with custom amounts, they're enabled to refund by default
3. With both items and custom amounts, nothing is enabled to refund by default

Also, please ensure that the fee wording is being replaced by custom amounts.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Only with items

https://github.com/woocommerce/woocommerce-ios/assets/1864060/05ecb92e-f34a-44e2-b29d-512248c7e48e

### Only with custom amounts

https://github.com/woocommerce/woocommerce-ios/assets/1864060/e98c18d4-8ab9-4b5e-b725-d891d29f3f3a

### With both items and custom amounts

https://github.com/woocommerce/woocommerce-ios/assets/1864060/b16e6246-6ca3-465e-a0ca-f0ddbd700c27

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
