### PR TITLE
In the Configure form, disable the stepper's -/+ CTA if the quantity cannot be decremented/incremented

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -123,7 +123,9 @@ struct CollapsibleProductRowCard: View {
 
 
             Button(Localization.removeProductLabel) {
-                viewModel.removeProductIntent()
+                if let removeProductIntent = viewModel.removeProductIntent {
+                    removeProductIntent()
+                }
             }
             .padding()
             .frame(maxWidth: .infinity, alignment: .center)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -173,6 +173,7 @@ private struct ProductStepper: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(height: Layout.stepperButtonSize * scale)
             }
+            .disabled(viewModel.shouldDisableQuantityIncrementer)
         }
         .padding(Layout.stepperPadding * scale)
         .frame(width: Layout.stepperWidth * scale)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -235,6 +235,15 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         }
     }
 
+    /// Whether the quantity can be incremented.
+    ///
+    var shouldDisableQuantityIncrementer: Bool {
+        guard let maximumQuantity else {
+            return false
+        }
+        return quantity >= maximumQuantity
+    }
+
     /// Closure to run when the quantity is changed.
     ///
     var quantityUpdatedCallback: (Decimal) -> Void

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -508,11 +508,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     func decrementQuantity() {
         guard quantity > minimumQuantity else {
-            if let removeProductIntent {
-                return removeProductIntent()
-            } else {
-                return
-            }
+            removeProductIntent?()
+            return
         }
         quantity -= 1
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -228,7 +228,11 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Whether the quantity can be decremented.
     ///
     var shouldDisableQuantityDecrementer: Bool {
-        quantity < minimumQuantity
+        if removeProductIntent != nil { // Allow decrementing below minimum quantity to remove product
+            return quantity < minimumQuantity
+        } else {
+            return quantity <= minimumQuantity
+        }
     }
 
     /// Closure to run when the quantity is changed.
@@ -237,7 +241,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Closure to run when the quantity is decremented below the minimum quantity.
     ///
-    var removeProductIntent: () -> Void
+    var removeProductIntent: (() -> Void)?
 
     /// Closure to configure a product if it is configurable.
     let configure: (() -> Void)?
@@ -276,7 +280,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
          quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
-         removeProductIntent: @escaping (() -> Void) = {},
+         removeProductIntent: (() -> Void)? = nil,
          configure: (() -> Void)? = nil) {
         self.id = id ?? Int64(UUID().uuidString.hashValue)
         self.selectedState = selectedState
@@ -495,7 +499,11 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     func decrementQuantity() {
         guard quantity > minimumQuantity else {
-            return removeProductIntent()
+            if let removeProductIntent {
+                return removeProductIntent()
+            } else {
+                return
+            }
         }
         quantity -= 1
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -343,7 +343,7 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.quantity, 6)
     }
 
-    func quantity_decrementer_disabled_at_minimum_quantity_when_removeProductIntent_is_nil() {
+    func test_quantity_decrementer_disabled_at_minimum_quantity_when_removeProductIntent_is_nil() {
         // Given
         let product = Product.fake()
         let viewModel = ProductRowViewModel(productOrVariationID: 1,
@@ -365,7 +365,7 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldDisableQuantityDecrementer)
     }
 
-    func quantity_decrementer_not_disabled_at_minimum_quantity_when_removeProductIntent_is_not_nil() {
+    func test_quantity_decrementer_not_disabled_at_minimum_quantity_when_removeProductIntent_is_not_nil() {
         // Given
         let product = Product.fake()
         let viewModel = ProductRowViewModel(productOrVariationID: 1,
@@ -388,7 +388,7 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldDisableQuantityDecrementer)
     }
 
-    func quantity_incrementer_disabled_at_maximum_quantity() {
+    func test_quantity_incrementer_disabled_at_maximum_quantity() {
         // Given
         let product = Product.fake()
         let viewModel = ProductRowViewModel(productOrVariationID: 1,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -388,6 +388,28 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldDisableQuantityDecrementer)
     }
 
+    func quantity_incrementer_disabled_at_maximum_quantity() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(productOrVariationID: 1,
+                                            name: "",
+                                            sku: nil,
+                                            price: nil,
+                                            stockStatusKey: "",
+                                            stockQuantity: nil,
+                                            manageStock: false,
+                                            quantity: 6,
+                                            minimumQuantity: 4,
+                                            maximumQuantity: 6,
+                                            canChangeQuantity: true,
+                                            imageURL: nil,
+                                            hasParentProduct: false,
+                                            isConfigurable: false)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisableQuantityIncrementer)
+    }
+
     func test_productRow_when_add_discount_button_is_tapped_then_orderProductDiscountAddButtonTapped_is_tracked() {
         // Given
         let product = Product.fake()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -343,6 +343,51 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.quantity, 6)
     }
 
+    func quantity_decrementer_disabled_at_minimum_quantity_when_removeProductIntent_is_nil() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(productOrVariationID: 1,
+                                            name: "",
+                                            sku: nil,
+                                            price: nil,
+                                            stockStatusKey: "",
+                                            stockQuantity: nil,
+                                            manageStock: false,
+                                            quantity: 3,
+                                            minimumQuantity: 3,
+                                            maximumQuantity: nil,
+                                            canChangeQuantity: true,
+                                            imageURL: nil,
+                                            hasParentProduct: false,
+                                            isConfigurable: false)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisableQuantityDecrementer)
+    }
+
+    func quantity_decrementer_not_disabled_at_minimum_quantity_when_removeProductIntent_is_not_nil() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductRowViewModel(productOrVariationID: 1,
+                                            name: "",
+                                            sku: nil,
+                                            price: nil,
+                                            stockStatusKey: "",
+                                            stockQuantity: nil,
+                                            manageStock: false,
+                                            quantity: 3,
+                                            minimumQuantity: 3,
+                                            maximumQuantity: nil,
+                                            canChangeQuantity: true,
+                                            imageURL: nil,
+                                            hasParentProduct: false,
+                                            isConfigurable: false,
+                                            removeProductIntent: {})
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisableQuantityDecrementer)
+    }
+
     func test_productRow_when_add_discount_button_is_tapped_then_orderProductDiscountAddButtonTapped_is_tracked() {
         // Given
         let product = Product.fake()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11193
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
When configuring a product bundle in an order, each bundle item has a minimum quantity and may have a maximum quantity. We need to disable the +/- buttons in the quantity stepper if a bundle item is already at its maximum/minimum quantity.

## How
* This adds a check to disable the + button (incrementer) if there is a maximum quantity and the quantity is already greater than or equal to the maximum.
* The minimum quantity is slightly more complicated: the same stepper is used to change the quantity of a product in an order, and decrementing the quantity below the minimum removes it from the order. So there are two main changes:
  * The callback `removeProductIntent` is now optional. When it is provided, the decrementer is not disabled if the quantity equals the minimum quantity (to allow removing the product by decrementing the quantity). This retains the current behavior for products in an order.
  * If `removeProductIntent` is not provided, the stepper respects the minimum quantity by disabling the - button if the quantity is already less than or equal to the minimum quantity.

## Testing instructions

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with at least one bundle item with no maximum quantity and one bundle item with a maximum quantity.

- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite
- Confirm the stepper is disabled when the quantity matches the minimum/maximum quantity for each bundle item.

Confidence check that removing a product from an order works as before:

- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select any product
- Tap `1 Product Selected` to add it to the order.
- Tap the down arrow next to the product in the product list to expand it.
- Tap `-` in the stepper and confirm the product is removed from the order.

## Screenshots

Configuring bundles:

https://github.com/woocommerce/woocommerce-ios/assets/8658164/1f438c2c-c100-435d-bcd7-088833c7785d

Removing a product:

https://github.com/woocommerce/woocommerce-ios/assets/8658164/9b44625c-b31b-420f-a99e-fa4602a9255b





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
