### PR TITLE
Fetch & Store the new storeID property.

### DIFF
--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Environment.swift
@@ -6,6 +6,7 @@ public extension SystemStatus {
     struct Environment: Decodable {
         public let homeURL: String
         public let siteURL: String
+        public let storeID: String?
         public let version: String
         public let logDirectoryWritable: Bool
         public let wpVersion: String
@@ -39,6 +40,7 @@ private extension SystemStatus.Environment {
     enum CodingKeys: String, CodingKey {
         case homeURL = "home_url"
         case siteURL = "site_url"
+        case storeID = "store_id"
         case version
         case logDirectoryWritable = "log_directory_writable"
         case wpVersion = "wp_version"

--- a/Networking/Networking/Remote/SystemStatusRemote.swift
+++ b/Networking/Networking/Remote/SystemStatusRemote.swift
@@ -4,17 +4,21 @@ import Foundation
 ///
 public class SystemStatusRemote: Remote {
 
-    /// Retrieves all of the `SystemPlugin`s for a given site.
+    /// Retrieves information from the system status that belongs to the current site.
+    /// Currently fetching:
+    ///   - Store ID
+    ///   - Active Plugins
+    ///   - Inactive Plugins
     ///
     /// - Parameters:
     ///   - siteID: Site for which we'll fetch the system plugins.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadSystemPlugins(for siteID: Int64,
-                            completion: @escaping (Result<[SystemPlugin], Error>) -> Void) {
+    public func loadSystemInformation(for siteID: Int64,
+                                      completion: @escaping (Result<SystemStatus, Error>) -> Void) {
         let path = Constants.systemStatusPath
         let parameters = [
-            ParameterKeys.fields: [ParameterValues.activePlugins, ParameterValues.inactivePlugins]
+            ParameterKeys.fields: [ParameterValues.environment, ParameterValues.activePlugins, ParameterValues.inactivePlugins]
         ]
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .get,
@@ -22,7 +26,7 @@ public class SystemStatusRemote: Remote {
                                      path: path,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        let mapper = SystemPluginMapper(siteID: siteID)
+        let mapper = SystemStatusMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -57,6 +61,7 @@ private extension SystemStatusRemote {
     enum ParameterValues {
         static let activePlugins: String = "active_plugins"
         static let inactivePlugins: String = "inactive_plugins"
+        static let environment: String = "environment"
     }
 
     enum ParameterKeys {

--- a/Networking/NetworkingTests/Remote/SystemStatusRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SystemStatusRemoteTests.swift
@@ -22,45 +22,47 @@ final class SystemStatusRemoteTests: XCTestCase {
 
     // MARK: - Load system plugins tests
 
-    /// Verifies that loadSystemPlugins properly parses the sample response.
+    /// Verifies that loadSystemInformation properly parses the sample response.
     ///
-    func test_loadSystemPlugins_properly_returns_systemPlugins() {
+    func test_loadSystemInformation_properly_returns_site_information() {
         let remote = SystemStatusRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "system_status", filename: "systemStatus")
 
         // When
-        let result: Result<[SystemPlugin], Error> = waitFor { promise in
-            remote.loadSystemPlugins(for: self.sampleSiteID) { result in
+        let result: Result<SystemStatus, Error> = waitFor { promise in
+            remote.loadSystemInformation(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
         // Then
         switch result {
-        case .success(let plugins):
-            XCTAssertEqual(plugins.count, 6)
+        case .success(let systemInfo):
+            XCTAssertEqual(systemInfo.activePlugins.count, 4)
+            XCTAssertEqual(systemInfo.inactivePlugins.count, 2)
+            XCTAssertEqual(systemInfo.environment?.storeID, "sample-store-uuid")
         case .failure(let error):
             XCTAssertNil(error)
         }
     }
 
-    /// Verifies that loadSystemPlugins properly relays Networking Layer errors.
+    /// Verifies that loadSystemInformation properly relays Networking Layer errors.
     ///
-    func test_loadSystemPlugins_properly_relays_netwoking_errors() {
+    func test_loadSystemInformation_properly_relays_netwoking_errors() {
         let remote = SystemStatusRemote(network: network)
 
         // When
-        let result: Result<[SystemPlugin], Error> = waitFor { promise in
-            remote.loadSystemPlugins(for: self.sampleSiteID) { result in
+        let result: Result<SystemStatus, Error> = waitFor { promise in
+            remote.loadSystemInformation(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
         // Then
         switch result {
-        case .success(let plugins):
-            XCTAssertNil(plugins)
+        case .success(let systemInformation):
+            XCTAssertNil(systemInformation)
         case .failure(let error):
             XCTAssertNotNil(error)
         }

--- a/Networking/NetworkingTests/Responses/systemStatus.json
+++ b/Networking/NetworkingTests/Responses/systemStatus.json
@@ -3,6 +3,7 @@
         "environment": {
             "home_url": "https://additional-beetle.jurassic.ninja",
             "site_url": "https://additional-beetle.jurassic.ninja",
+            "store_id": "sample-store-uuid",
             "version": "5.9.0",
             "log_directory": "/srv/users/user9fe179e8/apps/user9fe179e8/public/wp-content/uploads/wc-logs/",
             "log_directory_writable": true,

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -63,6 +63,7 @@ extension Storage.GeneralAppSettings {
 
 extension Storage.GeneralStoreSettings {
     public func copy(
+        storeID: NullableCopiableProp<String> = .copy,
         isTelemetryAvailable: CopiableProp<Bool> = .copy,
         telemetryLastReportedTime: NullableCopiableProp<Date> = .copy,
         areSimplePaymentTaxesEnabled: CopiableProp<Bool> = .copy,
@@ -72,6 +73,7 @@ extension Storage.GeneralStoreSettings {
         firstInPersonPaymentsTransactionsByReaderType: CopiableProp<[CardReaderType: Date]> = .copy,
         selectedTaxRateID: NullableCopiableProp<Int64> = .copy
     ) -> Storage.GeneralStoreSettings {
+        let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
         let telemetryLastReportedTime = telemetryLastReportedTime ?? self.telemetryLastReportedTime
         let areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled ?? self.areSimplePaymentTaxesEnabled
@@ -82,6 +84,7 @@ extension Storage.GeneralStoreSettings {
         let selectedTaxRateID = selectedTaxRateID ?? self.selectedTaxRateID
 
         return Storage.GeneralStoreSettings(
+            storeID: storeID,
             isTelemetryAvailable: isTelemetryAvailable,
             telemetryLastReportedTime: telemetryLastReportedTime,
             areSimplePaymentTaxesEnabled: areSimplePaymentTaxesEnabled,

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -17,6 +17,10 @@ public struct GeneralStoreSettingsBySite: Codable, Equatable {
 ///
 public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
 
+    /// The store unique identifier.
+    ///
+    public let storeID: String?
+
     /// The state(`true` or `false`) for the view add-on beta feature switch.
     ///
     public let isTelemetryAvailable: Bool
@@ -46,7 +50,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// The selected tax rate to apply to the orders
     public let selectedTaxRateID: Int64?
 
-    public init(isTelemetryAvailable: Bool = false,
+    public init(storeID: String? = nil,
+                isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
                 areSimplePaymentTaxesEnabled: Bool = false,
                 preferredInPersonPaymentGateway: String? = nil,
@@ -54,6 +59,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 lastSelectedStatsTimeRange: String = "",
                 firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date] = [:],
                 selectedTaxRateID: Int64? = nil) {
+        self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
         self.areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled
@@ -65,7 +71,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
-        GeneralStoreSettings(isTelemetryAvailable: isTelemetryAvailable,
+        GeneralStoreSettings(storeID: storeID,
+                             isTelemetryAvailable: isTelemetryAvailable,
                              telemetryLastReportedTime: telemetryLastReportedTime,
                              areSimplePaymentTaxesEnabled: areSimplePaymentTaxesEnabled,
                              preferredInPersonPaymentGateway: preferredInPersonPaymentGateway,
@@ -83,6 +90,7 @@ extension GeneralStoreSettings {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
+        self.storeID = try container.decodeIfPresent(String.self, forKey: .storeID)
         self.isTelemetryAvailable = try container.decodeIfPresent(Bool.self, forKey: .isTelemetryAvailable) ?? false
         self.telemetryLastReportedTime = try container.decodeIfPresent(Date.self, forKey: .telemetryLastReportedTime)
         self.areSimplePaymentTaxesEnabled = try container.decodeIfPresent(Bool.self, forKey: .areSimplePaymentTaxesEnabled) ?? false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -254,7 +254,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         stores.dispatch(settingsAction)
 
         // We need to sync plugins to see which CPP-supporting plugins are installed, up to date, and active
-        let systemPluginsAction = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { result in
+        let systemPluginsAction = SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
             if case let .failure(error) = result {
                 DDLogError("[CardPresentPaymentsOnboarding] Error syncing system plugins: \(error)")
                 errors.append(error)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/WooCommercePluginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/WooCommercePluginViewModel.swift
@@ -94,7 +94,7 @@ final class PluginDetailsViewModel: ObservableObject {
     /// Used to refresh the store after the webview is used to perform an update
     ///
     func refreshPlugin() {
-        let action = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { _ in }
+        let action = SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { _ in }
         storesManager.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -152,7 +152,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
         /// Synchronize system plugins for the WooCommerce plugin version row
         ///
         if let siteID = stores.sessionManager.defaultSite?.siteID {
-            let action = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID, onCompletion: { _ in })
+            let action = SystemStatusAction.synchronizeSystemInformation(siteID: siteID, onCompletion: { _ in })
             stores.dispatch(action)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -322,8 +322,8 @@ private extension JetpackSetupCoordinator {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: 0) { result in
                 switch result {
-                case let .success(plugins):
-                    if let plugin = plugins.first(where: { $0.name.lowercased() == Constants.jetpackPluginName.lowercased() }),
+                case let .success(systemInformation):
+                    if let plugin = systemInformation.systemPlugins.first(where: { $0.name.lowercased() == Constants.jetpackPluginName.lowercased() }),
                        plugin.active {
                         continuation.resume(returning: true)
                     } else {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -320,7 +320,7 @@ private extension JetpackSetupCoordinator {
     @MainActor
     func isJetpackInstalledAndActive() async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(SystemStatusAction.synchronizeSystemPlugins(siteID: 0) { result in
+            stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: 0) { result in
                 switch result {
                 case let .success(plugins):
                     if let plugin = plugins.first(where: { $0.name.lowercased() == Constants.jetpackPluginName.lowercased() }),

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -504,6 +504,7 @@ private extension DefaultStoresManager {
             dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
                 switch result {
                     case let .success(systemInformation):
+                        print("🚨 Store ID: \(systemInformation.storeID)") // TODO: This will be deleted in a later PR, when tracks get updated with this value
                         continuation.resume(returning: systemInformation.systemPlugins)
                     case let .failure(error):
                         DDLogError("⛔️ Failed to sync system plugins for siteID: \(siteID). Error: \(error)")

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -503,8 +503,8 @@ private extension DefaultStoresManager {
         await withCheckedContinuation { continuation in
             dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
                 switch result {
-                    case let .success(plugins):
-                        continuation.resume(returning: plugins)
+                    case let .success(systemInformation):
+                        continuation.resume(returning: systemInformation.systemPlugins)
                     case let .failure(error):
                         DDLogError("⛔️ Failed to sync system plugins for siteID: \(siteID). Error: \(error)")
                         continuation.resume(returning: nil)

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -501,7 +501,7 @@ private extension DefaultStoresManager {
     @MainActor
     func synchronizeSystemPlugins(siteID: Int64) async -> [SystemPlugin]? {
         await withCheckedContinuation { continuation in
-            dispatch(SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { result in
+            dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
                 switch result {
                     case let .success(plugins):
                         continuation.resume(returning: plugins)

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -209,7 +209,7 @@ private extension MockStoresManager {
         whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .synchronizeSystemInformation(_, onCompletion):
-                onCompletion(.success([.fake().copy(name: isJetpackInstalled ? "Jetpack" : "Plugin", active: isJetpackActive)]))
+                onCompletion(.success(.init(systemPlugins: [.fake().copy(name: isJetpackInstalled ? "Jetpack" : "Plugin", active: isJetpackActive)])))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -208,7 +208,7 @@ private extension MockStoresManager {
                           isJetpackActive: Bool = false) {
         whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
-            case let .synchronizeSystemPlugins(_, onCompletion):
+            case let .synchronizeSystemInformation(_, onCompletion):
                 onCompletion(.success([.fake().copy(name: isJetpackInstalled ? "Jetpack" : "Plugin", active: isJetpackActive)]))
             default:
                 break

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -179,6 +179,7 @@
 		263E37DC2641AD6B00260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37DB2641AD6B00260D3B /* Codegen */; };
 		263E38422641FF2300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38412641FF2300260D3B /* Codegen */; };
 		263E38442641FF2300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E38412641FF2300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		264D2C832B0B19F200FD2C05 /* SystemInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264D2C822B0B19F200FD2C05 /* SystemInformation.swift */; };
 		26577517243D5E42003168A5 /* ProductCategoryUpdated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */; };
 		265BCA0024301ACD004E53EE /* ProductCategoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BC9FF24301ACD004E53EE /* ProductCategoryStoreTests.swift */; };
 		2665034D2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2665034C2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift */; };
@@ -640,6 +641,7 @@
 		261CF2C6255C445A0090D8D3 /* PaymentGatewayStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayStoreTests.swift; sourceTree = "<group>"; };
 		261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryAction.swift; sourceTree = "<group>"; };
 		261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryStore.swift; sourceTree = "<group>"; };
+		264D2C822B0B19F200FD2C05 /* SystemInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemInformation.swift; sourceTree = "<group>"; };
 		26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryUpdated.swift; sourceTree = "<group>"; };
 		265BC9FF24301ACD004E53EE /* ProductCategoryStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryStoreTests.swift; sourceTree = "<group>"; };
 		2665034C2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAddOnOption+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1443,6 +1445,7 @@
 				0232372722F7DA5500715FAB /* Enums */,
 				B52E0036211A44FE00700FDE /* ReadOnly */,
 				B52E0035211A44F800700FDE /* Storage */,
+				264D2C822B0B19F200FD2C05 /* SystemInformation.swift */,
 				03EB998F2907B97800F06A39 /* JustInTimeMessage.swift */,
 				209AD3CD2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift */,
 				B53D89E420E6C22B00F90866 /* Model.swift */,
@@ -2127,6 +2130,7 @@
 				B5BC736520D1A98500B5B6FA /* AccountStore.swift in Sources */,
 				247CE8562583269900F9D9D1 /* MockProductActionHandler.swift in Sources */,
 				D4CBAE6226D4460900BBE6D1 /* AnnouncementsStore.swift in Sources */,
+				264D2C832B0B19F200FD2C05 /* SystemInformation.swift in Sources */,
 				312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */,
 				DE3C5B23286C03F90049E6AA /* MockCardPresentPaymentActionHandler.swift in Sources */,
 				2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -143,6 +143,14 @@ public enum AppSettingsAction: Action {
 
     // MARK: - General Store Settings
 
+    /// Sets the store uuid.
+    ///
+    case setStoreID(siteID: Int64, id: String?)
+
+    /// Gets the store uuid.
+    ///
+    case getStoreID(siteID: Int64, onCompletion: (String?) -> Void)
+
     /// Sets telemetry availability status information.
     ///
     case setTelemetryAvailability(siteID: Int64, isAvailable: Bool)

--- a/Yosemite/Yosemite/Actions/SystemStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/SystemStatusAction.swift
@@ -5,11 +5,8 @@ import Foundation
 public enum SystemStatusAction: Action {
 
     /// Synchronize store information from the system status for a site given its ID.
-    /// Currently syncs:
-    /// - System Plugins
-    /// - Store ID
     ///
-    case synchronizeSystemInformation(siteID: Int64, onCompletion: (Result<[SystemPlugin], Error>) -> Void)
+    case synchronizeSystemInformation(siteID: Int64, onCompletion: (Result<SystemInformation, Error>) -> Void)
 
     /// Fetch an specific systemPlugin by siteID and name
     ///

--- a/Yosemite/Yosemite/Actions/SystemStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/SystemStatusAction.swift
@@ -4,9 +4,12 @@ import Foundation
 ///
 public enum SystemStatusAction: Action {
 
-    /// Synchronize all system plugins for a site given its ID
+    /// Synchronize store information from the system status for a site given its ID.
+    /// Currently syncs:
+    /// - System Plugins
+    /// - Store ID
     ///
-    case synchronizeSystemPlugins(siteID: Int64, onCompletion: (Result<[SystemPlugin], Error>) -> Void)
+    case synchronizeSystemInformation(siteID: Int64, onCompletion: (Result<[SystemPlugin], Error>) -> Void)
 
     /// Fetch an specific systemPlugin by siteID and name
     ///

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
@@ -10,7 +10,7 @@ struct MockSystemStatusActionHandler: MockActionHandler {
 
     func handle(action: ActionType) {
         switch action {
-        case .synchronizeSystemPlugins(let siteID, let onCompletion):
+        case .synchronizeSystemInformation(let siteID, let onCompletion):
             synchronizeSystemPlugins(siteID: siteID, onCompletion: onCompletion)
         default:
             break

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
@@ -11,7 +11,9 @@ struct MockSystemStatusActionHandler: MockActionHandler {
     func handle(action: ActionType) {
         switch action {
         case .synchronizeSystemInformation(let siteID, let onCompletion):
-            synchronizeSystemPlugins(siteID: siteID, onCompletion: onCompletion)
+            synchronizeSystemPlugins(siteID: siteID) { result in
+                onCompletion(result.map { SystemInformation(systemPlugins: $0) })
+            }
         default:
             break
         }

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -229,7 +229,7 @@ private extension MockStoresManager {
 
     func synchronizeSystemPlugins(siteID: Int64) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            let action = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { _ in
+            let action = SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { _ in
                 continuation.resume(returning: ())
             }
             dispatch(action)

--- a/Yosemite/Yosemite/Model/SystemInformation.swift
+++ b/Yosemite/Yosemite/Model/SystemInformation.swift
@@ -1,0 +1,18 @@
+import Networking
+
+/// Store sytem information entity.
+///
+public struct SystemInformation {
+    /// Store UUID
+    ///
+    public let storeID: String?
+
+    /// Store plugins (Active, inactive)
+    ///
+    public let systemPlugins: [SystemPlugin]
+
+    public init(storeID: String? = nil, systemPlugins: [SystemPlugin]) {
+        self.storeID = storeID
+        self.systemPlugins = systemPlugins
+    }
+}

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -152,6 +152,10 @@ public class AppSettingsStore: Store {
             setJetpackBenefitsBannerLastDismissedTime(time: time)
         case .loadJetpackBenefitsBannerVisibility(currentTime: let currentTime, calendar: let calendar, onCompletion: let onCompletion):
             loadJetpackBenefitsBannerVisibility(currentTime: currentTime, calendar: calendar, onCompletion: onCompletion)
+        case .setStoreID(let siteID, let id):
+            setStoreID(siteID: siteID, id: id)
+        case .getStoreID(let siteID, let onCompletion):
+            getStoreID(siteID: siteID, onCompletion: onCompletion)
         case .setTelemetryAvailability(siteID: let siteID, isAvailable: let isAvailable):
             setTelemetryAvailability(siteID: siteID, isAvailable: isAvailable)
         case .setTelemetryLastReportedTime(siteID: let siteID, time: let time):
@@ -764,6 +768,19 @@ private extension AppSettingsStore {
             onCompletion?(.failure(error))
             DDLogError("⛔️ Saving store settings to file failed. Error: \(error)")
         }
+    }
+
+    // Store unique identifier
+
+    func setStoreID(siteID: Int64, id: String?) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(storeID: id)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func getStoreID(siteID: Int64, onCompletion: (String?) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        onCompletion(storeSettings.storeID)
     }
 
     // Telemetry data

--- a/Yosemite/Yosemite/Stores/SystemStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/SystemStatusStore.swift
@@ -47,18 +47,18 @@ public final class SystemStatusStore: Store {
 //
 private extension SystemStatusStore {
     func synchronizeSystemPlugins(siteID: Int64, completionHandler: @escaping (Result<[SystemPlugin], Error>) -> Void) {
-        remote.loadSystemPlugins(for: siteID) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let systemPlugins):
-                self.upsertSystemPluginsInBackground(siteID: siteID, readonlySystemPlugins: systemPlugins) { [weak self]_ in
-                    guard let self else { return }
-                    completionHandler(.success(self.storageManager.viewStorage.loadSystemPlugins(siteID: siteID).map { $0.toReadOnly() }))
-                }
-            case .failure(let error):
-                completionHandler(.failure(error))
-            }
-        }
+//        remote.loadSystemPlugins(for: siteID) { [weak self] result in
+//            guard let self = self else { return }
+//            switch result {
+//            case .success(let systemPlugins):
+//                self.upsertSystemPluginsInBackground(siteID: siteID, readonlySystemPlugins: systemPlugins) { [weak self]_ in
+//                    guard let self else { return }
+//                    completionHandler(.success(self.storageManager.viewStorage.loadSystemPlugins(siteID: siteID).map { $0.toReadOnly() }))
+//                }
+//            case .failure(let error):
+//                completionHandler(.failure(error))
+//            }
+//        }
     }
 
     func fetchSystemStatusReport(siteID: Int64, completionHandler: @escaping (Result<SystemStatus, Error>) -> Void) {

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -580,6 +580,42 @@ final class AppSettingsStoreTests: XCTestCase {
 
     // MARK: - General Store Settings
 
+    func test_setStoreID_stores_the_store_id_correctly() throws {
+        // Given
+        let siteID: Int64 = 1234
+
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        let action = AppSettingsAction.setStoreID(siteID: siteID, id: "sample-store-uuid")
+        subject?.onAction(action)
+
+        // Then
+        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
+        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+
+        XCTAssertEqual(settingsForSite?.storeID, "sample-store-uuid")
+    }
+
+    func test_getStoreID_retrieves_the_saved_store_id() throws {
+        // Given
+        let siteID: Int64 = 1234
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(storeID: "sample-store-uuid")])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        let storeID: String? = waitFor { promise in
+            let action = AppSettingsAction.getStoreID(siteID: siteID) { id in
+                promise(id)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(storeID, "sample-store-uuid")
+    }
+
     func test_saving_isTelemetryAvailable_works_correctly() throws {
         // Given
         let siteID: Int64 = 1234

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -42,7 +42,7 @@ final class SystemStatusStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(SystemStatusAction.synchronizeSystemPlugins(siteID: self.sampleSiteID) { result in
+            store.onAction(SystemStatusAction.synchronizeSystemInformation(siteID: self.sampleSiteID) { result in
                 promise(result)
             })
         }
@@ -65,7 +65,7 @@ final class SystemStatusStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(SystemStatusAction.synchronizeSystemPlugins(siteID: self.sampleSiteID) { result in
+            store.onAction(SystemStatusAction.synchronizeSystemInformation(siteID: self.sampleSiteID) { result in
                 promise(result)
             })
         }

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -35,8 +35,9 @@ final class SystemStatusStoreTests: XCTestCase {
         network = MockNetwork()
     }
 
-    func test_synchronizeSystemPlugins_stores_systemPlugins_correctly() {
+    func test_synchronizeSystemInformation_stores_systemInformation_correctly() {
         // Given
+        storageManager.insertSampleSite(readOnlySite: .fake().copy(siteID: sampleSiteID))
         network.simulateResponse(requestUrlSuffix: "system_status", filename: "systemStatus")
         let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
@@ -50,9 +51,12 @@ final class SystemStatusStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(viewStorage.countObjects(ofType: StorageSystemPlugin.self), 6) // number of systemPlugins in json file
+
+        let site = viewStorage.loadSite(siteID: sampleSiteID)
+        XCTAssertEqual(site?.storeID, "sample-store-uuid") // store id in json file
     }
 
-    func test_synchronizeSystemPlugins_removes_stale_systemPlugins_correctly() {
+    func test_synchronizeSystemInformation_removes_stale_systemPlugins_correctly() {
         // Given
         let staleSystemPluginName = "Stale System Plugin"
         let staleSystemPlugin = SystemPlugin.fake().copy(siteID: sampleSiteID, name: staleSystemPluginName)

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -51,9 +51,6 @@ final class SystemStatusStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(viewStorage.countObjects(ofType: StorageSystemPlugin.self), 6) // number of systemPlugins in json file
-
-        let site = viewStorage.loadSite(siteID: sampleSiteID)
-        XCTAssertEqual(site?.storeID, "sample-store-uuid") // store id in json file
     }
 
     func test_synchronizeSystemInformation_removes_stale_systemPlugins_correctly() {


### PR DESCRIPTION
Part of #11149

# Why

This PR takes care of fetching and storing the newly added `storeID` property from the `SystemStatus` API.

On the next PR, the `storeID` will be used to be sent on every track event.

# How

- Updated the `SystemStatusRemote` type to properly fetch the `storeID` from the environment object.

- Refactored the `SystemStatusStore` to not only fetch and store system plugins but also the `storeID`.

- Uses the `GeneralStoreSettings` type to save the new `storeID` value.  I previously attempted to store it inside the `Site` entity but the logic started to get quite complex and difficult to maintain(especially around bidirectional updates) as the `Site` APIs are not related to that new value.

# Testing Steps

**Note:** As https://github.com/woocommerce/woocommerce/pull/41341 has not been merged yet, we need to create a Jurassic Ninja store using the `add/store-id-to-telemetry-endpoint` branch.

- Create a Jurassic ninja store
- Run the app and log into that store
- See that a message similar to `🚨 Store ID: FGH58G-FGHJI-4567GH` is printed in the console

-----

- Log in to a different store (That runs a stable version of WC and does not has the store id field)
- See that a message similar to `🚨 Store ID: nil` is printed in the console


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
