### PR TITLE
[Bundle products in order form] Order form: fix product selector view model being initialized more than once

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -21,6 +21,9 @@ final class EditableOrderViewModel: ObservableObject {
 
     // MARK: - Product selector states
     @Published var productSelectorViewModel: ProductSelectorViewModel?
+
+    /// The source of truth of whether the product selector is presented.
+    /// This can be triggered by different CTAs like in the order form and close CTA in the product selector.
     @Published var isProductSelectorPresented: Bool = false
 
     private var cancellables: Set<AnyCancellable> = []

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1559,47 +1559,43 @@ private extension EditableOrderViewModel {
         $isProductSelectorPresented
             .removeDuplicates()
             .map { [weak self] isPresented in
-                guard let self else { return nil }
-                if isPresented {
-                    return ProductSelectorViewModel(
-                        siteID: siteID,
-                        selectedItemIDs: selectedProductsAndVariationsIDs,
-                        purchasableItemsOnly: true,
-                        storageManager: storageManager,
-                        stores: stores,
-                        toggleAllVariationsOnSelection: false,
-                        topProductsProvider: TopProductsFromCachedOrdersProvider(),
-                        onProductSelectionStateChanged: { [weak self] product in
-                            guard let self = self else { return }
-                            self.changeSelectionStateForProduct(product)
-                        },
-                        onVariationSelectionStateChanged: { [weak self] variation, parentProduct in
-                            guard let self = self else { return }
-                            self.changeSelectionStateForProductVariation(variation, parent: parentProduct)
-                        }, onMultipleSelectionCompleted: { [weak self] _ in
-                            guard let self = self else { return }
-                            self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
-                        }, onAllSelectionsCleared: { [weak self] in
-                            guard let self = self else { return }
-                            self.clearAllSelectedItems()
-                            self.trackClearAllSelectedItemsTapped()
-                        }, onSelectedVariationsCleared: { [weak self] in
-                            guard let self = self else { return }
-                            self.clearSelectedVariations()
-                        }, onCloseButtonTapped: { [weak self] in
-                            guard let self = self else { return }
-                            self.syncOrderItemSelectionStateOnDismiss()
-                        }, onConfigureProductRow: { [weak self] product in
+                guard let self, isPresented else { return nil }
+                return ProductSelectorViewModel(
+                    siteID: siteID,
+                    selectedItemIDs: selectedProductsAndVariationsIDs,
+                    purchasableItemsOnly: true,
+                    storageManager: storageManager,
+                    stores: stores,
+                    toggleAllVariationsOnSelection: false,
+                    topProductsProvider: TopProductsFromCachedOrdersProvider(),
+                    onProductSelectionStateChanged: { [weak self] product in
+                        guard let self = self else { return }
+                        self.changeSelectionStateForProduct(product)
+                    },
+                    onVariationSelectionStateChanged: { [weak self] variation, parentProduct in
+                        guard let self = self else { return }
+                        self.changeSelectionStateForProductVariation(variation, parent: parentProduct)
+                    }, onMultipleSelectionCompleted: { [weak self] _ in
+                        guard let self = self else { return }
+                        self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
+                    }, onAllSelectionsCleared: { [weak self] in
+                        guard let self = self else { return }
+                        self.clearAllSelectedItems()
+                        self.trackClearAllSelectedItemsTapped()
+                    }, onSelectedVariationsCleared: { [weak self] in
+                        guard let self = self else { return }
+                        self.clearSelectedVariations()
+                    }, onCloseButtonTapped: { [weak self] in
+                        guard let self = self else { return }
+                        self.syncOrderItemSelectionStateOnDismiss()
+                    }, onConfigureProductRow: { [weak self] product in
+                        guard let self else { return }
+                        productToConfigureViewModel = .init(product: product, orderItem: nil, childItems: [], onConfigure: { [weak self] configuration in
                             guard let self else { return }
-                            productToConfigureViewModel = .init(product: product, orderItem: nil, childItems: [], onConfigure: { [weak self] configuration in
-                                guard let self else { return }
-                                self.saveBundleConfigurationFromProductSelector(product: product, bundleConfiguration: configuration)
-                                self.productToConfigureViewModel = nil
-                            })
+                            self.saveBundleConfigurationFromProductSelector(product: product, bundleConfiguration: configuration)
+                            self.productToConfigureViewModel = nil
                         })
-                } else {
-                    return nil
-                }
+                    })
             }
             .assign(to: &$productSelectorViewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -19,6 +19,10 @@ final class EditableOrderViewModel: ObservableObject {
     private let featureFlagService: FeatureFlagService
     private let permissionChecker: CaptureDevicePermissionChecker
 
+    // MARK: - Product selector states
+    @Published var productSelectorViewModel: ProductSelectorViewModel?
+    @Published var isProductSelectorPresented: Bool = false
+
     private var cancellables: Set<AnyCancellable> = []
 
     enum Flow: Equatable {
@@ -484,6 +488,7 @@ final class EditableOrderViewModel: ObservableObject {
         configureTaxRates()
         configureGiftCardSupport()
         observeGiftCardStatesForAnalytics()
+        observeProductSelectorPresentationStateForViewModel()
     }
 
     /// Checks the latest Order sync, and returns the current items that are in the Order
@@ -523,46 +528,10 @@ final class EditableOrderViewModel: ObservableObject {
         selectedProductVariations.removeAll()
     }
 
-    /// View model for the product list, initialized with the selected order items
+    /// Toggles whether the product selector is shown or not.
     ///
-    func createProductSelectorViewModelWithOrderItemsSelected() -> ProductSelectorViewModel {
-        ProductSelectorViewModel(
-            siteID: siteID,
-            selectedItemIDs: selectedProductsAndVariationsIDs,
-            purchasableItemsOnly: true,
-            shouldDeleteStoredProductsOnFirstPage: false,
-            storageManager: storageManager,
-            stores: stores,
-            toggleAllVariationsOnSelection: false,
-            topProductsProvider: TopProductsFromCachedOrdersProvider(),
-            onProductSelectionStateChanged: { [weak self] product in
-                guard let self = self else { return }
-                self.changeSelectionStateForProduct(product)
-            },
-            onVariationSelectionStateChanged: { [weak self] variation, parentProduct in
-                guard let self = self else { return }
-                self.changeSelectionStateForProductVariation(variation, parent: parentProduct)
-            }, onMultipleSelectionCompleted: { [weak self] _ in
-                guard let self = self else { return }
-                self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
-            }, onAllSelectionsCleared: { [weak self] in
-                guard let self = self else { return }
-                self.clearAllSelectedItems()
-                self.trackClearAllSelectedItemsTapped()
-            }, onSelectedVariationsCleared: { [weak self] in
-                guard let self = self else { return }
-                self.clearSelectedVariations()
-            }, onCloseButtonTapped: { [weak self] in
-                guard let self = self else { return }
-                self.syncOrderItemSelectionStateOnDismiss()
-            }, onConfigureProductRow: { [weak self] product in
-                guard let self else { return }
-                productToConfigureViewModel = .init(product: product, orderItem: nil, childItems: [], onConfigure: { [weak self] configuration in
-                    guard let self else { return }
-                    self.saveBundleConfigurationFromProductSelector(product: product, bundleConfiguration: configuration)
-                    self.productToConfigureViewModel = nil
-                })
-            })
+    func toggleProductSelectorVisibility() {
+        isProductSelectorPresented.toggle()
     }
 
     /// Synchronizes the item selection state by clearing all items, then retrieving the latest saved state
@@ -1586,6 +1555,55 @@ private extension EditableOrderViewModel {
             .store(in: &cancellables)
     }
 
+    func observeProductSelectorPresentationStateForViewModel() {
+        $isProductSelectorPresented
+            .removeDuplicates()
+            .map { [weak self] isPresented in
+                guard let self else { return nil }
+                if isPresented {
+                    return ProductSelectorViewModel(
+                        siteID: siteID,
+                        selectedItemIDs: selectedProductsAndVariationsIDs,
+                        purchasableItemsOnly: true,
+                        storageManager: storageManager,
+                        stores: stores,
+                        toggleAllVariationsOnSelection: false,
+                        topProductsProvider: TopProductsFromCachedOrdersProvider(),
+                        onProductSelectionStateChanged: { [weak self] product in
+                            guard let self = self else { return }
+                            self.changeSelectionStateForProduct(product)
+                        },
+                        onVariationSelectionStateChanged: { [weak self] variation, parentProduct in
+                            guard let self = self else { return }
+                            self.changeSelectionStateForProductVariation(variation, parent: parentProduct)
+                        }, onMultipleSelectionCompleted: { [weak self] _ in
+                            guard let self = self else { return }
+                            self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
+                        }, onAllSelectionsCleared: { [weak self] in
+                            guard let self = self else { return }
+                            self.clearAllSelectedItems()
+                            self.trackClearAllSelectedItemsTapped()
+                        }, onSelectedVariationsCleared: { [weak self] in
+                            guard let self = self else { return }
+                            self.clearSelectedVariations()
+                        }, onCloseButtonTapped: { [weak self] in
+                            guard let self = self else { return }
+                            self.syncOrderItemSelectionStateOnDismiss()
+                        }, onConfigureProductRow: { [weak self] product in
+                            guard let self else { return }
+                            productToConfigureViewModel = .init(product: product, orderItem: nil, childItems: [], onConfigure: { [weak self] configuration in
+                                guard let self else { return }
+                                self.saveBundleConfigurationFromProductSelector(product: product, bundleConfiguration: configuration)
+                                self.productToConfigureViewModel = nil
+                            })
+                        })
+                } else {
+                    return nil
+                }
+            }
+            .assign(to: &$productSelectorViewModel)
+    }
+
     /// Tracks when customer details have been added
     ///
     func trackCustomerDetailsAdded() {
@@ -1835,6 +1853,7 @@ private extension EditableOrderViewModel {
         productSelectorBundleConfigurationsByProductID[product.productID] = (productSelectorBundleConfigurationsByProductID[product.productID] ?? [])
         + [bundleConfiguration]
         selectedProducts.append(product)
+        productSelectorViewModel?.addSelection(id: product.productID)
     }
 
     func addBundleConfigurationToOrderItem(item: OrderItem, bundleConfiguration: [BundledProductConfiguration]) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -390,10 +390,6 @@ private struct ProductsSection: View {
     /// Fix for breaking navbar button
     @Binding var navigationButtonID: UUID
 
-    /// Defines whether `AddProduct` modal is presented.
-    ///
-    @State private var showAddProduct: Bool = false
-
     /// Defines whether `AddProductViaSKUScanner` modal is presented.
     ///
     @State private var showAddProductViaSKUScanner: Bool = false
@@ -439,7 +435,7 @@ private struct ProductsSection: View {
                         .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
 
                         Button(action: {
-                            showAddProduct.toggle()
+                            viewModel.toggleProductSelectorVisibility()
                         }) {
                             Image(uiImage: .plusImage)
                         }
@@ -474,7 +470,7 @@ private struct ProductsSection: View {
 
                 HStack {
                     Button(OrderForm.Localization.addProducts) {
-                        showAddProduct.toggle()
+                        viewModel.toggleProductSelectorVisibility()
                     }
                     .id(addProductButton)
                     .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
@@ -488,19 +484,21 @@ private struct ProductsSection: View {
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()
             .background(Color(.listForeground(modal: true)))
-            .sheet(isPresented: $showAddProduct, onDismiss: {
+            .sheet(isPresented: $viewModel.isProductSelectorPresented, onDismiss: {
                 scroll.scrollTo(addProductButton)
             }, content: {
-                ProductSelectorNavigationView(
-                    configuration: ProductSelectorView.Configuration.addProductToOrder(),
-                    source: .orderForm(flow: flow),
-                    isPresented: $showAddProduct,
-                    viewModel: viewModel.createProductSelectorViewModelWithOrderItemsSelected())
-                .onDisappear {
-                    navigationButtonID = UUID()
-                }
-                .sheet(item: $viewModel.productToConfigureViewModel) { viewModel in
-                    ConfigurableBundleProductView(viewModel: viewModel)
+                if let productSelectorViewModel = viewModel.productSelectorViewModel {
+                    ProductSelectorNavigationView(
+                        configuration: ProductSelectorView.Configuration.addProductToOrder(),
+                        source: .orderForm(flow: flow),
+                        isPresented: $viewModel.isProductSelectorPresented,
+                        viewModel: productSelectorViewModel)
+                    .onDisappear {
+                        navigationButtonID = UUID()
+                    }
+                    .sheet(item: $viewModel.productToConfigureViewModel) { viewModel in
+                        ConfigurableBundleProductView(viewModel: viewModel)
+                    }
                 }
             })
             .actionSheet(isPresented: $showPermissionsSheet, content: {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -263,7 +263,13 @@ final class ProductSelectorViewModel: ObservableObject {
         }
     }
 
-    func toggleSelection(id: Int64) {
+    /// Adds a product or variation ID to the product selector from an external source (e.g. bundle configuration form for bundle products).
+    /// - Parameter id: Product or variation ID to add to the product selector.
+    func addSelection(id: Int64) {
+        selectedItemsIDs.append(id)
+    }
+
+    private func toggleSelection(id: Int64) {
         if selectedItemsIDs.contains(id) {
             selectedItemsIDs = selectedItemsIDs.filter { $0 != id }
         } else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -33,9 +33,13 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows.count, 0)
     }
 
-    func test_createProductSelectorViewModelWithOrderItemsSelected_returns_instance_initialized_with_expected_values() {
+    func test_createProductSelectorViewModelWithOrderItemsSelected_returns_instance_initialized_with_expected_values() throws {
+        // When
+        viewModel.toggleProductSelectorVisibility()
+
         // Then
-        XCTAssertFalse(viewModel.createProductSelectorViewModelWithOrderItemsSelected().toggleAllVariationsOnSelection)
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
+        XCTAssertFalse(productSelectorViewModel.toggleAllVariationsOnSelection)
     }
 
     func test_edition_view_model_inits_with_expected_values() {
@@ -269,11 +273,12 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "Processing")
     }
 
-    func test_view_model_is_updated_when_product_is_added_to_order() {
+    func test_view_model_is_updated_when_product_is_added_to_order() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -283,7 +288,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
     }
 
-    func test_order_details_are_updated_when_product_quantity_changes() {
+    func test_order_details_are_updated_when_product_quantity_changes() throws {
         // Given
 
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
@@ -292,7 +297,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
         storageManager.insertSampleProduct(readOnlyProduct: anotherProduct)
 
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -306,11 +312,12 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows[safe: 1]?.quantity, 1)
     }
 
-    func test_product_is_removed_when_quantity_is_decremented_below_1() {
+    func test_product_is_removed_when_quantity_is_decremented_below_1() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // Product quantity is 1
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -381,7 +388,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         productSelectorViewModel.completeMultipleSelection()
 
@@ -394,12 +402,13 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedProductViewModel?.productRowViewModel.id, expectedRow.id)
     }
 
-    func test_view_model_is_updated_when_product_is_removed_from_order_using_order_item() {
+    func test_view_model_is_updated_when_product_is_removed_from_order_using_order_item() throws {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         storageManager.insertProducts([product0, product1])
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // Given products are added to order
         productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
@@ -416,12 +425,13 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows.map { $0.id }, [expectedRemainingRow].map { $0.id })
     }
 
-    func test_view_model_is_updated_when_product_is_removed_from_order_using_product_row_ID() {
+    func test_view_model_is_updated_when_product_is_removed_from_order_using_product_row_ID() throws {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         storageManager.insertProducts([product0, product1])
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // Given products are added to order
         productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
@@ -767,13 +777,14 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     // MARK: - Payment Section Tests
 
-    func test_payment_section_when_products_and_custom_amounts_are_added_then_paymentDataViewModel_is_updated() {
+    func test_payment_section_when_products_and_custom_amounts_are_added_then_paymentDataViewModel_is_updated() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // Pre-check
         XCTAssertTrue(viewModel.paymentDataViewModel.orderIsEmpty)
@@ -796,7 +807,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.paymentDataViewModel.shouldShowProductsTotal)
     }
 
-    func test_payment_section_is_updated_when_products_update() {
+    func test_payment_section_is_updated_when_products_update() throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
@@ -805,7 +816,8 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                storageManager: storageManager,
                                                currencySettings: currencySettings,
                                                quantityDebounceDuration: 0)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When & Then
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -824,7 +836,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£17.00")
     }
 
-    func test_payment_section_is_updated_when_shipping_line_updated() {
+    func test_payment_section_is_updated_when_shipping_line_updated() throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
@@ -833,7 +845,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -862,7 +875,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
     }
 
-    func test_payment_when_custom_amount_is_added_then_section_is_updated() {
+    func test_payment_when_custom_amount_is_added_then_section_is_updated() throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
@@ -870,7 +883,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -894,7 +908,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -915,7 +930,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.paymentDataViewModel.couponLineViewModels.isEmpty)
     }
 
-    func test_payment_section_values_correct_when_shipping_line_is_negative() {
+    func test_payment_section_values_correct_when_shipping_line_is_negative() throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, price: "8.50", purchasable: true)
@@ -923,7 +938,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                currencySettings: currencySettings)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -1032,11 +1048,12 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasChanges)
     }
 
-    func test_hasChanges_returns_true_when_product_quantity_changes() {
+    func test_hasChanges_returns_true_when_product_quantity_changes() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -1102,7 +1119,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -1131,7 +1149,8 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                flow: .editing(initialOrder: .fake()),
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -1157,7 +1176,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // Given products are added to order
         productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
@@ -1178,15 +1198,17 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(properties, "creation")
     }
 
-    func test_product_selector_source_is_tracked_when_product_selector_clear_selection_button_is_tapped() {
+    func test_product_selector_source_is_tracked_when_product_selector_clear_selection_button_is_tapped() throws {
         // Given
         let analytics = MockAnalyticsProvider()
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
                                                analytics: WooAnalytics(analyticsProvider: analytics))
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
-        viewModel.createProductSelectorViewModelWithOrderItemsSelected().clearSelection()
+        productSelectorViewModel.clearSelection()
 
         // Then
         XCTAssertTrue(analytics.receivedEvents.contains(where: {
@@ -1505,7 +1527,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowNewTaxRateSection)
     }
 
-    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_customerBillingAddress_and_there_are_items_then_returns_true() {
+    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_customerBillingAddress_and_there_are_items_then_returns_true() throws {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
             switch action {
@@ -1529,7 +1551,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -1541,7 +1564,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
-    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_customerShippingAddress_and_there_are_items_then_returns_true() {
+    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_customerShippingAddress_and_there_are_items_then_returns_true() throws {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
             switch action {
@@ -1565,7 +1588,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -1639,7 +1663,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
-    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_shopBaseAddress_and_there_are_items_then_returns_false() {
+    func test_shouldShowNewTaxRateSection_when_taxBasedOnSetting_is_shopBaseAddress_and_there_are_items_then_returns_false() throws {
         // Given
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
             switch action {
@@ -1654,7 +1678,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        let productSelectorViewModel = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
@@ -2832,7 +2857,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores, storageManager: storageManager)
 
         // When entering the product selector
-        let productSelector = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelector = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // The child bundled item is not counted as a product in the product selector
         XCTAssertEqual(productSelector.totalSelectedItemsCount, 2)
@@ -2898,7 +2924,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores, storageManager: storageManager)
 
         // When entering the product selector
-        let productSelector = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelector = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // The child bundled item is not counted as a product in the product selector
         XCTAssertEqual(productSelector.totalSelectedItemsCount, 1)
@@ -2954,7 +2981,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores, storageManager: storageManager)
 
         // When entering the product selector
-        let productSelector = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelector = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // The child bundled item is not counted as a product in the product selector
         XCTAssertEqual(productSelector.totalSelectedItemsCount, 0)
@@ -3019,7 +3047,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores, storageManager: storageManager)
 
         // When entering the product selector
-        let productSelector = viewModel.createProductSelectorViewModelWithOrderItemsSelected()
+        viewModel.toggleProductSelectorVisibility()
+        let productSelector = try XCTUnwrap(viewModel.productSelectorViewModel)
 
         // The child bundled item is not counted as a product in the product selector
         XCTAssertEqual(productSelector.totalSelectedItemsCount, 0)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1000,6 +1000,18 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertTrue(onAllSelectionsClearedCalled)
     }
 
+    func test_addSelection_allows_multiple_same_ids() {
+        // Given
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, selectedItemIDs: [1, 12, 20])
+
+        // When
+        viewModel.addSelection(id: 1)
+        viewModel.addSelection(id: 1)
+
+        // Then
+        XCTAssertEqual(viewModel.totalSelectedItemsCount, 2)
+    }
+
     @MainActor
     func test_synchronizeProducts_are_triggered_with_correct_filters() async throws {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1009,7 +1009,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.addSelection(id: 1)
 
         // Then
-        XCTAssertEqual(viewModel.totalSelectedItemsCount, 2)
+        XCTAssertEqual(viewModel.totalSelectedItemsCount, 5)
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11198 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While inspecting the API requests debugging the variation issues https://github.com/woocommerce/woocommerce-ios/pull/11186#pullrequestreview-1736581081, I noticed that `ProductSelectorViewModel` was initialized every time a state in the product selector changes - selecting/deselecting a product, configuring a bundle product, etc. This is likely due to how SwiftUI works, the view is refreshed whenever a state (`ProductSelectorViewModel`) that is passed to the view (`ProductSelectorNavigationView`) changes. This behavior of reinitializing the view model every time a state changes results in same products API requests being made throughout the product selector session. In this PR, it fixes the duplicate API requests by not creating a product selector view model in the SwiftUI view.

## How

A straightforward fix would be to make `ProductSelectorViewModel` an optional observable property, and use the nullable state for the sheet in `OrderForm` through `.sheet(item:onDismiss:content:)` instead of the `isPresented` boolean state. This was my original implementation, but I noticed the dismissal stopped working. This is because the `isPresented` boolean state is passed to `ProductSelectorView` in order to dismiss the product selector in addition to the CTA from the order form to show the product selector. Without refactoring too much, I decided to keep the `isPresented` boolean state but move it from `OrderForm.ProductsSection.showAddProduct` to `ProductSelectorViewModel.isProductSelectorPresented` as the source of truth for whether the product selector is presented. A new function `EditableOrderViewModel.toggleProductSelectorVisibility` was added and is triggered when a merchant taps to view the product selector. When toggling the product selector to be visible, `ProductSelectorViewModel` is initialized and used to show the content of the presentation sheet in `OrderForm`.

Regarding the change to add `ProductSelectorViewModel.addSelection` function: this is to support external product selection like from configuring a bundle product so that the `# Products selected` text for the CTA at the bottom of the product selector can be updated. `ProductSelectorViewModel` is internally tracking the number of selected items (products and variations) to be shown in the CTA. However, product selection (from bundle configuration and maybe other extensions in the future) can happen outside of the core logic in `ProductSelectorViewModel` and multiple of the same product can be selected (right now `ProductSelectorViewModel` expects a product to be either selected or deselected). It'd be great if we could refactor the source of truth of selected items so that the same info in `EditableOrderViewModel.selectedProducts` and `ProductSelectorViewModel.selectedItemsIDs` can be consolidated.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

- Go to the orders tab
- Tap `+` to create an order
- Enable a tool to observe network requests
- Tap `Add Products` --> notice that there are 2 products API requests - this is a pre-existing behavior where both `onLoadTrigger` and `synchronizeProductFilterSearch` are both triggered to load products from initialization. This is beyond the scope of this PR, and I'll confirm this behavior separately
- Tap to select and deselect at least one product --> notice that there should be no extra products API requests except for loading product variations from tapping a variable product. The CTA text at the bottom should be updated accordingly
- Tap on a bundle product in the prerequisite to configure the bundle
- Update the configuration if needed so that the configuration is valid, then tap `Done` to save the bundle --> the CTA text at the bottom should be updated accordingly

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
