### PR TITLE
Product Subscriptions: Use default values while parsing Subscription model

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -948,6 +948,7 @@
 		EE80A24829547F8B003591E4 /* coupon-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24629547F8B003591E4 /* coupon-without-data.json */; };
 		EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */; };
 		EE839C262ABEF9C900049545 /* AIProductMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE839C252ABEF9C900049545 /* AIProductMapper.swift */; };
+		EE84D62B2B0B46E7008EA80A /* product-variation-subscription-incomplete.json in Resources */ = {isa = PBXBuildFile; fileRef = EE84D62A2B0B46E7008EA80A /* product-variation-subscription-incomplete.json */; };
 		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
 		EE8DE432294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */; };
 		EE99814E295AA7430074AE68 /* RequestAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE99814D295AA7430074AE68 /* RequestAuthenticator.swift */; };
@@ -1957,6 +1958,7 @@
 		EE80A24629547F8B003591E4 /* coupon-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-without-data.json"; sourceTree = "<group>"; };
 		EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports-without-data.json"; sourceTree = "<group>"; };
 		EE839C252ABEF9C900049545 /* AIProductMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProductMapper.swift; sourceTree = "<group>"; };
+		EE84D62A2B0B46E7008EA80A /* product-variation-subscription-incomplete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation-subscription-incomplete.json"; sourceTree = "<group>"; };
 		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
 		EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultApplicationPasswordUseCaseTests.swift; sourceTree = "<group>"; };
 		EE99814D295AA7430074AE68 /* RequestAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthenticator.swift; sourceTree = "<group>"; };
@@ -2789,6 +2791,7 @@
 				451274A525276C82009911FF /* product-variation.json */,
 				CE13681029FA809600EBF43C /* product-variation-min-max-quantities.json */,
 				CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */,
+				EE84D62A2B0B46E7008EA80A /* product-variation-subscription-incomplete.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				EEA6583D2966B41E00112DF0 /* products-load-all-without-data.json */,
 				2676F4CF290B0EC700C7A15B /* product-id-only.json */,
@@ -3760,6 +3763,7 @@
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
+				EE84D62B2B0B46E7008EA80A /* product-variation-subscription-incomplete.json in Resources */,
 				029B86902A6FBBE000E944D1 /* wcpay-account-null-isLive.json in Resources */,
 				02AED9D82AA03F3F006DC460 /* order-with-all-addon-types.json in Resources */,
 				DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */,

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -42,6 +42,20 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
         self.trialPeriod = trialPeriod
     }
 
+    /// Custom decoding to use default value when JSON doesn't have a key present
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        length = try container.decodeIfPresent(String.self, forKey: .length) ?? "0"
+        period = try container.decodeIfPresent(SubscriptionPeriod.self, forKey: .period) ?? .month
+        periodInterval = try container.decodeIfPresent(String.self, forKey: .periodInterval) ?? "0"
+        price = try container.decodeIfPresent(String.self, forKey: .price) ?? "0"
+        signUpFee = try container.decodeIfPresent(String.self, forKey: .signUpFee) ?? "0"
+        trialLength = try container.decodeIfPresent(String.self, forKey: .trialLength) ?? "0"
+        trialPeriod = try container.decodeIfPresent(SubscriptionPeriod.self, forKey: .trialPeriod) ?? .day
+    }
+
     func toKeyValuePairs() -> [KeyValuePair] {
         [
             .init(key: CodingKeys.length.rawValue, value: length),

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -384,6 +384,18 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.trialPeriod, .week)
     }
 
+    /// Test that `subscription` is nil when parsing non-subscription product response
+    ///
+    func test_subscription_is_nil_when_parsing_non_subscription_product_response() throws {
+        // Given
+        let productsToTest = try XCTUnwrap(mapLoadProductResponse())
+
+        // Then
+        for product in productsToTest {
+            XCTAssertNil(product.subscription)
+        }
+    }
+
     /// Test that products with properties from the Min/Max Quantities extension are properly parsed.
     ///
     func test_min_max_quantities_are_properly_parsed() throws {

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -64,6 +64,33 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.trialPeriod, .month)
     }
 
+    /// Test that the fields for variations of a subscription product are properly parsed when missing fields.
+    ///
+    func test_subscription_variations_are_properly_parsed_when_response_has_missing_fields() throws {
+        // Given
+        let productVariation = try XCTUnwrap(mapLoadSubscriptionVariationIncompleteResponse())
+        let subscriptionSettings = try XCTUnwrap(productVariation.subscription)
+
+        // Then
+        XCTAssertEqual(subscriptionSettings.length, "0")
+        XCTAssertEqual(subscriptionSettings.period, .week)
+        XCTAssertEqual(subscriptionSettings.periodInterval, "1")
+        XCTAssertEqual(subscriptionSettings.price, "0")
+        XCTAssertEqual(subscriptionSettings.signUpFee, "0")
+        XCTAssertEqual(subscriptionSettings.trialLength, "0")
+        XCTAssertEqual(subscriptionSettings.trialPeriod, .month)
+    }
+
+    /// Test that subscription is nil when parsing non-subscription product response
+    ///
+    func test_subscription_is_nil_when_parsing_non_subscription_product_response() throws {
+        // Given
+        let productVariation = try XCTUnwrap(mapLoadProductVariationResponse())
+
+        // Then
+        XCTAssertNil(productVariation.subscription)
+    }
+
     /// Test that product variations with properties from the Min/Max Quantities extension are properly parsed.
     ///
     func test_min_max_quantities_are_properly_parsed() throws {
@@ -113,6 +140,12 @@ private extension ProductVariationMapperTests {
     ///
     func mapLoadSubscriptionVariationResponse() -> ProductVariation? {
         return mapProductVariation(from: "product-variation-subscription")
+    }
+
+    /// Returns the ProductVariationMapper output upon receiving `product-variation-subscription-incomplete`
+    ///
+    func mapLoadSubscriptionVariationIncompleteResponse() -> ProductVariation? {
+        return mapProductVariation(from: "product-variation-subscription-incomplete")
     }
 
     /// Returns the ProductVariationMapper output upon receiving `product-variation-min-max-quantities`

--- a/Networking/NetworkingTests/Responses/product-variation-subscription-incomplete.json
+++ b/Networking/NetworkingTests/Responses/product-variation-subscription-incomplete.json
@@ -1,0 +1,160 @@
+{
+    "data": {
+        "id": 204,
+        "name": "Coffee Subscription (Choose your grind) - Whole bean, Weekly",
+        "slug": "coffee-subscription-your-choice-weekly-whole-bean",
+        "permalink": "https://example.com/product/coffee-subscription-choose-your-grind/?attribute_grind=Whole+bean&attribute_frequency=Weekly",
+        "date_created": "2023-01-24T18:24:06",
+        "date_created_gmt": "2023-01-24T18:24:06",
+        "date_modified": "2023-04-05T18:08:12",
+        "date_modified_gmt": "2023-04-05T17:08:12",
+        "type": "subscription_variation",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "",
+        "short_description": "",
+        "sku": "",
+        "price": "5",
+        "regular_price": "5",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "on_sale": false,
+        "purchasable": true,
+        "total_sales": "0",
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "low_stock_amount": null,
+        "sold_individually": false,
+        "weight": "",
+        "dimensions": {
+            "length": "",
+            "width": "",
+            "height": ""
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": false,
+        "average_rating": "0.00",
+        "rating_count": 0,
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 200,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [],
+        "images": [
+            {
+                "id": 199,
+                "date_created": "2023-01-24T18:16:07",
+                "date_created_gmt": "2023-01-24T18:16:07",
+                "date_modified": "2023-01-27T10:55:09",
+                "date_modified_gmt": "2023-01-27T10:55:09",
+                "src": "https://example.com/wp-content/uploads/2023/01/coffee-beans.jpg",
+                "name": "coffee-beans",
+                "alt": ""
+            }
+        ],
+        "attributes": [
+            {
+                "id": 0,
+                "name": "Grind",
+                "option": "Whole bean"
+            },
+            {
+                "id": 0,
+                "name": "Frequency",
+                "option": "Weekly"
+            }
+        ],
+        "default_attributes": [],
+        "variations": [],
+        "grouped_products": [],
+        "menu_order": 1,
+        "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>5.00</bdi></span> <span class=\"subscription-details\"> / week</span>",
+        "related_ids": [],
+        "meta_data": [
+            {
+                "id": 4464,
+                "key": "_subscription_period",
+                "value": "week"
+            },
+            {
+                "id": 4465,
+                "key": "_subscription_period_interval",
+                "value": "1"
+            },
+            {
+                "id": 4466,
+                "key": "_subscription_length",
+                "value": "0"
+            },
+            {
+                "id": 4467,
+                "key": "_subscription_trial_period",
+                "value": "month"
+            }
+        ],
+        "stock_status": "instock",
+        "has_options": true,
+        "composite_virtual": false,
+        "composite_layout": "",
+        "composite_add_to_cart_form_location": "",
+        "composite_editable_in_cart": false,
+        "composite_sold_individually_context": "",
+        "composite_shop_price_calc": "",
+        "composite_components": [],
+        "composite_scenarios": [],
+        "bundled_by": [],
+        "bundle_stock_status": "instock",
+        "bundle_stock_quantity": null,
+        "bundle_virtual": false,
+        "bundle_layout": "",
+        "bundle_add_to_cart_form_location": "",
+        "bundle_editable_in_cart": false,
+        "bundle_sold_individually_context": "",
+        "bundle_item_grouping": "",
+        "bundle_min_size": "",
+        "bundle_max_size": "",
+        "bundled_items": [],
+        "bundle_sell_ids": [],
+        "jetpack_publicize_connections": [],
+        "jetpack_sharing_enabled": true,
+        "jetpack_likes_enabled": true,
+        "brands": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/204"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products"
+                }
+            ],
+            "up": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/200"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11213 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

**What?**

Variable subscription products created from web doesn't have values for all fields in JSON. 

**Why?**

Web doesn't require us to enter values for all fields while creating a variation. This causes the subscription variation JSON to not have all subscription related fields. 

**Fix**

Start using default values while a subscription's JSON doesn't have fields.

## Testing instructions

**Prerequisites**
- Create a variable subscription product with a variation with empty price related values. i.e. Just create a variation and don't enter price details. 
- Enable `subscriptionProducts` feature flag by returning `true` from [this line](https://github.com/woocommerce/woocommerce-ios/blob/trunk/Experiments/Experiments/DefaultFeatureFlagService.swift#L90) 
- Launch the app and login 
- Navigate to products
- Tap on a variable subscription product
- Navigate to the variation detail screen and tap on the price row
- Validate that you see the Price screen for subscription product with fields like "Billing interval"

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/939e5143-672f-467b-b563-7e36609e1895



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
