### PR TITLE
[Bundle products in order form] Fix bundle with optional non-selected variable item can't be added successfully (without child items)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -217,7 +217,23 @@ extension ConfigurableBundleItemViewModel {
         switch product.productType {
             case .variable:
                 guard let variation = selectedVariation else {
-                    return nil
+                    // Even if a variation is optional and not selected, the product bundles API still expects a
+                    // variation ID and full array of attributes.
+                    // As a workaround, we have to come up with a placeholder variation ID and attributes from the
+                    // variation settings and variable product.
+                    guard let placeholderVariationID = variableProductSettings?.allowedVariations.first ?? product.variations.first else {
+                        return nil
+                    }
+                    let placeholderAttributes = product.attributesForVariations.map {
+                        ProductVariationAttribute(id: $0.attributeID, name: $0.name, option: $0.options.first ?? "")
+                    }
+
+                    return .init(bundledItemID: bundledItemID,
+                                 productOrVariation: .variation(productID: product.productID,
+                                                                variationID: placeholderVariationID,
+                                                                attributes: placeholderAttributes),
+                                 quantity: quantity,
+                                 isOptionalAndSelected: isOptionalAndSelected)
                 }
                 return .init(bundledItemID: bundledItemID,
                              productOrVariation: .variation(productID: product.productID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
@@ -217,6 +217,73 @@ final class ConfigurableBundleItemViewModelTests: XCTestCase {
         ])
     }
 
+    // MARK: - `toConfiguration`
+
+    func test_toConfiguration_sets_placeholder_variationID_and_attributes_when_selectedVariation_is_nil() {
+        // Given
+        let variableProduct = createVariableProduct()
+            .copy(attributes: [
+                .fake().copy(attributeID: 5, name: "Flavor", variation: true, options: ["Pineapple", "Blackberry"])
+            ], variations: [965])
+
+        // When
+        let viewModel = ConfigurableBundleItemViewModel(bundleItem: .fake(),
+                                                        product: variableProduct,
+                                                        variableProductSettings: .init(allowedVariations: [], defaultAttributes: [
+                                                            .init(id: 0, name: "Flavor", option: "Blackberry")
+                                                        ]),
+                                                        existingParentOrderItem: nil,
+                                                        existingOrderItem: nil)
+
+        // Then
+        XCTAssertNil(viewModel.selectedVariation)
+        XCTAssertEqual(viewModel.toConfiguration, .init(bundledItemID: 0,
+                                                        productOrVariation: .variation(productID: variableProduct.productID,
+                                                                                       variationID: 965,
+                                                                                       attributes: [
+                                                                                        .init(id: 5, name: "Flavor", option: "Pineapple")
+                                                                                       ]),
+                                                        quantity: 0,
+                                                        isOptionalAndSelected: false))
+    }
+
+    func test_toConfiguration_sets_variationID_and_attributes_when_selectedVariation_is_not_nil() {
+        // Given
+        let variableProduct = createVariableProduct()
+            .copy(attributes: [
+                .fake().copy(attributeID: 5, name: "Flavor", variation: true, options: ["Pineapple", "Blackberry"])
+            ])
+
+        // When
+        let viewModel = ConfigurableBundleItemViewModel(bundleItem: .fake(),
+                                                        product: variableProduct,
+                                                        variableProductSettings: .init(allowedVariations: [], defaultAttributes: [
+                                                            .init(id: 0, name: "Flavor", option: "Blackberry")
+                                                        ]),
+                                                        existingParentOrderItem: nil,
+                                                        existingOrderItem: nil)
+        viewModel.createVariationSelectorViewModel()
+        viewModel.variationSelectorViewModel?.onVariationSelectionStateChanged?(
+            // Selected variation.
+            .fake().copy(productVariationID: 7,
+                         attributes: []),
+            // Selected product.
+            variableProduct
+        )
+        viewModel.isOptionalAndSelected = true
+
+        // Then
+        XCTAssertNotNil(viewModel.selectedVariation)
+        XCTAssertEqual(viewModel.toConfiguration, .init(bundledItemID: 0,
+                                                        productOrVariation: .variation(productID: variableProduct.productID,
+                                                                                       variationID: 7,
+                                                                                       attributes: [
+                                                                                        .init(id: 5, name: "Flavor", option: "Blackberry")
+                                                                                       ]),
+                                                        quantity: 0,
+                                                        isOptionalAndSelected: true))
+    }
+
     // MARK: - Analytics
 
     func test_selecting_variation_tracks_orderFormBundleProductConfigurationChanged_event() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11232
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When a bundle includes an optional variable item, even though the variable item isn't selected, the bundle can't be saved properly before this PR (the selected child item(s) don't appear in the order, only the parent bundle item). After some API testing (direct API requests to the site instead of Jetpack requests show an error), it looks like the API expects a **valid** variation ID and attributes (not just any placeholder values) even though a variable item isn't selected. Before this PR, if a variable item is optional and not selected, the item is skipped in the bundle configuration field in the API. This PR fixes this issue by introducing a workaround to include the optional & non-selected variable item by using a placeholder variation ID and attributes.

This feels like an unexpected API behavior, I'll make sure to include this as a feature request to the extension owner after wrapping up the project. I also added this behavior to 
Pe5pgL-3Vd-p2#some-gotchas.

## How

In `ConfigurableBundleItemViewModel.toConfiguration` where the output is then serialized in the API request body for each bundle item in the bundle configuration, even if there's no selected variation for a variable item, a valid placeholder variation ID and attributes are used to return a `BundledProductConfiguration` instead of `nil` before.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with **1 optional variable item with non-empty variations** and another non-optional item.

- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite
- Configure the non-optional item if needed so that configuration is valid and contains at least one child item, then tap `Done` to save the bundle
- Tap `1 Product Selected` to confirm product selection
- Tap `Create` to create the order --> the bundle product should be added with the child item(s) to the order

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/072460e1-9471-4604-b8ff-638e183ea455



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.