### PR TITLE
[Deposits Summary] Add deposit summary to Payments Menu

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -65,6 +65,15 @@
         }
       },
       {
+        "package": "ScrollViewSectionKit",
+        "repositoryURL": "https://github.com/pavolkmet/ScrollViewSectionKit",
+        "state": {
+          "branch": null,
+          "revision": "44a0db25e86206bdb96fb7b93507417cfc36f016",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "swift-algorithms",
         "repositoryURL": "https://github.com/apple/swift-algorithms",
         "state": {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ScrollViewSectionKit
 
 struct InPersonPaymentsMenu: View {
     @ObservedObject private(set) var viewModel: InPersonPaymentsMenuViewModel
@@ -7,130 +8,135 @@ struct InPersonPaymentsMenu: View {
 
     var body: some View {
         VStack {
-            List {
-                Section {
-                    PaymentsRow(image: Image(uiImage: .moneyIcon),
-                                title: Localization.collectPayment)
-                    .onTapGesture {
-                        viewModel.collectPaymentTapped()
-                    }
-                    .sheet(isPresented: $viewModel.presentCollectPayment,
-                           onDismiss: {
-                        Task { @MainActor in
-                            await viewModel.onAppear()
+            ScrollView {
+                VStack(spacing: 0) {
+                    ScrollViewSection {
+                        PaymentsRow(image: Image(uiImage: .moneyIcon),
+                                    title: Localization.collectPayment)
+                        .onTapGesture {
+                            viewModel.collectPaymentTapped()
                         }
-                    }) {
-                        NavigationView {
-                            SimplePaymentsAmountHosted(
-                                viewModel: SimplePaymentsAmountViewModel(siteID: viewModel.siteID),
-                                presentNoticePublisher: viewModel.simplePaymentsNoticePublisher)
-                            .navigationBarTitleDisplayMode(.inline)
+                        .sheet(isPresented: $viewModel.presentCollectPayment,
+                               onDismiss: {
+                            Task { @MainActor in
+                                await viewModel.onAppear()
+                            }
+                        }) {
+                            NavigationView {
+                                SimplePaymentsAmountHosted(
+                                    viewModel: SimplePaymentsAmountViewModel(siteID: viewModel.siteID),
+                                    presentNoticePublisher: viewModel.simplePaymentsNoticePublisher)
+                                .navigationBarTitleDisplayMode(.inline)
+                            }
                         }
+                    } header: {
+                        Text(Localization.paymentActionsSectionTitle.uppercased())
                     }
-                } header: {
-                    Text(Localization.paymentActionsSectionTitle)
-                }
 
-                Section {
-                    PaymentsToggleRow(
-                        image: Image(uiImage: .creditCardIcon),
-                        title: Localization.toggleEnableCashOnDelivery,
-                        toggleRowViewModel: viewModel.payInPersonToggleViewModel)
-                    .customOpenURL(binding: $viewModel.safariSheetURL)
-                } header: {
-                    Text(Localization.paymentSettingsSectionTitle)
-                }
-
-                Section {
-                    PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
-                                title: viewModel.setUpTryOutTapToPayRowTitle,
-                                shouldBadgeImage: viewModel.shouldBadgeTapToPayOnIPhone)
-                    .onTapGesture {
-                        viewModel.setUpTryOutTapToPayTapped()
+                    ScrollViewSection {
+                        PaymentsToggleRow(
+                            image: Image(uiImage: .creditCardIcon),
+                            title: Localization.toggleEnableCashOnDelivery,
+                            toggleRowViewModel: viewModel.payInPersonToggleViewModel)
+                        .customOpenURL(binding: $viewModel.safariSheetURL)
+                        .padding(.vertical, Layout.cellVerticalPadding)
+                    } header: {
+                        Text(Localization.paymentSettingsSectionTitle.uppercased())
                     }
-                    .sheet(isPresented: $viewModel.presentSetUpTryOutTapToPay,
-                           onDismiss: {
-                        Task { @MainActor in
-                            await viewModel.onAppear()
+
+                    ScrollViewSection {
+                        PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
+                                    title: viewModel.setUpTryOutTapToPayRowTitle,
+                                    shouldBadgeImage: viewModel.shouldBadgeTapToPayOnIPhone)
+                        .onTapGesture {
+                            viewModel.setUpTryOutTapToPayTapped()
                         }
-                    }) {
-                        NavigationView {
-                            PaymentSettingsFlowPresentingView(
-                                viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)
-                            .navigationBarHidden(true)
+                        .sheet(isPresented: $viewModel.presentSetUpTryOutTapToPay,
+                               onDismiss: {
+                            Task { @MainActor in
+                                await viewModel.onAppear()
+                            }
+                        }) {
+                            NavigationView {
+                                PaymentSettingsFlowPresentingView(
+                                    viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)
+                                .navigationBarHidden(true)
+                            }
                         }
-                    }
 
-                    NavigationLink {
-                        AboutTapToPayView(viewModel: viewModel.aboutTapToPayViewModel)
-                    } label: {
-                        PaymentsRow(image: Image(uiImage: .infoOutlineImage),
-                                    title: Localization.aboutTapToPayOnIPhone)
-                    }
-
-                    PaymentsRow(image: Image(uiImage: .feedbackOutlineIcon.withRenderingMode(.alwaysTemplate)),
-                                title: Localization.tapToPayOnIPhoneFeedback)
-                    .foregroundColor(Color(uiColor: .textLink))
-                    .onTapGesture {
-                        viewModel.tapToPayFeedbackTapped()
-                    }
-                    .sheet(isPresented: $viewModel.presentTapToPayFeedback) {
-                        Survey(source: .tapToPayFirstPayment)
-                    }
-                    .renderedIf(viewModel.shouldShowTapToPayFeedbackRow)
-                } header: {
-                    Text(Localization.tapToPaySectionTitle)
-                }
-                .renderedIf(viewModel.shouldShowTapToPaySection)
-
-                Section {
-                    NavigationLink {
-                        AuthenticatedWebView(isPresented: .constant(true),
-                                             viewModel: viewModel.purchaseCardReaderWebViewModel)
-                    } label: {
-                        PaymentsRow(image: Image(uiImage: .shoppingCartIcon),
-                                    title: Localization.purchaseCardReader)
-                    }
-
-                    NavigationLink {
-                        PaymentSettingsFlowPresentingView(viewModelsAndViews: viewModel.manageCardReadersViewModelsAndViews)
-                    } label: {
-                        PaymentsRow(image: Image(uiImage: .creditCardIcon),
-                                    title: Localization.manageCardReader)
-                    }
-                    .disabled(viewModel.shouldDisableManageCardReaders)
-
-                    NavigationLink {
-                        CardReaderManualsView()
-                    } label: {
-                        PaymentsRow(image: Image(uiImage: .cardReaderManualIcon),
-                                    title: Localization.cardReaderManuals)
-                    }
-                } header: {
-                    Text(Localization.cardReaderSectionTitle)
-                } footer: {
-                    InPersonPaymentsLearnMore(viewModel: .inPersonPayments(source: .paymentsMenu),
-                                              showInfoIcon: false)
-                    .customOpenURL(binding: $viewModel.safariSheetURL)
-                }
-                .renderedIf(viewModel.shouldShowCardReaderSection)
-
-                Section {
-                    NavigationLink(isActive: $showingManagePaymentGateways) {
-                        InPersonPaymentsSelectPluginView(selectedPlugin: nil) { plugin in
-                            viewModel.dependencies.onboardingUseCase.clearPluginSelection()
-                            viewModel.dependencies.onboardingUseCase.selectPlugin(plugin)
-                            showingManagePaymentGateways = false
+                        NavigationLink {
+                            AboutTapToPayView(viewModel: viewModel.aboutTapToPayViewModel)
+                        } label: {
+                            PaymentsRow(image: Image(uiImage: .infoOutlineImage),
+                                        title: Localization.aboutTapToPayOnIPhone)
                         }
-                    } label: {
-                        PaymentsRow(image: Image(uiImage: .rectangleOnRectangleAngled),
-                                    title: Localization.managePaymentGateways,
-                                    subtitle: viewModel.activePaymentGatewayName)
+
+                        PaymentsRow(image: Image(uiImage: .feedbackOutlineIcon.withRenderingMode(.alwaysTemplate)),
+                                    title: Localization.tapToPayOnIPhoneFeedback)
+                        .foregroundColor(Color(uiColor: .textLink))
+                        .onTapGesture {
+                            viewModel.tapToPayFeedbackTapped()
+                        }
+                        .sheet(isPresented: $viewModel.presentTapToPayFeedback) {
+                            Survey(source: .tapToPayFirstPayment)
+                        }
+                        .renderedIf(viewModel.shouldShowTapToPayFeedbackRow)
+                    } header: {
+                        Text(Localization.tapToPaySectionTitle.uppercased())
                     }
-                    .renderedIf(viewModel.shouldShowManagePaymentGatewaysRow)
+                    .renderedIf(viewModel.shouldShowTapToPaySection)
+
+                    ScrollViewSection {
+                        NavigationLink {
+                            AuthenticatedWebView(isPresented: .constant(true),
+                                                 viewModel: viewModel.purchaseCardReaderWebViewModel)
+                        } label: {
+                            PaymentsRow(image: Image(uiImage: .shoppingCartIcon),
+                                        title: Localization.purchaseCardReader)
+                        }
+
+                        NavigationLink {
+                            PaymentSettingsFlowPresentingView(viewModelsAndViews: viewModel.manageCardReadersViewModelsAndViews)
+                        } label: {
+                            PaymentsRow(image: Image(uiImage: .creditCardIcon),
+                                        title: Localization.manageCardReader)
+                        }
+                        .disabled(viewModel.shouldDisableManageCardReaders)
+
+                        NavigationLink {
+                            CardReaderManualsView()
+                        } label: {
+                            PaymentsRow(image: Image(uiImage: .cardReaderManualIcon),
+                                        title: Localization.cardReaderManuals)
+                        }
+                    } header: {
+                        Text(Localization.cardReaderSectionTitle.uppercased())
+                    } footer: {
+                        InPersonPaymentsLearnMore(viewModel: .inPersonPayments(source: .paymentsMenu),
+                                                  showInfoIcon: false)
+                        .customOpenURL(binding: $viewModel.safariSheetURL)
+                    }
+                    .renderedIf(viewModel.shouldShowCardReaderSection)
+
+                    ScrollViewSection {
+                        NavigationLink(isActive: $showingManagePaymentGateways) {
+                            InPersonPaymentsSelectPluginView(selectedPlugin: nil) { plugin in
+                                viewModel.dependencies.onboardingUseCase.clearPluginSelection()
+                                viewModel.dependencies.onboardingUseCase.selectPlugin(plugin)
+                                showingManagePaymentGateways = false
+                            }
+                        } label: {
+                            PaymentsRow(image: Image(systemName: "rectangle.on.rectangle.angled"),
+                                        title: Localization.managePaymentGateways,
+                                        subtitle: viewModel.activePaymentGatewayName)
+                            .padding(.vertical, Layout.cellVerticalPadding)
+                        }
+                        .renderedIf(viewModel.shouldShowManagePaymentGatewaysRow)
+                    }
+                    .renderedIf(viewModel.shouldShowPaymentOptionsSection)
                 }
-                .renderedIf(viewModel.shouldShowPaymentOptionsSection)
             }
+            .scrollViewSectionStyle(.insetGrouped)
             .safariSheet(url: $viewModel.safariSheetURL)
 
             NavigationLink(isActive: $viewModel.shouldShowOnboarding) {
@@ -147,6 +153,10 @@ struct InPersonPaymentsMenu: View {
                 }
             }
         }
+        .background {
+            Color(UIColor.systemGroupedBackground)
+                .ignoresSafeArea()
+        }
         .task {
             await viewModel.onAppear()
         }
@@ -160,6 +170,10 @@ struct InPersonPaymentsMenu: View {
 }
 
 private extension InPersonPaymentsMenu {
+    enum Layout {
+        static let cellVerticalPadding = CGFloat(8.0)
+    }
+
     enum Localization {
         static let cardReaderSectionTitle = NSLocalizedString(
             "menu.payments.cardReader.section.title",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -8,7 +8,7 @@ struct InPersonPaymentsMenu: View {
     var body: some View {
         VStack {
             List {
-                Section(Localization.paymentActionsSectionTitle) {
+                Section {
                     PaymentsRow(image: Image(uiImage: .moneyIcon),
                                 title: Localization.collectPayment)
                     .onTapGesture {
@@ -27,17 +27,21 @@ struct InPersonPaymentsMenu: View {
                             .navigationBarTitleDisplayMode(.inline)
                         }
                     }
+                } header: {
+                    Text(Localization.paymentActionsSectionTitle)
                 }
 
-                Section(Localization.paymentSettingsSectionTitle) {
+                Section {
                     PaymentsToggleRow(
                         image: Image(uiImage: .creditCardIcon),
                         title: Localization.toggleEnableCashOnDelivery,
                         toggleRowViewModel: viewModel.payInPersonToggleViewModel)
                     .customOpenURL(binding: $viewModel.safariSheetURL)
+                } header: {
+                    Text(Localization.paymentSettingsSectionTitle)
                 }
 
-                Section(Localization.tapToPaySectionTitle) {
+                Section {
                     PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
                                 title: viewModel.setUpTryOutTapToPayRowTitle,
                                 shouldBadgeImage: viewModel.shouldBadgeTapToPayOnIPhone)
@@ -74,6 +78,8 @@ struct InPersonPaymentsMenu: View {
                         Survey(source: .tapToPayFirstPayment)
                     }
                     .renderedIf(viewModel.shouldShowTapToPayFeedbackRow)
+                } header: {
+                    Text(Localization.tapToPaySectionTitle)
                 }
                 .renderedIf(viewModel.shouldShowTapToPaySection)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 import ScrollViewSectionKit
 
 struct InPersonPaymentsMenu: View {
@@ -10,6 +11,12 @@ struct InPersonPaymentsMenu: View {
         VStack {
             ScrollView {
                 VStack(spacing: 0) {
+                    depositSummary
+                        .background {
+                            Color(UIColor.systemBackground)
+                                .ignoresSafeArea()
+                        }
+
                     ScrollViewSection {
                         PaymentsRow(image: Image(uiImage: .moneyIcon),
                                     title: Localization.collectPayment)
@@ -167,6 +174,16 @@ struct InPersonPaymentsMenu: View {
             }
         }
     }
+
+    @ViewBuilder
+    var depositSummary: some View {
+        if #available(iOS 16.0, *),
+           viewModel.shouldShowDepositSummary {
+            WooPaymentsDepositsOverviewView(viewModels: viewModel.depositCurrencyViewModels)
+        } else {
+            EmptyView()
+        }
+    }
 }
 
 private extension InPersonPaymentsMenu {
@@ -293,7 +310,8 @@ struct InPersonPaymentsMenu_Previews: PreviewProvider {
         dependencies: .init(
             cardPresentPaymentsConfiguration: .init(country: .US),
             onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
-            cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: 0)))
+            cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: 0),
+            wooPaymentsDepositsService: WooPaymentsDepositService(siteID: 0, credentials: .init(authToken: ""))))
     static var previews: some View {
         InPersonPaymentsMenu(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -5,8 +5,6 @@ import ScrollViewSectionKit
 struct InPersonPaymentsMenu: View {
     @ObservedObject private(set) var viewModel: InPersonPaymentsMenuViewModel
 
-    @State private var showingManagePaymentGateways: Bool = false
-
     var body: some View {
         VStack {
             ScrollView {
@@ -126,12 +124,9 @@ struct InPersonPaymentsMenu: View {
                     .renderedIf(viewModel.shouldShowCardReaderSection)
 
                     ScrollViewSection {
-                        NavigationLink(isActive: $showingManagePaymentGateways) {
-                            InPersonPaymentsSelectPluginView(selectedPlugin: nil) { plugin in
-                                viewModel.dependencies.onboardingUseCase.clearPluginSelection()
-                                viewModel.dependencies.onboardingUseCase.selectPlugin(plugin)
-                                showingManagePaymentGateways = false
-                            }
+                        NavigationLink(isActive: $viewModel.presentManagePaymentGateways) {
+                            InPersonPaymentsSelectPluginView(selectedPlugin: nil,
+                                                             onPluginSelected: viewModel.preferredPluginSelected)
                         } label: {
                             PaymentsRow(image: Image(systemName: "rectangle.on.rectangle.angled"),
                                         title: Localization.managePaymentGateways,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -17,6 +17,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published private(set) var cardPresentPaymentsOnboardingNotice: PermanentNotice?
     @Published var shouldShowOnboarding: Bool = false
     @Published private(set) var shouldShowManagePaymentGatewaysRow: Bool = false
+    @Published var presentManagePaymentGateways: Bool = false
     @Published private(set) var activePaymentGatewayName: String?
     @Published var presentCollectPayment: Bool = false
     @Published var presentSetUpTryOutTapToPay: Bool = false
@@ -110,6 +111,12 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     func tapToPayFeedbackTapped() {
         presentTapToPayFeedback = true
+    }
+
+    func preferredPluginSelected(plugin: CardPresentPaymentsPlugin) {
+        dependencies.onboardingUseCase.clearPluginSelection()
+        dependencies.onboardingUseCase.selectPlugin(plugin)
+        presentManagePaymentGateways = false
     }
 
     lazy var setUpTapToPayViewModelsAndViews: SetUpTapToPayViewModelsOrderedList = {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
@@ -42,6 +42,7 @@ struct PaymentsRow: View {
 
             Spacer()
         }
+        .foregroundColor(.primary)
         .contentShape(Rectangle())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -79,7 +79,9 @@ final class HubMenuViewModel: ObservableObject {
             dependencies: .init(
                 cardPresentPaymentsConfiguration: CardPresentConfigurationLoader().configuration,
                 onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
-                cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID)))
+                cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID),
+                wooPaymentsDepositsService: WooPaymentsDepositService(siteID: siteID,
+                                                                      credentials: ServiceLocator.stores.sessionManager.defaultCredentials!)))
     }()
 
     init(siteID: Int64,

--- a/WooCommerce/Resources/HTML/licenses.html
+++ b/WooCommerce/Resources/HTML/licenses.html
@@ -43,6 +43,7 @@
             <li><a href="https://github.com/gonzalezreal/AttributedText">AttributedText</a> by <a href="https://github.com/gonzalezreal">Guille Gonzalez</a></li>
             <li><a href="https://github.com/kishikawakatsumi/KeychainAccess">KeychainAccess</a> by <a href="https://github.com/kishikawakatsumi">Kishikawa Katsumi</a></li>
             <li><a href="https://github.com/onevcat/Kingfisher">Kingfisher</a> by <a href="https://github.com/onevcat">Wei Wang</a></li>
+            <li><a href="https://github.com/pavolkmet/ScrollViewSectionKit">ScrollViewSectionKit</a> by <a href="https://github.com/pavolkmet/">Pavol Kmet</a></li>
             <li><a href="https://github.com/stripe/stripe-terminal-ios">StripeTerminal</a> by <a href="https://github.com/stripe">Stripe</a></li>
             <li><a href="https://github.com/pmusolino/Wormholy">Wormholy</a> by <a href="https://github.com/pmusolino">Paolo Musolino</a></li>
             <li><a href="https://github.com/xmartlabs/XLPagerTabStrip">XLPagerTabStrip</a> by <a href="https://xmartlabs.com/">XMARTLABS</a></li>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -710,6 +710,7 @@
 		174CA86C27D90E8900126524 /* WooAboutScreenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA86B27D90E8900126524 /* WooAboutScreenConfiguration.swift */; };
 		174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */; };
 		201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */; };
+		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
@@ -5128,6 +5129,7 @@
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
 				B5C3B5E520D189EA0072CB9D /* Storage.framework in Frameworks */,
 				B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */,
+				202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */,
 				B5C3B5E320D189E60072CB9D /* Networking.framework in Frameworks */,
 				45455E322657C3F300BBB0C4 /* Shimmer in Frameworks */,
 				86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */,
@@ -11671,6 +11673,7 @@
 				3FFC5EAB2851942F00563C48 /* Charts */,
 				4598298028574688003A9AFE /* Inject */,
 				DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */,
+				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -11846,6 +11849,7 @@
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
+				202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -15551,6 +15555,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pavolkmet/ScrollViewSectionKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.0;
+			};
+		};
 		247CE89A2583402A00F9D9D1 /* XCRemoteSwiftPackageReference "Embassy" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/envoy/Embassy";
@@ -15622,6 +15634,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */;
 			productName = AutomatticAbout;
+		};
+		202496632B0B9E0D00EE527D /* ScrollViewSectionKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */;
+			productName = ScrollViewSectionKit;
 		};
 		247CE89B2583402A00F9D9D1 /* Embassy */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11219
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the HACK week Deposit summary to the new payments menu, behind a  feature flag.

There’s no loading state, expansion/contraction, and the design needs to be updated before this is ready to ship, this just puts it in the right place.

In order to style the different list sections, I've added a dependency on [ScrollViewSectionKit](https://github.com/pavolkmet/ScrollViewSectionKit) which makes it much easier to do this, and gives us some flexibility in future. This is MIT licensed, and I've reviewed the code for network access or anything else that we wouldn't want to add to the app. It has no dependencies of its own. Happy to discuss this further, but having fought with the layout using `List`, `VStack`, and `ScrollView` myself, I definitely think it's worth the dependency.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Build the app from Xcode
Switch to a store with WooPayments
Navigate to `Menu > Payments`
Observe that after a few moments the Deposits view is shown


Change the `wooPaymentsDepositsOverviewInPaymentsMenu` feature flag to `false`
Repeat the above test
Observe that the Deposits view is not shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/89677852-a7c7-4c81-8fe7-846d4749bfb5


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
