### PR TITLE
Product Subscriptions: Enable Downloadable setting

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -85,7 +85,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .customLoginUIForAccountCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .subscriptionProducts:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -21,19 +21,14 @@ enum ProductSettingsSections {
         let rows: [ProductSettingsRowMediator]
 
         init(_ settings: ProductSettings) {
-            if settings.productType == .simple {
-                let tempRows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
-                        ProductSettingsRows.Visibility(settings),
-                        ProductSettingsRows.CatalogVisibility(settings),
-                        ProductSettingsRows.VirtualProduct(settings),
-                        ProductSettingsRows.DownloadableProduct(settings)
-                ]
-                rows = tempRows.compactMap { $0 }
-            } else {
-                rows = [ProductSettingsRows.Status(settings),
-                        ProductSettingsRows.Visibility(settings),
-                        ProductSettingsRows.CatalogVisibility(settings)]
-            }
+            let shouldShowVirtualProductSetting = settings.productType == .simple
+            let shouldShowDownloadableProductSetting = settings.productType == .simple || settings.productType == .subscription
+            let rows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
+                    ProductSettingsRows.Visibility(settings),
+                    ProductSettingsRows.CatalogVisibility(settings),
+                    shouldShowVirtualProductSetting ? ProductSettingsRows.VirtualProduct(settings) : nil,
+                                                      shouldShowDownloadableProductSetting ? ProductSettingsRows.DownloadableProduct(settings) : nil]
+            self.rows = rows.compactMap { $0 }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -24,10 +24,10 @@ enum ProductSettingsSections {
             let shouldShowVirtualProductSetting = settings.productType == .simple
             let shouldShowDownloadableProductSetting = settings.productType == .simple || settings.productType == .subscription
             let rows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
-                    ProductSettingsRows.Visibility(settings),
-                    ProductSettingsRows.CatalogVisibility(settings),
-                    shouldShowVirtualProductSetting ? ProductSettingsRows.VirtualProduct(settings) : nil,
-                                                      shouldShowDownloadableProductSetting ? ProductSettingsRows.DownloadableProduct(settings) : nil]
+                                                       ProductSettingsRows.Visibility(settings),
+                                                       ProductSettingsRows.CatalogVisibility(settings),
+                                                       shouldShowVirtualProductSetting ? ProductSettingsRows.VirtualProduct(settings) : nil,
+                                                       shouldShowDownloadableProductSetting ? ProductSettingsRows.DownloadableProduct(settings) : nil]
             self.rows = rows.compactMap { $0 }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -311,6 +311,7 @@ private extension ProductFormActionsFactory {
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
         let canEditInventorySettingsRow = editingSubscriptionEnabled && editable && product.hasIntegerStockQuantity
         let canEditProductType = editingSubscriptionEnabled && editable
+        let shouldShowDownloadableProduct = product.downloadable
 
         let actions: [ProductFormEditAction?] = [
             editingSubscriptionEnabled ? .priceSettings(editable: editable, hideSeparator: false) : .subscription(actionable: true),
@@ -322,6 +323,7 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .addOns(editable: editable),
             .tags(editable: editable),
+            shouldShowDownloadableProduct ? .downloadableFiles(editable: editable): nil,
             .shortDescription(editable: editable),
             .linkedProducts(editable: editable),
             .productType(editable: canEditProductType)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -741,7 +741,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func test_view_model_for_subscription_product_when_downloadable() {
+    func test_view_model_for_subscription_product_when_product_is_downloadable() {
         // Arrange
         let product = Fixtures.subscriptionProduct.copy(downloadable: true)
         let model = EditableProductModel(product: product)
@@ -767,7 +767,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_subscription_product_when_not_downloadable() {
+    func test_view_model_for_subscription_product_when_product_is_not_downloadable() {
         // Arrange
         let product = Fixtures.subscriptionProduct.copy(downloadable: false)
         let model = EditableProductModel(product: product)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -741,6 +741,59 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
+    func test_view_model_for_subscription_product_when_downloadable() {
+        // Arrange
+        let product = Fixtures.subscriptionProduct.copy(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, editingSubscriptionEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
+                                                                       .subscriptionFreeTrial(editable: true),
+                                                                       .subscriptionExpiry(editable: true),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: true),
+                                                                       .downloadableFiles(editable: true),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
+
+    func test_view_model_for_subscription_product_when_not_downloadable() {
+        // Arrange
+        let product = Fixtures.subscriptionProduct.copy(downloadable: false)
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, editingSubscriptionEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
+                                                                       .subscriptionFreeTrial(editable: true),
+                                                                       .subscriptionExpiry(editable: true),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: true),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
+
+    // MARK: Quantity rules
+
     func test_viewModel_for_product_with_min_max_quantities_shows_quantity_rules_row_in_settings_section() {
         // Arrange
         let product = Fixtures.physicalSimpleProductWithImages.copy(minAllowedQuantity: "4",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -175,7 +175,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let subscription = ProductSubscription.fake().copy(length: "1", period: .month, periodInterval: "1", price: "5")
         let product = Product.fake().copy(productTypeKey: ProductType.subscription.rawValue, subscription: subscription)
         let model = EditableProductModel(product: product)
-        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit, editingSubscriptionEnabled: false)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
@@ -207,7 +207,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let subscription = ProductSubscription.fake().copy(length: "4", period: .month, periodInterval: "2", price: "5")
         let product = Product.fake().copy(productTypeKey: ProductType.subscription.rawValue, subscription: subscription)
         let model = EditableProductModel(product: product)
-        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit, editingSubscriptionEnabled: false)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
@@ -239,7 +239,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let subscription = ProductSubscription.fake().copy(length: "0", period: .month, periodInterval: "2", price: "")
         let product = Product.fake().copy(productTypeKey: ProductType.subscription.rawValue, subscription: subscription)
         let model = EditableProductModel(product: product)
-        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit, editingSubscriptionEnabled: false)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -53,48 +53,71 @@ final class ProductSettingsSectionsTests: XCTestCase {
     }
 
     func test_given_a_non_simple_product_then_it_does_not_show_the_downloadable_product_option() {
-         // Given
-         let settings = ProductSettings(productType: .grouped,
-                                        status: .draft,
-                                        featured: false,
-                                        password: nil,
-                                        catalogVisibility: .catalog,
-                                        virtual: false,
-                                        reviewsAllowed: false,
-                                        slug: "",
-                                        purchaseNote: nil,
-                                        menuOrder: 0,
-                                        downloadable: false)
+        // Given
+        let settings = ProductSettings(productType: .grouped,
+                                       status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0,
+                                       downloadable: false)
 
-          // When
+        // When
         let section = ProductSettingsSections.PublishSettings(settings)
 
-          // Then
-         XCTAssertNil(section.rows.first(where: {
-             $0 is ProductSettingsRows.DownloadableProduct
-         }))
-     }
+        // Then
+        XCTAssertNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.DownloadableProduct
+        }))
+    }
 
-      func test_given_a_simple_product_then_it_shows_the_downloadable_product_option() {
-         // Given
-         let settings = ProductSettings(productType: .simple,
-                                        status: .draft,
-                                        featured: false,
-                                        password: nil,
-                                        catalogVisibility: .catalog,
-                                        virtual: false,
-                                        reviewsAllowed: false,
-                                        slug: "",
-                                        purchaseNote: nil,
-                                        menuOrder: 0,
-                                        downloadable: false)
+    func test_given_a_simple_product_then_it_shows_the_downloadable_product_option() {
+        // Given
+        let settings = ProductSettings(productType: .simple,
+                                       status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0,
+                                       downloadable: false)
 
-          // When
-          let section = ProductSettingsSections.PublishSettings(settings)
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings)
 
-          // Then
-         XCTAssertNotNil(section.rows.first(where: {
-             $0 is ProductSettingsRows.DownloadableProduct
-         }))
-     }
+        // Then
+        XCTAssertNotNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.DownloadableProduct
+        }))
+    }
+
+    func test_given_a_subscription_product_then_it_shows_the_downloadable_product_option() {
+        // Given
+        let settings = ProductSettings(productType: .subscription,
+                                       status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0,
+                                       downloadable: false)
+
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings)
+
+        // Then
+        XCTAssertNotNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.DownloadableProduct
+        }))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11218 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Allows enabling the "Downloadable files" option in the Product form from Product settings. 

## Testing instructions

**Prerequisite**
1. Install Woo Subscription plugin on your store
1. Create a subscriptions product from `wp-admin`

**Steps**
1. Enable the feature flag subscriptionProducts and build the app.
2. On the app, log in to a store with Woo Subscription plugin set up.
3. Navigate to Products tab > select "+" > select manual option > Subscription product.
4. Tap on `...` > `Product settings`
5. You should see toggle "Downloadable Product"
6. Enable it, and you should see the "Downloadable files" option to upload files in the product form
7. Try uploading files and save the product

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 14 Pro - 2023-11-21 at 11 13 11](https://github.com/woocommerce/woocommerce-ios/assets/524475/e7f0189a-e189-426c-a152-a89aa4fcecea)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
