### PR TITLE
[Deposit Summary] Implement deposit schedule info link

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -347,6 +347,8 @@ extension WooConstants {
 
         case wooCorePaymentOptions = "https://woo.com/documentation/woocommerce/getting-started/sell-products/core-payment-options"
 
+        case wooPaymentsDepositSchedule = "https://woo.com/document/woopayments/deposits/deposit-schedule/"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -7,6 +7,8 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
 
     @Binding var isExpanded: Bool
 
+    @State private var showDepositSummaryInfo: Bool = false
+
     init(viewModel: WooPaymentsDepositsCurrencyOverviewViewModel,
          isExpanded: Binding<Bool>) {
         self.viewModel = viewModel
@@ -85,7 +87,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button {
-                    // TODO: Open a webview here: https://woo.com/document/woopayments/deposits/deposit-schedule/
+                    showDepositSummaryInfo = true
                 } label: {
                     HStack {
                         Image(systemName: "info.circle")
@@ -99,6 +101,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                 .padding(.bottom)
             }
         }
+        .safariSheet(isPresented: $showDepositSummaryInfo, url: WooConstants.URLs.wooPaymentsDepositSchedule.asURL())
         .animation(.easeOut, value: isExpanded)
         .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11226
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Deposit schedules are complex, and the details around them are explained in our WooPayments documentation.

This PR adds a link to the deposit schedules info from the new Deposit Summary on the Payments Menu.

Analytics will be covered in an upcoming PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app and switch to a WooPayments store
2. Navigate to `Menu > Payments` and wait a moment for the deposit summary to show
3. Expand the summary by tapping on it
4. Tap the info button
5. Observe that the payments schedule info doc is shown in a web view.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/302502f3-da83-4201-b7ca-6075af2245ca


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
