### PR TITLE
[Deposit Summary] Payment menu analytics for deposit summary

### DIFF
--- a/CodeGeneration/Sourcery/Copiable/WooFoundation-Copiable.sourcery.yaml
+++ b/CodeGeneration/Sourcery/Copiable/WooFoundation-Copiable.sourcery.yaml
@@ -1,0 +1,7 @@
+project:
+    file: ../../../WooFoundation/WooFoundation.xcodeproj
+    target:
+        name: WooFoundation
+templates:
+    - Models+Copiable.swifttemplate
+output: ../../../WooFoundation/WooFoundation/Model/Copiable/

--- a/CodeGeneration/Sourcery/Fakes/Fakes.swifttemplate
+++ b/CodeGeneration/Sourcery/Fakes/Fakes.swifttemplate
@@ -53,7 +53,7 @@ let specsToGenerate: [FakeableSpec] = matchingTypes.map { type in
 
     /// If we are generating for an `Enum`, return with `.value` for content 
     if let enumType = type as? Enum, let firstEnumCase = enumType.cases.first {
-        return FakeableSpec(name: enumType.name, accessLevelWithSpacePostfix: accessLevel, content: .value(firstEnumCase.name))
+        return FakeableSpec(name: enumType.globalName, accessLevelWithSpacePostfix: accessLevel, content: .value(firstEnumCase.name))
     }
 
     /// Make sure we have at least one non throwable-initializer to work with.

--- a/CodeGeneration/Sourcery/Fakes/Fakes.swifttemplate
+++ b/CodeGeneration/Sourcery/Fakes/Fakes.swifttemplate
@@ -80,6 +80,7 @@ let specsToGenerate: [FakeableSpec] = matchingTypes.map { type in
 import Yosemite
 import Networking
 import Hardware
+import WooFoundation
 
 <% for spec in specsToGenerate { -%>
 extension <%= spec.name -%> {

--- a/CodeGeneration/Sourcery/Fakes/WooFoundation-Fakes.yaml
+++ b/CodeGeneration/Sourcery/Fakes/WooFoundation-Fakes.yaml
@@ -1,0 +1,7 @@
+project:
+    file: ../../../WooFoundation/WooFoundation.xcodeproj
+    target:
+        name: WooFoundation
+templates:
+    - Fakes.swifttemplate
+output: ../../../Fakes/Fakes/WooFoundation.generated.swift

--- a/Fakes/Fakes.xcodeproj/project.pbxproj
+++ b/Fakes/Fakes.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		02B5147E2825532A00750B71 /* Hardware.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B5147D2825532A00750B71 /* Hardware.generated.swift */; };
+		20AD34D12B0CD9AF00F38F44 /* WooFoundation.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AD34D02B0CD9AF00F38F44 /* WooFoundation.generated.swift */; };
 		26106B3D25FA4F6C0000DF30 /* ProductFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26106B3C25FA4F6C0000DF30 /* ProductFactory.swift */; };
 		263E383C2641FED600260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E383B2641FED600260D3B /* Codegen */; };
 		26CA6D2625F6C87800B01F48 /* Fakes.h in Headers */ = {isa = PBXBuildFile; fileRef = 26CA6D2425F6C87800B01F48 /* Fakes.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -33,6 +34,7 @@
 
 /* Begin PBXFileReference section */
 		02B5147D2825532A00750B71 /* Hardware.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hardware.generated.swift; sourceTree = "<group>"; };
+		20AD34D02B0CD9AF00F38F44 /* WooFoundation.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WooFoundation.generated.swift; sourceTree = "<group>"; };
 		26106B3C25FA4F6C0000DF30 /* ProductFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFactory.swift; sourceTree = "<group>"; };
 		26CA6D2125F6C87800B01F48 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26CA6D2425F6C87800B01F48 /* Fakes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fakes.h; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 				02B5147D2825532A00750B71 /* Hardware.generated.swift */,
 				26EEDC8E26FE1C7B00D5BA0E /* Networking.generated.swift */,
 				26EEDC8F26FE1C7B00D5BA0E /* Yosemite.generated.swift */,
+				20AD34D02B0CD9AF00F38F44 /* WooFoundation.generated.swift */,
 				26106B3B25FA4F5F0000DF30 /* Products */,
 				26CA6D2425F6C87800B01F48 /* Fakes.h */,
 				26CA6D2525F6C87800B01F48 /* Info.plist */,
@@ -194,6 +197,7 @@
 				26CA6D2F25F6C8FC00B01F48 /* Fake.swift in Sources */,
 				02B5147E2825532A00750B71 /* Hardware.generated.swift in Sources */,
 				26EEDC9026FE1C7B00D5BA0E /* Networking.generated.swift in Sources */,
+				20AD34D12B0CD9AF00F38F44 /* WooFoundation.generated.swift in Sources */,
 				26106B3D25FA4F6C0000DF30 /* ProductFactory.swift in Sources */,
 				26EEDC9126FE1C7B00D5BA0E /* Yosemite.generated.swift in Sources */,
 			);

--- a/Fakes/Fakes/Hardware.generated.swift
+++ b/Fakes/Fakes/Hardware.generated.swift
@@ -6,10 +6,10 @@ import Networking
 import Hardware
 import WooFoundation
 
-extension CardBrand {
+extension Hardware.CardBrand {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> CardBrand {
+    public static func fake() -> Hardware.CardBrand {
         .visa
     }
 }
@@ -60,10 +60,10 @@ extension Hardware.Charge {
         )
     }
 }
-extension ChargeStatus {
+extension Hardware.ChargeStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ChargeStatus {
+    public static func fake() -> Hardware.ChargeStatus {
         .succeeded
     }
 }
@@ -82,17 +82,17 @@ extension Hardware.PaymentIntent {
         )
     }
 }
-extension PaymentIntentStatus {
+extension Hardware.PaymentIntentStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> PaymentIntentStatus {
+    public static func fake() -> Hardware.PaymentIntentStatus {
         .requiresPaymentMethod
     }
 }
-extension PaymentMethod {
+extension Hardware.PaymentMethod {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> PaymentMethod {
+    public static func fake() -> Hardware.PaymentMethod {
         .card
     }
 }

--- a/Fakes/Fakes/Hardware.generated.swift
+++ b/Fakes/Fakes/Hardware.generated.swift
@@ -4,6 +4,7 @@
 import Yosemite
 import Networking
 import Hardware
+import WooFoundation
 
 extension CardBrand {
     /// Returns a "ready to use" type filled with fake values.

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -72,10 +72,10 @@ extension Networking.AccountSettings {
         )
     }
 }
-extension AddOnDisplay {
+extension Networking.AddOnDisplay {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> AddOnDisplay {
+    public static func fake() -> Networking.AddOnDisplay {
         .dropdown
     }
 }
@@ -92,31 +92,31 @@ extension Networking.AddOnGroup {
         )
     }
 }
-extension AddOnPriceType {
+extension Networking.AddOnPriceType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> AddOnPriceType {
+    public static func fake() -> Networking.AddOnPriceType {
         .flatFee
     }
 }
-extension AddOnRestrictionsType {
+extension Networking.AddOnRestrictionsType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> AddOnRestrictionsType {
+    public static func fake() -> Networking.AddOnRestrictionsType {
         .any_text
     }
 }
-extension AddOnTitleFormat {
+extension Networking.AddOnTitleFormat {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> AddOnTitleFormat {
+    public static func fake() -> Networking.AddOnTitleFormat {
         .label
     }
 }
-extension AddOnType {
+extension Networking.AddOnType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> AddOnType {
+    public static func fake() -> Networking.AddOnType {
         .multipleChoice
     }
 }
@@ -174,10 +174,10 @@ extension Networking.BlazeCampaign {
         )
     }
 }
-extension CompositeComponentOptionType {
+extension Networking.CompositeComponentOptionType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> CompositeComponentOptionType {
+    public static func fake() -> Networking.CompositeComponentOptionType {
         .productIDs
     }
 }
@@ -224,10 +224,10 @@ extension Networking.Coupon {
         )
     }
 }
-extension Coupon.DiscountType {
+extension Networking.Coupon.DiscountType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> Coupon.DiscountType {
+    public static func fake() -> Networking.Coupon.DiscountType {
         .percent
     }
 }
@@ -291,10 +291,10 @@ extension Networking.DomainContactInfo {
         )
     }
 }
-extension DotcomError {
+extension Networking.DotcomError {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> DotcomError {
+    public static func fake() -> Networking.DotcomError {
         .empty
     }
 }
@@ -580,10 +580,10 @@ extension Networking.OrderFeeLine {
         )
     }
 }
-extension OrderFeeTaxStatus {
+extension Networking.OrderFeeTaxStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> OrderFeeTaxStatus {
+    public static func fake() -> Networking.OrderFeeTaxStatus {
         .taxable
     }
 }
@@ -776,10 +776,10 @@ extension Networking.OrderStatus {
         )
     }
 }
-extension OrderStatusEnum {
+extension Networking.OrderStatusEnum {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> OrderStatusEnum {
+    public static func fake() -> Networking.OrderStatusEnum {
         .autoDraft
     }
 }
@@ -1003,10 +1003,10 @@ extension Networking.ProductAttributeTerm {
         )
     }
 }
-extension ProductBackordersSetting {
+extension Networking.ProductBackordersSetting {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductBackordersSetting {
+    public static func fake() -> Networking.ProductBackordersSetting {
         .allowed
     }
 }
@@ -1031,17 +1031,17 @@ extension Networking.ProductBundleItem {
         )
     }
 }
-extension ProductBundleItemStockStatus {
+extension Networking.ProductBundleItemStockStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductBundleItemStockStatus {
+    public static func fake() -> Networking.ProductBundleItemStockStatus {
         .inStock
     }
 }
-extension ProductCatalogVisibility {
+extension Networking.ProductCatalogVisibility {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductCatalogVisibility {
+    public static func fake() -> Networking.ProductCatalogVisibility {
         .visible
     }
 }
@@ -1148,10 +1148,10 @@ extension Networking.ProductReview {
         )
     }
 }
-extension ProductReviewStatus {
+extension Networking.ProductReviewStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductReviewStatus {
+    public static func fake() -> Networking.ProductReviewStatus {
         .approved
     }
 }
@@ -1169,17 +1169,17 @@ extension Networking.ProductShippingClass {
         )
     }
 }
-extension ProductStatus {
+extension Networking.ProductStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductStatus {
+    public static func fake() -> Networking.ProductStatus {
         .published
     }
 }
-extension ProductStockStatus {
+extension Networking.ProductStockStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductStockStatus {
+    public static func fake() -> Networking.ProductStockStatus {
         .inStock
     }
 }
@@ -1210,17 +1210,17 @@ extension Networking.ProductTag {
         )
     }
 }
-extension ProductTaxStatus {
+extension Networking.ProductTaxStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductTaxStatus {
+    public static func fake() -> Networking.ProductTaxStatus {
         .taxable
     }
 }
-extension ProductType {
+extension Networking.ProductType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ProductType {
+    public static func fake() -> Networking.ProductType {
         .simple
     }
 }
@@ -1433,10 +1433,10 @@ extension Networking.ShippingLabelAddressVerification {
         )
     }
 }
-extension ShippingLabelAddressVerification.ShipType {
+extension Networking.ShippingLabelAddressVerification.ShipType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelAddressVerification.ShipType {
+    public static func fake() -> Networking.ShippingLabelAddressVerification.ShipType {
         .origin
     }
 }
@@ -1502,10 +1502,10 @@ extension Networking.ShippingLabelCustomsForm {
         )
     }
 }
-extension ShippingLabelCustomsForm.ContentsType {
+extension Networking.ShippingLabelCustomsForm.ContentsType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelCustomsForm.ContentsType {
+    public static func fake() -> Networking.ShippingLabelCustomsForm.ContentsType {
         .merchandise
     }
 }
@@ -1524,17 +1524,17 @@ extension Networking.ShippingLabelCustomsForm.Item {
         )
     }
 }
-extension ShippingLabelCustomsForm.NonDeliveryOption {
+extension Networking.ShippingLabelCustomsForm.NonDeliveryOption {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelCustomsForm.NonDeliveryOption {
+    public static func fake() -> Networking.ShippingLabelCustomsForm.NonDeliveryOption {
         .`return`
     }
 }
-extension ShippingLabelCustomsForm.RestrictionType {
+extension Networking.ShippingLabelCustomsForm.RestrictionType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelCustomsForm.RestrictionType {
+    public static func fake() -> Networking.ShippingLabelCustomsForm.RestrictionType {
         .none
     }
 }
@@ -1579,17 +1579,17 @@ extension Networking.ShippingLabelPackagesResponse {
         )
     }
 }
-extension ShippingLabelPaperSize {
+extension Networking.ShippingLabelPaperSize {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelPaperSize {
+    public static func fake() -> Networking.ShippingLabelPaperSize {
         .a4
     }
 }
-extension ShippingLabelPaymentCardType {
+extension Networking.ShippingLabelPaymentCardType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelPaymentCardType {
+    public static func fake() -> Networking.ShippingLabelPaymentCardType {
         .amex
     }
 }
@@ -1669,10 +1669,10 @@ extension Networking.ShippingLabelRefund {
         )
     }
 }
-extension ShippingLabelRefundStatus {
+extension Networking.ShippingLabelRefundStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelRefundStatus {
+    public static func fake() -> Networking.ShippingLabelRefundStatus {
         .pending
     }
 }
@@ -1687,10 +1687,10 @@ extension Networking.ShippingLabelSettings {
         )
     }
 }
-extension ShippingLabelStatus {
+extension Networking.ShippingLabelStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> ShippingLabelStatus {
+    public static func fake() -> Networking.ShippingLabelStatus {
         .purchased
     }
 }
@@ -1802,10 +1802,10 @@ extension Networking.SitePlugin {
         )
     }
 }
-extension SitePluginStatusEnum {
+extension Networking.SitePluginStatusEnum {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> SitePluginStatusEnum {
+    public static func fake() -> Networking.SitePluginStatusEnum {
         .active
     }
 }
@@ -1823,10 +1823,10 @@ extension Networking.SiteSetting {
         )
     }
 }
-extension SiteSettingGroup {
+extension Networking.SiteSettingGroup {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> SiteSettingGroup {
+    public static func fake() -> Networking.SiteSettingGroup {
         .general
     }
 }
@@ -1866,10 +1866,10 @@ extension Networking.SiteVisitStatsItem {
         )
     }
 }
-extension StatGranularity {
+extension Networking.StatGranularity {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> StatGranularity {
+    public static func fake() -> Networking.StatGranularity {
         .day
     }
 }
@@ -1883,10 +1883,10 @@ extension Networking.StateOfACountry {
         )
     }
 }
-extension StatsGranularityV4 {
+extension Networking.StatsGranularityV4 {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> StatsGranularityV4 {
+    public static func fake() -> Networking.StatsGranularityV4 {
         .hourly
     }
 }
@@ -1917,17 +1917,17 @@ extension Networking.Subscription {
         )
     }
 }
-extension SubscriptionPeriod {
+extension Networking.SubscriptionPeriod {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> SubscriptionPeriod {
+    public static func fake() -> Networking.SubscriptionPeriod {
         .day
     }
 }
-extension SubscriptionStatus {
+extension Networking.SubscriptionStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> SubscriptionStatus {
+    public static func fake() -> Networking.SubscriptionStatus {
         .pending
     }
 }
@@ -2052,24 +2052,24 @@ extension Networking.WCAnalyticsCustomer {
         )
     }
 }
-extension WCPayAccountStatusEnum {
+extension Networking.WCPayAccountStatusEnum {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WCPayAccountStatusEnum {
+    public static func fake() -> Networking.WCPayAccountStatusEnum {
         .complete
     }
 }
-extension WCPayCardBrand {
+extension Networking.WCPayCardBrand {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WCPayCardBrand {
+    public static func fake() -> Networking.WCPayCardBrand {
         .amex
     }
 }
-extension WCPayCardFunding {
+extension Networking.WCPayCardFunding {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WCPayCardFunding {
+    public static func fake() -> Networking.WCPayCardFunding {
         .credit
     }
 }
@@ -2130,31 +2130,31 @@ extension Networking.WCPayCharge {
         )
     }
 }
-extension WCPayChargeStatus {
+extension Networking.WCPayChargeStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WCPayChargeStatus {
+    public static func fake() -> Networking.WCPayChargeStatus {
         .succeeded
     }
 }
-extension WCPayPaymentIntentStatusEnum {
+extension Networking.WCPayPaymentIntentStatusEnum {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WCPayPaymentIntentStatusEnum {
+    public static func fake() -> Networking.WCPayPaymentIntentStatusEnum {
         .requiresPaymentMethod
     }
 }
-extension WCPayPaymentMethodDetails {
+extension Networking.WCPayPaymentMethodDetails {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WCPayPaymentMethodDetails {
+    public static func fake() -> Networking.WCPayPaymentMethodDetails {
         .unknown
     }
 }
-extension WCPayPaymentMethodType {
+extension Networking.WCPayPaymentMethodType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WCPayPaymentMethodType {
+    public static func fake() -> Networking.WCPayPaymentMethodType {
         .card
     }
 }
@@ -2223,24 +2223,24 @@ extension Networking.WooPaymentsDeposit {
         )
     }
 }
-extension WooPaymentsDepositInterval {
+extension Networking.WooPaymentsDepositInterval {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WooPaymentsDepositInterval {
+    public static func fake() -> Networking.WooPaymentsDepositInterval {
         .daily
     }
 }
-extension WooPaymentsDepositStatus {
+extension Networking.WooPaymentsDepositStatus {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WooPaymentsDepositStatus {
+    public static func fake() -> Networking.WooPaymentsDepositStatus {
         .estimated
     }
 }
-extension WooPaymentsDepositType {
+extension Networking.WooPaymentsDepositType {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> WooPaymentsDepositType {
+    public static func fake() -> Networking.WooPaymentsDepositType {
         .withdrawal
     }
 }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -4,6 +4,7 @@
 import Yosemite
 import Networking
 import Hardware
+import WooFoundation
 
 extension Networking.AIProduct {
     /// Returns a "ready to use" type filled with fake values.

--- a/Fakes/Fakes/WooFoundation.generated.swift
+++ b/Fakes/Fakes/WooFoundation.generated.swift
@@ -6,10 +6,10 @@ import Networking
 import Hardware
 import WooFoundation
 
-extension CurrencyCode {
+extension WooFoundation.CurrencyCode {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> CurrencyCode {
+    public static func fake() -> WooFoundation.CurrencyCode {
         .AED
     }
 }

--- a/Fakes/Fakes/WooFoundation.generated.swift
+++ b/Fakes/Fakes/WooFoundation.generated.swift
@@ -1,0 +1,15 @@
+// Generated using Sourcery 1.0.3 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import Yosemite
+import Networking
+import Hardware
+import WooFoundation
+
+extension CurrencyCode {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> CurrencyCode {
+        .AED
+    }
+}

--- a/Fakes/Fakes/Yosemite.generated.swift
+++ b/Fakes/Fakes/Yosemite.generated.swift
@@ -26,10 +26,10 @@ extension Yosemite.JustInTimeMessage {
         )
     }
 }
-extension JustInTimeMessageTemplate {
+extension Yosemite.JustInTimeMessageTemplate {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> JustInTimeMessageTemplate {
+    public static func fake() -> Yosemite.JustInTimeMessageTemplate {
         .banner
     }
 }

--- a/Fakes/Fakes/Yosemite.generated.swift
+++ b/Fakes/Fakes/Yosemite.generated.swift
@@ -4,6 +4,7 @@
 import Yosemite
 import Networking
 import Hardware
+import WooFoundation
 
 extension Yosemite.JustInTimeMessage {
     /// Returns a "ready to use" type filled with fake values.
@@ -40,6 +41,23 @@ extension Yosemite.ProductReviewFromNoteParcel {
             note: .fake(),
             review: .fake(),
             product: .fake()
+        )
+    }
+}
+extension Yosemite.WooPaymentsDepositsOverviewByCurrency {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Yosemite.WooPaymentsDepositsOverviewByCurrency {
+        .init(
+            currency: .fake(),
+            automaticDeposits: .fake(),
+            depositInterval: .fake(),
+            pendingBalanceAmount: .fake(),
+            pendingDepositsCount: .fake(),
+            pendingDepositDays: .fake(),
+            nextDeposit: .fake(),
+            lastDeposit: .fake(),
+            availableBalance: .fake()
         )
     }
 }

--- a/Rakefile
+++ b/Rakefile
@@ -178,7 +178,7 @@ end
 
 desc 'Run all code generation tasks'
 task :generate do
-  %w[Hardware Networking Storage Yosemite WooCommerce].each do |prefix|
+  %w[Hardware Networking Storage Yosemite WooCommerce WooFoundation].each do |prefix|
     puts "\n\nGenerating Copiable for #{prefix}..."
     puts '=' * 100
 
@@ -187,7 +187,7 @@ task :generate do
 
   puts "\n\nDONE. Generated Copiable for all projects."
 
-  %w[Hardware Networking Yosemite].each do |prefix|
+  %w[Hardware Networking Yosemite WooFoundation].each do |prefix|
     puts "\n\nGenerating Fakes for #{prefix}..."
     puts '=' * 100
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2155,6 +2155,21 @@ extension WooAnalyticsEvent {
     }
 }
 
+// MARK: - Deposit Summary
+//
+extension WooAnalyticsEvent {
+    enum DepositSummary {
+        enum Keys {
+            static let numberOfCurrencies = "number_of_currencies"
+        }
+
+        static func depositSummaryShown(numberOfCurrencies: Int) -> WooAnalyticsEvent{
+            WooAnalyticsEvent(statName: .paymentsMenuDepositSummaryShown,
+                              properties: [Keys.numberOfCurrencies: numberOfCurrencies])
+        }
+    }
+}
+
 // MARK: - Close Account
 //
 extension WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2163,9 +2163,13 @@ extension WooAnalyticsEvent {
             static let numberOfCurrencies = "number_of_currencies"
         }
 
-        static func depositSummaryShown(numberOfCurrencies: Int) -> WooAnalyticsEvent{
+        static func depositSummaryShown(numberOfCurrencies: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .paymentsMenuDepositSummaryShown,
                               properties: [Keys.numberOfCurrencies: numberOfCurrencies])
+        }
+
+        static func depositSummaryError(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .paymentsMenuDepositSummaryError, properties: [:], error: error)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1008,6 +1008,7 @@ public enum WooAnalyticsStat: String {
     case inPersonPaymentsLearnMoreTapped = "in_person_payments_learn_more_tapped"
     case setUpTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_tapped"
     case aboutTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_about_tapped"
+    case paymentsMenuDepositSummaryShown = "payments_hub_deposit_summary_shown"
 
     // MARK: Payments Menu
     case pluginsNotSyncedYet = "plugins_not_synced_yet"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1009,6 +1009,7 @@ public enum WooAnalyticsStat: String {
     case setUpTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_tapped"
     case aboutTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_about_tapped"
     case paymentsMenuDepositSummaryShown = "payments_hub_deposit_summary_shown"
+    case paymentsMenuDepositSummaryError = "payments_hub_deposit_summary_error"
 
     // MARK: Payments Menu
     case pluginsNotSyncedYet = "plugins_not_synced_yet"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -347,6 +347,8 @@ extension WooConstants {
 
         case wooCorePaymentOptions = "https://woo.com/documentation/woocommerce/getting-started/sell-products/core-payment-options"
 
+        case wooPaymentsDepositSchedule = "https://woo.com/document/woopayments/deposits/deposit-schedule/"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -7,6 +7,8 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
 
     @Binding var isExpanded: Bool
 
+    @State private var showDepositSummaryInfo: Bool = false
+
     init(viewModel: WooPaymentsDepositsCurrencyOverviewViewModel,
          isExpanded: Binding<Bool>) {
         self.viewModel = viewModel
@@ -85,7 +87,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button {
-                    // TODO: Open a webview here: https://woo.com/document/woopayments/deposits/deposit-schedule/
+                    showDepositSummaryInfo = true
                 } label: {
                     HStack {
                         Image(systemName: "info.circle")
@@ -99,6 +101,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                 .padding(.bottom)
             }
         }
+        .safariSheet(isPresented: $showDepositSummaryInfo, url: WooConstants.URLs.wooPaymentsDepositSchedule.asURL())
         .animation(.easeOut, value: isExpanded)
         .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -311,7 +311,7 @@ struct InPersonPaymentsMenu_Previews: PreviewProvider {
             cardPresentPaymentsConfiguration: .init(country: .US),
             onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
             cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: 0),
-            wooPaymentsDepositsService: WooPaymentsDepositService(siteID: 0, credentials: .init(authToken: ""))))
+            wooPaymentsDepositService: WooPaymentsDepositService(siteID: 0, credentials: .init(authToken: ""))))
     static var previews: some View {
         InPersonPaymentsMenu(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -105,6 +105,10 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
             WooPaymentsDepositsCurrencyOverviewViewModel(overview: $0)
         })
         shouldShowDepositSummary = depositCurrencyViewModels.count > 0
+
+        guard shouldShowDepositSummary else {
+            return
+        }
         dependencies.analytics.track(event: .DepositSummary.depositSummaryShown(numberOfCurrencies: depositCurrencyViewModels.count))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -81,22 +81,22 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
             .assign(to: &$shouldBadgeTapToPayOnIPhone)
 
         Task { @MainActor in
-            await updateOutputProperties()
+            await updateOutputProperties(trackAnalytics: false)
         }
 
         InPersonPaymentsMenuViewController().registerUserActivity()
     }
 
     @MainActor
-    private func updateOutputProperties() async {
+    private func updateOutputProperties(trackAnalytics: Bool = true) async {
         payInPersonToggleViewModel.refreshState()
         updateCardReadersSection()
         await updateTapToPaySection()
-        await refreshDepositSummary()
+        await refreshDepositSummary(trackAnalytics: trackAnalytics)
     }
 
     @MainActor
-    private func refreshDepositSummary() async {
+    private func refreshDepositSummary(trackAnalytics: Bool) async {
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.wooPaymentsDepositsOverviewInPaymentsMenu) else {
             shouldShowDepositSummary = false
             return
@@ -107,7 +107,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
             })
             shouldShowDepositSummary = depositCurrencyViewModels.count > 0
 
-            guard shouldShowDepositSummary else {
+            guard shouldShowDepositSummary, trackAnalytics else {
                 return
             }
             dependencies.analytics.track(event: .DepositSummary.depositSummaryShown(numberOfCurrencies: depositCurrencyViewModels.count))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -106,7 +106,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
                 WooPaymentsDepositsCurrencyOverviewViewModel(overview: $0)
             })
             shouldShowDepositSummary = depositCurrencyViewModels.count > 0
-            
+
             guard shouldShowDepositSummary else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -80,7 +80,7 @@ final class HubMenuViewModel: ObservableObject {
                 cardPresentPaymentsConfiguration: CardPresentConfigurationLoader().configuration,
                 onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
                 cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID),
-                wooPaymentsDepositsService: WooPaymentsDepositService(siteID: siteID,
+                wooPaymentsDepositService: WooPaymentsDepositService(siteID: siteID,
                                                                       credentials: ServiceLocator.stores.sessionManager.defaultCredentials!)))
     }()
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 		174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */; };
 		201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */; };
 		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
+		2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */; };
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
@@ -3278,6 +3279,7 @@
 		174CA86B27D90E8900126524 /* WooAboutScreenConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAboutScreenConfiguration.swift; sourceTree = "<group>"; };
 		174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextItemActivitySource.swift; sourceTree = "<group>"; };
 		201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayViewModel.swift; sourceTree = "<group>"; };
+		202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWooPaymentsDepositService.swift; sourceTree = "<group>"; };
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
@@ -8177,6 +8179,7 @@
 				EEB44A192A8A254700FE089E /* MockStoreCreationProfilerUploadAnswersUseCase.swift */,
 				B935D3602A9F50F50067B927 /* MockWPAdminTaxSettingsURLProvider.swift */,
 				EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */,
+				202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14099,6 +14102,7 @@
 				0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */,
 				2602A64827BDBF8000B347F1 /* ProductInputTransformerTests.swift in Sources */,
 				02C27BD0282CDF9E0065471A /* CardPresentPaymentReceiptEmailCoordinatorTests.swift in Sources */,
+				2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */,
 				DE61978D289A5326005E4362 /* WooSetupWebViewModelTests.swift in Sources */,
 				D802548726552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift in Sources */,
 				B9DC770729F2D4910013B191 /* MockProductSelectorTopProductsProvider.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockWooPaymentsDepositService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockWooPaymentsDepositService.swift
@@ -3,9 +3,14 @@ import Yosemite
 
 final class MockWooPaymentsDepositService: WooPaymentsDepositServiceProtocol {
     var onFetchDepositsOverviewThenReturn: [WooPaymentsDepositsOverviewByCurrency] = []
+    var onFetchDepositsOverviewShouldThrow: Error? = nil
     var spyDidCallFetchDepositsOverview = false
-    func fetchDepositsOverview() async -> [WooPaymentsDepositsOverviewByCurrency] {
+    func fetchDepositsOverview() async throws -> [WooPaymentsDepositsOverviewByCurrency] {
         spyDidCallFetchDepositsOverview = true
-        return onFetchDepositsOverviewThenReturn
+        if let error = onFetchDepositsOverviewShouldThrow {
+            throw error
+        } else {
+            return onFetchDepositsOverviewThenReturn
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockWooPaymentsDepositService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockWooPaymentsDepositService.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Yosemite
+
+final class MockWooPaymentsDepositService: WooPaymentsDepositServiceProtocol {
+    var onFetchDepositsOverviewThenReturn: [WooPaymentsDepositsOverviewByCurrency] = []
+    var spyDidCallFetchDepositsOverview = false
+    func fetchDepositsOverview() async -> [WooPaymentsDepositsOverviewByCurrency] {
+        spyDidCallFetchDepositsOverview = true
+        return onFetchDepositsOverviewThenReturn
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import TestKit
 @testable import Yosemite
 @testable import WooCommerce
+import Networking
 
 /// Temporarily removed pending a rewrite for the new InPersonPaymentsMenuViewModel #11168
 class InPersonPaymentsMenuViewModelTests: XCTestCase {
@@ -66,7 +67,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
 
     func test_onAppear_when_deposit_service_gets_an_error_depositSummaryError_is_tracked() async {
         // Given
-        mockDepositService.onFetchDepositsOverviewShouldThrow = WooPaymentsDepositServiceError.unknown
+        mockDepositService.onFetchDepositsOverviewShouldThrow = DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "description"))
 
         // When
         await sut.onAppear()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -41,6 +41,19 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
             eventName == WooAnalyticsStat.paymentsMenuDepositSummaryShown.rawValue
         }))
     }
+
+    func test_onAppear_when_deposit_summaries_are_returned_depositSummaryShown_is_tracked() async {
+        // Given
+        mockDepositService.onFetchDepositsOverviewThenReturn = [.fake().copy(currency: .USD), .fake().copy(currency: .GBP)]
+
+        // When
+        await sut.onAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains(where: { eventName in
+            eventName == WooAnalyticsStat.paymentsMenuDepositSummaryShown.rawValue
+        }))
+    }
 //     private var stores: MockStoresManager!
 
 //     private var analyticsProvider: MockAnalyticsProvider!

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -64,6 +64,17 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         assertEqual(properties["number_of_currencies"], 2)
     }
 
+    func test_onAppear_when_deposit_service_gets_an_error_depositSummaryError_is_tracked() async {
+        // Given
+        mockDepositService.onFetchDepositsOverviewShouldThrow = WooPaymentsDepositServiceError.unknown
+
+        // When
+        await sut.onAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.paymentsMenuDepositSummaryError.rawValue))
+    }
+
 //     private var stores: MockStoresManager!
 
 //     private var analyticsProvider: MockAnalyticsProvider!

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import TestKit
 @testable import Yosemite
 @testable import WooCommerce
-import Networking
 
 /// Temporarily removed pending a rewrite for the new InPersonPaymentsMenuViewModel #11168
 class InPersonPaymentsMenuViewModelTests: XCTestCase {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -42,7 +42,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         }))
     }
 
-    func test_onAppear_when_deposit_summaries_are_returned_depositSummaryShown_is_tracked() async {
+    func test_onAppear_when_deposit_summaries_are_returned_depositSummaryShown_is_tracked() async throws {
         // Given
         mockDepositService.onFetchDepositsOverviewThenReturn = [.fake().copy(currency: .USD), .fake().copy(currency: .GBP)]
 
@@ -50,10 +50,20 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         await sut.onAppear()
 
         // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains(where: { eventName in
-            eventName == WooAnalyticsStat.paymentsMenuDepositSummaryShown.rawValue
-        }))
+        let eventIndex = try? XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: WooAnalyticsStat.paymentsMenuDepositSummaryShown.rawValue))
+
+        XCTAssertNotNil(eventIndex)
+
+        guard let eventIndex else {
+            return XCTFail("Expected event not found")
+        }
+
+        guard let properties = try XCTUnwrap(analyticsProvider.receivedProperties[safe: eventIndex]) as? [String: Int] else {
+            return XCTFail("Expected properties not tracked")
+        }
+        assertEqual(properties["number_of_currencies"], 2)
     }
+
 //     private var stores: MockStoresManager!
 
 //     private var analyticsProvider: MockAnalyticsProvider!

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		036563D728F93F8D00D84BFD /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 036563D628F93F8D00D84BFD /* TestKit */; };
 		03B8C3892914083F002235B1 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8C3882914083F002235B1 /* Bundle+Woo.swift */; };
 		203758752AD55670000E4281 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203758742AD55670000E4281 /* CountryCode.swift */; };
+		20AD34D32B0CDB8900F38F44 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 20AD34D22B0CDB8900F38F44 /* Codegen */; };
 		265C99D828B93F04005E6117 /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 265C99D728B93F04005E6117 /* ColorPalette.xcassets */; };
 		265C99DD28B941D5005E6117 /* UIColor+Muriel-Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265C99DC28B941D5005E6117 /* UIColor+Muriel-Tests.swift */; };
 		265C99DF28B94271005E6117 /* MurielColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265C99DE28B94271005E6117 /* MurielColorTests.swift */; };
@@ -59,6 +60,19 @@
 			remoteInfo = Tools;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		20AD34D42B0CDB8900F38F44 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0331A7502A39DECC001D2C2C /* Color+RGBStringDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+RGBStringDecoding.swift"; sourceTree = "<group>"; };
@@ -118,6 +132,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				20AD34D32B0CDB8900F38F44 /* Codegen in Frameworks */,
 				9FA5113235035AC9A6079B0D /* Pods_WooFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -352,12 +367,16 @@
 				B9C9C631283E703C001B879F /* Sources */,
 				B9C9C632283E703C001B879F /* Frameworks */,
 				B9C9C633283E703C001B879F /* Resources */,
+				20AD34D42B0CDB8900F38F44 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = WooFoundation;
+			packageProductDependencies = (
+				20AD34D22B0CDB8900F38F44 /* Codegen */,
+			);
 			productName = Tools;
 			productReference = B9C9C635283E703C001B879F /* WooFoundation.framework */;
 			productType = "com.apple.product-type.framework";
@@ -941,6 +960,10 @@
 		036563D628F93F8D00D84BFD /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestKit;
+		};
+		20AD34D22B0CDB8900F38F44 /* Codegen */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Codegen;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
@@ -1,7 +1,8 @@
 import Foundation
+import Codegen
 /// The 3-letter country code for supported currencies
 ///
-public enum CurrencyCode: String, CaseIterable, Codable {
+public enum CurrencyCode: String, CaseIterable, Codable, GeneratedFakeable {
     // A
     case AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN,
     // B

--- a/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -3,6 +3,7 @@
 import Codegen
 import Foundation
 import Networking
+import WooFoundation
 
 
 extension Yosemite.JustInTimeMessage {
@@ -64,6 +65,42 @@ extension Yosemite.ProductReviewFromNoteParcel {
             note: note,
             review: review,
             product: product
+        )
+    }
+}
+
+extension Yosemite.WooPaymentsDepositsOverviewByCurrency {
+    public func copy(
+        currency: CopiableProp<CurrencyCode> = .copy,
+        automaticDeposits: CopiableProp<Bool> = .copy,
+        depositInterval: CopiableProp<WooPaymentsDepositInterval> = .copy,
+        pendingBalanceAmount: CopiableProp<NSDecimalNumber> = .copy,
+        pendingDepositsCount: CopiableProp<Int> = .copy,
+        pendingDepositDays: CopiableProp<Int> = .copy,
+        nextDeposit: NullableCopiableProp<WooPaymentsDepositsOverviewByCurrency.NextDeposit> = .copy,
+        lastDeposit: NullableCopiableProp<WooPaymentsDepositsOverviewByCurrency.LastDeposit> = .copy,
+        availableBalance: CopiableProp<NSDecimalNumber> = .copy
+    ) -> Yosemite.WooPaymentsDepositsOverviewByCurrency {
+        let currency = currency ?? self.currency
+        let automaticDeposits = automaticDeposits ?? self.automaticDeposits
+        let depositInterval = depositInterval ?? self.depositInterval
+        let pendingBalanceAmount = pendingBalanceAmount ?? self.pendingBalanceAmount
+        let pendingDepositsCount = pendingDepositsCount ?? self.pendingDepositsCount
+        let pendingDepositDays = pendingDepositDays ?? self.pendingDepositDays
+        let nextDeposit = nextDeposit ?? self.nextDeposit
+        let lastDeposit = lastDeposit ?? self.lastDeposit
+        let availableBalance = availableBalance ?? self.availableBalance
+
+        return Yosemite.WooPaymentsDepositsOverviewByCurrency(
+            currency: currency,
+            automaticDeposits: automaticDeposits,
+            depositInterval: depositInterval,
+            pendingBalanceAmount: pendingBalanceAmount,
+            pendingDepositsCount: pendingDepositsCount,
+            pendingDepositDays: pendingDepositDays,
+            nextDeposit: nextDeposit,
+            lastDeposit: lastDeposit,
+            availableBalance: availableBalance
         )
     }
 }

--- a/Yosemite/Yosemite/Model/WooPaymentsDepositsOverview.swift
+++ b/Yosemite/Yosemite/Model/WooPaymentsDepositsOverview.swift
@@ -1,8 +1,9 @@
 import Foundation
 import WooFoundation
 import Networking
+import Codegen
 
-public struct WooPaymentsDepositsOverviewByCurrency {
+public struct WooPaymentsDepositsOverviewByCurrency: GeneratedCopiable, GeneratedFakeable {
     public let currency: CurrencyCode
     public let automaticDeposits: Bool
     public let depositInterval: WooPaymentsDepositInterval

--- a/Yosemite/Yosemite/Tools/Payments/WooPaymentsDepositService.swift
+++ b/Yosemite/Yosemite/Tools/Payments/WooPaymentsDepositService.swift
@@ -2,7 +2,11 @@ import Foundation
 import Networking
 import WooFoundation
 
-public class WooPaymentsDepositService {
+public protocol WooPaymentsDepositServiceProtocol {
+    func fetchDepositsOverview() async -> [WooPaymentsDepositsOverviewByCurrency]
+}
+
+public final class WooPaymentsDepositService: WooPaymentsDepositServiceProtocol {
     // MARK: - Properties
 
     private let wooPaymentsRemote: WCPayRemote

--- a/Yosemite/Yosemite/Tools/Payments/WooPaymentsDepositService.swift
+++ b/Yosemite/Yosemite/Tools/Payments/WooPaymentsDepositService.swift
@@ -25,10 +25,6 @@ public final class WooPaymentsDepositService: WooPaymentsDepositServiceProtocol 
         do {
             let overview = try await wooPaymentsRemote.loadDepositsOverview(for: siteID)
             return depositsOverviewForViews(overview)
-        } catch let error as DotcomError {
-            throw WooPaymentsDepositServiceError.network(underlying: error)
-        } catch {
-            throw WooPaymentsDepositServiceError.unknown
         }
     }
 
@@ -116,9 +112,4 @@ public final class WooPaymentsDepositService: WooPaymentsDepositServiceProtocol 
                                          type: lastDeposit.type),
             date: lastDeposit.date)
     }
-}
-
-public enum WooPaymentsDepositServiceError: Error {
-    case network(underlying: DotcomError)
-    case unknown
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11234 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds two of the five analytics for the new Deposit Summary view on the Payments menu.

The others will be implemented in the Deposit Summary view itself, so make sense to do in a separate PR as this is getting large.

The reason for the excessive size (for two analytics) is that we did not previously support fake/copy for WooFoundation files – this PR rectifies that, and also fixes enum fakes which previously did not declare the module they were from, leading to potential conflicts. Going commit-by-commit _might_ be an easier way to review this.

### Known issues
The `Shown` event was being tracked when the HubMenu was loaded, because we fetch the deposit summary on init. This is prevented with a flag, but I'm intending to move that to an `onAppear` on the depositSummary itself. Since we don't currently have a viewModel for that, I'm leaving it as is for the moment.

The `Error` event is tracked for stores which don't have WooPayments installed. I'll handle this separately, as I may deal with it by only fetching data for stores with WooPayments, or by suppressing the `restNoRoute` tracking. If other extensions implement the `overview-all` API, it would be nice to show their information here, but that does seem unlikely as it's not a published api spec.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Switch to a WooPayments Store
3. Navigate to `Menu > Payments`
4. Observe that when the deposit summary shows, the `PAYMENTS_HUB_DEPOSIT_SUMMARY_SHOWN` event is tracked, with the number of currencies.

### Errors

1. Repeat the above test, with Proxyman configured to breakpoint on the `/wc/v3/payments/deposits/overview-all` endpoint
2. Edit the response to a 500 error, then continue
3. Observe that the `PAYMENTS_HUB_DEPOSIT_SUMMARY_ERROR` event is tracked, along with the error description.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Screenshot showing the two above events tracked in the Xcode console](https://github.com/woocommerce/woocommerce-ios/assets/2472348/49c12c62-710c-4586-8c5f-09f014c8015b)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
