### PR TITLE
[Custom amounts M4] Taxes percentage new design

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
@@ -40,6 +40,7 @@ struct AddCustomAmountPercentageView: View {
 private extension AddCustomAmountPercentageView {
     enum Layout {
         static let mainVerticalSpacing: CGFloat = 8
+        static let textFieldMaxWidth: CGFloat = 200
         static func percentageFontSize(scale: CGFloat) -> CGFloat {
             56 * scale
         }
@@ -74,7 +75,7 @@ private extension AddCustomAmountPercentageView {
                 .focused($focused, equals: true)
                 .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
                 .keyboardType(.decimalPad)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: Layout.textFieldMaxWidth)
                 .fixedSize()
                 .onAppear {
                   DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
@@ -63,6 +63,7 @@ private extension AddCustomAmountPercentageView {
     struct PercentageInputField: View {
         @ScaledMetric private var scale: CGFloat = 1.0
         @Binding var text: String
+        @FocusState var focused: Bool?
 
         var body: some View {
             HStack(spacing: 0) {
@@ -70,10 +71,16 @@ private extension AddCustomAmountPercentageView {
                           text: $text,
                           prompt: Text("0").foregroundColor(Color(.textSubtle))
                 )
+                .focused($focused, equals: true)
                 .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
                 .keyboardType(.decimalPad)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize()
+                .onAppear {
+                  DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+                    self.focused = true
+                  }
+                }
 
                 Text("%")
                     .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct AddCustomAmountPercentageView: View {
+    @ObservedObject private(set) var viewModel: AddCustomAmountPercentageViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
+            HStack() {
+                Text(Localization.percentageInputTitle)
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+
+                Spacer()
+
+                Text("(\(viewModel.baseAmountForPercentageString))")
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+            }
+
+            PercentageInputField(text: $viewModel.percentage)
+
+            Divider()
+                .padding(.bottom, Layout.mainVerticalSpacing)
+
+            HStack() {
+                Text(Localization.amountTitle)
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+
+                Spacer()
+
+                Text(viewModel.percentageCalculatedAmount)
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+            }
+        }
+    }
+}
+
+private extension AddCustomAmountPercentageView {
+    enum Layout {
+        static let mainVerticalSpacing: CGFloat = 8
+        static func percentageFontSize(scale: CGFloat) -> CGFloat {
+            56 * scale
+        }
+    }
+}
+
+private extension AddCustomAmountPercentageView {
+    enum Localization {
+        static let amountTitle = NSLocalizedString("Amount", comment: "Title above the amount field on the add custom amount view in orders.")
+
+        static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
+                                                            value: "Enter percentage of order total",
+                                                            comment: "Title for entering an custom amount through a percentage")
+        static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
+                                                                  value: "Enter percentage",
+                                                                  comment: "Placeholder for entering an custom amount through a percentage")
+    }
+}
+
+private extension AddCustomAmountPercentageView {
+    struct PercentageInputField: View {
+        @ScaledMetric private var scale: CGFloat = 1.0
+        @Binding var text: String
+
+        var body: some View {
+            HStack(spacing: 0) {
+                TextField("",
+                          text: $text,
+                          prompt: Text("0").foregroundColor(Color(.textSubtle))
+                )
+                .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
+                .keyboardType(.decimalPad)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize()
+
+                Text("%")
+                    .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
+                    .foregroundColor(text.isEmpty ? Color(.textSubtle) : Color(.text))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageView.swift
@@ -49,14 +49,13 @@ private extension AddCustomAmountPercentageView {
 
 private extension AddCustomAmountPercentageView {
     enum Localization {
-        static let amountTitle = NSLocalizedString("Amount", comment: "Title above the amount field on the add custom amount view in orders.")
+        static let amountTitle = NSLocalizedString("addCustomAmountPercentageView.amount.title",
+                                                   value: "Amount",
+                                                   comment: "Title above the amount field on the add custom amount view in orders.")
 
-        static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
+        static let percentageInputTitle = NSLocalizedString("addCustomAmountPercentageView.percentageTextField.title",
                                                             value: "Enter percentage of order total",
                                                             comment: "Title for entering an custom amount through a percentage")
-        static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
-                                                                  value: "Enter percentage",
-                                                                  comment: "Placeholder for entering an custom amount through a percentage")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
@@ -1,0 +1,58 @@
+import Combine
+import WooFoundation
+import SwiftUI
+import Yosemite
+
+final class AddCustomAmountPercentageViewModel: ObservableObject {
+    let currencyFormatter: CurrencyFormatter
+    let baseAmountForPercentage: Decimal
+
+    @Published var percentageCalculatedAmount: String = "" {
+        didSet {
+            guard percentageCalculatedAmount != oldValue else { return }
+
+            percentageCalculatedAmount = currencyFormatter.formatAmount(percentageCalculatedAmount) ?? ""
+        }
+    }
+
+    var baseAmountForPercentageString: String {
+        guard let formattedAmount = currencyFormatter.formatAmount(baseAmountForPercentage) else {
+            return ""
+        }
+
+        return formattedAmount
+    }
+
+    @Published var percentage = "" {
+        didSet {
+            guard oldValue != percentage else { return }
+
+            updateAmountBasedOnPercentage(percentage)
+        }
+    }
+
+    init(baseAmountForPercentage: Decimal, currencyFormatter: CurrencyFormatter) {
+        self.baseAmountForPercentage = baseAmountForPercentage
+        self.currencyFormatter = currencyFormatter
+        percentageCalculatedAmount = "0"
+    }
+
+    func updateAmountBasedOnPercentage(_ percentage: String) {
+        guard percentage.isNotEmpty,
+              let decimalInput = currencyFormatter.convertToDecimal(percentage) else {
+            percentageCalculatedAmount = "0"
+            return
+        }
+
+        percentageCalculatedAmount = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
+    }
+
+    func preset(with fee: OrderFeeLine) {
+        guard let totalDecimal = currencyFormatter.convertToDecimal(fee.total) else {
+            return
+        }
+
+        percentage = currencyFormatter.localize(((totalDecimal as Decimal / baseAmountForPercentage) * 100)) ?? "0"
+        percentageCalculatedAmount = fee.total
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
@@ -6,30 +6,30 @@ import Yosemite
 final class AddCustomAmountPercentageViewModel: ObservableObject {
     let currencyFormatter: CurrencyFormatter
     let baseAmountForPercentage: Decimal
-
+    
     @Published var percentageCalculatedAmount: String = ""
     var baseAmountForPercentageString: String {
         guard let formattedAmount = currencyFormatter.formatAmount(baseAmountForPercentage) else {
             return ""
         }
-
+        
         return formattedAmount
     }
-
+    
     @Published var percentage = "" {
         didSet {
             guard oldValue != percentage else { return }
-
+            
             updateAmountBasedOnPercentage(percentage)
         }
     }
-
+    
     init(baseAmountForPercentage: Decimal, currencyFormatter: CurrencyFormatter) {
         self.baseAmountForPercentage = baseAmountForPercentage
         self.currencyFormatter = currencyFormatter
         percentageCalculatedAmount = "0"
     }
-
+    
     func updateAmountBasedOnPercentage(_ percentage: String) {
         guard percentage.isNotEmpty,
               let decimalInput = currencyFormatter.convertToDecimal(percentage) else {
@@ -40,12 +40,12 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
         let amountString = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
         percentageCalculatedAmount = currencyFormatter.formatAmount(amountString) ?? ""
     }
-
+    
     func preset(with fee: OrderFeeLine) {
         guard let totalDecimal = currencyFormatter.convertToDecimal(fee.total) else {
             return
         }
-
+        
         percentage = currencyFormatter.localize(((totalDecimal as Decimal / baseAmountForPercentage) * 100)) ?? "0"
         percentageCalculatedAmount = fee.total
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
@@ -6,30 +6,30 @@ import Yosemite
 final class AddCustomAmountPercentageViewModel: ObservableObject {
     let currencyFormatter: CurrencyFormatter
     let baseAmountForPercentage: Decimal
-    
+
     @Published var percentageCalculatedAmount: String = ""
     var baseAmountForPercentageString: String {
         guard let formattedAmount = currencyFormatter.formatAmount(baseAmountForPercentage) else {
             return ""
         }
-        
+
         return formattedAmount
     }
-    
+
     @Published var percentage = "" {
         didSet {
             guard oldValue != percentage else { return }
-            
+
             updateAmountBasedOnPercentage(percentage)
         }
     }
-    
+
     init(baseAmountForPercentage: Decimal, currencyFormatter: CurrencyFormatter) {
         self.baseAmountForPercentage = baseAmountForPercentage
         self.currencyFormatter = currencyFormatter
         percentageCalculatedAmount = "0"
     }
-    
+
     func updateAmountBasedOnPercentage(_ percentage: String) {
         guard percentage.isNotEmpty,
               let decimalInput = currencyFormatter.convertToDecimal(percentage) else {
@@ -40,12 +40,12 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
         let amountString = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
         percentageCalculatedAmount = currencyFormatter.formatAmount(amountString) ?? ""
     }
-    
+
     func preset(with fee: OrderFeeLine) {
         guard let totalDecimal = currencyFormatter.convertToDecimal(fee.total) else {
             return
         }
-        
+
         percentage = currencyFormatter.localize(((totalDecimal as Decimal / baseAmountForPercentage) * 100)) ?? "0"
         percentageCalculatedAmount = fee.total
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
@@ -7,14 +7,7 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
     let currencyFormatter: CurrencyFormatter
     let baseAmountForPercentage: Decimal
 
-    @Published var percentageCalculatedAmount: String = "" {
-        didSet {
-            guard percentageCalculatedAmount != oldValue else { return }
-
-            percentageCalculatedAmount = currencyFormatter.formatAmount(percentageCalculatedAmount) ?? ""
-        }
-    }
-
+    @Published var percentageCalculatedAmount: String = ""
     var baseAmountForPercentageString: String {
         guard let formattedAmount = currencyFormatter.formatAmount(baseAmountForPercentage) else {
             return ""
@@ -43,8 +36,9 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
             percentageCalculatedAmount = "0"
             return
         }
-
-        percentageCalculatedAmount = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
+        
+        let amountString = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
+        percentageCalculatedAmount = currencyFormatter.formatAmount(amountString) ?? ""
     }
 
     func preset(with fee: OrderFeeLine) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
@@ -36,7 +36,6 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
             percentageCalculatedAmount = "0"
             return
         }
-
         let amountString = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
         percentageCalculatedAmount = currencyFormatter.formatAmount(amountString) ?? ""
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
@@ -4,8 +4,8 @@ import SwiftUI
 import Yosemite
 
 final class AddCustomAmountPercentageViewModel: ObservableObject {
-    let currencyFormatter: CurrencyFormatter
-    let baseAmountForPercentage: Decimal
+    private let currencyFormatter: CurrencyFormatter
+    private let baseAmountForPercentage: Decimal
 
     @Published var percentageCalculatedAmount: String = ""
     var baseAmountForPercentageString: String {
@@ -30,6 +30,17 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
         percentageCalculatedAmount = "0"
     }
 
+    func preset(with fee: OrderFeeLine) {
+        guard let totalDecimal = currencyFormatter.convertToDecimal(fee.total) else {
+            return
+        }
+
+        percentage = currencyFormatter.localize(((totalDecimal as Decimal / baseAmountForPercentage) * 100)) ?? "0"
+        percentageCalculatedAmount = fee.total
+    }
+}
+
+extension AddCustomAmountPercentageViewModel {
     func updateAmountBasedOnPercentage(_ percentage: String) {
         guard percentage.isNotEmpty,
               let decimalInput = currencyFormatter.convertToDecimal(percentage) else {
@@ -38,14 +49,5 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
         }
         let amountString = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
         percentageCalculatedAmount = currencyFormatter.formatAmount(amountString) ?? ""
-    }
-
-    func preset(with fee: OrderFeeLine) {
-        guard let totalDecimal = currencyFormatter.convertToDecimal(fee.total) else {
-            return
-        }
-
-        percentage = currencyFormatter.localize(((totalDecimal as Decimal / baseAmountForPercentage) * 100)) ?? "0"
-        percentageCalculatedAmount = fee.total
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountPercentageViewModel.swift
@@ -36,7 +36,7 @@ final class AddCustomAmountPercentageViewModel: ObservableObject {
             percentageCalculatedAmount = "0"
             return
         }
-        
+
         let amountString = "\(baseAmountForPercentage * (decimalInput as Decimal) * 0.01)"
         percentageCalculatedAmount = currencyFormatter.formatAmount(amountString) ?? ""
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -11,32 +11,54 @@ struct AddCustomAmountView: View {
             GeometryReader { geometry in
                 ScrollView {
                     VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
-                        Text(Localization.amountTitle)
-                            .font(.title3)
-                            .foregroundColor(Color(.textSubtle))
 
-                        FormattableAmountTextField(viewModel: viewModel.formattableAmountTextFieldViewModel)
-                            .renderedIf(viewModel.shouldShowFixedAmountInput)
-
-                        VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
-                            Text(String.localizedStringWithFormat(Localization.percentageInputTitle, viewModel.baseAmountForPercentageString))
-                                .font(.subheadline)
+                        Group {
+                            Text(Localization.amountTitle)
+                                .font(.title3)
                                 .foregroundColor(Color(.textSubtle))
 
-                            HStack(spacing: Layout.inputFieldVerticalSpacing) {
-                                InputField(placeholder: Localization.percentageInputPlaceholder,
-                                           text: $viewModel.percentage)
+                            FormattableAmountTextField(viewModel: viewModel.formattableAmountTextFieldViewModel)
+                                .renderedIf(viewModel.shouldShowFixedAmountInput)
 
-                                Text("%")
-                                    .font(.title3)
+                            Divider()
+                                .padding(.bottom, Layout.mainVerticalSpacing)
+                        }
+                        .renderedIf(viewModel.shouldShowFixedAmountInput)
+
+
+                        VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
+                            HStack() {
+                                Text(Localization.percentageInputTitle)
+                                    .font(.subheadline)
+                                    .foregroundColor(Color(.textSubtle))
+
+                                Spacer()
+
+                                Text("(\(viewModel.baseAmountForPercentageString))")
+                                    .font(.subheadline)
                                     .foregroundColor(Color(.textSubtle))
                             }
+
+                            PercentageInputField(text: $viewModel.percentage)
+
+                            Divider()
+                                .padding(.bottom, Layout.mainVerticalSpacing)
+
+                            HStack() {
+                                Text(Localization.amountTitle)
+                                    .font(.subheadline)
+                                    .foregroundColor(Color(.textSubtle))
+
+                                Spacer()
+
+                                Text(viewModel.percentageCalculatedAmount)
+                                    .font(.subheadline)
+                                    .foregroundColor(Color(.textSubtle))
+                            }
+
                         }
                         .padding(.bottom, Layout.mainVerticalSpacing)
                         .renderedIf(viewModel.shouldShowPercentageInput)
-
-                        Divider()
-                            .padding(.bottom, Layout.mainVerticalSpacing)
 
                         Toggle(Localization.chargeTaxesToggleTitle, isOn: $viewModel.isTaxable)
                             .font(.title3)
@@ -78,21 +100,26 @@ struct AddCustomAmountView: View {
 }
 
 private extension AddCustomAmountView {
-    struct InputField: View {
-        let placeholder: String
+    struct PercentageInputField: View {
+        @ScaledMetric private var scale: CGFloat = 1.0
         @Binding var text: String
 
         var body: some View {
-            TextField(placeholder, text: $text)
-            .keyboardType(.decimalPad)
-            .padding(EdgeInsets(top: 0, leading: Layout.inputFieldInnerVerticalPadding, bottom: 0, trailing: Layout.inputFieldInnerVerticalPadding))
-            .frame(maxWidth: .infinity, minHeight: Layout.inputFieldHeight, maxHeight: Layout.inputFieldHeight)
-            .overlay {
-                RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
-                    .inset(by: Layout.inputFieldOverlayInset)
-                    .stroke(Color(uiColor: .wooCommercePurple(.shade50)), lineWidth: Layout.borderLineWidth)
+            HStack(spacing: 0) {
+                TextField("",
+                          text: $text,
+                          prompt: Text("0").foregroundColor(Color(.textSubtle))
+                )
+                .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
+                .keyboardType(.decimalPad)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize()
+
+                Text("%")
+                    .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
+                    .foregroundColor(text.isEmpty ? Color(.textSubtle) : Color(.text))
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .cornerRadius(Layout.frameCornerRadius)
         }
     }
 }
@@ -100,13 +127,9 @@ private extension AddCustomAmountView {
 private extension AddCustomAmountView {
     enum Layout {
         static let mainVerticalSpacing: CGFloat = 8
-        static let rowHeight: CGFloat = 44
-        static let frameCornerRadius: CGFloat = 4
-        static let borderLineWidth: CGFloat = 1
-        static let inputFieldOverlayInset: CGFloat = 0.25
-        static let inputFieldHeight: CGFloat = 44
-        static let inputFieldInnerVerticalPadding: CGFloat = 8
-        static let inputFieldVerticalSpacing: CGFloat = 8
+        static func percentageFontSize(scale: CGFloat) -> CGFloat {
+            56 * scale
+        }
     }
 }
 
@@ -118,7 +141,7 @@ private extension AddCustomAmountView {
         static let navigationCancelButtonTitle = NSLocalizedString("Cancel",
                                                                 comment: "Cancel button title on the navigation bar on the add custom amount view in orders.")
         static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
-                                                             value: "Or enter percentage of the order total (%1$@)",
+                                                             value: "Enter percentage of order total",
                                                              comment: "Title for entering an custom amount through a percentage")
         static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
                                                              value: "Enter percentage",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -10,9 +10,7 @@ struct AddCustomAmountView: View {
         NavigationView {
             GeometryReader { geometry in
                 ScrollView {
-                    VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
-                        Spacer()
-
+                    VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
                         Text(Localization.amountTitle)
                             .font(.title3)
                             .foregroundColor(Color(.textSubtle))
@@ -37,9 +35,11 @@ struct AddCustomAmountView: View {
                         .padding(.bottom, Layout.mainVerticalSpacing)
                         .renderedIf(viewModel.shouldShowPercentageInput)
 
+                        Divider()
+                            .padding(.bottom, Layout.mainVerticalSpacing)
+
                         Toggle(Localization.chargeTaxesToggleTitle, isOn: $viewModel.isTaxable)
                             .font(.title3)
-                            .foregroundColor(Color(.textSubtle))
                             .padding(.bottom, Layout.mainVerticalSpacing)
 
                         Text(Localization.nameTitle)
@@ -49,7 +49,6 @@ struct AddCustomAmountView: View {
                         TextField(viewModel.customAmountPlaceholder, text: $viewModel.name)
                             .secondaryTitleStyle()
                             .foregroundColor(Color(.textSubtle))
-                            .multilineTextAlignment(.center)
 
                         Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -18,6 +18,7 @@ struct AddCustomAmountView: View {
                             .foregroundColor(Color(.textSubtle))
 
                         FormattableAmountTextField(viewModel: viewModel.formattableAmountTextFieldViewModel)
+                            .renderedIf(viewModel.shouldShowFixedAmountInput)
 
                         VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
                             Text(String.localizedStringWithFormat(Localization.percentageInputTitle, viewModel.baseAmountForPercentageString))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -24,12 +24,11 @@ struct AddCustomAmountView: View {
                                     .padding(.bottom, Layout.mainVerticalSpacing)
                             }
                         }
-//
+
                         if let percentageViewModel = viewModel.percentageViewModel {
                             AddCustomAmountPercentageView(viewModel: percentageViewModel)
                                 .padding(.bottom, Layout.mainVerticalSpacing)
                         }
-
 
                         Toggle(Localization.chargeTaxesToggleTitle, isOn: $viewModel.isTaxable)
                             .font(.title3)
@@ -75,9 +74,6 @@ struct AddCustomAmountView: View {
 private extension AddCustomAmountView {
     enum Layout {
         static let mainVerticalSpacing: CGFloat = 8
-        static func percentageFontSize(scale: CGFloat) -> CGFloat {
-            56 * scale
-        }
     }
 }
 
@@ -101,93 +97,5 @@ private extension AddCustomAmountView {
 
     enum AccessibilityIdentifiers {
         static let addCustomAmountButton = "order-add-custom-amount-view-add-custom-amount-button"
-    }
-}
-
-struct AddCustomAmountPercentageView: View {
-    @ObservedObject private(set) var viewModel: AddCustomAmountPercentageViewModel
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack() {
-                Text(Localization.percentageInputTitle)
-                    .font(.subheadline)
-                    .foregroundColor(Color(.textSubtle))
-
-                Spacer()
-
-                Text("(\(viewModel.baseAmountForPercentageString))")
-                    .font(.subheadline)
-                    .foregroundColor(Color(.textSubtle))
-            }
-
-            PercentageInputField(text: $viewModel.percentage)
-
-            Divider()
-                .padding(.bottom, 8)
-
-            HStack() {
-                Text(Localization.amountTitle)
-                    .font(.subheadline)
-                    .foregroundColor(Color(.textSubtle))
-
-                Spacer()
-
-                Text(viewModel.percentageCalculatedAmount)
-                    .font(.subheadline)
-                    .foregroundColor(Color(.textSubtle))
-            }
-
-        }
-    }
-}
-private extension AddCustomAmountPercentageView {
-    enum Layout {
-        static let mainVerticalSpacing: CGFloat = 8
-        static func percentageFontSize(scale: CGFloat) -> CGFloat {
-            56 * scale
-        }
-    }
-}
-
-private extension AddCustomAmountPercentageView {
-    enum Localization {
-        static let amountTitle = NSLocalizedString("Amount", comment: "Title above the amount field on the add custom amount view in orders.")
-
-        static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
-                                                             value: "Enter percentage of order total",
-                                                             comment: "Title for entering an custom amount through a percentage")
-        static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
-                                                             value: "Enter percentage",
-                                                             comment: "Placeholder for entering an custom amount through a percentage")
-    }
-
-    enum AccessibilityIdentifiers {
-        static let addCustomAmountButton = "order-add-custom-amount-view-add-custom-amount-button"
-    }
-}
-
-private extension AddCustomAmountPercentageView {
-    struct PercentageInputField: View {
-        @ScaledMetric private var scale: CGFloat = 1.0
-        @Binding var text: String
-
-        var body: some View {
-            HStack(spacing: 0) {
-                TextField("",
-                          text: $text,
-                          prompt: Text("0").foregroundColor(Color(.textSubtle))
-                )
-                .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
-                .keyboardType(.decimalPad)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize()
-
-                Text("%")
-                    .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
-                    .foregroundColor(text.isEmpty ? Color(.textSubtle) : Color(.text))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -84,12 +84,6 @@ private extension AddCustomAmountView {
         static let navigationTitle = NSLocalizedString("Custom Amount", comment: "Navigation title on the add custom amount view in orders.")
         static let navigationCancelButtonTitle = NSLocalizedString("Cancel",
                                                                 comment: "Cancel button title on the navigation bar on the add custom amount view in orders.")
-        static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
-                                                             value: "Enter percentage of order total",
-                                                             comment: "Title for entering an custom amount through a percentage")
-        static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
-                                                             value: "Enter percentage",
-                                                             comment: "Placeholder for entering an custom amount through a percentage")
         static let chargeTaxesToggleTitle = NSLocalizedString("addCustomAmountView.chargeTaxesToggle.title",
                                                              value: "Charge Taxes",
                                                              comment: "Title for the charge taxes toggle in the custom amounts screen.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -49,7 +49,7 @@ struct AddCustomAmountView: View {
                             dismiss()
                         }
                         .buttonStyle(PrimaryButtonStyle())
-                        .disabled(viewModel.shouldDisableDoneButton)
+                        .disabled(!viewModel.shouldEnableDoneButton)
                         .accessibilityIdentifier(AccessibilityIdentifiers.addCustomAmountButton)
                     }
                     .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountView.swift
@@ -12,53 +12,24 @@ struct AddCustomAmountView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
 
-                        Group {
-                            Text(Localization.amountTitle)
-                                .font(.title3)
-                                .foregroundColor(Color(.textSubtle))
-
-                            FormattableAmountTextField(viewModel: viewModel.formattableAmountTextFieldViewModel)
-                                .renderedIf(viewModel.shouldShowFixedAmountInput)
-
-                            Divider()
-                                .padding(.bottom, Layout.mainVerticalSpacing)
-                        }
-                        .renderedIf(viewModel.shouldShowFixedAmountInput)
-
-
-                        VStack(alignment: .leading, spacing: Layout.mainVerticalSpacing) {
-                            HStack() {
-                                Text(Localization.percentageInputTitle)
-                                    .font(.subheadline)
-                                    .foregroundColor(Color(.textSubtle))
-
-                                Spacer()
-
-                                Text("(\(viewModel.baseAmountForPercentageString))")
-                                    .font(.subheadline)
-                                    .foregroundColor(Color(.textSubtle))
-                            }
-
-                            PercentageInputField(text: $viewModel.percentage)
-
-                            Divider()
-                                .padding(.bottom, Layout.mainVerticalSpacing)
-
-                            HStack() {
+                        if let formattableAmountTextFieldViewModel = viewModel.formattableAmountTextFieldViewModel {
+                            Group {
                                 Text(Localization.amountTitle)
-                                    .font(.subheadline)
+                                    .font(.title3)
                                     .foregroundColor(Color(.textSubtle))
 
-                                Spacer()
+                                FormattableAmountTextField(viewModel: formattableAmountTextFieldViewModel)
 
-                                Text(viewModel.percentageCalculatedAmount)
-                                    .font(.subheadline)
-                                    .foregroundColor(Color(.textSubtle))
+                                Divider()
+                                    .padding(.bottom, Layout.mainVerticalSpacing)
                             }
-
                         }
-                        .padding(.bottom, Layout.mainVerticalSpacing)
-                        .renderedIf(viewModel.shouldShowPercentageInput)
+//
+                        if let percentageViewModel = viewModel.percentageViewModel {
+                            AddCustomAmountPercentageView(viewModel: percentageViewModel)
+                                .padding(.bottom, Layout.mainVerticalSpacing)
+                        }
+
 
                         Toggle(Localization.chargeTaxesToggleTitle, isOn: $viewModel.isTaxable)
                             .font(.title3)
@@ -99,30 +70,7 @@ struct AddCustomAmountView: View {
     }
 }
 
-private extension AddCustomAmountView {
-    struct PercentageInputField: View {
-        @ScaledMetric private var scale: CGFloat = 1.0
-        @Binding var text: String
 
-        var body: some View {
-            HStack(spacing: 0) {
-                TextField("",
-                          text: $text,
-                          prompt: Text("0").foregroundColor(Color(.textSubtle))
-                )
-                .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
-                .keyboardType(.decimalPad)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize()
-
-                Text("%")
-                    .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
-                    .foregroundColor(text.isEmpty ? Color(.textSubtle) : Color(.text))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-        }
-    }
-}
 
 private extension AddCustomAmountView {
     enum Layout {
@@ -153,5 +101,93 @@ private extension AddCustomAmountView {
 
     enum AccessibilityIdentifiers {
         static let addCustomAmountButton = "order-add-custom-amount-view-add-custom-amount-button"
+    }
+}
+
+struct AddCustomAmountPercentageView: View {
+    @ObservedObject private(set) var viewModel: AddCustomAmountPercentageViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack() {
+                Text(Localization.percentageInputTitle)
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+
+                Spacer()
+
+                Text("(\(viewModel.baseAmountForPercentageString))")
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+            }
+
+            PercentageInputField(text: $viewModel.percentage)
+
+            Divider()
+                .padding(.bottom, 8)
+
+            HStack() {
+                Text(Localization.amountTitle)
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+
+                Spacer()
+
+                Text(viewModel.percentageCalculatedAmount)
+                    .font(.subheadline)
+                    .foregroundColor(Color(.textSubtle))
+            }
+
+        }
+    }
+}
+private extension AddCustomAmountPercentageView {
+    enum Layout {
+        static let mainVerticalSpacing: CGFloat = 8
+        static func percentageFontSize(scale: CGFloat) -> CGFloat {
+            56 * scale
+        }
+    }
+}
+
+private extension AddCustomAmountPercentageView {
+    enum Localization {
+        static let amountTitle = NSLocalizedString("Amount", comment: "Title above the amount field on the add custom amount view in orders.")
+
+        static let percentageInputTitle = NSLocalizedString("addCustomAmountView.percentageTextField.title",
+                                                             value: "Enter percentage of order total",
+                                                             comment: "Title for entering an custom amount through a percentage")
+        static let percentageInputPlaceholder = NSLocalizedString("addCustomAmountView.percentageTextField.placeholder",
+                                                             value: "Enter percentage",
+                                                             comment: "Placeholder for entering an custom amount through a percentage")
+    }
+
+    enum AccessibilityIdentifiers {
+        static let addCustomAmountButton = "order-add-custom-amount-view-add-custom-amount-button"
+    }
+}
+
+private extension AddCustomAmountPercentageView {
+    struct PercentageInputField: View {
+        @ScaledMetric private var scale: CGFloat = 1.0
+        @Binding var text: String
+
+        var body: some View {
+            HStack(spacing: 0) {
+                TextField("",
+                          text: $text,
+                          prompt: Text("0").foregroundColor(Color(.textSubtle))
+                )
+                .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
+                .keyboardType(.decimalPad)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize()
+
+                Text("%")
+                    .font(.system(size: Layout.percentageFontSize(scale: scale), weight: .bold))
+                    .foregroundColor(text.isEmpty ? Color(.textSubtle) : Color(.text))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -4,7 +4,7 @@ import UIKit
 import SwiftUI
 import Yosemite
 
-/// Provides a adapter depending on the input type
+/// Provides an adapter depending on the input type
 ///
 final class AddCustomAmountInputTypeViewModelAdapterProvider {
     func provideAddCustomAmountInputTypeViewModelAdapter(with type: AddCustomAmountViewModel.InputType) -> AddCustomAmountInputTypeViewModelAdapter {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -17,7 +17,7 @@ final class AddCustomAmountInputTypeViewModelAdapterProvider {
     }
 }
 
-/// Classes implementing this protocol will act as a adapter between `AddCustomAmountViewModel` and the input type view models.
+/// Classes implementing this protocol will act as an adapter between `AddCustomAmountViewModel` and the input type view models.
 /// This way, the former can be agnostic of what type of view model we have before the scenes,
 /// and doesn't have to type check to access their concrete implementation.
 /// Having a adapter keeps the classes loosely coupled, as the type view model doesn't have to adapt for `AddCustomAmountViewModel`,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -23,7 +23,7 @@ final class AddCustomAmountViewModel: ObservableObject {
         didSet {
             guard percentageCalculatedAmount != oldValue else { return }
 
-            return currencyFormatter.formatAmount(percentageCalculatedAmount) ?? ""
+            percentageCalculatedAmount = currencyFormatter.formatAmount(percentageCalculatedAmount) ?? ""
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -82,7 +82,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     /// Variable that holds the name of the custom amount.
     ///
     @Published var name = ""
-    @Published private(set) var shouldDisableDoneButton: Bool = true
+    @Published private(set) var shouldEnableDoneButton: Bool = false
     @Published var isTaxable: Bool = true
     private var feeID: Int64? = nil
 
@@ -139,8 +139,10 @@ private extension AddCustomAmountViewModel {
 
     func listenToAmountChanges() {
         inputTypeViewModelAdapter.amountPublisher?.map { [weak self] value in
-            !(self?.amountIsValid(amount: value) ?? true)
-        }.assign(to: &$shouldDisableDoneButton)
+            guard let self = self else { return false }
+
+            return self.amountIsValid(amount: value)
+        }.assign(to: &$shouldEnableDoneButton)
     }
 
     func amountIsValid(amount: String) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -72,7 +72,6 @@ final class AddCustomAmountViewModel: ObservableObject {
         case orderTotalPercentage(baseAmount: Decimal)
     }
 
-    private let inputType: InputType
     private var inputTypeViewModelAdapter: AddCustomAmountInputTypeViewModelAdapter
     private let onCustomAmountEntered: CustomAmountEntered
     private let analytics: Analytics
@@ -103,7 +102,6 @@ final class AddCustomAmountViewModel: ObservableObject {
          onCustomAmountEntered: @escaping CustomAmountEntered) {
         self.inputTypeViewModelAdapter = AddCustomAmountInputTypeViewModelAdapterProvider().provideAddCustomAmountInputTypeViewModelAdapter(with: inputType)
         self.currencyFormatter = .init(currencySettings: storeCurrencySettings)
-        self.inputType = inputType
         self.analytics = analytics
         self.onCustomAmountEntered = onCustomAmountEntered
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -15,7 +15,6 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
 
             if resetAmountWithNewValue,
                 let newInput = amount.last {
-                onWillResetAmountWithNewValue?()
                 amount = String(newInput)
                 resetAmountWithNewValue = false
             }
@@ -49,8 +48,6 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
     var amountTextColor: UIColor {
         amount.isEmpty ? .textSubtle : .text
     }
-
-    var onWillResetAmountWithNewValue: (() -> Void)?
 
     init(locale: Locale = Locale.autoupdatingCurrent,
         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
 struct OrderCustomAmountsSection: View {
+    enum ConfirmationOption {
+        case fixedAmount
+        case orderTotalPercentage
+    }
+
     /// View model to drive the view content
     @ObservedObject var viewModel: EditableOrderViewModel
 
@@ -8,12 +13,16 @@ struct OrderCustomAmountsSection: View {
     ///
     @State private var showAddCustomAmount: Bool = false
 
+    @State private var showAddCustomAmountConfirmationDialog: Bool = false
+
+    @State private var addCustomAmountOption: ConfirmationOption = .fixedAmount
+
     var body: some View {
         VStack {
             HStack {
                 Button(Localization.addCustomAmount) {
                     viewModel.onAddCustomAmountButtonTapped()
-                    showAddCustomAmount.toggle()
+                    showAddCustomAmountConfirmationDialog.toggle()
                 }
                 .accessibilityIdentifier(Accessibility.addCustomAmountIdentifier)
                 .buttonStyle(PlusButtonStyle())
@@ -50,11 +59,22 @@ struct OrderCustomAmountsSection: View {
         }
         .padding()
         .background(Color(.listForeground(modal: true)))
+        .confirmationDialog("How do you want to add your custom amount?", isPresented: $showAddCustomAmountConfirmationDialog, titleVisibility: .visible) {
+            Button("Enter as fixed amount $") {
+                addCustomAmountOption = .fixedAmount
+                showAddCustomAmount = true
+            }
+
+            Button("Percentage of order total %") {
+                addCustomAmountOption = .orderTotalPercentage
+                showAddCustomAmount = true
+            }
+        }
         .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
-            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
+            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel(with: addCustomAmountOption))
         })
         .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
-            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel)
+            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel(with: addCustomAmountOption))
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -15,14 +15,14 @@ struct OrderCustomAmountsSection: View {
 
     @State private var showAddCustomAmountConfirmationDialog: Bool = false
 
-    @State private var addCustomAmountOption: ConfirmationOption = .fixedAmount
+    @State private var addCustomAmountOption: ConfirmationOption?
 
     var body: some View {
         VStack {
             HStack {
                 Button(Localization.addCustomAmount) {
-                    viewModel.onAddCustomAmountButtonTapped()
-                    showAddCustomAmountConfirmationDialog.toggle()
+
+                    onAddCustomAmountRequested()
                 }
                 .accessibilityIdentifier(Accessibility.addCustomAmountIdentifier)
                 .buttonStyle(PlusButtonStyle())
@@ -42,8 +42,7 @@ struct OrderCustomAmountsSection: View {
                         .renderedIf(viewModel.shouldShowNonEditableIndicators)
 
                     Button(action: {
-                        viewModel.onAddCustomAmountButtonTapped()
-                        showAddCustomAmount.toggle()
+                        onAddCustomAmountRequested()
                     }) {
                         Image(uiImage: .plusImage)
                     }
@@ -76,6 +75,12 @@ struct OrderCustomAmountsSection: View {
         .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel(with: addCustomAmountOption))
         })
+    }
+}
+private extension OrderCustomAmountsSection {
+    func onAddCustomAmountRequested() {
+        viewModel.onAddCustomAmountButtonTapped()
+        viewModel.enableAddingCustomAmountViaOrderTotalPercentage ? showAddCustomAmountConfirmationDialog.toggle() : showAddCustomAmount.toggle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -159,15 +159,15 @@ private extension OrderCustomAmountsSection {
                                                      value: "Custom Amounts",
                                                      comment: "Title text of the section that shows the Custom Amounts when creating or editing an order")
         static let optionsDialogAddCustomAmountTitle = NSLocalizedString("orderForm.customAmounts.addOptionsDialogTitle",
-                                                                         value: "How do you want to add your custom amount?",
-                                                                         comment: "Title text of the confirmation dialog that shows the add custom amounts options.")
+                                                        value: "How do you want to add your custom amount?",
+                                                        comment: "Title text of the confirmation dialog that shows the add custom amounts options.")
         static let optionsDialogFixedAmountButtonTitle = NSLocalizedString("orderForm.customAmounts.addOptionsDialogFixedAmountButtonTitle",
-                                                                           value: "A fixed amount",
-                                                                           comment: "Button title for the fixed amount option in the custom amounts option sheet.")
+                                                        value: "A fixed amount",
+                                                        comment: "Button title for the fixed amount option in the custom amounts option sheet.")
         static let optionsDialogPercentageButtonTitle = NSLocalizedString("orderForm.customAmounts.addOptionsDialogPercentageButtonTitle",
-                                                                          value: "A percentage of the order total",
-                                                                          comment: "Button title for the percentage option in the custom amounts option sheet.")
-        
+                                                        value: "A percentage of the order total",
+                                                        comment: "Button title for the percentage option in the custom amounts option sheet.")
+
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -65,7 +65,11 @@ struct OrderCustomAmountsSection: View {
         .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: onDismissOptionsDialog) {
             optionsWithDetentsBottomSheetContent
         }
-        .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
+        .sheet(isPresented: $showAddCustomAmount,
+               onDismiss: {
+            viewModel.onDismissAddCustomAmountView()
+            addCustomAmountOption = nil
+        }, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel(with: addCustomAmountOption))
         })
     }
@@ -150,20 +154,20 @@ private extension OrderCustomAmountsSection {
     }
     enum Localization {
         static let addCustomAmount = NSLocalizedString("Add Custom Amount",
-                                                   comment: "Title text of the button that allows to add a custom amount when creating or editing an order")
+                                                       comment: "Title text of the button that allows to add a custom amount when creating or editing an order")
         static let customAmounts = NSLocalizedString("orderForm.customAmounts",
                                                      value: "Custom Amounts",
                                                      comment: "Title text of the section that shows the Custom Amounts when creating or editing an order")
         static let optionsDialogAddCustomAmountTitle = NSLocalizedString("orderForm.customAmounts.addOptionsDialogTitle",
-                                                     value: "How do you want to add your custom amount?",
-                                                     comment: "Title text of the confirmation dialog that shows the add custom amounts options.")
+                                                                         value: "How do you want to add your custom amount?",
+                                                                         comment: "Title text of the confirmation dialog that shows the add custom amounts options.")
         static let optionsDialogFixedAmountButtonTitle = NSLocalizedString("orderForm.customAmounts.addOptionsDialogFixedAmountButtonTitle",
-                                                     value: "A fixed amount",
-                                                     comment: "Button title for the fixed amount option in the custom amounts option sheet.")
+                                                                           value: "A fixed amount",
+                                                                           comment: "Button title for the fixed amount option in the custom amounts option sheet.")
         static let optionsDialogPercentageButtonTitle = NSLocalizedString("orderForm.customAmounts.addOptionsDialogPercentageButtonTitle",
-                                                     value: "A percentage of the order total",
-                                                     comment: "Button title for the percentage option in the custom amounts option sheet.")
-
+                                                                          value: "A percentage of the order total",
+                                                                          comment: "Button title for the percentage option in the custom amounts option sheet.")
+        
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -18,6 +18,8 @@ struct OrderCustomAmountsSection: View {
 
     @State private var addCustomAmountOption: ConfirmationOption?
 
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
     var body: some View {
         VStack {
             HStack {
@@ -57,6 +59,7 @@ struct OrderCustomAmountsSection: View {
             }
             .renderedIf(viewModel.customAmountRows.isNotEmpty)
         }
+        .padding(.horizontal, insets: safeAreaInsets)
         .padding()
         .background(Color(.listForeground(modal: true)))
         .sheet(isPresented: $showAddCustomAmountOptionsDialog, onDismiss: onDismissOptionsDialog) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -59,24 +59,30 @@ struct OrderCustomAmountsSection: View {
         .padding()
         .background(Color(.listForeground(modal: true)))
         .confirmationDialog("How do you want to add your custom amount?", isPresented: $showAddCustomAmountConfirmationDialog, titleVisibility: .visible) {
-            Button("Enter as fixed amount $") {
-                addCustomAmountOption = .fixedAmount
-                showAddCustomAmount = true
-            }
-
-            Button("Percentage of order total %") {
-                addCustomAmountOption = .orderTotalPercentage
-                showAddCustomAmount = true
-            }
+            confirmationDialogActions
+        }
+        .confirmationDialog("How do you want to edit your custom amount?", isPresented: $viewModel.showEditCustomAmount, titleVisibility: .visible) {
+            confirmationDialogActions
         }
         .sheet(isPresented: $showAddCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel(with: addCustomAmountOption))
         })
-        .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: viewModel.onDismissAddCustomAmountView, content: {
-            AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel(with: addCustomAmountOption))
-        })
+    }
+
+    @ViewBuilder
+    private var confirmationDialogActions: some View {
+        Button("Enter as fixed amount $") {
+            addCustomAmountOption = .fixedAmount
+            showAddCustomAmount = true
+        }
+
+        Button("Percentage of order total %") {
+            addCustomAmountOption = .orderTotalPercentage
+            showAddCustomAmount = true
+        }
     }
 }
+
 private extension OrderCustomAmountsSection {
     func onAddCustomAmountRequested() {
         viewModel.onAddCustomAmountButtonTapped()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -24,7 +24,6 @@ struct OrderCustomAmountsSection: View {
         VStack {
             HStack {
                 Button(Localization.addCustomAmount) {
-
                     onAddCustomAmountRequested()
                 }
                 .accessibilityIdentifier(Accessibility.addCustomAmountIdentifier)
@@ -101,9 +100,7 @@ struct OrderCustomAmountsSection: View {
 
                 Button(Localization.optionsDialogFixedAmountButtonTitle) {
                     addCustomAmountOption = .fixedAmount
-                    showAddCustomAmountAfterOptionsDialog = true
-                    showAddCustomAmountOptionsDialog = false
-                    viewModel.showEditCustomAmount = false
+                    showAddCustomAmountsAfterOptionsDialog()
 
                 }
                 .bodyStyle()
@@ -117,9 +114,7 @@ struct OrderCustomAmountsSection: View {
 
                 Button(Localization.optionsDialogPercentageButtonTitle) {
                     addCustomAmountOption = .orderTotalPercentage
-                    showAddCustomAmountAfterOptionsDialog = true
-                    showAddCustomAmountOptionsDialog = false
-                    viewModel.showEditCustomAmount = false
+                    showAddCustomAmountsAfterOptionsDialog()
                 }
                 .bodyStyle()
             }
@@ -142,6 +137,12 @@ private extension OrderCustomAmountsSection {
             showAddCustomAmountAfterOptionsDialog = false
             showAddCustomAmount = true
         }
+    }
+
+    func showAddCustomAmountsAfterOptionsDialog() {
+        showAddCustomAmountAfterOptionsDialog = true
+        showAddCustomAmountOptionsDialog = false
+        viewModel.showEditCustomAmount = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -810,6 +810,7 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     func onAddCustomAmountButtonTapped() {
+        editingFee = nil
         analytics.track(.orderCreationAddCustomAmountTapped)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -100,6 +100,10 @@ final class EditableOrderViewModel: ObservableObject {
         featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner)
     }
 
+    var enableAddingCustomAmountViaOrderTotalPercentage: Bool {
+        orderSynchronizer.order.items.isNotEmpty || orderSynchronizer.order.fees.isNotEmpty
+    }
+
     var title: String {
         switch flow {
         case .creation:
@@ -809,11 +813,8 @@ final class EditableOrderViewModel: ObservableObject {
         analytics.track(.orderCreationAddCustomAmountTapped)
     }
 
-    func addCustomAmountViewModel(with option: OrderCustomAmountsSection.ConfirmationOption) -> AddCustomAmountViewModel {
-
-        let orderTotals = OrderTotalsCalculator(for: orderSynchronizer.order, using: self.currencyFormatter)
-
-        let viewModel = AddCustomAmountViewModel(inputType: addCustomAmountInputType(from: option),
+    func addCustomAmountViewModel(with option: OrderCustomAmountsSection.ConfirmationOption?) -> AddCustomAmountViewModel {
+        let viewModel = AddCustomAmountViewModel(inputType: addCustomAmountInputType(from: option ?? .fixedAmount),
                                                  onCustomAmountEntered: { [weak self] amount, name, feeID, isTaxable in
             let taxStatus: OrderFeeTaxStatus = isTaxable ? .taxable : .none
             if let feeID = feeID {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1693,6 +1693,7 @@
 		B93E03262A94EE63009CA9C1 /* TaxLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93E03252A94EE63009CA9C1 /* TaxLineViewModel.swift */; };
 		B943E7252AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B943E7242AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift */; };
 		B94403C9289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94403C8289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift */; };
+		B945F8862B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B945F8852B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift */; };
 		B946880C29B626A1000646B0 /* SpotlightManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946880B29B626A1000646B0 /* SpotlightManager.swift */; };
 		B946880E29B627EB000646B0 /* SearchableActivityConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946880D29B627EB000646B0 /* SearchableActivityConvertable.swift */; };
 		B946881029B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946880F29B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift */; };
@@ -4261,6 +4262,7 @@
 		B93E03252A94EE63009CA9C1 /* TaxLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxLineViewModel.swift; sourceTree = "<group>"; };
 		B943E7242AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsCustomAmountCellViewModel.swift; sourceTree = "<group>"; };
 		B94403C8289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmountFlowOpener.swift; sourceTree = "<group>"; };
+		B945F8852B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCustomAmountPercentageViewModel.swift; sourceTree = "<group>"; };
 		B946880B29B626A1000646B0 /* SpotlightManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightManager.swift; sourceTree = "<group>"; };
 		B946880D29B627EB000646B0 /* SearchableActivityConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableActivityConvertable.swift; sourceTree = "<group>"; };
 		B946880F29B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InPersonPaymentsMenuViewController+Activity.swift"; sourceTree = "<group>"; };
@@ -9327,6 +9329,7 @@
 				B9D19A412AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift */,
 				B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */,
 				B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */,
+				B945F8852B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift */,
 			);
 			path = CustomAmounts;
 			sourceTree = "<group>";
@@ -13146,6 +13149,7 @@
 				02C37B79296694A900F0CF9E /* StoreCreationCategoryQuestionOptions.swift in Sources */,
 				451750B224470CD5004FDA65 /* EnhancedTextView.swift in Sources */,
 				02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */,
+				B945F8862B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift in Sources */,
 				E1E125B226EB8EE80068A9B0 /* UpdateProgressImage.swift in Sources */,
 				B5A82EE7210263460053ADC8 /* UIViewController+Helpers.swift in Sources */,
 				03E471D829424CF9001A58AD /* CardPresentModalBuiltInReaderProcessing.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1694,6 +1694,7 @@
 		B943E7252AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B943E7242AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift */; };
 		B94403C9289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94403C8289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift */; };
 		B945F8862B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B945F8852B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift */; };
+		B945F8882B0CE74800B8281C /* AddCustomAmountPercentageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B945F8872B0CE74800B8281C /* AddCustomAmountPercentageView.swift */; };
 		B946880C29B626A1000646B0 /* SpotlightManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946880B29B626A1000646B0 /* SpotlightManager.swift */; };
 		B946880E29B627EB000646B0 /* SearchableActivityConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946880D29B627EB000646B0 /* SearchableActivityConvertable.swift */; };
 		B946881029B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946880F29B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift */; };
@@ -4263,6 +4264,7 @@
 		B943E7242AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsCustomAmountCellViewModel.swift; sourceTree = "<group>"; };
 		B94403C8289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmountFlowOpener.swift; sourceTree = "<group>"; };
 		B945F8852B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCustomAmountPercentageViewModel.swift; sourceTree = "<group>"; };
+		B945F8872B0CE74800B8281C /* AddCustomAmountPercentageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCustomAmountPercentageView.swift; sourceTree = "<group>"; };
 		B946880B29B626A1000646B0 /* SpotlightManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightManager.swift; sourceTree = "<group>"; };
 		B946880D29B627EB000646B0 /* SearchableActivityConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableActivityConvertable.swift; sourceTree = "<group>"; };
 		B946880F29B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InPersonPaymentsMenuViewController+Activity.swift"; sourceTree = "<group>"; };
@@ -9330,6 +9332,7 @@
 				B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */,
 				B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */,
 				B945F8852B0CE51A00B8281C /* AddCustomAmountPercentageViewModel.swift */,
+				B945F8872B0CE74800B8281C /* AddCustomAmountPercentageView.swift */,
 			);
 			path = CustomAmounts;
 			sourceTree = "<group>";
@@ -13002,6 +13005,7 @@
 				B9CB14DC2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift in Sources */,
 				0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
+				B945F8882B0CE74800B8281C /* AddCustomAmountPercentageView.swift in Sources */,
 				039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */,
 				7E7C5F792719A8F900315B61 /* EditProductCategoryListViewModel.swift in Sources */,
 				DE69C55527C5E317000BB888 /* ShippingLabelSampleData.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -2,14 +2,15 @@
 @testable import Yosemite
 import XCTest
 import Fakes
+import WooFoundation
 
 final class AddCustomAmountViewModelTests: XCTestCase {
     func test_shouldDisableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {
         // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _, _ in })
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: {_, _, _, _ in })
 
         // When
-        viewModel.formattableAmountTextFieldViewModel.amount = "$0"
+        viewModel.formattableAmountTextFieldViewModel?.amount = "$0"
 
         // Then
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
@@ -17,10 +18,10 @@ final class AddCustomAmountViewModelTests: XCTestCase {
 
     func test_shouldDisableDoneButton_when_there_is_no_amount_then_disables_done_button() {
         // Given
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: {_, _, _, _ in })
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: {_, _, _, _ in })
 
         // When
-        viewModel.formattableAmountTextFieldViewModel.amount = ""
+        viewModel.formattableAmountTextFieldViewModel?.amount = ""
 
         // Then
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
@@ -29,7 +30,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
     func test_doneButtonPressed_when_there_is_no_name_then_passes_placeholder() {
         // Given
         var passedName: String?
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _, _ in
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: { amount, name, _, _ in
             passedName = name
         })
 
@@ -43,7 +44,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
     func test_doneButtonPressed_then_isTaxable_is_true_by_default() {
         // Given
         var passedIsTaxable: Bool?
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { _, _, _, isTaxable in
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: { _, _, _, isTaxable in
             passedIsTaxable = isTaxable
         })
 
@@ -64,13 +65,13 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         var passedAmount: String?
         var passedIsTaxable: Bool?
 
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, _, isTaxable in
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: { amount, name, _, isTaxable in
             passedAmount = amount
             passedName = name
             passedIsTaxable = isTaxable
         })
 
-        viewModel.formattableAmountTextFieldViewModel.amount = amount
+        viewModel.formattableAmountTextFieldViewModel?.amount = amount
         viewModel.name = name
         viewModel.isTaxable = isTaxable
 
@@ -93,7 +94,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         var passedAmount: String?
         var passedFeeID: Int64?
 
-        let viewModel = AddCustomAmountViewModel(onCustomAmountEntered: { amount, name, feeID, _ in
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: { amount, name, feeID, _ in
             passedAmount = amount
             passedName = name
             passedFeeID = feeID
@@ -115,7 +116,9 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
 
         // When
-        let viewModel = AddCustomAmountViewModel(analytics: WooAnalytics(analyticsProvider: analytics), onCustomAmountEntered: {_, _, _, _ in })
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, 
+                                                 analytics: WooAnalytics(analyticsProvider: analytics),
+                                                 onCustomAmountEntered: {_, _, _, _ in })
         viewModel.name = ""
         viewModel.doneButtonPressed()
 
@@ -129,7 +132,9 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
 
         // When
-        let viewModel = AddCustomAmountViewModel(analytics: WooAnalytics(analyticsProvider: analytics), onCustomAmountEntered: {_, _, _, _ in })
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, 
+                                                 analytics: WooAnalytics(analyticsProvider: analytics),
+                                                 onCustomAmountEntered: {_, _, _, _ in })
         viewModel.name = "test"
         viewModel.doneButtonPressed()
 
@@ -137,41 +142,21 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         XCTAssertNotNil(analytics.receivedEvents.first(where: { $0 == WooAnalyticsStat.addCustomAmountNameAdded.rawValue }))
     }
 
-    func test_shouldShowPercentageInput_when_baseAmountForPercentage_is_zero_then_returns_false() {
-        // When
-        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 0, onCustomAmountEntered: {_, _, _, _ in })
-
-        // Then
-        XCTAssertFalse(viewModel.shouldShowPercentageInput)
-    }
-
-    func test_shouldShowPercentageInput_when_baseAmountForPercentage_is_bigger_than_zero_then_returns_true() {
-        // When
-        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: 1, onCustomAmountEntered: {_, _, _, _ in })
-
-        // Then
-        XCTAssertTrue(viewModel.shouldShowPercentageInput)
-    }
-
-    func test_shouldShowPercentageInput_when_baseAmountForPercentage_is_negative_then_returns_false() {
-        // When
-        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: -1, onCustomAmountEntered: {_, _, _, _  in })
-
-        // Then
-        XCTAssertFalse(viewModel.shouldShowPercentageInput)
-    }
-
     func test_percentage_then_updates_amount() {
         // Given
         let baseAmountForPercentage = 200
         let percentage = 25
+        let amountString = "\(baseAmountForPercentage / 100 * percentage)"
+        let usStoreSettings = CurrencySettings()
+        let currencyFormatter = CurrencyFormatter(currencySettings: usStoreSettings)
 
         // When
-        let viewModel = AddCustomAmountViewModel(baseAmountForPercentage: Decimal(baseAmountForPercentage),
+        let viewModel = AddCustomAmountViewModel(inputType: .orderTotalPercentage(baseAmount: Decimal(baseAmountForPercentage)),
+                                                 storeCurrencySettings: usStoreSettings,
                                                  onCustomAmountEntered: {_, _, _, _ in })
-        viewModel.percentage = "\(percentage)"
+        viewModel.percentageViewModel?.percentage = "\(percentage)"
 
         // Then
-        XCTAssertEqual(viewModel.formattableAmountTextFieldViewModel.amount, "\(baseAmountForPercentage / 100 * percentage)")
+        XCTAssertEqual(viewModel.percentageViewModel?.percentageCalculatedAmount, currencyFormatter.formatAmount(amountString))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -5,7 +5,7 @@ import Fakes
 import WooFoundation
 
 final class AddCustomAmountViewModelTests: XCTestCase {
-    func test_shouldDisableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {
+    func test_shouldEnableDoneButton_when_amount_is_not_greater_than_zero_then_disables_done_button() {
         // Given
         let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: {_, _, _, _ in })
 
@@ -13,10 +13,10 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         viewModel.formattableAmountTextFieldViewModel?.amount = "$0"
 
         // Then
-        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+        XCTAssertFalse(viewModel.shouldEnableDoneButton)
     }
 
-    func test_shouldDisableDoneButton_when_there_is_no_amount_then_disables_done_button() {
+    func test_shouldEnableDoneButton_when_there_is_no_amount_then_disables_done_button() {
         // Given
         let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: {_, _, _, _ in })
 
@@ -24,7 +24,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         viewModel.formattableAmountTextFieldViewModel?.amount = ""
 
         // Then
-        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+        XCTAssertFalse(viewModel.shouldEnableDoneButton)
     }
 
     func test_doneButtonPressed_when_there_is_no_name_then_passes_placeholder() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -116,7 +116,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
 
         // When
-        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, 
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount,
                                                  analytics: WooAnalytics(analyticsProvider: analytics),
                                                  onCustomAmountEntered: {_, _, _, _ in })
         viewModel.name = ""
@@ -132,7 +132,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
 
         // When
-        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, 
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount,
                                                  analytics: WooAnalytics(analyticsProvider: analytics),
                                                  onCustomAmountEntered: {_, _, _, _ in })
         viewModel.name = "test"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -490,7 +490,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let customAmountName = "Test"
 
         // When
-        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
         addCustomAmountViewModel.name = customAmountName
         addCustomAmountViewModel.doneButtonPressed()
 
@@ -516,7 +516,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // When
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        viewModel.addCustomAmountViewModel(with: .fixedAmount).doneButtonPressed()
 
         // Then
         XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.orderFeeAdd.rawValue)
@@ -524,8 +524,9 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_view_model_is_updated_when_custom_amount_is_removed_from_order() {
         // When
-        viewModel.addCustomAmountViewModel.name = "Test"
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.name = "Test"
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Check previous condition
         XCTAssertEqual(viewModel.customAmountRows.count, 1)
@@ -541,7 +542,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
 
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        viewModel.addCustomAmountViewModel(with: .fixedAmount).doneButtonPressed()
 
         // When
         viewModel.customAmountRows.first?.onRemoveCustomAmount()
@@ -556,7 +557,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let newFeeName = "Test 2"
 
         // When
-        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
         addCustomAmountViewModel.name = "Test"
         addCustomAmountViewModel.doneButtonPressed()
 
@@ -578,15 +579,16 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
-        viewModel.addCustomAmountViewModel.name = "Test"
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.name = "Test"
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Check previous condition
         XCTAssertEqual(viewModel.customAmountRows.count, 1)
 
-        viewModel.addCustomAmountViewModel.preset(with: OrderFeeLine.fake().copy(feeID: viewModel.customAmountRows.first?.id ?? 0))
+        addCustomAmountViewModel.preset(with: OrderFeeLine.fake().copy(feeID: viewModel.customAmountRows.first?.id ?? 0))
         viewModel.customAmountRows.first?.onEditCustomAmount()
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Then
         XCTAssertNotNil(analytics.receivedEvents.first(where: { $0 == WooAnalyticsStat.orderFeeUpdate.rawValue }))
@@ -780,8 +782,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.paymentDataViewModel.shouldShowProductsTotal)
 
         // When
-        viewModel.addCustomAmountViewModel.formattableAmountTextFieldViewModel.amount = "10"
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.formattableAmountTextFieldViewModel?.amount = "10"
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Pre-check
         XCTAssertFalse(viewModel.paymentDataViewModel.orderIsEmpty)
@@ -875,8 +878,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         // When
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         productSelectorViewModel.completeMultipleSelection()
-        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel
-        addCustomAmountViewModel.formattableAmountTextFieldViewModel.amount = "10"
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.formattableAmountTextFieldViewModel?.amount = "10"
         addCustomAmountViewModel.doneButtonPressed()
 
         // Then
@@ -1600,7 +1603,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
 
         // When
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Then
         waitUntil {
@@ -1631,7 +1635,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
 
         // When
-        viewModel.addCustomAmountViewModel.doneButtonPressed()
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.doneButtonPressed()
 
         // Then
         waitUntil {

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -36,7 +36,8 @@ final class OrdersTests: XCTestCase {
             .addProduct(byName: "Black Coral shades")
             .addCustomerDetails(name: order.billing.first_name)
             .addShipping(amount: order.shipping_lines[0].total, name: order.shipping_lines[0].method_title)
-            .addCustomAmount(amount: order.fee_lines[1].amount)
+            // Disabled temporarily until we add support for the custom amounts options dialog
+            //.addCustomAmount(amount: order.fee_lines[1].amount)
             .addCustomerNote(order.customer_note)
             .createOrder()
             .verifySingleOrderScreenLoaded()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Sorry for the large PR. Much of it is refactors, e.g. moving classes to other files, but I'm happy to split this PR in smaller ones if required.

Closes: #11220 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the new design for Percentages in custom amounts. Here we:

- Refactor the AddCustomAmountsViewModel and view to implement the new design.
- Implement options dialog with the bottom sheet in `OrderCustomAmountsSection`
- Refactor the `EditableOrderViewModel` for the new case
- Add unit tests

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to order
2. Tap on + to create a new order
3. Add a custom amount. See that you see no options dialog, and you go directly to add the custom amount with fixed amount.
4. When you're back to the order creation screen, tap to add a new amount. See that you see the dialog. Tap on percentage.
5. See that you can add a custom amount based on the order total percentage.
6. When you are back to the order details screen, tap to edit a custom amount. See that in both cases, fixed amount and percentage, data is filled.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/c7187ac1-9186-46f6-97f3-02a9e5c75656

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
