### PR TITLE
Product Subscriptions: Enable virtual product setting for a simple subscription product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -21,7 +21,7 @@ enum ProductSettingsSections {
         let rows: [ProductSettingsRowMediator]
 
         init(_ settings: ProductSettings) {
-            let shouldShowVirtualProductSetting = settings.productType == .simple
+            let shouldShowVirtualProductSetting = settings.productType == .simple || settings.productType == .subscription
             let shouldShowDownloadableProductSetting = settings.productType == .simple || settings.productType == .subscription
             let rows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
                                                        ProductSettingsRows.Visibility(settings),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -6,6 +6,8 @@ import Yosemite
 ///
 final class ProductSettingsSectionsTests: XCTestCase {
 
+    // MARK: Simple product
+
     func test_given_a_non_simple_product_then_it_does_not_show_the_virtual_product_option() {
         // Given
         let settings = ProductSettings(productType: .grouped,
@@ -98,6 +100,8 @@ final class ProductSettingsSectionsTests: XCTestCase {
         }))
     }
 
+    // MARK: Subscription product
+
     func test_given_a_subscription_product_then_it_shows_the_downloadable_product_option() {
         // Given
         let settings = ProductSettings(productType: .subscription,
@@ -118,6 +122,29 @@ final class ProductSettingsSectionsTests: XCTestCase {
         // Then
         XCTAssertNotNil(section.rows.first(where: {
             $0 is ProductSettingsRows.DownloadableProduct
+        }))
+    }
+
+    func test_given_a_subscription_product_then_it_shows_the_virtual_product_option() {
+        // Given
+        let settings = ProductSettings(productType: .subscription,
+                                       status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0,
+                                       downloadable: false)
+
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings)
+
+        // Then
+        XCTAssertNotNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.VirtualProduct
         }))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11240 


## Description
Allows marking a subscription product as virtual from Product settings.

## Testing instructions

**Prerequisite**
1. Install Woo Subscription plugin on your store
1. Create a subscriptions product from `wp-admin`

**Steps**
1. Launch the app and Log in to the store.
3. Navigate to Products tab > select "+" > select manual option > Subscription product.
4. Tap on `...` > `Product settings`
5. You should see the toggle "Virtual Product"
6. Enable it and save the product
7. Validate from the `wp-admin` page that the "Virtual Product" setting is properly updated for the product.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Simple subscription or simple product | Variable subscription product |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 10 17 55](https://github.com/woocommerce/woocommerce-ios/assets/524475/78ca15e7-29fb-4782-a63d-49156f9e2162) | ![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 10 19 05](https://github.com/woocommerce/woocommerce-ios/assets/524475/99241086-9a08-4de0-a164-62879588c5f5) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
