### PR TITLE
Product Subscriptions: Shipping section for simple subscription product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -312,12 +312,14 @@ private extension ProductFormActionsFactory {
         let canEditInventorySettingsRow = editingSubscriptionEnabled && editable && product.hasIntegerStockQuantity
         let canEditProductType = editingSubscriptionEnabled && editable
         let shouldShowDownloadableProduct = product.downloadable
+        let shouldShowShippingSettingsRow = product.isShippingEnabled()
 
         let actions: [ProductFormEditAction?] = [
             editingSubscriptionEnabled ? .priceSettings(editable: editable, hideSeparator: false) : .subscription(actionable: true),
             editingSubscriptionEnabled ? .subscriptionFreeTrial(editable: editable) : nil,
             editingSubscriptionEnabled ? .subscriptionExpiry(editable: editable) : nil,
             shouldShowReviewsRow ? .reviews: nil,
+            shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
             .inventorySettings(editable: canEditInventorySettingsRow),
             shouldShowQuantityRulesRow ? .quantityRules : nil,
             .categories(editable: editable),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -820,6 +820,57 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
+    func test_actions_for_subscription_product_does_not_contain_shippingSettings_action_when_product_is_virtual() {
+        // Given
+        let product = Fixtures.subscriptionProduct.copy(virtual: true)
+        let model = EditableProductModel(product: product)
+
+        // When
+        let factory = ProductFormActionsFactory(product: model, formType: .edit, variationsPrice: .set)
+
+        // Then
+        let containsShippingSettingsAction = factory.settingsSectionActions().contains(ProductFormEditAction.shippingSettings(editable: true))
+        XCTAssertFalse(containsShippingSettingsAction)
+    }
+
+    func test_actions_for_subscription_product_contains_shippingSettings_action_when_product_is_not_virtual() {
+        // Given
+        let product = Fixtures.subscriptionProduct.copy(virtual: false)
+        let model = EditableProductModel(product: product)
+
+        // When
+        let factory = ProductFormActionsFactory(product: model, formType: .edit, variationsPrice: .unknown)
+
+        // Then
+        let containsShippingSettingsAction = factory.settingsSectionActions().contains(ProductFormEditAction.shippingSettings(editable: true))
+        XCTAssertTrue(containsShippingSettingsAction)
+    }
+
+    func test_actions_for_subscription_product_does_not_contain_shippingSettings_action_when_product_is_downloadable() {
+        // Given
+        let product = Fixtures.subscriptionProduct.copy(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // When
+        let factory = ProductFormActionsFactory(product: model, formType: .edit, variationsPrice: .set)
+
+        // Then
+        let containsShippingSettingsAction = factory.settingsSectionActions().contains(ProductFormEditAction.shippingSettings(editable: true))
+        XCTAssertFalse(containsShippingSettingsAction)
+    }
+
+    func test_actions_for_subscription_product_contains_shippingSettings_action_when_product_is_not_downloadable() {
+        // Given
+        let product = Fixtures.subscriptionProduct.copy(downloadable: false)
+        let model = EditableProductModel(product: product)
+
+        // When
+        let factory = ProductFormActionsFactory(product: model, formType: .edit, variationsPrice: .unknown)
+
+        // Then
+        let containsShippingSettingsAction = factory.settingsSectionActions().contains(ProductFormEditAction.shippingSettings(editable: true))
+        XCTAssertTrue(containsShippingSettingsAction)
+    }
 
     // MARK: Quantity rules
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -609,6 +609,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .subscriptionFreeTrial(editable: true),
                                                                        .subscriptionExpiry(editable: true),
                                                                        .reviews,
+                                                                       .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
@@ -632,6 +633,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.subscription(actionable: true),
                                                                        .reviews,
+                                                                       .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: false),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: false)]
@@ -783,6 +785,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .subscriptionFreeTrial(editable: true),
                                                                        .subscriptionExpiry(editable: true),
                                                                        .reviews,
+                                                                       .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
@@ -791,6 +794,32 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
+
+    func test_view_model_for_subscription_product_when_product_is_virtual() {
+        // Arrange
+        let product = Fixtures.subscriptionProduct.copy(virtual: true)
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, editingSubscriptionEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
+                                                                       .subscriptionFreeTrial(editable: true),
+                                                                       .subscriptionExpiry(editable: true),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: true),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
+
 
     // MARK: Quantity rules
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11242 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Show the "Shipping" option under the "+ Add more details" of the product form for a simple subscription type product.


## Testing instructions

**Prerequisite**
1. Install Woo Subscription plugin on your store
1. Create a subscriptions product from `wp-admin`

**Steps**
1. Launch the app and Log in to the store.
3. Navigate to Products tab > select "+" > select manual option > Subscription product.
4. Tap on `+ Add more details`
5. You should see the "Shipping" row
6. Tap on it and enter the shipping info
7. Save the product
8. Validate from the `wp-admin` page that the shipping info is properly saved.
9. From `wp-admin` page enable the "Virtual" or the "Downloadable" toggle

<img width="640" alt="Screenshot 2023-11-22 at 11 35 58 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/746ce89b-5246-4ef2-b2b9-3e1582b773bf">

10. Open the product form in the mobile app and tap on `+ Add more details` 
11. Ensure that the "Shipping" row is not displayed for a virtual or downloadable product.

## Screenshots
| Simple subscription | Simple subscription virtual |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 11 38 25](https://github.com/woocommerce/woocommerce-ios/assets/524475/1af3eead-8362-4699-bd9d-083595f6ffac) | ![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 11 38 31](https://github.com/woocommerce/woocommerce-ios/assets/524475/47eb1486-eb9c-4bce-8a9c-4b33af2fc68b) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
