### PR TITLE
Product Subscriptions: Stop assigning random length in unit tests

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/SubscriptionExpiryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/SubscriptionExpiryViewModelTests.swift
@@ -80,8 +80,7 @@ final class SubscriptionExpiryViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldEnableDoneButton)
 
         // When
-        let newSelection = try XCTUnwrap(viewModel.lengthOptions.randomElement())
-        viewModel.selectedLength = newSelection
+        viewModel.selectedLength = .init(title: "2", value: 2)
 
         // Then
         XCTAssertTrue(viewModel.shouldEnableDoneButton)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11090 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

**Why is the test flaky?**
- We have been using `randomElement` to select a length from the available length options
- `randomElement` might return a length that is already selected. 
- This will not enable the `Done` button as the length is not changed. 

**Fix**
- Stop using `randomElement` to select a length and instead manually create a length which is different from the already selected length. 

## Testing instructions
CI should pass.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
