### PR TITLE
[Deposit summary] Analytics continued

### DIFF
--- a/Fakes/Fakes/Yosemite.generated.swift
+++ b/Fakes/Fakes/Yosemite.generated.swift
@@ -44,6 +44,16 @@ extension Yosemite.ProductReviewFromNoteParcel {
         )
     }
 }
+extension Yosemite.SystemInformation {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Yosemite.SystemInformation {
+        .init(
+            storeID: .fake(),
+            systemPlugins: .fake()
+        )
+    }
+}
 extension Yosemite.WooPaymentsDepositsOverviewByCurrency {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2161,6 +2161,7 @@ extension WooAnalyticsEvent {
     enum DepositSummary {
         enum Keys {
             static let numberOfCurrencies = "number_of_currencies"
+            static let currency = "currency"
         }
 
         static func depositSummaryShown(numberOfCurrencies: Int) -> WooAnalyticsEvent {
@@ -2170,6 +2171,11 @@ extension WooAnalyticsEvent {
 
         static func depositSummaryError(error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .paymentsMenuDepositSummaryError, properties: [:], error: error)
+        }
+
+        static func depositSummaryCurrencySelected(currency: CurrencyCode) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .paymentsMenuDepositSummaryCurrencySelected,
+                              properties: [Keys.currency: currency.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1012,6 +1012,7 @@ public enum WooAnalyticsStat: String {
     case paymentsMenuDepositSummaryError = "payments_hub_deposit_summary_error"
     case paymentsMenuDepositSummaryExpanded = "payments_hub_deposit_summary_expanded"
     case paymentsMenuDepositSummaryLearnMoreTapped = "payments_hub_deposit_summary_learn_more_clicked"
+    case paymentsMenuDepositSummaryCurrencySelected = "payments_hub_deposit_summary_currency_selected"
 
     // MARK: Payments Menu
     case pluginsNotSyncedYet = "plugins_not_synced_yet"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1010,6 +1010,7 @@ public enum WooAnalyticsStat: String {
     case aboutTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_about_tapped"
     case paymentsMenuDepositSummaryShown = "payments_hub_deposit_summary_shown"
     case paymentsMenuDepositSummaryError = "payments_hub_deposit_summary_error"
+    case paymentsMenuDepositSummaryExpanded = "payments_hub_deposit_summary_expanded"
 
     // MARK: Payments Menu
     case pluginsNotSyncedYet = "plugins_not_synced_yet"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1011,6 +1011,7 @@ public enum WooAnalyticsStat: String {
     case paymentsMenuDepositSummaryShown = "payments_hub_deposit_summary_shown"
     case paymentsMenuDepositSummaryError = "payments_hub_deposit_summary_error"
     case paymentsMenuDepositSummaryExpanded = "payments_hub_deposit_summary_expanded"
+    case paymentsMenuDepositSummaryLearnMoreTapped = "payments_hub_deposit_summary_learn_more_clicked"
 
     // MARK: Payments Menu
     case pluginsNotSyncedYet = "plugins_not_synced_yet"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -77,6 +77,8 @@ enum WooConstants {
     /// App login deep link prefix
     ///
     static let appLoginURLPrefix = "woocommerce://app-login"
+
+    static let wooPaymentsPluginPath = "woocommerce-payments/woocommerce-payments.php"
 }
 
 // MARK: URLs

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -89,6 +89,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
 
                 Button {
                     showDepositSummaryInfo = true
+                    viewModel.learnMoreTapped()
                 } label: {
                     HStack {
                         Image(systemName: "info.circle")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -38,6 +38,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                     withAnimation {
                         isExpanded.toggle()
                     }
+                    viewModel.expandTapped(expanded: isExpanded)
                 }
 
                 if isExpanded {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -88,7 +88,6 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button {
-                    showDepositSummaryInfo = true
                     viewModel.learnMoreTapped()
                 } label: {
                     HStack {
@@ -103,7 +102,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                 .padding(.bottom)
             }
         }
-        .safariSheet(isPresented: $showDepositSummaryInfo, url: WooConstants.URLs.wooPaymentsDepositSchedule.asURL())
+        .safariSheet(url: $viewModel.showWebviewURL)
         .animation(.easeOut, value: isExpanded)
         .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -33,6 +33,7 @@ class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     @Published var depositScheduleHint: String = ""
     @Published var balanceTypeHint: String = ""
     @Published var pendingFundsDepositsSummary: String = ""
+    @Published var showWebviewURL: URL? = nil
 
     private func formatAmount(_ amount: NSDecimalNumber) -> String {
         return numberFormatter.string(from: amount) ?? ""
@@ -88,6 +89,7 @@ class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     }
 
     func learnMoreTapped() {
+        showWebviewURL = WooConstants.URLs.wooPaymentsDepositSchedule.asURL()
         analytics.track(.paymentsMenuDepositSummaryLearnMoreTapped)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -3,9 +3,12 @@ import Yosemite
 
 class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     let overview: WooPaymentsDepositsOverviewByCurrency
+    private let analytics: Analytics
 
-    init(overview: WooPaymentsDepositsOverviewByCurrency) {
+    init(overview: WooPaymentsDepositsOverviewByCurrency,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.overview = overview
+        self.analytics = analytics
         setupProperties()
     }
 
@@ -77,6 +80,12 @@ class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
         formatter.currencyCode = overview.currency.rawValue
         return formatter
     }()
+
+    func expandTapped(expanded: Bool) {
+        if expanded {
+            analytics.track(.paymentsMenuDepositSummaryExpanded)
+        }
+    }
 }
 
 private extension WooPaymentsDepositInterval {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -86,6 +86,10 @@ class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
             analytics.track(.paymentsMenuDepositSummaryExpanded)
         }
     }
+
+    func learnMoreTapped() {
+        analytics.track(.paymentsMenuDepositSummaryLearnMoreTapped)
+    }
 }
 
 private extension WooPaymentsDepositInterval {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 import WooFoundation
 
-class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
+final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     private let overview: WooPaymentsDepositsOverviewByCurrency
     private let analytics: Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -1,14 +1,17 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
-    let overview: WooPaymentsDepositsOverviewByCurrency
+    private let overview: WooPaymentsDepositsOverviewByCurrency
     private let analytics: Analytics
 
     init(overview: WooPaymentsDepositsOverviewByCurrency,
          analytics: Analytics = ServiceLocator.analytics) {
         self.overview = overview
         self.analytics = analytics
+        self.currency = overview.currency
+        self.tabTitle = overview.currency.rawValue.uppercased()
         setupProperties()
     }
 
@@ -34,6 +37,8 @@ class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     @Published var balanceTypeHint: String = ""
     @Published var pendingFundsDepositsSummary: String = ""
     @Published var showWebviewURL: URL? = nil
+    @Published var currency: CurrencyCode
+    @Published var tabTitle: String
 
     private func formatAmount(_ amount: NSDecimalNumber) -> String {
         return numberFormatter.string(from: amount) ?? ""

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
@@ -17,7 +17,7 @@ struct WooPaymentsDepositsOverviewView: View {
     var body: some View {
         VStack {
             TopTabView(tabs: tabs,
-                       isExpanded: $isExpanded)
+                       showTabs: $isExpanded)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
@@ -3,18 +3,17 @@ import Yosemite
 
 @available(iOS 16.0, *)
 struct WooPaymentsDepositsOverviewView: View {
-    let viewModels: [WooPaymentsDepositsCurrencyOverviewViewModel]
+    @ObservedObject var viewModel: WooPaymentsDepositsOverviewViewModel
 
     @State var isExpanded: Bool = false
 
     var tabs: [TopTabItem] {
-        viewModels.map { tabViewModel in
-            TopTabItem(name: tabViewModel.tabTitle,
-                       view: AnyView(WooPaymentsDepositsCurrencyOverviewView(viewModel: tabViewModel,
+        viewModel.currencyViewModels.map { currencyViewModel in
+            TopTabItem(name: currencyViewModel.tabTitle,
+                       view: AnyView(WooPaymentsDepositsCurrencyOverviewView(viewModel: currencyViewModel,
                                                                              isExpanded: $isExpanded)),
                        onSelected: {
-                ServiceLocator.analytics.track(
-                    event: .DepositSummary.depositSummaryCurrencySelected(currency: tabViewModel.currency))
+                viewModel.currencySelected(currencyViewModel: currencyViewModel)
             })
         }
     }
@@ -72,6 +71,6 @@ struct WooPaymentsDepositsOverviewView_Previews: PreviewProvider {
 
         let viewModel2 = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overviewData2)
 
-        WooPaymentsDepositsOverviewView(viewModels: [viewModel1, viewModel2])
+        WooPaymentsDepositsOverviewView(viewModel: .init(currencyViewModels: [viewModel1, viewModel2]))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
@@ -23,6 +23,7 @@ struct WooPaymentsDepositsOverviewView: View {
             TopTabView(tabs: tabs,
                        showTabs: $isExpanded)
         }
+        .onAppear(perform: viewModel.onAppear)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
@@ -9,8 +9,13 @@ struct WooPaymentsDepositsOverviewView: View {
 
     var tabs: [TopTabItem] {
         viewModels.map { tabViewModel in
-            TopTabItem(name: tabViewModel.overview.currency.rawValue,
-                       view: AnyView(WooPaymentsDepositsCurrencyOverviewView(viewModel: tabViewModel, isExpanded: $isExpanded)))
+            TopTabItem(name: tabViewModel.tabTitle,
+                       view: AnyView(WooPaymentsDepositsCurrencyOverviewView(viewModel: tabViewModel,
+                                                                             isExpanded: $isExpanded)),
+                       onSelected: {
+                ServiceLocator.analytics.track(
+                    event: .DepositSummary.depositSummaryCurrencySelected(currency: tabViewModel.currency))
+            })
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewViewModel.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class WooPaymentsDepositsOverviewViewModel: ObservableObject {
+    @Published var currencyViewModels: [WooPaymentsDepositsCurrencyOverviewViewModel]
+
+    let analytics: Analytics
+
+    init(currencyViewModels: [WooPaymentsDepositsCurrencyOverviewViewModel],
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.currencyViewModels = currencyViewModels
+        self.analytics = analytics
+    }
+
+    func currencySelected(currencyViewModel: WooPaymentsDepositsCurrencyOverviewViewModel) {
+        analytics.track(event: .DepositSummary.depositSummaryCurrencySelected(currency: currencyViewModel.currency))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewViewModel.swift
@@ -11,6 +11,10 @@ final class WooPaymentsDepositsOverviewViewModel: ObservableObject {
         self.analytics = analytics
     }
 
+    func onAppear() {
+        analytics.track(event: .DepositSummary.depositSummaryShown(numberOfCurrencies: currencyViewModels.count))
+    }
+
     func currencySelected(currencyViewModel: WooPaymentsDepositsCurrencyOverviewViewModel) {
         analytics.track(event: .DepositSummary.depositSummaryCurrencySelected(currency: currencyViewModel.currency))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -174,8 +174,9 @@ struct InPersonPaymentsMenu: View {
     @ViewBuilder
     var depositSummary: some View {
         if #available(iOS 16.0, *),
-           viewModel.shouldShowDepositSummary {
-            WooPaymentsDepositsOverviewView(viewModels: viewModel.depositCurrencyViewModels)
+           viewModel.shouldShowDepositSummary,
+           let depositViewModel = viewModel.depositViewModel {
+            WooPaymentsDepositsOverviewView(viewModel: depositViewModel)
         } else {
             EmptyView()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -24,7 +24,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var presentTapToPayFeedback: Bool = false
     @Published var safariSheetURL: URL? = nil
     @Published var presentSupport: Bool = false
-    @Published var depositCurrencyViewModels: [WooPaymentsDepositsCurrencyOverviewViewModel] = []
+    @Published var depositViewModel: WooPaymentsDepositsOverviewViewModel? = nil
 
     var shouldAlwaysHideSetUpButtonOnAboutTapToPay: Bool = false
 
@@ -103,12 +103,16 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
             return
         }
         do {
-            depositCurrencyViewModels = try await dependencies.wooPaymentsDepositService.fetchDepositsOverview().map({
+            let depositCurrencyViewModels = try await dependencies.wooPaymentsDepositService.fetchDepositsOverview().map({
                 WooPaymentsDepositsCurrencyOverviewViewModel(overview: $0)
             })
             shouldShowDepositSummary = depositCurrencyViewModels.count > 0
+            guard shouldShowDepositSummary else {
+                return
+            }
+            depositViewModel = WooPaymentsDepositsOverviewViewModel(currencyViewModels: depositCurrencyViewModels)
 
-            guard shouldShowDepositSummary, trackAnalytics else {
+            guard trackAnalytics else {
                 return
             }
             dependencies.analytics.track(event: .DepositSummary.depositSummaryShown(numberOfCurrencies: depositCurrencyViewModels.count))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -82,22 +82,22 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
             .assign(to: &$shouldBadgeTapToPayOnIPhone)
 
         Task { @MainActor in
-            await updateOutputProperties(trackAnalytics: false)
+            await updateOutputProperties()
         }
 
         InPersonPaymentsMenuViewController().registerUserActivity()
     }
 
     @MainActor
-    private func updateOutputProperties(trackAnalytics: Bool = true) async {
+    private func updateOutputProperties() async {
         payInPersonToggleViewModel.refreshState()
         updateCardReadersSection()
         await updateTapToPaySection()
-        await refreshDepositSummary(trackAnalytics: trackAnalytics)
+        await refreshDepositSummary()
     }
 
     @MainActor
-    private func refreshDepositSummary(trackAnalytics: Bool) async {
+    private func refreshDepositSummary() async {
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.wooPaymentsDepositsOverviewInPaymentsMenu) else {
             shouldShowDepositSummary = false
             return
@@ -111,11 +111,6 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
                 return
             }
             depositViewModel = WooPaymentsDepositsOverviewViewModel(currencyViewModels: depositCurrencyViewModels)
-
-            guard trackAnalytics else {
-                return
-            }
-            dependencies.analytics.track(event: .DepositSummary.depositSummaryShown(numberOfCurrencies: depositCurrencyViewModels.count))
         } catch {
             shouldShowDepositSummary = false
             dependencies.analytics.track(event: .DepositSummary.depositSummaryError(error: error))

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -10,20 +10,20 @@ struct TopTabView: View {
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
 
-    @Binding var isExpanded: Bool
+    @Binding var showTabs: Bool
 
     let tabs: [TopTabItem]
 
     init(tabs: [TopTabItem],
-         isExpanded: Binding<Bool> = .constant(true)) {
+         showTabs: Binding<Bool> = .constant(true)) {
         self.tabs = tabs
-        self._isExpanded = isExpanded
+        self._showTabs = showTabs
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            if tabs.count > 1 && isExpanded {
+            if tabs.count > 1 && showTabs {
                 ScrollView(.horizontal, showsIndicators: false) {
                     ScrollViewReader { scrollViewProxy in
                         HStack(spacing: Layout.tabPadding * 2) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -3,6 +3,15 @@ import SwiftUI
 struct TopTabItem {
     let name: String
     let view: AnyView
+    let onSelected: (() -> Void)?
+
+    init(name: String,
+         view: AnyView,
+         onSelected: (() -> Void)? = nil) {
+        self.name = name
+        self.view = view
+        self.onSelected = onSelected
+    }
 }
 
 struct TopTabView: View {
@@ -36,6 +45,7 @@ struct TopTabView: View {
                                         .onTapGesture {
                                             withAnimation {
                                                 selectedTab = index
+                                                tabs[selectedTab].onSelected?()
                                                 underlineOffset = calculateOffset(index: index)
                                                 scrollViewProxy.scrollTo(index, anchor: .center)
                                             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
 		20BCF6EE2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */; };
 		20BCF6F02B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */; };
+		20BCF6F72B0E5AF000954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */; };
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
 		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
 		20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */; };
@@ -3296,6 +3297,7 @@
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
 		20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModel.swift; sourceTree = "<group>"; };
 		20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModelTests.swift; sourceTree = "<group>"; };
+		20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusService.swift; sourceTree = "<group>"; };
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
 		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -8203,6 +8205,7 @@
 				B935D3602A9F50F50067B927 /* MockWPAdminTaxSettingsURLProvider.swift */,
 				EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */,
 				202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */,
+				20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -13988,6 +13991,7 @@
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				035BA3A8291000E90056F0AD /* JustInTimeMessageViewModelTests.swift in Sources */,
+				20BCF6F72B0E5AF000954840 /* MockSystemStatusService.swift in Sources */,
 				DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */,
 				023EC2E624DAB1270021DA91 /* EditableProductVariationModelTests.swift in Sources */,
 				09BE3A9127C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -720,6 +720,8 @@
 		20AE33C52B0510BF00527B60 /* PaymentsMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */; };
 		20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C62B0510D200527B60 /* HubMenuDestination.swift */; };
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
+		20BCF6EE2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */; };
+		20BCF6F02B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */; };
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
 		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
 		20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */; };
@@ -3292,6 +3294,8 @@
 		20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsMenuDestination.swift; sourceTree = "<group>"; };
 		20AE33C62B0510D200527B60 /* HubMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubMenuDestination.swift; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
+		20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModel.swift; sourceTree = "<group>"; };
+		20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModelTests.swift; sourceTree = "<group>"; };
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
 		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -6681,6 +6685,7 @@
 				209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */,
 				209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */,
 				203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */,
+				20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */,
 			);
 			path = "Deposits Overview";
 			sourceTree = "<group>";
@@ -6698,6 +6703,7 @@
 			isa = PBXGroup;
 			children = (
 				20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */,
+				20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */,
 			);
 			path = "Deposits Overview";
 			sourceTree = "<group>";
@@ -12539,6 +12545,7 @@
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,
 				02BBD6E729A268F300243BE2 /* StoreOnboardingViewModel.swift in Sources */,
 				B9B0391828A6838400DC1C83 /* PermanentNoticeView.swift in Sources */,
+				20BCF6EE2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift in Sources */,
 				DEC6C51827466B59006832D3 /* StoreStatsEmptyView.swift in Sources */,
 				0373A12D2A1D1E6000731236 /* BadgedLeftImageTableViewCell.swift in Sources */,
 				31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */,
@@ -14437,6 +14444,7 @@
 				0248042D2887C92A00991319 /* MockLoggedOutAppSettings.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,
+				20BCF6F02B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift in Sources */,
 				261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,
 				02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
 		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
+		20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */; };
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
 		20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* AboutTapToPayView.swift */; };
@@ -3293,6 +3294,7 @@
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
 		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
+		20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModelTests.swift; sourceTree = "<group>"; };
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* AboutTapToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayView.swift; sourceTree = "<group>"; };
@@ -6569,6 +6571,7 @@
 		03A6C18128B52ACC00AADF23 /* In-Person Payments */ = {
 			isa = PBXGroup;
 			children = (
+				20CCBF1F2B0E159D003102E6 /* Deposits Overview */,
 				03A6C18228B52ADB00AADF23 /* Onboarding Errors */,
 				03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */,
 				03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */,
@@ -6689,6 +6692,14 @@
 				20AE33C62B0510D200527B60 /* HubMenuDestination.swift */,
 			);
 			path = Destinations;
+			sourceTree = "<group>";
+		};
+		20CCBF1F2B0E159D003102E6 /* Deposits Overview */ = {
+			isa = PBXGroup;
+			children = (
+				20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */,
+			);
+			path = "Deposits Overview";
 			sourceTree = "<group>";
 		};
 		20D5CB4F2AFCF82D009A39C3 /* Payments Menu */ = {
@@ -14190,6 +14201,7 @@
 				EEADF626281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift in Sources */,
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
+				20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */,
 				2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */,
 				0235354E2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift in Sources */,
 				4535EE80281BE4E0004212B4 /* CouponAmountInputFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Yosemite
+
+public final class MockSystemStatusService: SystemStatusServiceProtocol {
+    public init() { }
+
+    public var didCallSynchronizeSystemInformation = false
+    public var spySynchronizeSystemInformationSiteID: Int64? = nil
+    public var onSynchronizeSystemInformationThenReturn: SystemInformation? = nil
+    public var onSynchronizeSystemInformationThenThrow: Error? = nil
+    public func synchronizeSystemInformation(siteID: Int64) async throws -> SystemInformation {
+        didCallSynchronizeSystemInformation = true
+        spySynchronizeSystemInformationSiteID = siteID
+        if let shouldThrow = onSynchronizeSystemInformationThenThrow {
+            throw shouldThrow
+        } else {
+            return onSynchronizeSystemInformationThenReturn ?? .fake()
+        }
+    }
+
+    public var didCallFetchSystemPluginWithPath = false
+    public var spyFetchSystemPluginWithPathSiteID: Int64? = nil
+    public var onFetchSystemPluginWithPathThenReturn: SystemPlugin? = nil
+    public func fetchSystemPluginWithPath(siteID: Int64, pluginPath: String) async -> SystemPlugin? {
+        didCallFetchSystemPluginWithPath = true
+        spyFetchSystemPluginWithPathSiteID = siteID
+        return onFetchSystemPluginWithPathThenReturn
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift
@@ -20,10 +20,12 @@ public final class MockSystemStatusService: SystemStatusServiceProtocol {
 
     public var didCallFetchSystemPluginWithPath = false
     public var spyFetchSystemPluginWithPathSiteID: Int64? = nil
-    public var onFetchSystemPluginWithPathThenReturn: SystemPlugin? = nil
+    public var onFetchSystemPluginWithPath: ((String) -> SystemPlugin?) = { _ in
+        return nil
+    }
     public func fetchSystemPluginWithPath(siteID: Int64, pluginPath: String) async -> SystemPlugin? {
         didCallFetchSystemPluginWithPath = true
         spyFetchSystemPluginWithPathSiteID = siteID
-        return onFetchSystemPluginWithPathThenReturn
+        return onFetchSystemPluginWithPath(pluginPath)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import WooCommerce
+
+final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
+
+    var sut: WooPaymentsDepositsCurrencyOverviewViewModel!
+    var analyticsProvider: MockAnalyticsProvider!
+
+    override func setUp() {
+        analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: .fake(), analytics: analytics)
+    }
+
+    func test_when_expand_is_tapped_analytic_event_is_tracked() {
+        // Given
+        let expanded = true
+
+        // When
+        sut.expandTapped(expanded: expanded)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.paymentsMenuDepositSummaryExpanded.rawValue))
+    }
+
+    func test_when_collapse_is_tapped_analytic_event_is_not_tracked() {
+        // Given
+        let collapse = false
+
+        // When
+        sut.expandTapped(expanded: collapse)
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.paymentsMenuDepositSummaryExpanded.rawValue))
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
@@ -43,4 +43,15 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.paymentsMenuDepositSummaryLearnMoreTapped.rawValue))
     }
+
+    func test_when_learn_more_is_tapped_deposit_schedule_info_webview_is_shown() {
+        // Given
+
+        // When
+        sut.learnMoreTapped()
+
+        // Then
+        assertEqual(WooConstants.URLs.wooPaymentsDepositSchedule.asURL(), sut.showWebviewURL)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
@@ -34,4 +34,13 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
         XCTAssertFalse(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.paymentsMenuDepositSummaryExpanded.rawValue))
     }
 
+    func test_when_learn_more_is_tapped_analytic_event_is_tracked() {
+        // Given
+
+        // When
+        sut.learnMoreTapped()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.paymentsMenuDepositSummaryLearnMoreTapped.rawValue))
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewViewModelTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import WooCommerce
+
+final class WooPaymentsDepositsOverviewViewModelTests: XCTestCase {
+
+    var sut: WooPaymentsDepositsOverviewViewModel!
+    var analyticsProvider: MockAnalyticsProvider!
+
+    override func setUp() {
+        analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        sut = WooPaymentsDepositsOverviewViewModel(currencyViewModels: [.init(overview: .fake().copy(currency: .GBP))],
+                                                   analytics: analytics)
+    }
+
+    func test_when_tab_is_selected_analytic_event_is_tracked() {
+        // Given
+        let gbpViewModel = WooPaymentsDepositsCurrencyOverviewViewModel(overview: .fake().copy(currency: .GBP))
+
+        // When
+        sut.currencySelected(currencyViewModel: gbpViewModel)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.paymentsMenuDepositSummaryCurrencySelected.rawValue))
+        guard let index = analyticsProvider.receivedEvents.firstIndex(of: WooAnalyticsStat.paymentsMenuDepositSummaryCurrencySelected.rawValue),
+              let properties = analyticsProvider.receivedProperties[safe: index],
+              let trackedCurrencyProperty = properties[WooAnalyticsEvent.DepositSummary.Keys.currency] as? String
+        else {
+            return XCTFail("Expected properties not found")
+        }
+
+        assertEqual("GBP", trackedCurrencyProperty)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -29,41 +29,6 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
                                                 analytics: analytics))
     }
 
-    func test_onAppear_when_no_deposit_summaries_are_returned_depositSummaryShown_is_not_tracked() async {
-        // Given
-        mockDepositService.onFetchDepositsOverviewThenReturn = []
-
-        // When
-        await sut.onAppear()
-
-        // Then
-        XCTAssertFalse(analyticsProvider.receivedEvents.contains(where: { eventName in
-            eventName == WooAnalyticsStat.paymentsMenuDepositSummaryShown.rawValue
-        }))
-    }
-
-    func test_onAppear_when_deposit_summaries_are_returned_depositSummaryShown_is_tracked() async throws {
-        // Given
-        mockDepositService.onFetchDepositsOverviewThenReturn = [.fake().copy(currency: .USD), .fake().copy(currency: .GBP)]
-
-        // When
-        await sut.onAppear()
-
-        // Then
-        let eventIndex = try? XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: WooAnalyticsStat.paymentsMenuDepositSummaryShown.rawValue))
-
-        XCTAssertNotNil(eventIndex)
-
-        guard let eventIndex else {
-            return XCTFail("Expected event not found")
-        }
-
-        guard let properties = try XCTUnwrap(analyticsProvider.receivedProperties[safe: eventIndex]) as? [String: Int] else {
-            return XCTFail("Expected properties not tracked")
-        }
-        assertEqual(properties["number_of_currencies"], 2)
-    }
-
     func test_onAppear_when_deposit_service_gets_an_error_depositSummaryError_is_tracked() async {
         // Given
         mockDepositService.onFetchDepositsOverviewShouldThrow = DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "description"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -24,7 +24,9 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         mockDepositService = MockWooPaymentsDepositService()
         mockOnboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed(plugin: .wcPayOnly))
         systemStatusService = MockSystemStatusService()
-        systemStatusService.onFetchSystemPluginWithPathThenReturn = .fake().copy()
+        systemStatusService.onFetchSystemPluginWithPath = { _ in
+            return .fake()
+        }
         sut = makeSut()
     }
 
@@ -42,7 +44,9 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
     func test_fetchDepositsOverview_is_not_called_for_stores_which_do_not_support_the_route() async {
         // Currently, assume this is only WooPayments stores, but it would be better to check the /wc/v3 base endpoint.
         // Given
-        systemStatusService.onFetchSystemPluginWithPathThenReturn = nil
+        systemStatusService.onFetchSystemPluginWithPath = { _ in
+            return nil
+        }
 
         // When
         await sut.onAppear()
@@ -54,7 +58,12 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
     func test_fetchDepositsOverview_is_called_for_stores_which_support_the_route() async {
         // Currently, assume this is only WooPayments stores, but it would be better to check the /wc/v3 base endpoint.
         // Given
-        systemStatusService.onFetchSystemPluginWithPathThenReturn = .fake().copy()
+        systemStatusService.onFetchSystemPluginWithPath = { path in
+            guard path == "woocommerce-payments/woocommerce-payments.php" else {
+                return nil
+            }
+            return .fake().copy(siteID: self.sampleStoreID, plugin: "woocommerce-payments/woocommerce-payments.php")
+        }
 
         // When
         await sut.onAppear()

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -143,6 +143,8 @@
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		209AD3CC2AC1A68800825D76 /* WooPaymentsDepositService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CB2AC1A68800825D76 /* WooPaymentsDepositService.swift */; };
 		209AD3CE2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CD2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift */; };
+		20BCF6F22B0E554500954840 /* SystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F12B0E554500954840 /* SystemStatusService.swift */; };
+		20BCF6F52B0E57AB00954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */; };
 		24163B9E257F41A600F94EC3 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24163B9D257F41A600F94EC3 /* StoresManager.swift */; };
 		24163BA8257F41C500F94EC3 /* SessionManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24163BA7257F41C500F94EC3 /* SessionManagerProtocol.swift */; };
 		247CE7AB2582DB9300F9D9D1 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247CE7AA2582DB9300F9D9D1 /* String+Extensions.swift */; };
@@ -608,6 +610,8 @@
 		077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStoreTests.swift; sourceTree = "<group>"; };
 		209AD3CB2AC1A68800825D76 /* WooPaymentsDepositService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositService.swift; sourceTree = "<group>"; };
 		209AD3CD2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverview.swift; sourceTree = "<group>"; };
+		20BCF6F12B0E554500954840 /* SystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusService.swift; sourceTree = "<group>"; };
+		20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockSystemStatusService.swift; path = ../../../WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift; sourceTree = "<group>"; };
 		24163B9D257F41A600F94EC3 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
 		24163BA7257F41C500F94EC3 /* SessionManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerProtocol.swift; sourceTree = "<group>"; };
 		247CE7AA2582DB9300F9D9D1 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
@@ -1127,6 +1131,14 @@
 			path = Payments;
 			sourceTree = "<group>";
 		};
+		20BCF6F32B0E558500954840 /* SystemStatus */ = {
+			isa = PBXGroup;
+			children = (
+				20BCF6F12B0E554500954840 /* SystemStatusService.swift */,
+			);
+			path = SystemStatus;
+			sourceTree = "<group>";
+		};
 		247CE7AF2582DBD000F9D9D1 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1456,6 +1468,7 @@
 		B56C1EBC20EABD1C00D749F9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				20BCF6F32B0E558500954840 /* SystemStatus */,
 				B9C0C1062A3C665300DF84EA /* ProductVariations */,
 				E18FDAFC28F97E9C008519BA /* InAppPurchases */,
 				02FF054423D983C40058E6E7 /* Media */,
@@ -1734,6 +1747,7 @@
 				0248B36A2459127200A271A4 /* MockNetwork+Path.swift */,
 				022F9318257F24730011CD94 /* MockShippingLabel.swift */,
 				022F931C257F27B40011CD94 /* MockShippingLabelAddress.swift */,
+				20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2172,6 +2186,7 @@
 				D87F614A22657A690031A13B /* AppSettingsAction.swift in Sources */,
 				02031DF42AA6DDBF00D13669 /* MediaUIImageExporter.swift in Sources */,
 				E16C59BD28F9394F007D55BB /* InAppPurchaseAction.swift in Sources */,
+				20BCF6F22B0E554500954840 /* SystemStatusService.swift in Sources */,
 				744A321B216D57D40051439B /* SiteVisitStats+ReadOnlyType.swift in Sources */,
 				02124DAE2431C11600980D74 /* Media+ProductImage.swift in Sources */,
 				DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */,
@@ -2383,6 +2398,7 @@
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				02DAE7F8291A9F11009342B7 /* DomainStoreTests.swift in Sources */,
 				DED91DF62AD67F8F00CDCC53 /* MockBlazeRemote.swift in Sources */,
+				20BCF6F52B0E57AB00954840 /* MockSystemStatusService.swift in Sources */,
 				D8652E322630741000350F37 /* PaymentIntent+ReceiptParametersTests.swift in Sources */,
 				029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */,
 				022F00C72472963E008CD97F /* NotificationCountStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -69,6 +69,21 @@ extension Yosemite.ProductReviewFromNoteParcel {
     }
 }
 
+extension Yosemite.SystemInformation {
+    public func copy(
+        storeID: NullableCopiableProp<String> = .copy,
+        systemPlugins: CopiableProp<[Networking.SystemPlugin]> = .copy
+    ) -> Yosemite.SystemInformation {
+        let storeID = storeID ?? self.storeID
+        let systemPlugins = systemPlugins ?? self.systemPlugins
+
+        return Yosemite.SystemInformation(
+            storeID: storeID,
+            systemPlugins: systemPlugins
+        )
+    }
+}
+
 extension Yosemite.WooPaymentsDepositsOverviewByCurrency {
     public func copy(
         currency: CopiableProp<CurrencyCode> = .copy,

--- a/Yosemite/Yosemite/Model/SystemInformation.swift
+++ b/Yosemite/Yosemite/Model/SystemInformation.swift
@@ -1,8 +1,9 @@
 import Networking
+import Codegen
 
 /// Store sytem information entity.
 ///
-public struct SystemInformation {
+public struct SystemInformation: GeneratedFakeable, GeneratedCopiable {
     /// Store UUID
     ///
     public let storeID: String?

--- a/Yosemite/Yosemite/Tools/SystemStatus/SystemStatusService.swift
+++ b/Yosemite/Yosemite/Tools/SystemStatus/SystemStatusService.swift
@@ -22,7 +22,7 @@ public struct SystemStatusService: SystemStatusServiceProtocol {
         }
     }
 
-    @MainActor  
+    @MainActor
     public func fetchSystemPluginWithPath(siteID: Int64, pluginPath: String) async -> SystemPlugin? {
         await withCheckedContinuation({ continuation in
             let action = SystemStatusAction.fetchSystemPluginWithPath(siteID: siteID,

--- a/Yosemite/Yosemite/Tools/SystemStatus/SystemStatusService.swift
+++ b/Yosemite/Yosemite/Tools/SystemStatus/SystemStatusService.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public protocol SystemStatusServiceProtocol {
+    func synchronizeSystemInformation(siteID: Int64) async throws -> SystemInformation
+    func fetchSystemPluginWithPath(siteID: Int64, pluginPath: String) async -> SystemPlugin?
+}
+
+public struct SystemStatusService: SystemStatusServiceProtocol {
+    let stores: StoresManager
+
+    public init(stores: StoresManager) {
+        self.stores = stores
+    }
+
+    @MainActor
+    public func synchronizeSystemInformation(siteID: Int64) async throws -> SystemInformation {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
+                continuation.resume(with: result)
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    @MainActor  
+    public func fetchSystemPluginWithPath(siteID: Int64, pluginPath: String) async -> SystemPlugin? {
+        await withCheckedContinuation({ continuation in
+            let action = SystemStatusAction.fetchSystemPluginWithPath(siteID: siteID,
+                                                                      pluginPath: pluginPath) { plugin in
+                continuation.resume(returning: plugin)
+            }
+            stores.dispatch(action)
+        })
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11234 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the remaining Analytics:
- PAYMENTS_HUB_DEPOSIT_SUMMARY_CURRENCY_SELECTED
- PAYMENTS_HUB_DEPOSIT_SUMMARY_LEARN_MORE_CLICKED
- PAYMENTS_HUB_DEPOSIT_SUMMARY_EXPANDED

Additionally, it moves `PAYMENTS_HUB_DEPOSIT_SUMMARY_SHOWN` to the DepositSummaryView, so it's only logged when that actually appears (not when it's inited.)

Finally, we only fetch the deposit details for WooPayments stores now, so the PAYMENTS_HUB_DEPOSIT_SUMMARY_ERROR event won't be tracked on non-WooPayments stores any more.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app and switch to a WooPayments store
2. Navigate to `Menu > Payments`
3. Observe that when the Deposit summary appears, `PAYMENTS_HUB_DEPOSIT_SUMMARY_SHOWN` is tracked with the appropriate number of currencies
4. Tap the summary to expand it
5. Observe that `PAYMENTS_HUB_DEPOSIT_SUMMARY_EXPANDED` is tracked
6. Tap `Learn More about when you'll receive your funds`
7. Observe that `PAYMENTS_HUB_DEPOSIT_SUMMARY_LEARN_MORE_CLICKED` is tracked
8. Close the webview and switch to a different currency in the view
9. Observe that `PAYMENTS_HUB_DEPOSIT_SUMMARY_CURRENCY_SELECTED` is tracked, along with the `currency` property.

### Non-WooPayments stores
1. Switch to a Stripe store
2. Repeat the above test
3. Observe that the Deposit Summary is not shown, and `PAYMENTS_HUB_DEPOSIT_SUMMARY_ERROR` is not tracked.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="1245" alt="Console logs showing the above analytic events" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/34cb9c5c-6d1d-4213-a931-c8d50724f628">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
