### PR TITLE
[WIP][Bundle products in order] Group parent and child bundle items in order creation screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleBundleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleBundleProductRowCard.swift
@@ -56,6 +56,7 @@ struct CollapsibleBundleProductRowCard: View {
                                           shouldDisableDiscountEditing: shouldDisableDiscountEditing,
                                           shouldDisallowDiscounts: shouldDisallowDiscounts,
                                           onAddDiscount: onAddDiscount) // TODO: #11250 Update design of child items in product bundle
+                Divider().padding(.horizontal)
             }
         }
         .overlay {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleBundleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleBundleProductRowCard.swift
@@ -45,6 +45,9 @@ struct CollapsibleBundleProductRowCard: View {
                                       shouldDisableDiscountEditing: shouldDisableDiscountEditing,
                                       shouldDisallowDiscounts: shouldDisallowDiscounts,
                                       onAddDiscount: onAddDiscount)
+            Divider()
+                .frame(height: Layout.borderLineWidth)
+                .overlay(Color(.separator))
 
             // Child products
             ForEach(childViewModels) { viewModel in
@@ -72,7 +75,7 @@ private extension CollapsibleBundleProductRowCard {
 #if DEBUG
 #Preview {
     let product = Product.swiftUIPreviewSample()
-    let parentViewModel = ProductRowViewModel(id: 1, product: product, canChangeQuantity: true)
+    let parentViewModel = ProductRowViewModel(id: 1, product: product, canChangeQuantity: true, hasChildProducts: true)
     let childViewModels = [ProductRowViewModel(id: 2, product: product, canChangeQuantity: true, hasParentProduct: true),
                            ProductRowViewModel(id: 3, product: product, canChangeQuantity: true, hasParentProduct: true)]
     return CollapsibleBundleProductRowCard(parentViewModel: parentViewModel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleBundleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleBundleProductRowCard.swift
@@ -1,0 +1,86 @@
+import Yosemite
+import SwiftUI
+
+/// Displays a collapsible product row for a bundle product parent item, grouped with its child items
+///
+struct CollapsibleBundleProductRowCard: View {
+    /// View model for the parent product
+    @ObservedObject var parentViewModel: ProductRowViewModel
+
+    /// View models for the child products
+    var childViewModels: [ProductRowViewModel]
+
+    /// Used for tracking order form events.
+    let flow: WooAnalyticsEvent.Orders.Flow
+
+    var onAddDiscount: () -> Void
+
+    /// Tracks if discount editing should be enabled or disabled. False by default
+    var shouldDisableDiscountEditing: Bool = false
+
+    /// Tracks if discount should be allowed or disallowed.
+    var shouldDisallowDiscounts: Bool = false
+
+    @ScaledMetric private var scale: CGFloat = 1
+
+    init(parentViewModel: ProductRowViewModel,
+         childViewModels: [ProductRowViewModel],
+         flow: WooAnalyticsEvent.Orders.Flow,
+         shouldDisableDiscountEditing: Bool,
+         shouldDisallowDiscounts: Bool,
+         onAddDiscount: @escaping () -> Void) {
+        self.parentViewModel = parentViewModel
+        self.childViewModels = childViewModels
+        self.flow = flow
+        self.shouldDisableDiscountEditing = shouldDisableDiscountEditing
+        self.shouldDisallowDiscounts = shouldDisallowDiscounts
+        self.onAddDiscount = onAddDiscount
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Parent product
+            CollapsibleProductRowCard(viewModel: parentViewModel,
+                                      flow: flow,
+                                      shouldDisableDiscountEditing: shouldDisableDiscountEditing,
+                                      shouldDisallowDiscounts: shouldDisallowDiscounts,
+                                      onAddDiscount: onAddDiscount)
+
+            // Child products
+            ForEach(childViewModels) { viewModel in
+                CollapsibleProductRowCard(viewModel: viewModel,
+                                          flow: flow,
+                                          shouldDisableDiscountEditing: shouldDisableDiscountEditing,
+                                          shouldDisallowDiscounts: shouldDisallowDiscounts,
+                                          onAddDiscount: onAddDiscount) // TODO: #11250 Update design of child items in product bundle
+            }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
+                .stroke(Color(uiColor: .separator), lineWidth: Layout.borderLineWidth)
+        }
+    }
+}
+
+private extension CollapsibleBundleProductRowCard {
+    enum Layout {
+        static let frameCornerRadius: CGFloat = 4
+        static let borderLineWidth: CGFloat = 1
+    }
+}
+
+#if DEBUG
+#Preview {
+    let product = Product.swiftUIPreviewSample()
+    let parentViewModel = ProductRowViewModel(id: 1, product: product, canChangeQuantity: true)
+    let childViewModels = [ProductRowViewModel(id: 2, product: product, canChangeQuantity: true, hasParentProduct: true),
+                           ProductRowViewModel(id: 3, product: product, canChangeQuantity: true, hasParentProduct: true)]
+    return CollapsibleBundleProductRowCard(parentViewModel: parentViewModel,
+                                           childViewModels: childViewModels,
+                                           flow: .creation,
+                                           shouldDisableDiscountEditing: false,
+                                           shouldDisallowDiscounts: false,
+                                           onAddDiscount: {})
+    .padding()
+}
+#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -141,14 +141,24 @@ struct CollapsibleProductRowCard: View {
         .padding(Layout.padding)
         .frame(maxWidth: .infinity, alignment: .center)
         .background(Color(.listForeground(modal: false)))
-        .overlay {
-            RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
-                .inset(by: 0.25)
-                .stroke(isCollapsed ? Color(uiColor: .separator) : Color(uiColor: .black),
-                        lineWidth: Layout.borderLineWidth)
-                .renderedIf(!viewModel.hasParentProduct)
-        }
-        .cornerRadius(Layout.frameCornerRadius)
+        .if(!viewModel.hasParentProduct, transform: {
+            $0.overlay {
+                if viewModel.hasChildProducts, #available(iOS 16.0, *) {
+                    UnevenRoundedRectangle(topLeadingRadius: Layout.frameCornerRadius,
+                                           bottomLeadingRadius: 0,
+                                           bottomTrailingRadius: 0,
+                                           topTrailingRadius: Layout.frameCornerRadius,
+                                           style: .circular)
+                    .inset(by: 0.25)
+                    .stroke(Color(uiColor: .black), lineWidth: Layout.borderLineWidth)
+                    .renderedIf(!isCollapsed)
+                } else {
+                    RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
+                        .inset(by: 0.25)
+                        .stroke(isCollapsed ? Color(uiColor: .separator) : Color(uiColor: .black), lineWidth: Layout.borderLineWidth)
+                }
+            }
+        })
     }
 
 
@@ -275,6 +285,11 @@ struct CollapsibleProductRowCard_Previews: PreviewProvider {
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
         VStack {
             CollapsibleProductRowCard(viewModel: viewModel,
+                                      flow: .creation,
+                                      shouldDisableDiscountEditing: false,
+                                      shouldDisallowDiscounts: false,
+                                      onAddDiscount: {})
+            CollapsibleProductRowCard(viewModel: ProductRowViewModel(product: product, canChangeQuantity: true, hasChildProducts: true),
                                       flow: .creation,
                                       shouldDisableDiscountEditing: false,
                                       shouldDisallowDiscounts: false,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCard.swift
@@ -57,7 +57,6 @@ struct CollapsibleProductRowCard: View {
                         isCollapsed: $isCollapsed,
                         safeAreaInsets: EdgeInsets(),
                         shouldShowDividers: shouldShowDividers,
-                        backgroundColor: viewModel.backgroundColor,
                         label: {
             VStack {
                 HStack(alignment: .center, spacing: Layout.padding) {
@@ -141,7 +140,7 @@ struct CollapsibleProductRowCard: View {
         }
         .padding(Layout.padding)
         .frame(maxWidth: .infinity, alignment: .center)
-        .background(Color(viewModel.backgroundColor))
+        .background(Color(.listForeground(modal: false)))
         .overlay {
             RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
                 .inset(by: 0.25)
@@ -266,13 +265,6 @@ private extension CollapsibleProductRowCard {
         static let configureBundleProduct = NSLocalizedString(
             "Configure",
             comment: "Text in the product row card to configure a bundle product")
-    }
-}
-
-private extension ProductRowViewModel {
-    var backgroundColor: UIColor {
-        hasParentProduct ?
-        .tertiarySystemGroupedBackground: .listForeground(modal: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -651,6 +651,7 @@ final class EditableOrderViewModel: ObservableObject {
                                        quantity: item.quantity,
                                        canChangeQuantity: canChangeQuantity,
                                        hasParentProduct: item.parent != nil,
+                                       hasChildProducts: item.bundleConfiguration.isNotEmpty,
                                        quantityUpdatedCallback: { [weak self] _ in
                 guard let self = self else { return }
                 self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductQuantityChange(flow: self.flow.analyticsFlow))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -34,6 +34,9 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Whether a product in an order item has a parent order item
     let hasParentProduct: Bool
 
+    /// Whether a product is the parent of child order items
+    let hasChildProducts: Bool
+
     /// Whether a product in an order item is configurable
     ///
     let isConfigurable: Bool
@@ -285,6 +288,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          variationDisplayMode: VariationDisplayMode? = nil,
          selectedState: ProductRow.SelectedState = .notSelected,
          hasParentProduct: Bool,
+         hasChildProducts: Bool = false,
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
@@ -307,6 +311,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.canChangeQuantity = canChangeQuantity
         self.imageURL = imageURL
         self.hasParentProduct = hasParentProduct
+        self.hasChildProducts = hasChildProducts
         self.isConfigurable = isConfigurable
         self.currencyFormatter = currencyFormatter
         self.analytics = analytics
@@ -326,6 +331,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      canChangeQuantity: Bool,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      hasParentProduct: Bool = false,
+                     hasChildProducts: Bool = false,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      analytics: Analytics = ServiceLocator.analytics,
                      quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
@@ -392,6 +398,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   numberOfVariations: product.variations.count,
                   selectedState: selectedState,
                   hasParentProduct: hasParentProduct,
+                  hasChildProducts: hasChildProducts,
                   isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
                   analytics: analytics,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1965,6 +1965,7 @@
 		CE85FD5320F677770080B73E /* Dashboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE85FD5220F677770080B73E /* Dashboard.storyboard */; };
 		CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85FD5920F7A7640080B73E /* TableFooterView.swift */; };
 		CE85FD5C20F7A7740080B73E /* TableFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE85FD5B20F7A7740080B73E /* TableFooterView.xib */; };
+		CE86EEFB2B0E1F6200813F6C /* CollapsibleBundleProductRowCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE86EEFA2B0E1F6200813F6C /* CollapsibleBundleProductRowCard.swift */; };
 		CE8CCD43239AC06E009DBD22 /* RefundDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */; };
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
@@ -4542,6 +4543,7 @@
 		CE85FD5220F677770080B73E /* Dashboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Dashboard.storyboard; sourceTree = "<group>"; };
 		CE85FD5920F7A7640080B73E /* TableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableFooterView.swift; sourceTree = "<group>"; };
 		CE85FD5B20F7A7740080B73E /* TableFooterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TableFooterView.xib; sourceTree = "<group>"; };
+		CE86EEFA2B0E1F6200813F6C /* CollapsibleBundleProductRowCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleBundleProductRowCard.swift; sourceTree = "<group>"; };
 		CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewController.swift; sourceTree = "<group>"; };
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
@@ -9862,6 +9864,7 @@
 				AE264C04275A493800B52996 /* StatusSection */,
 				02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */,
 				68A905002ACCFC13004C71D3 /* CollapsibleProductRowCard.swift */,
+				CE86EEFA2B0E1F6200813F6C /* CollapsibleBundleProductRowCard.swift */,
 				B99B87A62AEFCF0A006B8AB1 /* Order+Empty.swift */,
 			);
 			path = "Order Creation";
@@ -12543,6 +12546,7 @@
 				FEDD70AF26A7223500194C3A /* StorageEligibilityErrorInfo+Woo.swift in Sources */,
 				DE653EAD2A70D09F00937C78 /* CreateTestOrderView.swift in Sources */,
 				AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */,
+				CE86EEFB2B0E1F6200813F6C /* CollapsibleBundleProductRowCard.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
 				EEBDF7DA2A2EF69B00EFEF47 /* ShareProductCoordinator.swift in Sources */,
 				DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
⚠️ WIP ⚠️ 

Closes: #11249
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
We want to update the design for bundle products in orders. The first set of design changes is to group the parent and child bundle items in the order:

* Wrap all the bundle product cards in one – so, reduce the gaps between them to zero, and only have rounded corners on the first and last.
* Keep a solid, continuous bottom border between the bundle product and its children.
* Use indented (left and right) bottom borders between all the children products.

## How
This adds a `CollapsibleBundleProductRowCard` to display all the bundle products cards in a group, with the updated design.

Challenge: This requires pre-filtering the product rows in the order to group parent/child bundle items. Line items in an order aren't grouped already, so we'll have to do this grouping manually.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Collapsed|Expanded
-|-
![Screenshot 2023-11-22 at 17 48 39](https://github.com/woocommerce/woocommerce-ios/assets/8658164/c5d338e4-e18f-4fe0-b86a-2034371e9056)|![Screenshot 2023-11-22 at 17 48 48](https://github.com/woocommerce/woocommerce-ios/assets/8658164/b80200f1-6a6b-46b7-bf59-3bd32fafc0e0)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
