### PR TITLE
[Bundle products in order] Product selector design updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -88,9 +88,9 @@ struct ProductRow: View {
                         Text(viewModel.productDetailsLabel)
                             .subheadlineStyle()
                             .renderedIf(viewModel.productDetailsLabel.isNotEmpty)
-                        Text(viewModel.skuLabel)
+                        Text(viewModel.secondaryProductDetailsLabel)
                             .subheadlineStyle()
-                            .renderedIf(viewModel.skuLabel.isNotEmpty)
+                            .renderedIf(viewModel.secondaryProductDetailsLabel.isNotEmpty)
                     }
                     .multilineTextAlignment(.leading)
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -196,6 +196,17 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             .joined(separator: " • ")
     }
 
+    /// Label showing secondary product details. Can include product type (if the row is configurable), and SKU (if available).
+    ///
+    var secondaryProductDetailsLabel: String {
+        [productTypeLabel, skuLabel]
+            .compactMap({ $0 })
+            .filter { $0.isNotEmpty }
+            .joined(separator: " • ")
+    }
+
+    private let productTypeLabel: String?
+
     /// Label showing product SKU
     ///
     lazy var skuLabel: String = {
@@ -271,6 +282,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          productOrVariationID: Int64,
          name: String,
          sku: String?,
+         productTypeLabel: String? = nil,
          price: String?,
          discount: Decimal? = nil,
          stockStatusKey: String,
@@ -296,6 +308,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.productOrVariationID = productOrVariationID
         self.name = name
         self.sku = sku
+        self.productTypeLabel = productTypeLabel
         self.price = price
         self.discount = discount
         self.stockStatus = .init(rawValue: stockStatusKey)
@@ -377,10 +390,13 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         && product.bundledItems.isNotEmpty
         && configure != nil
 
+        let productTypeLabel: String? = isConfigurable ? product.productType.description: nil
+
         self.init(id: id,
                   productOrVariationID: product.productID,
                   name: product.name,
                   sku: product.sku,
+                  productTypeLabel: productTypeLabel,
                   price: price,
                   discount: discount,
                   stockStatusKey: stockStatusKey,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -213,8 +213,7 @@ struct ProductSelectorView: View {
                            viewModel: rowViewModel)
                 .accessibilityHint(configuration.productRowAccessibilityHint)
 
-                Text(Localization.configureButton)
-                    .linkStyle()
+                ConfigurationIndicator()
                     .renderedIf(rowViewModel.isConfigurable)
                     .onAppear {
                         guard !hasTrackedBundleProductConfigureCTAShownEvent else {
@@ -275,11 +274,6 @@ private extension ProductSelectorView {
                                                                      comment: "Accessibility label for placeholder rows while products are loading")
         static let clearSelection = NSLocalizedString("Clear selection", comment: "Button to clear selection on the Select Products screen")
         static let doneButton = NSLocalizedString("Done", comment: "Button to submit the product selector without any product selected.")
-        static let configureButton = NSLocalizedString(
-            "productSelector.configureProductRow",
-            value: "Configure",
-            comment: "Action to configure a product row in the product selector."
-        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ConfigurationIndicator.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ConfigurationIndicator.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Shown as an accessory view in a row to indicate the row is configurable.
+struct ConfigurationIndicator: View {
+    var body: some View {
+        Image(systemName: Constants.symbolName)
+            .font(.system(size: Constants.size))
+            .foregroundColor(Color(UIColor.primary))
+            .accessibility(hidden: true)
+    }
+}
+
+// MARK: Constants
+private extension ConfigurationIndicator {
+    enum Constants {
+        static let size: CGFloat = 22.0
+        static let symbolName = "gearshape"
+    }
+}
+
+struct ConfigurationIndicator_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ConfigurationIndicator()
+                .previewLayout(.sizeThatFits)
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 		028E19BC2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E19BB2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift */; };
 		028E1F702833DD0A001F8829 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */; };
 		028E1F722833E954001F8829 /* DashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E1F712833E954001F8829 /* DashboardViewModelTests.swift */; };
+		028F3F962B0F1A2A00F8E227 /* ConfigurationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028F3F952B0F1A2A00F8E227 /* ConfigurationIndicator.swift */; };
 		028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */; };
 		028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */; };
 		028FF8E32AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FF8E22AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift */; };
@@ -2944,6 +2945,7 @@
 		028E19BB2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundSubmissionUseCaseTests.swift; sourceTree = "<group>"; };
 		028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		028E1F712833E954001F8829 /* DashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModelTests.swift; sourceTree = "<group>"; };
+		028F3F952B0F1A2A00F8E227 /* ConfigurationIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationIndicator.swift; sourceTree = "<group>"; };
 		028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModel.swift; sourceTree = "<group>"; };
 		028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextSectionHeaderView.swift; sourceTree = "<group>"; };
 		028FF8E22AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductDetailsCellViewModel+AddOns.swift"; sourceTree = "<group>"; };
@@ -10423,6 +10425,7 @@
 				0373A12E2A1D1F2100731236 /* DotView.swift */,
 				B98D425A2AF9374400973C76 /* LargeHeightLeftImageTableViewCell.swift */,
 				B98D425C2AF9400900973C76 /* LargeHeightLeftImageTableViewCell.xib */,
+				028F3F952B0F1A2A00F8E227 /* ConfigurationIndicator.swift */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -13543,6 +13546,7 @@
 				03E471C2293A1F6B001A58AD /* BluetoothReaderConnectionAlertsProvider.swift in Sources */,
 				6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */,
 				DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */,
+				028F3F962B0F1A2A00F8E227 /* ConfigurationIndicator.swift in Sources */,
 				B9F3DAAF29BB73CD00DDD545 /* CreateOrderAppIntent.swift in Sources */,
 				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,
 				7E7C5F862719A93C00315B61 /* ProductCategoryViewModelBuilder.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -239,6 +239,60 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.skuLabel, expectedSKULabel)
     }
 
+    func test_secondaryProductDetailsLabel_is_formatted_correctly_for_non_configurable_product_with_sku() {
+        // Given
+        let sku = "123456"
+        let product = Product.fake().copy(sku: sku)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let format = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
+        let expectedSKULabel = String.localizedStringWithFormat(format, sku)
+        XCTAssertEqual(viewModel.secondaryProductDetailsLabel, expectedSKULabel)
+    }
+
+    func test_secondaryProductDetailsLabel_is_empty_for_non_configurable_product_without_sku() {
+        // Given
+        let sku = ""
+        let product = Product.fake().copy(sku: sku)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        let expectedSKULabel = ""
+        XCTAssertEqual(viewModel.secondaryProductDetailsLabel, expectedSKULabel)
+    }
+
+    func test_secondaryProductDetailsLabel_contains_product_type_and_formatted_correctly_for_configurable_bundle_product_with_sku() {
+        // Given
+        let sku = "123456"
+        let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, sku: sku, bundledItems: [.fake()])
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, configure: {})
+
+        // Then
+        let format = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
+        let expectedSKULabel = String.localizedStringWithFormat(format, sku)
+        XCTAssertTrue(viewModel.secondaryProductDetailsLabel.contains(ProductType.bundle.description))
+        XCTAssertTrue(viewModel.secondaryProductDetailsLabel.contains(expectedSKULabel))
+    }
+
+    func test_secondaryProductDetailsLabel_is_product_type_for_configurable_bundle_product_without_sku() {
+        // Given
+        let sku = ""
+        let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, sku: sku, bundledItems: [.fake()])
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, configure: {})
+
+        // Then
+        XCTAssertEqual(viewModel.secondaryProductDetailsLabel, ProductType.bundle.description)
+    }
+
     func test_increment_and_decrement_quantity_have_step_value_of_one() {
         // Given
         let product = Product.fake()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -270,9 +270,10 @@ final class ProductRowViewModelTests: XCTestCase {
         // Given
         let sku = "123456"
         let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, sku: sku, bundledItems: [.fake()])
+        let featureFlagService = MockFeatureFlagService(productBundlesInOrderForm: true)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, configure: {})
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, featureFlagService: featureFlagService, configure: {})
 
         // Then
         let format = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
@@ -285,9 +286,10 @@ final class ProductRowViewModelTests: XCTestCase {
         // Given
         let sku = ""
         let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, sku: sku, bundledItems: [.fake()])
+        let featureFlagService = MockFeatureFlagService(productBundlesInOrderForm: true)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, configure: {})
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, featureFlagService: featureFlagService, configure: {})
 
         // Then
         XCTAssertEqual(viewModel.secondaryProductDetailsLabel, ProductType.bundle.description)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11256 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We implemented the feature without a formal design, and we've got Joe's design review to improve the product selector screen for the product bundles extension support (design file w3JBReW1UJesCf02sj43kR-fi-993_9822):

> - Use a cog icon for configure indicator
> - Identify the product as a Bundle (where the variation information would otherwise go)

## How

For the cog icon in the product row's accessory view, `ConfigurationIndicator` was created for potential reuse.

For showing the "Bundle" label in the product row, `secondaryProductDetailsLabel` was added to include the product type (when the row is configurable, which is only supported for bundle products now) and SKU (when it's set). Since `skuLabel` is used externally in `CollapsibleProductRowCard`, I didn't mark this property as private.

Regarding the second point, showing a "Bundle" label in the product row next to the SKU, the design shows that the product type/SKU info is shown before the price/stock info. I left a comment in the design to confirm this label order change w3JBReW1UJesCf02sj43kR-fi-993:9822#624767565 since it wasn't mentioned in the original design review pe5pgL-42P-p2#comment-3267.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

- Go to the Orders tab
- Tap `+`
- Tap `Add Products`, and search for bundle product(s) if needed --> the non-bundle products should have a cog icon in the trailing edge, and the row should say "Bundle" next to the SKU (if available)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/e9f9ca55-30c1-412b-9598-d0b4c3c03611" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/3b95ccd0-edc4-4ea5-af35-ed57d9f72d0f" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.