### PR TITLE
Remove warnings from unused constant

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -345,7 +345,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
     func test_quantity_decrementer_disabled_at_minimum_quantity_when_removeProductIntent_is_nil() {
         // Given
-        let product = Product.fake()
         let viewModel = ProductRowViewModel(productOrVariationID: 1,
                                             name: "",
                                             sku: nil,
@@ -367,7 +366,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
     func test_quantity_decrementer_not_disabled_at_minimum_quantity_when_removeProductIntent_is_not_nil() {
         // Given
-        let product = Product.fake()
         let viewModel = ProductRowViewModel(productOrVariationID: 1,
                                             name: "",
                                             sku: nil,
@@ -390,7 +388,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
     func test_quantity_incrementer_disabled_at_maximum_quantity() {
         // Given
-        let product = Product.fake()
         let viewModel = ProductRowViewModel(productOrVariationID: 1,
                                             name: "",
                                             sku: nil,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we remove some swiftlint warnings caused by an unused let constant.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI should pass

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
