### PR TITLE
Subscriptions: Temporarily hide "Shipping" option from subscription product.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -212,7 +212,11 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
     }
 
     func isShippingEnabled() -> Bool {
-        product.downloadable == false && product.virtual == false
+        // TODO 11178 remove this check to re-enable Shipping for Subscriptions.
+        if product.subscription != nil {
+            return false
+        }
+        return product.downloadable == false && product.virtual == false
     }
 
     var existsRemotely: Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -609,7 +609,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .subscriptionFreeTrial(editable: true),
                                                                        .subscriptionExpiry(editable: true),
                                                                        .reviews,
-                                                                       .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
@@ -714,7 +713,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .subscriptionFreeTrial(editable: true),
                                                                        .subscriptionExpiry(editable: true),
                                                                        .reviews,
-                                                                       .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
@@ -762,7 +760,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertFalse(containsShippingSettingsAction)
     }
 
-    func test_actions_for_subscription_product_contains_shippingSettings_action_when_product_is_not_virtual() {
+    func test_actions_for_subscription_product_does_not_contain_shippingSettings_action_when_product_is_not_virtual() {
         // Given
         let product = Fixtures.subscriptionProduct.copy(virtual: false)
         let model = EditableProductModel(product: product)
@@ -772,7 +770,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Then
         let containsShippingSettingsAction = factory.settingsSectionActions().contains(ProductFormEditAction.shippingSettings(editable: true))
-        XCTAssertTrue(containsShippingSettingsAction)
+        XCTAssertFalse(containsShippingSettingsAction)
     }
 
     func test_actions_for_subscription_product_does_not_contain_shippingSettings_action_when_product_is_downloadable() {
@@ -788,7 +786,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertFalse(containsShippingSettingsAction)
     }
 
-    func test_actions_for_subscription_product_contains_shippingSettings_action_when_product_is_not_downloadable() {
+    func test_actions_for_subscription_product_does_not_contain_shippingSettings_action_when_product_is_not_downloadable() {
         // Given
         let product = Fixtures.subscriptionProduct.copy(downloadable: false)
         let model = EditableProductModel(product: product)
@@ -798,7 +796,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Then
         let containsShippingSettingsAction = factory.settingsSectionActions().contains(ProductFormEditAction.shippingSettings(editable: true))
-        XCTAssertTrue(containsShippingSettingsAction)
+        XCTAssertFalse(containsShippingSettingsAction)
     }
 
     // MARK: Quantity rules


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11263
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR temporarily hides the "Shipping" option for subscription products, as well as updates the unit tests related to it.

It's all done in one commit. The idea is that once we're working on  #11178, the commit can just be reverted in one go.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisite

1. Install Woo Subscription plugin on your store
2. Create a subscriptions product from wp-admin
#### Steps
1. Launch the app and Log in to the store.
2. Navigate to Products tab > select "+" > select manual option > Subscription product.
3. Tap on + Add more details
4. You should **not** see the "Shipping" row
