### PR TITLE
[Deposit Summary] Loading State

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -191,12 +191,30 @@ struct InPersonPaymentsMenu: View {
     @ViewBuilder
     var depositSummary: some View {
         if #available(iOS 16.0, *),
-           viewModel.shouldShowDepositSummary,
-           let depositViewModel = viewModel.depositViewModel {
-            WooPaymentsDepositsOverviewView(viewModel: depositViewModel)
+           viewModel.shouldShowDepositSummary {
+            if viewModel.isLoadingDepositSummary {
+                WooPaymentsDepositsOverviewView(viewModel: depositSummaryLoadingViewModel)
+                    .redacted(reason: .placeholder)
+                    .shimmering()
+            } else if let depositViewModel = viewModel.depositViewModel {
+                WooPaymentsDepositsOverviewView(viewModel: depositViewModel)
+            }
         } else {
             EmptyView()
         }
+    }
+
+    private var depositSummaryLoadingViewModel: WooPaymentsDepositsOverviewViewModel {
+        .init(currencyViewModels: [.init(overview: .init(
+            currency: .AED,
+            automaticDeposits: false,
+            depositInterval: .daily,
+            pendingBalanceAmount: .zero,
+            pendingDepositsCount: 0,
+            pendingDepositDays: 0,
+            nextDeposit: nil,
+            lastDeposit: nil,
+            availableBalance: .zero))])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -196,6 +196,8 @@ struct InPersonPaymentsMenu: View {
                 WooPaymentsDepositsOverviewView(viewModel: depositSummaryLoadingViewModel)
                     .redacted(reason: .placeholder)
                     .shimmering()
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(Localization.loadingDepositSummaryAccessibilityLabel)
             } else if let depositViewModel = viewModel.depositViewModel {
                 WooPaymentsDepositsOverviewView(viewModel: depositViewModel)
             }
@@ -332,6 +334,12 @@ private extension InPersonPaymentsMenu {
                      A label prompting users to learn more about card readers.
                      This part is the link to the website, and forms part of a longer sentence which it should be considered a part of.
                      """
+        )
+
+        static let loadingDepositSummaryAccessibilityLabel = NSLocalizedString(
+            "menu.payments.depositSummary.loading.accessibilityLabel",
+            value: "Loading balances...",
+            comment: "An accessibility label used when the balances are loading on the payments menu"
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -29,6 +29,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var safariSheetURL: URL? = nil
     @Published var presentSupport: Bool = false
     @Published var depositViewModel: WooPaymentsDepositsOverviewViewModel? = nil
+    @Published var isLoadingDepositSummary: Bool = false
 
     var shouldAlwaysHideSetUpButtonOnAboutTapToPay: Bool = false
 
@@ -117,17 +118,21 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
             shouldShowDepositSummary = false
             return
         }
+
+        shouldShowDepositSummary = true
+
         do {
+            if depositViewModel == nil {
+                isLoadingDepositSummary = true
+            }
             let depositCurrencyViewModels = try await dependencies.wooPaymentsDepositService.fetchDepositsOverview().map({
                 WooPaymentsDepositsCurrencyOverviewViewModel(overview: $0)
             })
-            shouldShowDepositSummary = depositCurrencyViewModels.count > 0
-            guard shouldShowDepositSummary else {
-                return
-            }
+            isLoadingDepositSummary = false
             depositViewModel = WooPaymentsDepositsOverviewViewModel(currencyViewModels: depositCurrencyViewModels)
         } catch {
             shouldShowDepositSummary = false
+            isLoadingDepositSummary = false
             analytics.track(event: .DepositSummary.depositSummaryError(error: error))
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11264 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a loading state for the Deposit Summary view on the Payments menu

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Switch to a WooPayments store
3. Navigate to `Menu > Payments`
4. Observe that the deposit summary view is shown with a loading state, changing to loaded data when the network request completes.
5. Go out and back in to the screen, or to one of the sub screens and back again
6. Observe that even though the deposit summary is refreshed, a loading state is not shown, the old data remains.

Repeat the above with a non-WooPayments store
Observe that the loading state isn't shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/01b50af4-41ed-4e77-9130-daee14b9321e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
