### PR TITLE
[Bundle products in order] Group parent and child bundle items in order creation screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -6,10 +6,10 @@ struct CollapsibleProductCard: View {
     @ObservedObject var viewModel: ProductRowViewModel
 
     /// Used for tracking order form events.
-    let flow: WooAnalyticsEvent.Orders.Flow
+    private let flow: WooAnalyticsEvent.Orders.Flow
 
     /// Handles when "Add Discount" is tapped on the row with the provided `ProductRowViewModel.id`
-    var onAddDiscount: (Int64) -> Void
+    private let onAddDiscount: (Int64) -> Void
 
     /// Tracks if discount editing should be enabled or disabled. False by default
     var shouldDisableDiscountEditing: Bool = false
@@ -87,7 +87,7 @@ private struct CollapsibleProductRowCard: View {
     @ObservedObject var viewModel: ProductRowViewModel
 
     /// Used for tracking order form events.
-    let flow: WooAnalyticsEvent.Orders.Flow
+    private let flow: WooAnalyticsEvent.Orders.Flow
 
     @State private var isCollapsed: Bool = true
 
@@ -97,7 +97,7 @@ private struct CollapsibleProductRowCard: View {
 
     @ScaledMetric private var scale: CGFloat = 1
 
-    var onAddDiscount: (Int64) -> Void
+    private let onAddDiscount: (Int64) -> Void
 
     // Tracks if discount editing should be enabled or disabled. False by default
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -8,7 +8,7 @@ struct CollapsibleProductCard: View {
     /// Used for tracking order form events.
     let flow: WooAnalyticsEvent.Orders.Flow
 
-    /// Handles when a discount is added to the row with the provided `ProductRowViewModel` ID
+    /// Handles when "Add Discount" is tapped on the row with the provided `ProductRowViewModel.id`
     var onAddDiscount: (Int64) -> Void
 
     /// Tracks if discount editing should be enabled or disabled. False by default
@@ -23,7 +23,7 @@ struct CollapsibleProductCard: View {
          flow: WooAnalyticsEvent.Orders.Flow,
          shouldDisableDiscountEditing: Bool,
          shouldDisallowDiscounts: Bool,
-         onAddDiscount: @escaping (Int64) -> Void) {
+         onAddDiscount: @escaping (_ productRowID: Int64) -> Void) {
         self.viewModel = viewModel
         self.flow = flow
         self.shouldDisableDiscountEditing = shouldDisableDiscountEditing
@@ -124,7 +124,7 @@ private struct CollapsibleProductRowCard: View {
          flow: WooAnalyticsEvent.Orders.Flow,
          shouldDisableDiscountEditing: Bool,
          shouldDisallowDiscounts: Bool,
-         onAddDiscount: @escaping (Int64) -> Void) {
+         onAddDiscount: @escaping (_ productRowID: Int64) -> Void) {
         self.viewModel = viewModel
         self.flow = flow
         self.shouldDisableDiscountEditing = shouldDisableDiscountEditing

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -8,6 +8,7 @@ struct CollapsibleProductCard: View {
     /// Used for tracking order form events.
     let flow: WooAnalyticsEvent.Orders.Flow
 
+    /// Handles when a discount is added to the row with the provided `ProductRowViewModel` ID
     var onAddDiscount: (Int64) -> Void
 
     /// Tracks if discount editing should be enabled or disabled. False by default

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -39,9 +39,7 @@ struct CollapsibleProductCard: View {
                                       shouldDisallowDiscounts: shouldDisallowDiscounts,
                                       onAddDiscount: onAddDiscount)
             .overlay {
-                RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
-                    .inset(by: 0.25)
-                    .stroke(Color(uiColor: .separator), lineWidth: Layout.borderLineWidth)
+                cardBorder
             }
         } else {
             VStack(spacing: 0) {
@@ -66,9 +64,7 @@ struct CollapsibleProductCard: View {
                 }
             }
             .overlay {
-                RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
-                    .inset(by: 0.25)
-                    .stroke(Color(uiColor: .separator), lineWidth: Layout.borderLineWidth)
+                cardBorder
             }
         }
     }
@@ -78,6 +74,12 @@ private extension CollapsibleProductCard {
     enum Layout {
         static let frameCornerRadius: CGFloat = 4
         static let borderLineWidth: CGFloat = 1
+    }
+
+    var cardBorder: some View {
+        RoundedRectangle(cornerRadius: Layout.frameCornerRadius)
+            .inset(by: 0.25)
+            .stroke(Color(uiColor: .separator), lineWidth: Layout.borderLineWidth)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -600,15 +600,10 @@ final class EditableOrderViewModel: ObservableObject {
                                        removeProductIntent: { [weak self] in
                 self?.removeItemFromOrder(item)})
         } else if let product = allProducts.first(where: { $0.productID == item.productID }) {
+            // If the parent product is a bundle product, quantity cannot be changed.
+            let canChildItemsChangeQuantity = product.productType != .bundle
             let childProductRows = childItems.compactMap { childItem in
-                // If the parent product is a bundle product, quantity cannot be changed.
-                let canChangeQuantity: Bool = {
-                    guard let parentProduct = allProducts.first(where: { $0.productID == item.productID }) else {
-                        return true
-                    }
-                    return parentProduct.productType != .bundle
-                }()
-                return createProductRowViewModel(for: childItem, canChangeQuantity: canChangeQuantity)
+                return createProductRowViewModel(for: childItem, canChangeQuantity: canChildItemsChangeQuantity)
             }
             return ProductRowViewModel(id: item.itemID,
                                        product: product,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -448,13 +448,11 @@ private struct ProductsSection: View {
                 .renderedIf(viewModel.shouldShowProductsSectionHeader)
 
                 ForEach(viewModel.productRows) { productRow in
-                    CollapsibleProductRowCard(viewModel: productRow,
-                                              flow: flow,
-                                              shouldDisableDiscountEditing: viewModel.paymentDataViewModel.isLoading,
-                                              shouldDisallowDiscounts: viewModel.shouldDisallowDiscounts,
-                                              onAddDiscount: {
-                        viewModel.selectOrderItem(productRow.id)
-                    })
+                    CollapsibleProductCard(viewModel: productRow,
+                                           flow: flow,
+                                           shouldDisableDiscountEditing: viewModel.paymentDataViewModel.isLoading,
+                                           shouldDisallowDiscounts: viewModel.shouldDisallowDiscounts,
+                                           onAddDiscount: viewModel.selectOrderItem)
                     .sheet(item: $viewModel.selectedProductViewModel, content: { productViewModel in
                         ProductDiscountView(imageURL: productRow.imageURL,
                                             name: productRow.name,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -3,7 +3,7 @@ import Foundation
 import Yosemite
 import WooFoundation
 
-/// View model for `ProductRow`.
+/// View model for product rows or cards, e.g. `ProductRow` or `CollapsibleProductCard`.
 ///
 final class ProductRowViewModel: ObservableObject, Identifiable {
     private let currencyFormatter: CurrencyFormatter

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -34,6 +34,9 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Whether a product in an order item has a parent order item
     let hasParentProduct: Bool
 
+    /// Child product rows, if the product is the parent of child order items
+    @Published private(set) var childProductRows: [ProductRowViewModel]
+
     /// Whether a product in an order item is configurable
     ///
     let isConfigurable: Bool
@@ -285,6 +288,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          variationDisplayMode: VariationDisplayMode? = nil,
          selectedState: ProductRow.SelectedState = .notSelected,
          hasParentProduct: Bool,
+         childProductRows: [ProductRowViewModel] = [],
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
@@ -307,6 +311,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.canChangeQuantity = canChangeQuantity
         self.imageURL = imageURL
         self.hasParentProduct = hasParentProduct
+        self.childProductRows = childProductRows
         self.isConfigurable = isConfigurable
         self.currencyFormatter = currencyFormatter
         self.analytics = analytics
@@ -326,6 +331,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      canChangeQuantity: Bool,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      hasParentProduct: Bool = false,
+                     childProductRows: [ProductRowViewModel] = [],
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      analytics: Analytics = ServiceLocator.analytics,
                      quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
@@ -392,6 +398,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   numberOfVariations: product.variations.count,
                   selectedState: selectedState,
                   hasParentProduct: hasParentProduct,
+                  childProductRows: childProductRows,
                   isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
                   analytics: analytics,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1304,7 +1304,7 @@
 		6881CCC42A5EE6BF00AEDE36 /* WooPlanCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */; };
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
 		6888A2CA2A66C42C0026F5C0 /* FullFeatureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */; };
-		68A905012ACCFC13004C71D3 /* CollapsibleProductRowCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A905002ACCFC13004C71D3 /* CollapsibleProductRowCard.swift */; };
+		68A905012ACCFC13004C71D3 /* CollapsibleProductCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */; };
 		68AC9D292ACE598B0042F784 /* ProductImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC9D282ACE598B0042F784 /* ProductImageThumbnail.swift */; };
 		68B6F22B2ADE7ED500D171FC /* TooltipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B6F22A2ADE7ED500D171FC /* TooltipView.swift */; };
 		68C31B712A8617C500AE5C5A /* NewNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C31B702A8617C500AE5C5A /* NewNoteViewModel.swift */; };
@@ -3850,7 +3850,7 @@
 		6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPlanCardView.swift; sourceTree = "<group>"; };
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
 		6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListViewModel.swift; sourceTree = "<group>"; };
-		68A905002ACCFC13004C71D3 /* CollapsibleProductRowCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductRowCard.swift; sourceTree = "<group>"; };
+		68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCard.swift; sourceTree = "<group>"; };
 		68AC9D282ACE598B0042F784 /* ProductImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageThumbnail.swift; sourceTree = "<group>"; };
 		68B6F22A2ADE7ED500D171FC /* TooltipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipView.swift; sourceTree = "<group>"; };
 		68C31B702A8617C500AE5C5A /* NewNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteViewModel.swift; sourceTree = "<group>"; };
@@ -9881,7 +9881,7 @@
 				AE9E04732776034B003FA09E /* CustomerSection */,
 				AE264C04275A493800B52996 /* StatusSection */,
 				02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */,
-				68A905002ACCFC13004C71D3 /* CollapsibleProductRowCard.swift */,
+				68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */,
 				B99B87A62AEFCF0A006B8AB1 /* Order+Empty.swift */,
 			);
 			path = "Order Creation";
@@ -12832,7 +12832,7 @@
 				02DD81F9242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.swift in Sources */,
 				D8C2A28823190B2300F503E9 /* StorageProductReview+Woo.swift in Sources */,
 				02FADA9F2A5F34BD00FE8683 /* AddProductFromImageTextFieldView.swift in Sources */,
-				68A905012ACCFC13004C71D3 /* CollapsibleProductRowCard.swift in Sources */,
+				68A905012ACCFC13004C71D3 /* CollapsibleProductCard.swift in Sources */,
 				02D3B68529657061009BF0BC /* SupportButton.swift in Sources */,
 				2664210126F3E1BB001FC5B4 /* ModalHostingPresentationController.swift in Sources */,
 				D8B4D5F026C2C7EC00F34E94 /* InPersonPaymentsStripeAccountPendingView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -359,7 +359,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                           quantityDebounceDuration: 0)
 
         waitUntil {
-            self.viewModel.productRows.count == 2
+            self.viewModel.productRows.count == 1
         }
 
         let orderToUpdate: Order = waitFor { promise in
@@ -2780,6 +2780,35 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(paymentDataViewModel.shouldRenderCouponsInfoTooltip)
     }
 
+    // MARK: Parent/child order items
+
+    func test_bundle_child_order_items_excluded_from_productRows_and_added_to_parent_childProductRows() throws {
+        let bundleItem = ProductBundleItem.fake().copy(productID: 5)
+        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
+        storageManager.insertProducts([.fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
+        let order = Order.fake().copy(siteID: sampleSiteID, orderID: 1, items: [
+            // Bundle product order item.
+            .fake().copy(itemID: 6, productID: bundleProduct.productID, quantity: 2),
+            // Child bundled item with `parent` equal to the bundle parent item ID.
+            .fake().copy(itemID: 2, productID: bundleItem.productID, quantity: 1, parent: 6),
+        ])
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: order),
+                                               stores: stores,
+                                               storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.productRows.count, 1)
+
+        let parentOrderItemRow = try XCTUnwrap(viewModel.productRows[0])
+        XCTAssertEqual(parentOrderItemRow.quantity, 2)
+
+        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.childProductRows[0])
+        XCTAssertEqual(childOrderItemRow.quantity, 1)
+    }
+
     func test_bundle_child_order_item_has_canChangeQuantity_false() throws {
         // Given
         let bundleItem = ProductBundleItem.fake().copy(productID: 5)
@@ -2799,14 +2828,10 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                storageManager: storageManager)
 
         // Then
-        XCTAssertEqual(viewModel.productRows.count, 2)
-
         let parentOrderItemRow = try XCTUnwrap(viewModel.productRows[0])
-        XCTAssertEqual(parentOrderItemRow.quantity, 2)
         XCTAssertTrue(parentOrderItemRow.canChangeQuantity)
 
-        let childOrderItemRow = try XCTUnwrap(viewModel.productRows[1])
-        XCTAssertEqual(childOrderItemRow.quantity, 1)
+        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.childProductRows[0])
         XCTAssertFalse(childOrderItemRow.canChangeQuantity)
     }
 
@@ -2830,13 +2855,13 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                storageManager: storageManager)
 
         // Then
-        XCTAssertEqual(viewModel.productRows.count, 2)
+        XCTAssertEqual(viewModel.productRows.count, 1)
 
         let parentOrderItemRow = try XCTUnwrap(viewModel.productRows[0])
         XCTAssertEqual(parentOrderItemRow.quantity, 2)
         XCTAssertTrue(parentOrderItemRow.canChangeQuantity)
 
-        let childOrderItemRow = try XCTUnwrap(viewModel.productRows[1])
+        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.childProductRows[0])
         XCTAssertEqual(childOrderItemRow.quantity, 1)
         XCTAssertTrue(childOrderItemRow.canChangeQuantity)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -66,6 +66,21 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.quantity, 1)
     }
 
+    func test_viewModel_is_created_with_correct_initial_values_from_product_with_child_product_rows() {
+        // Given
+        let product = Product.fake()
+        let childProductRows = [ProductRowViewModel(product: .fake(), canChangeQuantity: false),
+                                ProductRowViewModel(product: .fake(), canChangeQuantity: false)]
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true, childProductRows: childProductRows)
+
+        // Then
+        XCTAssertTrue(viewModel.canChangeQuantity)
+        XCTAssertEqual(viewModel.childProductRows.count, 2)
+        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).canChangeQuantity)
+    }
+
     func test_view_model_creates_expected_label_for_product_with_managed_stock() {
         // Given
         let stockQuantity: Decimal = 7


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11249
Part of https://github.com/woocommerce/woocommerce-ios/issues/10428
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
We want to update the design for bundle products in orders. This PR groups parent and child order items with the following changes:

* Wrap all the bundle product cards in one – so, reduce the gaps between them to zero, and only have rounded corners on the first and last.
* Keep a solid, continuous bottom border between the bundle product and its children.
* Use indented (left and right) bottom borders between all the children products.

I applied this change to all parent/child order items, not just bundle items, for consistency in how they are grouped and displayed on this screen.

Note: There are some remaining tasks for updating the design on this screen: updating how child bundle items appear in the `CollapsibleProductCard` (#11250 - this will make them read-only instead of collapsible/editable) and identifying the parent product (#11251). Those will be done in a separate PR.

## How

This introduces `CollapsibleProductCard` as a higher level UI element that can display a single `CollapsibleProductRowCard` (like before) or a new grouped card style with multiple `CollapsibleProductRowCards` to display parent/child order items together.

To make this work, we have to group parent/child order items for display:

* `ProductRowViewModel` now has `childProductRows` to hold the view models for children of a parent item.
* In `EditableOrderViewModel.createProductRows` we exclude child items (items with a parent) so only the parent items are represented in the order form product rows. Then, when we create the parent's view model in `EditableOrderViewModel.createProductRowViewModel` we get all of the child items and add them to the parent's `ProductRowViewModel.childProductRows`.

Note: One thing from the design that I couldn't get to work quite right was the border styling for expanded cards. The designs show partially rounded black rectangles (e.g. the top corners rounded but the bottom corners straight when the bundle parent is expanded). This will be possible in iOS 16+ with `UnevenRoundedRectangle` but I couldn't find a way to make it work for iOS 15. Instead, I left the borders rounded on all corners when a bundle item row is expanded.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and tap on a non-bundle product to select it
- Tap on a bundle product from the prerequisite
- Configure the bundle and tap "Done"
- Add the products to the order
- On the order form, confirm the non-bundle product looks and behaves as before
- Confirm the bundle items are grouped with a rounded rectangle around the entire group, a solid border under the parent, and indented dividers between the children
- Tap the bundle items and confirm they behave as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Collapsed|Expanded
-|-
![Simulator Screenshot - iPhone 14 Pro - 2023-11-23 at 16 55 27](https://github.com/woocommerce/woocommerce-ios/assets/8658164/3d254082-4cb8-4c46-ab22-bccf7452f463)|![Simulator Screenshot - iPhone 14 Pro - 2023-11-23 at 16 55 32](https://github.com/woocommerce/woocommerce-ios/assets/8658164/c1bbb48d-39ab-4658-a636-14e3069b26a4)


https://github.com/woocommerce/woocommerce-ios/assets/8658164/e034ebd0-c9b8-48a4-b8c3-ade72b8ef1f3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
