### PR TITLE
[Deposit Summary] Currency formatting 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -54,7 +54,7 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
 
     private func formatAmount(_ amount: NSDecimalNumber) -> String {
         if let wooCurrencyFormatter {
-            return wooCurrencyFormatter.formatAmount(amount, numberOfDecimals: 2) ?? ""
+            return wooCurrencyFormatter.formatAmount(amount) ?? ""
         } else {
             return systemCurrencyFormatter.string(from: amount) ?? ""
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -5,13 +5,25 @@ import WooFoundation
 final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     private let overview: WooPaymentsDepositsOverviewByCurrency
     private let analytics: Analytics
+    private let currencySettings: CurrencySettings?
+    private let locale: Locale
 
     init(overview: WooPaymentsDepositsOverviewByCurrency,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         siteCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         locale: Locale = Locale.current) {
         self.overview = overview
         self.analytics = analytics
         self.currency = overview.currency
         self.tabTitle = overview.currency.rawValue.uppercased()
+        self.locale = locale
+
+        if overview.currency == siteCurrencySettings.currencyCode {
+            currencySettings = siteCurrencySettings
+        } else {
+            currencySettings = nil
+        }
+
         setupProperties()
     }
 
@@ -41,7 +53,11 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     @Published var tabTitle: String
 
     private func formatAmount(_ amount: NSDecimalNumber) -> String {
-        return numberFormatter.string(from: amount) ?? ""
+        if let wooCurrencyFormatter {
+            return wooCurrencyFormatter.formatAmount(amount, numberOfDecimals: 2) ?? ""
+        } else {
+            return systemCurrencyFormatter.string(from: amount) ?? ""
+        }
     }
 
     private func nextDepositDateText() -> String {
@@ -80,8 +96,16 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
         return dateFormatter.string(from: date)
     }
 
-    private lazy var numberFormatter: NumberFormatter = {
+    private lazy var wooCurrencyFormatter: CurrencyFormatter? = {
+        guard let currencySettings else {
+            return nil
+        }
+        return CurrencyFormatter(currencySettings: currencySettings)
+    }()
+
+    private lazy var systemCurrencyFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
+        formatter.locale = locale
         formatter.numberStyle = .currency
         formatter.currencyCode = overview.currency.rawValue
         return formatter

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 @testable import WooCommerce
+import WooFoundation
+import Yosemite
 
 final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
 
@@ -52,6 +54,38 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
 
         // Then
         assertEqual(WooConstants.URLs.wooPaymentsDepositSchedule.asURL(), sut.showWebviewURL)
+    }
+
+    func test_when_currency_matches_site_settings_amounts_formatted_using_woo_currency_formatter() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .left,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+        let overview = WooPaymentsDepositsOverviewByCurrency.fake().copy(currency: .USD, availableBalance: .init(string: "12.35"))
+
+        // When
+        sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview, locale: Locale(identifier: "en-ca"))
+
+        // Then
+        assertEqual(sut.availableBalance, "$12.35")
+    }
+
+    func test_when_currency_doesnt_match_site_settings_amounts_formatted_using_system_locale_currency_formatter() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .left,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+        let overview = WooPaymentsDepositsOverviewByCurrency.fake().copy(currency: .CAD, availableBalance: .init(string: "12.35"))
+
+        // When
+        sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview, locale: Locale(identifier: "en-us"))
+
+        // Then
+        assertEqual(sut.availableBalance, "CA$12.35")
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11267 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since currencies are usually formatted according to the site settings, we want to do that in the deposit summary for the default currency. For other currencies, we can't be sure of the appropriate settings for the currency formatting, so instead we should use the system locale-based formatter.

This PR implements and tests the above logic

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a simulator
1. Launch the app and switch to a multi-currency store
2. Observe that the amounts are formatted correctly
3. Switch the region such that the currencies would be shown with a different format
4. Observe that the non-default amount is shown according to the locale, while the default currency is shown as per the site settings.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/b7509121-5cd0-4135-a0fb-e0a5146f71e2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
