### PR TITLE
[Deposit Summary] Enable deposit summary in 16.4 release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -77,7 +77,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .giftCardInOrderForm:
             return true
         case .wooPaymentsDepositsOverviewInPaymentsMenu:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .tapToPayOnIPhoneInUK:
             return true
         case .productBundlesInOrderForm:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables the Deposit summary for all WooPayments merchants.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. Launch the app in a simulator, using a Release scheme
2. Switch to a WooPayments store
3. Navigate to `Menu > Payments`
4. Observe that the deposit summary is shown.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
