### PR TITLE
[UI Test] - Fix Create New Order test - Add support to Custom Amount sheet

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -104,6 +104,7 @@ struct OrderCustomAmountsSection: View {
 
                 }
                 .bodyStyle()
+                .accessibilityIdentifier(Accessibility.fixedAmountIdentifier)
             }
             .padding(.bottom, Layout.optionsBottomSheetContentVerticalSpacing)
 
@@ -117,6 +118,7 @@ struct OrderCustomAmountsSection: View {
                     showAddCustomAmountsAfterOptionsDialog()
                 }
                 .bodyStyle()
+                .accessibilityIdentifier(Accessibility.percentageAmountIdentifier)
             }
 
             Spacer()
@@ -176,5 +178,7 @@ private extension OrderCustomAmountsSection {
 
     enum Accessibility {
         static let addCustomAmountIdentifier = "new-order-add-custom-amount-button"
+        static let fixedAmountIdentifier = "custom-amount-fixed-button"
+        static let percentageAmountIdentifier = "custom-amount-percentage-button"
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -160,10 +160,6 @@ public final class UnifiedOrderScreen: ScreenObject {
         fixedAmountButton.waitAndTap()
     }
 
-    private func selectPercentageOrderTotal() {
-        percentageOfTotalButton.waitAndTap()
-    }
-
     /// Opens the Customer Note screen.
     /// - Returns: Customer Note screen object.
     public func openCustomerNoteScreen() throws -> CustomerNoteScreen {

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -83,7 +83,7 @@ public final class UnifiedOrderScreen: ScreenObject {
     ///
     private var addNoteButton: XCUIElement { addNoteButtonGetter(app) }
 
-    /// Fixed Amount in Custom Amount ssheet.
+    /// Fixed Amount in Custom Amount sheet.
     ///
     private var fixedAmountButton: XCUIElement { fixedAmountButtonGetter(app) }
 

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -41,6 +41,14 @@ public final class UnifiedOrderScreen: ScreenObject {
         $0.buttons["add-customer-note-button"]
     }
 
+    private let fixedAmountButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["custom-amount-fixed-button"]
+    }
+
+    private let percentageOfTotalButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["custom-amount-percentage-button"]
+    }
+
     private var createButton: XCUIElement { createButtonGetter(app) }
 
     /// Cancel button in the Navigation bar.
@@ -74,6 +82,14 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Add Note button in the Customer Note section.
     ///
     private var addNoteButton: XCUIElement { addNoteButtonGetter(app) }
+
+    /// Fixed Amount in Custom Amount ssheet.
+    ///
+    private var fixedAmountButton: XCUIElement { fixedAmountButtonGetter(app) }
+
+    /// Percentage of Order Total Button in Custom Amount ssheet.
+    ///
+    private var percentageOfTotalButton: XCUIElement { percentageOfTotalButtonGetter(app) }
 
     public enum Flow {
         case creation
@@ -136,7 +152,16 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// - Returns: Add Custom Amount screen object.
     public func openAddCustomAmountScreen() throws -> AddCustomAmountScreen {
         addCustomAmountButton.tap()
+        selectFixedAmount()
         return try AddCustomAmountScreen()
+    }
+
+    private func selectFixedAmount() {
+        fixedAmountButton.waitAndTap()
+    }
+
+    private func selectPercentageOrderTotal() {
+        percentageOfTotalButton.waitAndTap()
     }
 
     /// Opens the Customer Note screen.

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -36,8 +36,7 @@ final class OrdersTests: XCTestCase {
             .addProduct(byName: "Black Coral shades")
             .addCustomerDetails(name: order.billing.first_name)
             .addShipping(amount: order.shipping_lines[0].total, name: order.shipping_lines[0].method_title)
-            // Disabled temporarily until we add support for the custom amounts options dialog
-            //.addCustomAmount(amount: order.fee_lines[1].amount)
+            .addCustomAmount(amount: order.fee_lines[1].amount)
             .addCustomerNote(order.customer_note)
             .createOrder()
             .verifySingleOrderScreenLoaded()


### PR DESCRIPTION
## Description
This PR re-enables the `.addCustomAmount(amount: order.fee_lines[1].amount)` step in `test_create_new_order()` by adding support to the recently added bottom sheet to select whether to add the custom amount as a fixed amount or percentage.

![image](https://github.com/woocommerce/woocommerce-ios/assets/42008628/0433e7d8-fce8-4921-b205-6d5d8b14592d)


## Testing instructions
test_create_new_order should now work as expected and CI should be 🟢

