### PR TITLE
Move Blaze section under Stats in Dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [Internal] Payments: Updated StripeTerminal pod to 3.1.0 [https://github.com/woocommerce/woocommerce-ios/pull/11080]
 - [***] Merchants can now create or edit subscription products. [https://github.com/woocommerce/woocommerce-ios/issues/11183]
 - [*] Order form: when adding/updating a bundle with an optional & non-selected variable item, any other bundled items should be added/updated properly. [https://github.com/woocommerce/woocommerce-ios/pull/11254]
-- [*] Now the Blaze section in the Dashboard (My store tab) is displayed under the Stats. [https://github.com/woocommerce/woocommerce-ios/pull/11275]
+- [*] Now the Blaze section in the Dashboard (My store tab) is displayed under the Stats. Before, it was on top of the view. [https://github.com/woocommerce/woocommerce-ios/pull/11275]
 
 16.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [Internal] Payments: Updated StripeTerminal pod to 3.1.0 [https://github.com/woocommerce/woocommerce-ios/pull/11080]
 - [***] Merchants can now create or edit subscription products. [https://github.com/woocommerce/woocommerce-ios/issues/11183]
 - [*] Order form: when adding/updating a bundle with an optional & non-selected variable item, any other bundled items should be added/updated properly. [https://github.com/woocommerce/woocommerce-ios/pull/11254]
+- [*] Now the Blaze section in the Dashboard (My store tab) is displayed under the Stats. [https://github.com/woocommerce/woocommerce-ios/pull/11275]
 
 16.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -360,15 +360,15 @@ private extension DashboardViewController {
         containerStackView.insertArrangedSubview(contentView, at: indexAfterHeader)
     }
 
-    func addViewBelowOnboardingCard(_ contentView: UIView) {
+    func addViewBelowStats(_ contentView: UIView) {
         let indexOfHeader = containerStackView.arrangedSubviews.firstIndex(of: headerStackView) ?? -1
-        let indexAfterOnboardingCard: Int = {
-            if let onboardingView {
-                return (containerStackView.arrangedSubviews.firstIndex(of: onboardingView) ?? indexOfHeader) + 1
+        let indexAfterStats: Int = {
+            if let storeStatsAndTopPerformersViewControllerView = self.storeStatsAndTopPerformersViewController.view {
+                return (containerStackView.arrangedSubviews.firstIndex(of: storeStatsAndTopPerformersViewControllerView) ?? indexOfHeader) + 1
             }
             return indexOfHeader + 1
         }()
-        containerStackView.insertArrangedSubview(contentView, at: indexAfterOnboardingCard)
+        containerStackView.insertArrangedSubview(contentView, at: indexAfterStats)
     }
 
     func configureStackView() {
@@ -814,7 +814,7 @@ extension DashboardViewController {
             return
         }
         campaignView.translatesAutoresizingMaskIntoConstraints = false
-        addViewBelowOnboardingCard(campaignView)
+        addViewBelowStats(campaignView)
         addChild(hostingController)
         hostingController.didMove(toParent: self)
         blazeCampaignHostingController = hostingController


### PR DESCRIPTION
Given the changes requested here pe5sF9-2fS-p2  to move the Blaze section in the Dashboard under stats, this PR introduces a new method `addViewBelowStats` to add a view below the statistics view. The method first finds the index of the `headerStackView` in `containerStackView`. Then, it checks if `storeStatsAndTopPerformersViewController.view` exists and if it does, it finds its index in the `containerStackView`. If it doesn't exist, it defaults to the index of `headerStackView`.

The `showBlazeCampaignView` method has been updated to use this new `addViewBelowStats` method instead of `addViewBelowOnboardingCard`. This ensures that the Blaze Campaign View is added below the stats view.

Screenshots:

| Before |  After |
:-------------------------:|:-------------------------:
![Before](https://github.com/woocommerce/woocommerce-ios/assets/495617/627d8bb7-824f-40cd-93ba-33c244cf902f) | ![After](https://github.com/woocommerce/woocommerce-ios/assets/495617/05aaa034-d821-429a-9e7b-c4a9b8ff6125)
 