### PR TITLE
Product Subscriptions: Variable subscription use default values if subscription is `nil`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -22,7 +22,7 @@ final class EditableProductVariationModel {
 
         /// Assigning default subscription value for a variable subscription type product if `nil`
         ///
-        /// The API sometimes doesn't send any value for variation's subscription even thought the parent product type is `variableSubscription`.
+        /// The API sometimes doesn't send any value for variation's subscription even though the parent product type is `variableSubscription`.
         ///
         /// https://github.com/woocommerce/woocommerce-ios/issues/11258
         ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -3,19 +3,40 @@ import Yosemite
 /// Represents an editable data model based on `ProductVariation`.
 final class EditableProductVariationModel {
     let productVariation: ProductVariation
+    private let parentProductType: ProductType
 
     let allAttributes: [ProductAttribute]
     let parentProductDisablesQuantityRules: Bool?
 
-    init(productVariation: ProductVariation, allAttributes: [ProductAttribute], parentProductSKU: String?, parentProductDisablesQuantityRules: Bool?) {
+    init(productVariation: ProductVariation,
+         parentProductType: ProductType,
+         allAttributes: [ProductAttribute],
+         parentProductSKU: String?,
+         parentProductDisablesQuantityRules: Bool?) {
         self.allAttributes = allAttributes
 
         // API sets a variation's SKU to be its parent product's SKU by default.
         // However, variation API update will fail if we send the variation's SKU as its parent product's SKU (duplicate SKU error).
         // As a workaround, we set a variation's SKU to nil if it has the same SKU as its parent product during initialization.
         let sku = parentProductSKU == productVariation.sku ? nil: productVariation.sku
-        self.productVariation = productVariation.copy(sku: sku)
 
+        /// Assigning default subscription value for a variable subscription type product if `nil`
+        ///
+        /// The API sometimes doesn't send any value for variation's subscription even thought the parent product type is `variableSubscription`.
+        ///
+        /// https://github.com/woocommerce/woocommerce-ios/issues/11258
+        ///
+        let subscription: ProductSubscription? = {
+            guard parentProductType == .variableSubscription && productVariation.subscription == nil else {
+                return productVariation.subscription
+            }
+
+            return .empty
+        }()
+
+        self.productVariation = productVariation.copy(sku: sku, subscription: subscription)
+
+        self.parentProductType = parentProductType
         self.parentProductDisablesQuantityRules = parentProductDisablesQuantityRules
     }
 }
@@ -94,7 +115,7 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
     }
 
     var productType: ProductType {
-        .variable
+        parentProductType
     }
 
     var weight: String? {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -207,6 +207,7 @@ extension ProductVariationFormViewModel {
             return
         }
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(image: images.first),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -214,6 +215,7 @@ extension ProductVariationFormViewModel {
 
     func updateDescription(_ newDescription: String) {
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(description: newDescription),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -253,6 +255,7 @@ extension ProductVariationFormViewModel {
                 taxClass: taxClass?.slug,
                 subscription: subscription
             ),
+            parentProductType: productVariation.productType,
             allAttributes: allAttributes,
             parentProductSKU: parentProductSKU,
             parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -269,6 +272,7 @@ extension ProductVariationFormViewModel {
                                                                                                                   stockQuantity: stockQuantity,
                                                                                                                   stockStatus: stockStatus,
                                                                                                                   backordersKey: backordersSetting?.rawValue),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -279,6 +283,7 @@ extension ProductVariationFormViewModel {
                                                  dimensions: dimensions,
                                                  shippingClass: shippingClass ?? "",
                                                  shippingClassID: shippingClassID ?? 0),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -320,6 +325,7 @@ extension ProductVariationFormViewModel {
         ServiceLocator.analytics.track(.productVariationDetailViewStatusSwitchTapped)
         let status: ProductStatus = isEnabled ? .published: .privateStatus
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(status: status),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -335,6 +341,7 @@ extension ProductVariationFormViewModel {
 
     func updateVariationAttributes(_ attributes: [ProductVariationAttribute]) {
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(attributes: attributes),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -348,6 +355,7 @@ extension ProductVariationFormViewModel {
         let subscription = productVariation.subscription?.copy(trialLength: trialLength,
                                                                trialPeriod: trialPeriod)
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(subscription: subscription),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -356,6 +364,7 @@ extension ProductVariationFormViewModel {
     func updateSubscriptionExpirySettings(length: String) {
         let subscription = productVariation.subscription?.copy(length: length)
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(subscription: subscription),
+                                                         parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -377,6 +386,7 @@ extension ProductVariationFormViewModel {
             case .success(let productVariation):
                 ServiceLocator.analytics.track(.productVariationDetailUpdateSuccess)
                 let model = EditableProductVariationModel(productVariation: productVariation,
+                                                          parentProductType: self.productVariation.productType,
                                                           allAttributes: self.allAttributes,
                                                           parentProductSKU: self.parentProductSKU,
                                                           parentProductDisablesQuantityRules: self.parentProductDisablesQuantityRules)
@@ -424,12 +434,14 @@ extension ProductVariationFormViewModel {
                 case .success(let images):
                     let currentProduct = self.productVariation
                     self.resetProductVariation(.init(productVariation: self.originalProductVariation.productVariation.copy(image: images.first),
+                                                     parentProductType: productVariation.productType,
                                                      allAttributes: self.allAttributes,
                                                      parentProductSKU: self.parentProductSKU,
                                                      parentProductDisablesQuantityRules: self.parentProductDisablesQuantityRules))
                     // Because `resetProductVariation` also internally updates the latest `productVariation`, the
                     // `productVariation` is set with the value before `resetProductVariation` to retain any local changes.
                     self.productVariation = .init(productVariation: currentProduct.productVariation,
+                                                  parentProductType: productVariation.productType,
                                                   allAttributes: self.allAttributes,
                                                   parentProductSKU: self.parentProductSKU,
                                                   parentProductDisablesQuantityRules: self.parentProductDisablesQuantityRules)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -37,6 +37,7 @@ private extension ProductVariationDetailsFactory {
                                         productImageUploader: ProductImageUploaderProtocol) -> UIViewController {
         let vc: UIViewController
         let productVariationModel = EditableProductVariationModel(productVariation: productVariation,
+                                                                  parentProductType: parentProduct.productType,
                                                                   allAttributes: parentProduct.attributes,
                                                                   parentProductSKU: parentProduct.sku,
                                                                   parentProductDisablesQuantityRules: parentProduct.combineVariationQuantities)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -100,6 +100,10 @@ final class ProductVariationsViewController: UIViewController, GhostableViewCont
         product.sku
     }
 
+    private var parentProductType: ProductType {
+        product.productType
+    }
+
     private var parentProductDisablesQuantityRules: Bool? {
         product.combineVariationQuantities
     }
@@ -399,6 +403,7 @@ extension ProductVariationsViewController: UITableViewDataSource {
 
         let productVariation = resultsController.object(at: indexPath)
         let model = EditableProductVariationModel(productVariation: productVariation,
+                                                  parentProductType: parentProductType,
                                                   allAttributes: allAttributes,
                                                   parentProductSKU: parentProductSKU,
                                                   parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
@@ -529,6 +534,7 @@ private extension ProductVariationsViewController {
 
     private func navigateToVariationDetail(for productVariation: ProductVariation) {
         let model = EditableProductVariationModel(productVariation: productVariation,
+                                                  parentProductType: parentProductType,
                                                   allAttributes: allAttributes,
                                                   parentProductSKU: parentProductSKU,
                                                   parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
@@ -176,6 +176,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
                                                                                 groupOfQuantity: "4",
                                                                                 overrideProductQuantities: true)
         let model = EditableProductVariationModel(productVariation: productVariation,
+                                                  parentProductType: .variable,
                                                   allAttributes: [],
                                                   parentProductSKU: nil,
                                                   parentProductDisablesQuantityRules: false)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
@@ -166,6 +166,55 @@ final class EditableProductVariationModelTests: XCTestCase {
         XCTAssertEqual(model.productVariation.sku, sku)
     }
 
+    // MARK: - `subscription`
+
+    func test_it_sets_default_values_for_subscription_when_given_variation_has_nil_subscription_and_parentProductType_is_variableSubscription() {
+        // Given
+        let variation = MockProductVariation().productVariation().copy(subscription: nil)
+
+        // When
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variableSubscription,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: nil)
+
+        // Then
+        XCTAssertEqual(model.productVariation.subscription, .empty)
+    }
+
+    func test_it_does_not_alter_subscription_value_when_parentProductType_is_not_variableSubscription() {
+        // Given
+        let mockSubscription = ProductSubscription.fake().copy(price: "10")
+        let variation = MockProductVariation().productVariation().copy(subscription: mockSubscription)
+
+        // When
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variable,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: nil)
+
+        // Then
+        XCTAssertEqual(model.productVariation.subscription, mockSubscription)
+    }
+
+    func test_it_does_not_alter_subscription_value_when_given_variation_has_non_nil_subscription() {
+        // Given
+        let mockSubscription = ProductSubscription.fake().copy(price: "10")
+        let variation = MockProductVariation().productVariation().copy(subscription: mockSubscription)
+
+        // When
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variableSubscription,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: nil)
+
+        // Then
+        XCTAssertEqual(model.productVariation.subscription, mockSubscription)
+    }
+
     // MARK: - `hasQuantityRules`
 
     func test_hasQuantityRules_is_false_for_a_variation_with_nil_quantity_rules() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
@@ -22,6 +22,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let name = EditableProductVariationModel(productVariation: variation,
+                                                 parentProductType: .variable,
                                                  allAttributes: allAttributes,
                                                  parentProductSKU: nil,
                                                  parentProductDisablesQuantityRules: nil).name
@@ -49,6 +50,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let name = EditableProductVariationModel(productVariation: variation,
+                                                 parentProductType: .variable,
                                                  allAttributes: allAttributes,
                                                  parentProductSKU: nil,
                                                  parentProductDisablesQuantityRules: nil).name
@@ -137,6 +139,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variable,
                                                   allAttributes: [],
                                                   parentProductSKU: sku,
                                                   parentProductDisablesQuantityRules: nil)
@@ -153,6 +156,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variable,
                                                   allAttributes: [],
                                                   parentProductSKU: "",
                                                   parentProductDisablesQuantityRules: nil)
@@ -181,6 +185,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variable,
                                                   allAttributes: [],
                                                   parentProductSKU: nil,
                                                   parentProductDisablesQuantityRules: false)
@@ -195,6 +200,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variable,
                                                   allAttributes: [],
                                                   parentProductSKU: nil,
                                                   parentProductDisablesQuantityRules: false)
@@ -209,6 +215,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variable,
                                                   allAttributes: [],
                                                   parentProductSKU: nil,
                                                   parentProductDisablesQuantityRules: false)
@@ -223,6 +230,7 @@ final class EditableProductVariationModelTests: XCTestCase {
 
         // Action
         let model = EditableProductVariationModel(productVariation: variation,
+                                                  parentProductType: .variable,
                                                   allAttributes: [],
                                                   parentProductSKU: nil,
                                                   parentProductDisablesQuantityRules: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -287,7 +287,11 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
 // Helper in unit tests
 extension EditableProductVariationModel {
     convenience init(productVariation: ProductVariation) {
-        self.init(productVariation: productVariation, allAttributes: [], parentProductSKU: nil, parentProductDisablesQuantityRules: nil)
+        self.init(productVariation: productVariation,
+                  parentProductType: .variable,
+                  allAttributes: [],
+                  parentProductSKU: nil,
+                  parentProductDisablesQuantityRules: nil)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11258
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

### Problem 
The API doesn't send the subscription-related metadata fields in a product variation's response even though the parent product's type is variable subscription. 


### Fix
We are setting default values for the product variation when it is `nil` and the parent product type is is variable subscription.


## Testing instructions

1. create a regular variable product,
2. set attributes and generate some variations,
3. bulk update the variations to have some price,
4. go back to the main product and change its product type to variable subscriptions,
5. save changes,
6. go to a variation, 
7. validate that you can see subscription-related fields Price, Free trial, Expiration dates.

## Screenshots

Subscription related fields in variation form

<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/d56f88a5-7a5d-48ce-b55d-9b209ebe6422" width="320"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
