### PR TITLE
[Order Creation] Fix discount screen showing the wrong product details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [internal] Payments: Restored analytics for Payments Menu after SwiftUI rewrite [https://github.com/woocommerce/woocommerce-ios/pull/11262]
 - [***] Merchants can now create or edit subscription products. [https://github.com/woocommerce/woocommerce-ios/issues/11183]
 - [*] Order form: when adding/updating a bundle with an optional & non-selected variable item, any other bundled items should be added/updated properly. [https://github.com/woocommerce/woocommerce-ios/pull/11254]
+- [internal] Order form: Fix a bug where the wrong product details appeared when adding a discount to a product in an order. [https://github.com/woocommerce/woocommerce-ios/pull/11280]
 
 16.3
 -----

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -84,7 +84,7 @@
       },
       {
         "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": null,
           "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -453,12 +453,12 @@ private struct ProductsSection: View {
                                            shouldDisableDiscountEditing: viewModel.paymentDataViewModel.isLoading,
                                            shouldDisallowDiscounts: viewModel.shouldDisallowDiscounts,
                                            onAddDiscount: viewModel.selectOrderItem)
-                    .sheet(item: $viewModel.selectedProductViewModel, content: { productViewModel in
-                        ProductDiscountView(imageURL: productRow.imageURL,
-                                            name: productRow.name,
-                                            stockLabel: productRow.stockQuantityLabel,
-                                            productRowViewModel: productRow,
-                                            discountViewModel: productViewModel.discountDetailsViewModel)
+                    .sheet(item: $viewModel.selectedProductViewModel, content: { selectedProduct in
+                        ProductDiscountView(imageURL: selectedProduct.productRowViewModel.imageURL,
+                                            name: selectedProduct.productRowViewModel.name,
+                                            stockLabel: selectedProduct.productRowViewModel.stockQuantityLabel,
+                                            productRowViewModel: selectedProduct.productRowViewModel,
+                                            discountViewModel: selectedProduct.discountDetailsViewModel)
                     })
                     .sheet(item: $viewModel.configurableProductViewModel) { configurableProductViewModel in
                         ConfigurableBundleProductView(viewModel: configurableProductViewModel)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11269
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
While testing changes to the order creation screen (https://github.com/woocommerce/woocommerce-ios/pull/11268#issuecomment-1824762159) I noticed that the discount screen wasn't fully reusable. It was always showing the same product details.

This fixes the discount screen so it displays the product details for the selected product (the product row where "Add Discount" is tapped).

## How
When using a `sheet` with a `ForEach` loop, the sheet isn't recreated for each element in the loop. We were relying on `productRow` (the view model from the `ForEach` loop of `viewModel.productRows`) instead of `viewModel.selectedProductViewModel` (the specific item used as the data source for the sheet) to display the product details in `ProductDiscountView`.

This updates `ProductDiscountView` to use the selected view model from `$viewModel.selectedProductViewModel` for everything in the view. I also renamed it to `selectedProduct` for clarity (to distinguish it from `productRow`).

## Testing instructions

1. Go to the Orders tab
2. Tap `+` to create an order
3. Add multiple products to the order
4. Expand each product and tap "Add Discount" to open the discount screen. Confirm the correct product details are displayed for the product you selected.

## Screenshots


https://github.com/woocommerce/woocommerce-ios/assets/8658164/90790b24-dc65-4edd-b7bd-71c462ca79e9




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
