### PR TITLE
[Mobile Payments] Fix Set up Tap to Pay and Manage Card Reader flows

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsFlowPresentingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsFlowPresentingView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import Yosemite
+
+struct CardReaderSettingsFlowPresentingView: View {
+    let configuration: CardPresentPaymentsConfiguration
+    let siteID: Int64
+
+    var body: some View {
+        PaymentSettingsFlowPresentingView(
+            viewModelsAndViews: CardReaderSettingsViewModelsOrderedList(
+                configuration: configuration,
+                siteID: siteID)
+        )
+    }
+}
+
+struct CardReaderSettingsFlowPresentingView_Previews: PreviewProvider {
+    static var previews: some View {
+        CardReaderSettingsFlowPresentingView(configuration: .init(country: .US),
+                                             siteID: 12345)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsFlowPresentingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsFlowPresentingView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 import Yosemite
 
+/// This wrapper exists to ensure that the `CardReaderSettingsViewModelsOrderedList` has the same lifecycle as the
+/// view which presents it. If it doesn't, it's likely that the view model will cause unwanted disconnections
+/// from Tap to Pay when it's connected in other parts of the app.
 struct CardReaderSettingsFlowPresentingView: View {
     let configuration: CardPresentPaymentsConfiguration
     let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
@@ -79,6 +79,12 @@ private extension PaymentSettingsFlowPresentingViewController {
 
 // MARK: - SwiftUI compatibility
 //
+
+/// N.B. this should not be used directly for the two concrete use cases it enables
+/// `SetUpTapToPayViewModelsOrderedList` and `CardReaderSettingsViewModelsOrderedList`
+/// If you use it directly, the view models will outlive the views, and likely disconnect readers which we subsequently connect to.
+/// Instead, use one of these wrappers, to ensure the view model has the same lifecycle as the view:
+/// `TapToPaySettingsFlowPresentingView` or `CardReaderSettingsFlowPresentingView`
 struct PaymentSettingsFlowPresentingView: UIViewControllerRepresentable {
     typealias UIViewControllerType = PaymentSettingsFlowPresentingViewController
     let viewModelsAndViews: PaymentSettingsFlowPrioritizedViewModelsProvider

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPaySettingsFlowPresentingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPaySettingsFlowPresentingView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import Yosemite
 
+
+/// This wrapper exists to ensure that the `SetUpTapToPayViewModelsOrderedList` has the same lifecycle as the
+/// view which presents it. If it doesn't, it's likely that the view model will cause unwanted disconnections
+/// from Bluetooth readers which are connected in other parts of the app.
 struct TapToPaySettingsFlowPresentingView: View {
     let configuration: CardPresentPaymentsConfiguration
     let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPaySettingsFlowPresentingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPaySettingsFlowPresentingView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import Yosemite
+
+struct TapToPaySettingsFlowPresentingView: View {
+    let configuration: CardPresentPaymentsConfiguration
+    let siteID: Int64
+    let onboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol
+
+    var body: some View {
+        PaymentSettingsFlowPresentingView(
+            viewModelsAndViews: SetUpTapToPayViewModelsOrderedList(
+                siteID: siteID,
+                configuration: configuration,
+                onboardingUseCase: onboardingUseCase)
+            )
+    }
+}
+
+struct TapToPaySettingsFlowPresentingView_Previews: PreviewProvider {
+    static var previews: some View {
+        TapToPaySettingsFlowPresentingView(configuration: .init(country: .US),
+                                           siteID: 12345,
+                                           onboardingUseCase: CardPresentPaymentsOnboardingUseCase())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -65,8 +65,10 @@ struct InPersonPaymentsMenu: View {
                             }
                         }) {
                             NavigationView {
-                                PaymentSettingsFlowPresentingView(
-                                    viewModelsAndViews: viewModel.setUpTapToPayViewModelsAndViews)
+                                TapToPaySettingsFlowPresentingView(
+                                    configuration: viewModel.cardPresentPaymentsConfiguration,
+                                    siteID: viewModel.siteID,
+                                    onboardingUseCase: viewModel.onboardingUseCase)
                                 .navigationBarHidden(true)
                             }
                         }
@@ -114,7 +116,9 @@ struct InPersonPaymentsMenu: View {
                             PaymentsRow(image: Image(uiImage: .creditCardIcon),
                                         title: Localization.manageCardReader,
                                         isActive: $viewModel.presentManageCardReaders) {
-                                PaymentSettingsFlowPresentingView(viewModelsAndViews: viewModel.manageCardReadersViewModelsAndViews)
+                                CardReaderSettingsFlowPresentingView(
+                                    configuration: viewModel.cardPresentPaymentsConfiguration,
+                                    siteID: viewModel.siteID)
                             }
                         }
                         .disabled(viewModel.shouldDisableManageCardReaders)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -114,11 +114,21 @@ struct InPersonPaymentsMenu: View {
                             viewModel.manageCardReadersTapped()
                         } label: {
                             PaymentsRow(image: Image(uiImage: .creditCardIcon),
-                                        title: Localization.manageCardReader,
-                                        isActive: $viewModel.presentManageCardReaders) {
+                                        title: Localization.manageCardReader)
+                        }
+                        .sheet(isPresented: $viewModel.presentManageCardReaders,
+                               onDismiss: {
+                            Task { @MainActor in
+                                await viewModel.onAppear()
+                            }
+                        }) {
+                            NavigationView {
                                 CardReaderSettingsFlowPresentingView(
                                     configuration: viewModel.cardPresentPaymentsConfiguration,
                                     siteID: viewModel.siteID)
+                                .navigationBarItems(leading: Button(Localization.done, action: {
+                                    viewModel.presentManageCardReaders = false
+                                }))
                             }
                         }
                         .disabled(viewModel.shouldDisableManageCardReaders)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -67,11 +67,11 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     private let dependencies: Dependencies
 
-    private var cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration {
+    var cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration {
         dependencies.cardPresentPaymentsConfiguration
     }
 
-    private var onboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol {
+    var onboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol {
         dependencies.onboardingUseCase
     }
 
@@ -190,25 +190,12 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
         presentManagePaymentGateways = false
     }
 
-    lazy var setUpTapToPayViewModelsAndViews: SetUpTapToPayViewModelsOrderedList = {
-        SetUpTapToPayViewModelsOrderedList(
-            siteID: siteID,
-            configuration: cardPresentPaymentsConfiguration,
-            onboardingUseCase: onboardingUseCase)
-    }()
-
     lazy var aboutTapToPayViewModel: AboutTapToPayViewModel = {
         AboutTapToPayViewModel(
             siteID: siteID,
             configuration: cardPresentPaymentsConfiguration,
             cardPresentPaymentsOnboardingUseCase: onboardingUseCase,
             shouldAlwaysHideSetUpTapToPayButton: shouldAlwaysHideSetUpButtonOnAboutTapToPay)
-    }()
-
-    lazy var manageCardReadersViewModelsAndViews: CardReaderSettingsViewModelsOrderedList = {
-        CardReaderSettingsViewModelsOrderedList(
-            configuration: cardPresentPaymentsConfiguration,
-            siteID: siteID)
     }()
 
     lazy var purchaseCardReaderWebViewModel: PurchaseCardReaderWebViewViewModel = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -719,6 +719,8 @@
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
+		20A3AFE32B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */; };
+		20A3AFE52B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE42B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift */; };
 		20AE33C52B0510BF00527B60 /* PaymentsMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */; };
 		20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C62B0510D200527B60 /* HubMenuDestination.swift */; };
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
@@ -3295,6 +3297,8 @@
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
+		20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsFlowPresentingView.swift; sourceTree = "<group>"; };
+		20A3AFE42B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPaySettingsFlowPresentingView.swift; sourceTree = "<group>"; };
 		20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsMenuDestination.swift; sourceTree = "<group>"; };
 		20AE33C62B0510D200527B60 /* HubMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubMenuDestination.swift; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
@@ -7233,6 +7237,8 @@
 				314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */,
 				3188533B2639FE5800F66A9C /* PaymentSettingsFlowPresentedViewModel.swift */,
 				318853352639FC9C00F66A9C /* PaymentSettingsFlowPresentingViewController.swift */,
+				20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */,
+				20A3AFE42B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift */,
 				31EF399B26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift */,
 				31B19B66263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift */,
 				0365986829AFB0C100F297D3 /* SetUpTapToPayInformationViewModel.swift */,
@@ -12938,6 +12944,7 @@
 				021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */,
 				CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */,
 				B6440FB6292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift in Sources */,
+				20A3AFE52B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift in Sources */,
 				D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */,
 				317F679826420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift in Sources */,
 				DE279BA426E9C4DC002BA963 /* ShippingLabelPackagesForm.swift in Sources */,
@@ -13449,6 +13456,7 @@
 				020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */,
 				2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */,
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
+				20A3AFE32B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
 				02BA53432A380D7D0069224D /* ProductDescriptionAICoordinator.swift in Sources */,
 				EED028662A7AB53900C5DE03 /* StoreCreationChallengesQuestionViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

**_I broke In Person Payments_** 😬

Prior to this change, the two flows for IPP settings from the new SwiftUI Payments Menu were broken.

Both their view models were created when the Payments Menu loaded, and each immediately started listening for card reader connections. Any connection of a reader which didn’t match their type would result in it being automatically disconnected.

Since both were listening, any Bluetooth readers were disconnected by the Tap to Pay flow, and the Tap to Pay reader was disconnected by the Bluetooth reader flow. This made it impossible to take any In Person Payment after opening the Payments Menu.

When previously presented from UIKit, the lifecycle was different; the flow view models weren’t created until the user opened either flow, and they were disposed of when they dismissed the flow. This meant they were only listening for readers when the flow was on screen.

To fix this in SwiftUI, we use a wrapper view. The `CardReaderSettingsFlowPresentingView` and `TapToPaySettingsFlowPresentingView` are responsible for making the view models for the flows, and only do it when their `body` function is called. This happens when the wrapper is presented (i.e. the user opens the flow) not when it’s created (i.e. when the user opens the menu.

When the wrapper is dismissed, the viewModels are disposed of.

This gives us the same lifecycle as we had in UIKit, and restores the expected functionality.

### Known issues
If you have one of reader flows open in the Payments tab, and you switch to the orders tab to take a payment there, attempts to use the other reader type for payment in the orders tab will fail with payment interrupted, as shown in the video. This is _probably_ pre-existing, but I'm checking that.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Switch to a UK or US-based WooPayments store
3. Navigate to `Menu > Payments`
4. Tap `Set up Tap to Pay on iPhone`
5. Observe that you can complete the flow and test payment

Before the fix, this would have been impossible; you'd have got the `Payment interrupted` error when the built in reader was auto-disconnected by the Manage Card Readers flow.

1. Continue by opening the Manage Card Readers flow
2. Observe that the autoconnection starts if you have a known reader, or tap Connect
3. Go through the flow
4. Observe that you can finish it and connect to a reader

This would also have been impossible, for the same reason as above.

Take some more payments via the various ways of doing it, switching between TTP and Card Reader, observe that each is disconnected automatically as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/fb251c96-3789-4da4-b833-83364a941ed2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
