### PR TITLE
[Deposit Summary] Deposit summary and Payments Menu accessibility improvements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -60,6 +60,7 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityAddTraits(.isHeader)
                 LazyVGrid(columns: [GridItem(.flexible(maximum: 70), alignment: .leading),
                                     GridItem(alignment: .leading),
                                     GridItem(alignment: .trailing)],
@@ -118,6 +119,7 @@ struct AccountSummaryItem: View {
         VStack(alignment: .leading, spacing: 4) {
             Text(title)
                 .font(.subheadline)
+                .accessibilityAddTraits(.isHeader)
 
             Text(amount)
                 .font(.title2)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -36,6 +36,7 @@ struct InPersonPaymentsMenu: View {
                         }
                     } header: {
                         Text(Localization.paymentActionsSectionTitle.uppercased())
+                            .accessibilityAddTraits(.isHeader)
                     }
 
                     if let payInPersonToggleViewModel = viewModel.payInPersonToggleViewModel as? InPersonPaymentsCashOnDeliveryToggleRowViewModel {
@@ -48,6 +49,7 @@ struct InPersonPaymentsMenu: View {
                             .padding(.vertical, Layout.cellVerticalPadding)
                         } header: {
                             Text(Localization.paymentSettingsSectionTitle.uppercased())
+                                .accessibilityAddTraits(.isHeader)
                         }
                     }
 
@@ -93,6 +95,7 @@ struct InPersonPaymentsMenu: View {
                         .renderedIf(viewModel.shouldShowTapToPayFeedbackRow)
                     } header: {
                         Text(Localization.tapToPaySectionTitle.uppercased())
+                            .accessibilityAddTraits(.isHeader)
                     }
                     .renderedIf(viewModel.shouldShowTapToPaySection)
 
@@ -131,6 +134,7 @@ struct InPersonPaymentsMenu: View {
                         .accessibilityIdentifier(AccessibilityIdentifiers.cardReaderManualRow)
                     } header: {
                         Text(Localization.cardReaderSectionTitle.uppercased())
+                            .accessibilityAddTraits(.isHeader)
                     } footer: {
                         InPersonPaymentsLearnMore(viewModel: .inPersonPayments(source: .paymentsMenu),
                                                   showInfoIcon: false)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -83,6 +83,7 @@ struct InPersonPaymentsMenu: View {
                                 AboutTapToPayView(viewModel: viewModel.aboutTapToPayViewModel)
                             }
                         }
+                        .buttonStyle(.scrollViewRow)
 
                         PaymentsRow(image: Image(uiImage: .feedbackOutlineIcon.withRenderingMode(.alwaysTemplate)),
                                     title: Localization.tapToPayOnIPhoneFeedback)
@@ -112,6 +113,7 @@ struct InPersonPaymentsMenu: View {
                                                      viewModel: viewModel.purchaseCardReaderWebViewModel)
                             }
                         }
+                        .buttonStyle(.scrollViewRow)
 
                         Button {
                             viewModel.manageCardReadersTapped()
@@ -122,6 +124,7 @@ struct InPersonPaymentsMenu: View {
                                 PaymentSettingsFlowPresentingView(viewModelsAndViews: viewModel.manageCardReadersViewModelsAndViews)
                             }
                         }
+                        .buttonStyle(.scrollViewRow)
                         .disabled(viewModel.shouldDisableManageCardReaders)
 
                         Button {
@@ -133,6 +136,7 @@ struct InPersonPaymentsMenu: View {
                                 CardReaderManualsView()
                             }
                         }
+                        .buttonStyle(.scrollViewRow)
                         .accessibilityIdentifier(AccessibilityIdentifiers.cardReaderManualRow)
                     } header: {
                         Text(Localization.cardReaderSectionTitle.uppercased())
@@ -157,6 +161,7 @@ struct InPersonPaymentsMenu: View {
                             }
                             .padding(.vertical, Layout.cellVerticalPadding)
                         }
+                        .buttonStyle(.scrollViewRow)
                         .renderedIf(viewModel.shouldShowManagePaymentGatewaysRow)
                     }
                     .renderedIf(viewModel.shouldShowPaymentOptionsSection)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -57,6 +57,7 @@ struct InPersonPaymentsMenu: View {
                         PaymentsRow(image: Image(uiImage: .tapToPayOnIPhoneIcon),
                                     title: viewModel.setUpTryOutTapToPayRowTitle,
                                     shouldBadgeImage: viewModel.shouldBadgeTapToPayOnIPhone)
+                        .accessibilityAddTraits(.isButton)
                         .onTapGesture {
                             viewModel.setUpTryOutTapToPayTapped()
                         }
@@ -85,6 +86,7 @@ struct InPersonPaymentsMenu: View {
 
                         PaymentsRow(image: Image(uiImage: .feedbackOutlineIcon.withRenderingMode(.alwaysTemplate)),
                                     title: Localization.tapToPayOnIPhoneFeedback)
+                        .accessibility(addTraits: .isButton)
                         .foregroundColor(Color(uiColor: .textLink))
                         .onTapGesture {
                             viewModel.tapToPayFeedbackTapped()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
@@ -48,7 +48,6 @@ struct PaymentsRow<Destination>: View where Destination: View {
 
             Spacer()
         }
-        .foregroundColor(.primary)
         .contentShape(Rectangle())
 
         navigationLink

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -50,6 +50,8 @@ struct TopTabView: View {
                                                 scrollViewProxy.scrollTo(index, anchor: .center)
                                             }
                                         }
+                                        .accessibilityAddTraits(.isButton)
+                                        .accessibilityAddTraits(selectedTab == index ? [.isSelected, .isHeader] : [])
                                 }
                                 .padding()
                                 .background(GeometryReader { geometry in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11279
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds the various traits to parts of the Payments menu to ensure it's easily accessible with VO.

### Changes:
- Payments menu section headers are now marked as headings, for quicker navigation.
- The active currency tab in the deposit summary is annouced as `selected` and as a heading (it's the heading for the following deposits.
- The two main balances are shown as headings, for prominence
- All the items in the Payments Menu are announced as buttons

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app, and switch to a WooPayments store (ideally multi-currency)
2. Navigate to `Menu > Payments`
3. Turn on Voiceover
4. Use the rotor to select `Headings`
5. Swipe vertically to navigate by heading, check that relevant headings are accessible this way
6. Swipe horizontally through every element on the screen, checking that only those which should be accessible are announced, and that they correctly announce interactivity and their labels.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/a8f43100-e0db-43cc-b19a-d9a44628ab8c




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
