### PR TITLE
Shipping Label: Fix the display of customs form printing view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 16.5
 -----
+- [**] Shipping Labels: Fixed issue presenting the printing view for customs forms.
 
 
 16.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.5
 -----
-- [**] Shipping Labels: Fixed issue presenting the printing view for customs forms.
+- [**] Shipping Labels: Fixed issue presenting the printing view for customs forms. [https://github.com/woocommerce/woocommerce-ios/pull/11288]
 
 
 16.4

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Customs Form/PrintCustomsFormsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Customs Form/PrintCustomsFormsView.swift
@@ -53,18 +53,14 @@ struct PrintCustomsFormsView: View {
                                 if printingInvoicePath == url {
                                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                                 } else {
-                                    Button(action: {
+                                    Button(Localization.printButton) {
                                         showPrintingView(for: url)
-                                    }, label: {
-                                        HStack {
-                                            Spacer()
-                                            Text(Localization.printButton)
-                                        }
-                                    })
-                                    .buttonStyle(LinkButtonStyle())
+                                    }
+                                    .buttonStyle(.plain)
+                                    .foregroundColor(.accentColor)
                                 }
                             }
-                            .padding(.leading, Constants.horizontalPadding)
+                            .padding(.horizontal, Constants.horizontalPadding)
                             .frame(height: Constants.printRowHeight)
                             Divider()
                         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11286 
<!-- Id number of the GitHub issue this PR addresses. -->

## What
This PR fixes an issue with displaying the printing view for customs form in the shipping label flow.

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we were using the `InProgressView` to show the progress while content for customs form are being downloaded before printing. We display the printing view [immediately](https://github.com/woocommerce/woocommerce-ios/blob/407f76f5c2e66fce339a365f89eaa543ff52f44b/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Shipping%20Labels/Print%20Customs%20Form/PrintCustomsFormsView.swift#L107-L110) after dismissing the progress view, and the presenting fails if the progress view is not done dismissing.

## How
Instead of presenting a separate view for the progress, I updated the buttons to show the progress state while customs form contents are being downloaded. This simplifies the UX and avoids complicated issue with presenting views.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites: Set up Woo Shipping & Tax plugin in your test store.


Single customs form:
- Place an order on your test store with an international address to your store address.
- On the app, collect payment if needed.
- When the order is complete, select Create Shipping Label and complete the flow (including the customs form).
- After purchasing the new label, navigate back to the order detail screen and select the ellipsis menu in the Shipping Label section.
- Select Print Customs Form.
- On the new Print customs invoice view, tap Print customs form.
- Notice that the print button displays a loading indicator, and then a print view is presented without being dismissed immediately.

Multiple customs forms:
- Comment out the [check](https://github.com/woocommerce/woocommerce-ios/blob/407f76f5c2e66fce339a365f89eaa543ff52f44b/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Shipping%20Labels/Print%20Shipping%20Label/PrintShippingLabelCoordinator.swift#L113) for completion of shipping label printing and build the app. This helps us test the feature without having to actually print labels.
- Place an order with multiple items on your test store.
- On the app, collect payment if needed.
- When the order is complete, select Create Shipping Label and complete the flow (including the customs form). Make sure you move each item to a separate package so that you have more than one shipping label and custom form for the order (see the recording below).
- Notice that a new view is displayed after purchase is complete asking you to print the labels.
- Select Print button and then dismiss the print view.
- The customs form printing view should be displayed with all the forms you created. Tap any Print button, notice that a loading indicator is displayed in place of it before the print view is displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Single customs form:

https://github.com/woocommerce/woocommerce-ios/assets/5533851/8ea7af3a-bd66-4ae4-94f2-7e5778c2c46b

Multiple customs forms:


https://github.com/woocommerce/woocommerce-ios/assets/5533851/28b47124-9d3d-4328-a734-459ec1285dde


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
