### PR TITLE
[Bundle products in order] Configuration form: enable/disable save CTA when the configuration is valid/invalid

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -48,8 +48,8 @@ final class ConfigurableBundleItemViewModel: ObservableObject, Identifiable {
 
     // MARK: - Validation
     /// The actual quantity when being counted for the bundle. When the item is optional and not selected, the quantity is considered 0.
-    @Published var quantityInBundle: Decimal = 0
-    @Published var errorMessage: String?
+    @Published private(set) var quantityInBundle: Decimal = 0
+    @Published private(set) var errorMessage: String?
 
     private let product: Product
     private let bundleItem: ProductBundleItem

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Yosemite
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
@@ -57,9 +57,6 @@ struct ConfigurableBundleProductView: View {
                 }
 
                 Button(Localization.save) {
-                    guard viewModel.validate() else {
-                        return
-                    }
                     viewModel.configure()
                     presentation.wrappedValue.dismiss()
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductViewModel.swift
@@ -225,14 +225,14 @@ private extension ConfigurableBundleProductViewModel {
     }
 
     func observeBundleItemsForValidation() {
+        bundleItemErrorMessagesByItemID.removeAll()
+        bundleItemQuantitiesByItemID.removeAll()
         bundleItemViewModels.forEach { itemViewModel in
-            bundleItemErrorMessagesByItemID.removeAll()
             itemViewModel.$errorMessage.sink { [weak self] errorMessage in
                 self?.bundleItemErrorMessagesByItemID[itemViewModel.bundledItemID] = errorMessage
             }
             .store(in: &bundleItemSubscriptions)
 
-            bundleItemQuantitiesByItemID.removeAll()
             itemViewModel.$quantityInBundle.sink { [weak self] quantity in
                 self?.bundleItemQuantitiesByItemID[itemViewModel.bundledItemID] = quantity
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
@@ -319,6 +319,56 @@ final class ConfigurableBundleItemViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isIncludedInBundle)
     }
 
+    // MARK: - `quantityInBundle`
+
+    func test_quantityInBundle_is_0_for_optional_item_when_quantity_is_non_zero_and_isOptionalAndSelected_is_false() {
+        // Given
+        let viewModel = ConfigurableBundleItemViewModel(bundleItem: .fake().copy(isOptional: true),
+                                                        product: .fake(),
+                                                        variableProductSettings: nil,
+                                                        existingParentOrderItem: nil,
+                                                        existingOrderItem: nil)
+
+        // When
+        viewModel.quantity = 8
+        viewModel.isOptionalAndSelected = false
+
+        // Then
+        XCTAssertEqual(viewModel.quantityInBundle, 0)
+    }
+
+    func test_quantityInBundle_is_non_zero_for_optional_item_when_isOptionalAndSelected_is_true() {
+        // Given
+        let viewModel = ConfigurableBundleItemViewModel(bundleItem: .fake().copy(isOptional: true),
+                                                        product: .fake(),
+                                                        variableProductSettings: nil,
+                                                        existingParentOrderItem: nil,
+                                                        existingOrderItem: nil)
+
+        // When
+        viewModel.quantity = 8
+        viewModel.isOptionalAndSelected = true
+
+        // Then
+        XCTAssertEqual(viewModel.quantityInBundle, 8)
+    }
+
+    func test_quantityInBundle_is_non_zero_for_required_item() {
+        // Given
+        let viewModel = ConfigurableBundleItemViewModel(bundleItem: .fake().copy(isOptional: false),
+                                                        product: .fake(),
+                                                        variableProductSettings: nil,
+                                                        existingParentOrderItem: nil,
+                                                        existingOrderItem: nil)
+
+        // When
+        viewModel.quantity = 8
+        viewModel.isOptionalAndSelected = false
+
+        // Then
+        XCTAssertEqual(viewModel.quantityInBundle, 8)
+    }
+
     // MARK: - Analytics
 
     func test_selecting_variation_tracks_orderFormBundleProductConfigurationChanged_event() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
@@ -28,8 +28,8 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         // The bundle size has to be 5.
         let product = Product.fake().copy(productID: 1, bundleMinSize: 5, bundleMaxSize: 5, bundledItems: [
             // One optional item
-            .fake().copy(productID: 2, isOptional: true),
-            .fake().copy(productID: 3, isOptional: false)
+            .fake().copy(bundledItemID: 1, productID: 2, isOptional: true),
+            .fake().copy(bundledItemID: 2, productID: 3, isOptional: false)
         ])
         let productsFromRetrieval = [1, 2, 3].map { Product.fake().copy(productID: $0) }
         mockProductsRetrieval(result: .success((products: productsFromRetrieval, hasNextPage: false)))
@@ -53,7 +53,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         nonOptionalItem.quantity = 2
 
         // Then
-        XCTAssertTrue(viewModel.validate())
+        XCTAssertTrue(viewModel.isConfigureEnabled)
         XCTAssertNil(viewModel.validationErrorMessage)
     }
 
@@ -82,13 +82,13 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         optionalItem.quantity = 6
         optionalItem.isOptionalAndSelected = false
 
-        XCTAssertTrue(viewModel.validate())
+        XCTAssertTrue(viewModel.isConfigureEnabled)
 
         let nonOptionalItem = try XCTUnwrap(viewModel.bundleItemViewModels[1])
         nonOptionalItem.quantity = 6
 
         // Then
-        XCTAssertFalse(viewModel.validate())
+        XCTAssertFalse(viewModel.isConfigureEnabled)
         XCTAssertNotNil(viewModel.validationErrorMessage)
     }
 
@@ -114,7 +114,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         item.quantity = 4
 
         // Then
-        XCTAssertFalse(viewModel.validate())
+        XCTAssertFalse(viewModel.isConfigureEnabled)
         XCTAssertNotNil(viewModel.validationErrorMessage)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11259 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As shared by Joe in the design review pe5pgL-42P-p2#comment-3267, we'd like to follow Android so that the Save CTA in the configuration form is only enabled when the configuration is valid.

## How

### Challenge

This sounds simple, but I encountered a challenge when implementing this change because there are two types of validation checks:

- Bundle size (total number of selected bundle items) at the bundle level (`ConfigurableBundleProductViewModel`)
- Each bundle item (e.g. quantity, optional selected state, variation state for variable items) at the item level (`ConfigurableBundleItemViewModel`)

Since the bundle item view models (`bundleItemViewModels: [ConfigurableBundleItemViewModel]` in `ConfigurableBundleProductViewModel`) are in an array, any @Published var changes in the array element won't notify any mapped observable properties used in SwiftUI in `ConfigurableBundleProductViewModel` even though the view model is an `ObservableObject`. For example, `ConfigurableBundleProductViewModel.bundleItemViewModels.map { $0.errorMessage == nil }.contains(false).assign(to: &$somePublishedVarUsedInSwiftUI)`. From my search, this seems like the expected behavior in SwiftUI since the array **itself** does not change. It's usually fine when we just make SwiftUI views for each nested element, but now we need to propagate the info (error message) from each nested element to the array owner and combine them for another UI state (whether the Save CTA is enabled). I also tried the Combine approach, but the CombineLatest publisher only takes up to 4 publishers 😐 .

### Proposed solution

To work around this SiwftUI behavior, I ended up creating a dictionary that maps a bundle item ID to each state property that is needed for validation. The dictionary is updated when each bundle item view model's corresponding property changes using Combine when the bundle items are set. For the validation use case, two dictionaries are needed - `bundleItemErrorMessagesByItemID` (item-level validation) and `bundleItemQuantitiesByItemID` (bundle-level validation on the bundle size). The validation logic should remain the same as before, just in a reactive way (any changes in the form trigger validation).

I would like to create a sample project and p2 about it. If you have any ideas/suggestions, please lemme know!

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with **at least 1 optional variable item** with non-empty variations and at least 1 non-variable item.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite
- Configure the non-variable items so that they are valid --> the Save CTA should be enabled
- Tap the circle to select the variable item --> the Save CTA should be disabled while an error message appears about selecting a variation
- Tap `Choose variation` to choose a variation
- In the configuration form, the attributes should be shown that look like the expected design
- Configure the variable item so that it's valid --> the Save CTA should be enabled
- Tap `Save Configuration`
- Tap `1 Product Selected` --> the bundle product should be added to the order with the expected configuration

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/ed359808-0c72-4e8c-9d0e-452f61cce3db



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.