### PR TITLE
[Deposit Summary] Design updates

### DIFF
--- a/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
+++ b/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
@@ -85,6 +85,21 @@ public struct WooPaymentsDeposit: Codable, GeneratedFakeable, GeneratedCopiable,
         case feePercentage = "fee_percentage"
         case created
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.date = try container.decode(Date.self, forKey: .date)
+        self.type = try container.decode(WooPaymentsDepositType.self, forKey: .type)
+        self.amount = try container.decode(Int.self, forKey: .amount)
+        self.status = container.failsafeDecodeIfPresent(WooPaymentsDepositStatus.self, forKey: .status) ?? .unknown
+        self.bankAccount = try container.decodeIfPresent(String.self, forKey: .bankAccount)
+        self.currency = try container.decode(String.self, forKey: .currency)
+        self.automatic = try container.decode(Bool.self, forKey: .automatic)
+        self.fee = try container.decode(Int.self, forKey: .fee)
+        self.feePercentage = try container.decode(Int.self, forKey: .feePercentage)
+        self.created = try container.decode(Int.self, forKey: .created)
+    }
 }
 
 public struct WooPaymentsManualDeposit: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
@@ -137,6 +152,7 @@ public enum WooPaymentsDepositStatus: String, Codable, Equatable, GeneratedFakea
     case paid
     case canceled
     case failed
+    case unknown
 }
 
 public struct WooPaymentsCurrencyBalances: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositStatusDisplayDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositStatusDisplayDetails.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import Yosemite
+import WooFoundation
+
+extension WooPaymentsDepositStatus {
+    var backgroundColor: Color {
+        switch self {
+        case .estimated:
+            return Color(light: Color.withColorStudio(name: .gray, shade: .shade5),
+                         dark: Color.withColorStudio(name: .gray, shade: .shade80))
+        case .pending:
+            return Color(light: Color.withColorStudio(name: .yellow, shade: .shade10),
+                         dark: Color.withColorStudio(name: .yellow, shade: .shade70))
+        case .inTransit:
+            return Color(light: Color.withColorStudio(name: .orange, shade: .shade5),
+                         dark: Color.withColorStudio(name: .orange, shade: .shade70))
+        case .paid:
+            return Color(light: Color.withColorStudio(name: .green, shade: .shade0),
+                         dark: Color.withColorStudio(name: .green, shade: .shade50))
+        case .canceled:
+            return Color(light: Color.withColorStudio(name: .wooCommercePurple, shade: .shade10),
+                         dark: Color.withColorStudio(name: .wooCommercePurple, shade: .shade80))
+        case .failed:
+            return Color(light: Color.withColorStudio(name: .red, shade: .shade5),
+                         dark: Color.withColorStudio(name: .red, shade: .shade70))
+        case .unknown:
+            return Color(light: Color.withColorStudio(name: .gray, shade: .shade5),
+                         dark: Color.withColorStudio(name: .gray, shade: .shade80))
+        }
+    }
+
+    var textColor: Color {
+        switch self {
+        case .estimated:
+            return Color(light: Color.withColorStudio(name: .gray, shade: .shade80),
+                         dark: Color.withColorStudio(name: .gray, shade: .shade5))
+        case .pending:
+            return Color(light: Color.withColorStudio(name: .yellow, shade: .shade70),
+                         dark: Color.withColorStudio(name: .yellow, shade: .shade10))
+        case .inTransit:
+            return Color(light: Color.withColorStudio(name: .orange, shade: .shade70),
+                         dark: Color.withColorStudio(name: .orange, shade: .shade5))
+        case .paid:
+            return Color(light: Color.withColorStudio(name: .green, shade: .shade50),
+                         dark: Color.withColorStudio(name: .green, shade: .shade0))
+        case .canceled:
+            return Color(light: Color.withColorStudio(name: .wooCommercePurple, shade: .shade80),
+                         dark: Color.withColorStudio(name: .wooCommercePurple, shade: .shade10))
+        case .failed:
+            return Color(light: Color.withColorStudio(name: .red, shade: .shade70),
+                         dark: Color.withColorStudio(name: .red, shade: .shade5))
+        case .unknown:
+            return Color(light: Color.withColorStudio(name: .gray, shade: .shade80),
+                         dark: Color.withColorStudio(name: .gray, shade: .shade5))
+        }
+    }
+
+    var localizedName: String {
+        switch self {
+        case .estimated:
+            return Localization.estimated
+        case .pending:
+            return Localization.pending
+        case .inTransit:
+            return Localization.inTransit
+        case .paid:
+            return Localization.paid
+        case .canceled:
+            return Localization.canceled
+        case .failed:
+            return Localization.failed
+        case .unknown:
+            return Localization.unknown
+        }
+    }
+}
+
+private extension WooPaymentsDepositStatus {
+    enum Localization {
+        static let estimated = NSLocalizedString(
+            "deposits.currency.overview.depositTable.status.estimated.title",
+            value: "Estimated",
+            comment: "A status for a deposit, shown in a small badge view")
+
+        static let pending = NSLocalizedString(
+            "deposits.currency.overview.depositTable.status.pending.title",
+            value: "Pending",
+            comment: "A status for a deposit, shown in a small badge view")
+
+        static let inTransit = NSLocalizedString(
+            "deposits.currency.overview.depositTable.status.inTransit.title",
+            value: "In Transit",
+            comment: "A status for a deposit, shown in a small badge view")
+
+        static let paid = NSLocalizedString(
+            "deposits.currency.overview.depositTable.status.paid.title",
+            value: "Paid",
+            comment: "A status for a deposit, shown in a small badge view")
+
+        static let canceled = NSLocalizedString(
+            "deposits.currency.overview.depositTable.status.canceled.title",
+            value: "Canceled",
+            comment: "A status for a deposit, shown in a small badge view")
+
+        static let failed = NSLocalizedString(
+            "deposits.currency.overview.depositTable.status.failed.title",
+            value: "Failed",
+            comment: "A status for a deposit, shown in a small badge view")
+
+        static let unknown = NSLocalizedString(
+            "deposits.currency.overview.depositTable.status.unknown.title",
+            value: "Unknown",
+            comment: "A status for a deposit, shown in a small badge view")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -61,18 +61,21 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .accessibilityAddTraits(.isHeader)
-                LazyVGrid(columns: [GridItem(.flexible(maximum: 70), alignment: .leading),
+                LazyVGrid(columns: [GridItem(.flexible(maximum: 60), alignment: .leading),
                                     GridItem(alignment: .leading),
+                                    GridItem(.flexible(minimum: 100), alignment: .leading),
                                     GridItem(alignment: .trailing)],
                           spacing: 16) {
                     Text(Localization.nextDepositRowTitle)
                     Text(viewModel.nextDepositDate)
+                    WooPaymentsDepositsBadge(status: viewModel.nextDepositStatus)
                     Text(viewModel.nextDepositAmount)
 
-                    Text(Localization.paidDepositRowTitle)
-                        .foregroundColor(.withColorStudio(name: .green, shade: .shade50))
+                    Text(Localization.lastDepositRowTitle)
+                        .foregroundColor(.secondary)
                     Text(viewModel.lastDepositDate)
                         .foregroundColor(.secondary)
+                    WooPaymentsDepositsBadge(status: viewModel.lastDepositStatus)
                     Text(viewModel.lastDepositAmount)
                         .foregroundColor(.secondary)
                 }
@@ -135,6 +138,25 @@ struct AccountSummaryItem: View {
     }
 }
 
+struct WooPaymentsDepositsBadge: View {
+    let status: WooPaymentsDepositStatus
+
+    var body: some View {
+        Text(status.localizedName)
+            .foregroundColor(status.textColor)
+            .padding(Layout.padding)
+            .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(status.backgroundColor))
+    }
+}
+
+private extension WooPaymentsDepositsBadge {
+    enum Layout {
+        static let padding: CGFloat = 8.0
+        static let cornerRadius: CGFloat = 8.0
+    }
+}
+
 @available(iOS 16.0, *)
 private extension WooPaymentsDepositsCurrencyOverviewView {
     enum Localization {
@@ -152,9 +174,10 @@ private extension WooPaymentsDepositsCurrencyOverviewView {
         static let nextDepositRowTitle = NSLocalizedString(
             "Next",
             comment: "Row title for the next deposit in the WooPayments Deposits overview")
-        static let paidDepositRowTitle = NSLocalizedString(
-            "Paid",
-            comment: "Row title for the last paid deposit in the WooPayments Deposits overview")
+        static let lastDepositRowTitle = NSLocalizedString(
+            "deposits.currency.overview.depositTable.last.title",
+            value: "Last",
+            comment: "Row title for the last (previous) deposit in the WooPayments Deposits overview")
         static let learnMoreButtonText = NSLocalizedString(
             "Learn more about when you'll receive your funds",
             comment: "Button text to view more about payment schedules on the WooPayments Deposits View.")
@@ -186,7 +209,8 @@ struct WooPaymentsDepositsCurrencyOverviewView_Previews: PreviewProvider {
             ),
             lastDeposit: WooPaymentsDepositsOverviewByCurrency.LastDeposit(
                 amount: 500.0,
-                date: Date()
+                date: Date(),
+                status: .inTransit
             ),
             availableBalance: 1500.0
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -33,6 +33,8 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
         lastDepositAmount = formatAmount(overview.lastDeposit?.amount ?? NSDecimalNumber(value: 0))
         nextDepositDate = nextDepositDateText()
         lastDepositDate = formatDate(overview.lastDeposit?.date) ?? Localization.noDateString
+        nextDepositStatus = overview.nextDeposit?.status ?? .unknown
+        lastDepositStatus = overview.lastDeposit?.status ?? .unknown
         availableBalance = formatAmount(overview.availableBalance)
         depositScheduleHint = depositScheduleHintText()
         balanceTypeHint = balanceTypeHintText()
@@ -44,6 +46,8 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     @Published var lastDepositAmount: String = ""
     @Published var nextDepositDate: String = ""
     @Published var lastDepositDate: String = ""
+    @Published var nextDepositStatus: WooPaymentsDepositStatus = .unknown
+    @Published var lastDepositStatus: WooPaymentsDepositStatus = .unknown
     @Published var availableBalance: String = ""
     @Published var depositScheduleHint: String = ""
     @Published var balanceTypeHint: String = ""

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
@@ -44,7 +44,8 @@ struct WooPaymentsDepositsOverviewView_Previews: PreviewProvider {
             ),
             lastDeposit: WooPaymentsDepositsOverviewByCurrency.LastDeposit(
                 amount: 500.0,
-                date: Date()
+                date: Date(),
+                status: .inTransit
             ),
             availableBalance: 1500.0
         )
@@ -65,7 +66,8 @@ struct WooPaymentsDepositsOverviewView_Previews: PreviewProvider {
             ),
             lastDeposit: WooPaymentsDepositsOverviewByCurrency.LastDeposit(
                 amount: 600.0,
-                date: Date()
+                date: Date(),
+                status: .canceled
             ),
             availableBalance: 1900.0
         )

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -728,6 +728,7 @@
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
 		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
 		20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */; };
+		20D210BE2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D210BD2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift */; };
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
 		20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* AboutTapToPayView.swift */; };
@@ -3304,6 +3305,7 @@
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
 		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModelTests.swift; sourceTree = "<group>"; };
+		20D210BD2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositStatusDisplayDetails.swift; sourceTree = "<group>"; };
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* AboutTapToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayView.swift; sourceTree = "<group>"; };
@@ -6688,6 +6690,7 @@
 			children = (
 				209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */,
 				209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */,
+				20D210BD2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift */,
 				203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */,
 				20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */,
 			);
@@ -13625,6 +13628,7 @@
 				2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */,
 				02863F6A29246E18006A06AA /* StoreCreationPlanFeaturesView.swift in Sources */,
 				B6C838DE28793B3A003AB786 /* OrderCustomFieldsViewModel.swift in Sources */,
+				20D210BE2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift in Sources */,
 				E1E125AA26EB42530068A9B0 /* CardPresentModalUpdateProgress.swift in Sources */,
 				B998DF4A2A98AE4200D1C6E8 /* TaxEducationalDialogViewModel.swift in Sources */,
 				E1C5E78226C2A971008D4C47 /* InPersonPaymentsPluginNotSetup.swift in Sources */,

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		036563D728F93F8D00D84BFD /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 036563D628F93F8D00D84BFD /* TestKit */; };
 		03B8C3892914083F002235B1 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8C3882914083F002235B1 /* Bundle+Woo.swift */; };
 		203758752AD55670000E4281 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203758742AD55670000E4281 /* CountryCode.swift */; };
+		20A3AFE92B14BAB20033AF2D /* Color+Adaptivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE82B14BAB20033AF2D /* Color+Adaptivity.swift */; };
 		20AD34D32B0CDB8900F38F44 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 20AD34D22B0CDB8900F38F44 /* Codegen */; };
 		265C99D828B93F04005E6117 /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 265C99D728B93F04005E6117 /* ColorPalette.xcassets */; };
 		265C99DD28B941D5005E6117 /* UIColor+Muriel-Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265C99DC28B941D5005E6117 /* UIColor+Muriel-Tests.swift */; };
@@ -85,6 +86,7 @@
 		035BA3A5290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMProviderProtocolExtensionTests.swift; sourceTree = "<group>"; };
 		03B8C3882914083F002235B1 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		203758742AD55670000E4281 /* CountryCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCode.swift; sourceTree = "<group>"; };
+		20A3AFE82B14BAB20033AF2D /* Color+Adaptivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Adaptivity.swift"; sourceTree = "<group>"; };
 		265C99D728B93F04005E6117 /* ColorPalette.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorPalette.xcassets; sourceTree = "<group>"; };
 		265C99DC28B941D5005E6117 /* UIColor+Muriel-Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Muriel-Tests.swift"; sourceTree = "<group>"; };
 		265C99DE28B94271005E6117 /* MurielColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MurielColorTests.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 			children = (
 				26AF1F4F28B8362800937BA9 /* UIColor+SemanticColors.swift */,
 				0331A75A2A3B553A001D2C2C /* Color+ColorStudio.swift */,
+				20A3AFE82B14BAB20033AF2D /* Color+Adaptivity.swift */,
 				26AF1F5028B8362800937BA9 /* ColorStudio.swift */,
 				26AF1F5128B8362800937BA9 /* UIColor+ColorStudio.swift */,
 				26AF1F5228B8362800937BA9 /* UIColor+SystemColors.swift */,
@@ -552,6 +555,7 @@
 				26AF1F5928B9011100937BA9 /* WooStyleModifiers.swift in Sources */,
 				686BE912288EE0D300967C86 /* TypedPredicates.swift in Sources */,
 				B9C9C65E283E71C8001B879F /* CurrencySettings.swift in Sources */,
+				20A3AFE92B14BAB20033AF2D /* Color+Adaptivity.swift in Sources */,
 				26AF1F5528B8362800937BA9 /* UIColor+ColorStudio.swift in Sources */,
 				26AF1F5428B8362800937BA9 /* ColorStudio.swift in Sources */,
 				68FBC5B328926B2C00A05461 /* Collection+Extensions.swift in Sources */,

--- a/WooFoundation/WooFoundation/Colors/Color+Adaptivity.swift
+++ b/WooFoundation/WooFoundation/Colors/Color+Adaptivity.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+public extension Color {
+    init(light lightModeColor: @escaping @autoclosure () -> Color,
+         dark darkModeColor: @escaping @autoclosure () -> Color) {
+        self.init(uiColor: UIColor(
+            light: UIColor(lightModeColor()),
+            dark: UIColor(darkModeColor())
+        ))
+    }
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -186,6 +186,7 @@ public typealias WCPayCardPresentReceiptDetails = Networking.WCPayCardPresentRec
 public typealias WCPayPaymentMethodDetails = Networking.WCPayPaymentMethodDetails
 public typealias WCPayChargeStatus = Networking.WCPayChargeStatus
 public typealias WooPaymentsDepositInterval = Networking.WooPaymentsDepositInterval
+public typealias WooPaymentsDepositStatus = Networking.WooPaymentsDepositStatus
 public typealias StoreOnboardingTask = Networking.StoreOnboardingTask
 public typealias WCAnalyticsCustomer = Networking.WCAnalyticsCustomer
 

--- a/Yosemite/Yosemite/Model/WooPaymentsDepositsOverview.swift
+++ b/Yosemite/Yosemite/Model/WooPaymentsDepositsOverview.swift
@@ -29,10 +29,12 @@ public struct WooPaymentsDepositsOverviewByCurrency: GeneratedCopiable, Generate
     public struct LastDeposit {
         public let amount: NSDecimalNumber
         public let date: Date
+        public let status: WooPaymentsDepositStatus
 
-        public init(amount: NSDecimalNumber, date: Date) {
+        public init(amount: NSDecimalNumber, date: Date, status: WooPaymentsDepositStatus) {
             self.amount = amount
             self.date = date
+            self.status = status
         }
     }
 

--- a/Yosemite/Yosemite/Tools/Payments/WooPaymentsDepositService.swift
+++ b/Yosemite/Yosemite/Tools/Payments/WooPaymentsDepositService.swift
@@ -110,6 +110,7 @@ public final class WooPaymentsDepositService: WooPaymentsDepositServiceProtocol 
             amount: depositAmountDecimal(from: lastDeposit.amount,
                                          currency: currency,
                                          type: lastDeposit.type),
-            date: lastDeposit.date)
+            date: lastDeposit.date,
+            status: lastDeposit.status)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11290 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since the HACK week project, the design has been slightly changed to include the status badges for the two deposit summary rows.

This PR adds those badges.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. 
2. Launch the app, and switch to a WooPayments store
3. Navigate to `Menu > Payments`
4. Observe that the two deposit rows show their status as a badge.
5. Switch between light/dark mode
6. Observe that the colours are legible and appropriate for each appearance.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/c752d052-1941-41cb-80a1-791e9a2eea96



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
