### PR TITLE
Product Subscriptions: Parse one time shipping value from network response

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1194,7 +1194,8 @@ extension Networking.ProductSubscription {
             price: .fake(),
             signUpFee: .fake(),
             trialLength: .fake(),
-            trialPeriod: .fake()
+            trialPeriod: .fake(),
+            oneTimeShipping: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1734,7 +1734,8 @@ extension Networking.ProductSubscription {
         price: CopiableProp<String> = .copy,
         signUpFee: CopiableProp<String> = .copy,
         trialLength: CopiableProp<String> = .copy,
-        trialPeriod: CopiableProp<SubscriptionPeriod> = .copy
+        trialPeriod: CopiableProp<SubscriptionPeriod> = .copy,
+        oneTimeShipping: CopiableProp<Bool> = .copy
     ) -> Networking.ProductSubscription {
         let length = length ?? self.length
         let period = period ?? self.period
@@ -1743,6 +1744,7 @@ extension Networking.ProductSubscription {
         let signUpFee = signUpFee ?? self.signUpFee
         let trialLength = trialLength ?? self.trialLength
         let trialPeriod = trialPeriod ?? self.trialPeriod
+        let oneTimeShipping = oneTimeShipping ?? self.oneTimeShipping
 
         return Networking.ProductSubscription(
             length: length,
@@ -1751,7 +1753,8 @@ extension Networking.ProductSubscription {
             price: price,
             signUpFee: signUpFee,
             trialLength: trialLength,
-            trialPeriod: trialPeriod
+            trialPeriod: trialPeriod,
+            oneTimeShipping: oneTimeShipping
         )
     }
 }

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -26,13 +26,17 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
     /// Period of the free trial, if any.
     public let trialPeriod: SubscriptionPeriod
 
+    /// Only charge shipping once on the initial order if `true`.
+    public let oneTimeShipping: Bool
+
     public init(length: String,
                 period: SubscriptionPeriod,
                 periodInterval: String,
                 price: String,
                 signUpFee: String,
                 trialLength: String,
-                trialPeriod: SubscriptionPeriod) {
+                trialPeriod: SubscriptionPeriod,
+                oneTimeShipping: Bool) {
         self.length = length
         self.period = period
         self.periodInterval = periodInterval
@@ -40,6 +44,7 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
         self.signUpFee = signUpFee
         self.trialLength = trialLength
         self.trialPeriod = trialPeriod
+        self.oneTimeShipping = oneTimeShipping
     }
 
     /// Custom decoding to use default value when JSON doesn't have a key present
@@ -54,6 +59,13 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
         signUpFee = try container.decodeIfPresent(String.self, forKey: .signUpFee) ?? "0"
         trialLength = try container.decodeIfPresent(String.self, forKey: .trialLength) ?? "0"
         trialPeriod = try container.decodeIfPresent(SubscriptionPeriod.self, forKey: .trialPeriod) ?? .day
+        oneTimeShipping = {
+            guard let stringValue = try? container.decodeIfPresent(String.self, forKey: .oneTimeShipping) else {
+                return false
+            }
+
+            return stringValue == Constants.yes
+        }()
     }
 
     func toKeyValuePairs() -> [KeyValuePair] {
@@ -64,7 +76,8 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
             .init(key: CodingKeys.price.rawValue, value: price),
             .init(key: CodingKeys.signUpFee.rawValue, value: signUpFee),
             .init(key: CodingKeys.trialLength.rawValue, value: trialLength),
-            .init(key: CodingKeys.trialPeriod.rawValue, value: trialPeriod.rawValue)
+            .init(key: CodingKeys.trialPeriod.rawValue, value: trialPeriod.rawValue),
+            .init(key: CodingKeys.oneTimeShipping.rawValue, value: oneTimeShipping ? Constants.yes : Constants.no)
         ]
     }
 }
@@ -73,13 +86,14 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
 //
 private extension ProductSubscription {
     enum CodingKeys: String, CodingKey {
-        case length         = "_subscription_length"
-        case period         = "_subscription_period"
-        case periodInterval = "_subscription_period_interval"
-        case price          = "_subscription_price"
-        case signUpFee      = "_subscription_sign_up_fee"
-        case trialLength    = "_subscription_trial_length"
-        case trialPeriod    = "_subscription_trial_period"
+        case length             = "_subscription_length"
+        case period             = "_subscription_period"
+        case periodInterval     = "_subscription_period_interval"
+        case price              = "_subscription_price"
+        case signUpFee          = "_subscription_sign_up_fee"
+        case trialLength        = "_subscription_trial_length"
+        case trialPeriod        = "_subscription_trial_period"
+        case oneTimeShipping    = "_subscription_one_time_shipping"
     }
 }
 
@@ -97,4 +111,9 @@ public enum SubscriptionPeriod: String, Decodable, GeneratedFakeable, CaseIterab
 struct KeyValuePair: Encodable, Equatable {
     let key: String
     let value: String
+}
+
+private enum Constants {
+    static let yes = "yes"
+    static let no = "no"
 }

--- a/Networking/NetworkingTests/Encoder/ProductEncoderTests.swift
+++ b/Networking/NetworkingTests/Encoder/ProductEncoderTests.swift
@@ -10,7 +10,8 @@ final class ProductEncoderTests: XCTestCase {
                                                price: "99",
                                                signUpFee: "25",
                                                trialLength: "1",
-                                               trialPeriod: .month)
+                                               trialPeriod: .month,
+                                               oneTimeShipping: true)
         let product = Product.fake().copy(productTypeKey: "subscription",
                                           subscription: subscription)
 
@@ -40,6 +41,9 @@ final class ProductEncoderTests: XCTestCase {
 
         let trialPeriod = try XCTUnwrap(metadata.first(where: { $0["key"] as? String == "_subscription_trial_period"}))
         XCTAssertEqual(trialPeriod["value"] as? String, "month")
+
+        let oneTimeShipping = try XCTUnwrap(metadata.first(where: { $0["key"] as? String == "_subscription_one_time_shipping"}))
+        XCTAssertEqual(oneTimeShipping["value"] as? String, "yes")
     }
 
     func test_it_does_not_encode_metadata_without_subscription() throws {

--- a/Networking/NetworkingTests/Encoder/ProductSubscriptionTests.swift
+++ b/Networking/NetworkingTests/Encoder/ProductSubscriptionTests.swift
@@ -10,7 +10,8 @@ final class ProductSubscriptionTests: XCTestCase {
                                                price: "99",
                                                signUpFee: "25",
                                                trialLength: "1",
-                                               trialPeriod: .month)
+                                               trialPeriod: .month,
+                                               oneTimeShipping: true)
 
         // When
         let keyValuePairs = subscription.toKeyValuePairs()
@@ -23,5 +24,6 @@ final class ProductSubscriptionTests: XCTestCase {
         XCTAssertTrue(keyValuePairs.contains(.init(key: "_subscription_sign_up_fee", value: "25")))
         XCTAssertTrue(keyValuePairs.contains(.init(key: "_subscription_trial_length", value: "1")))
         XCTAssertTrue(keyValuePairs.contains(.init(key: "_subscription_trial_period", value: "month")))
+        XCTAssertTrue(keyValuePairs.contains(.init(key: "_subscription_one_time_shipping", value: "yes")))
     }
 }

--- a/Networking/NetworkingTests/Encoder/ProductVariationEncoderTests.swift
+++ b/Networking/NetworkingTests/Encoder/ProductVariationEncoderTests.swift
@@ -40,6 +40,9 @@ final class ProductVariationEncoderTests: XCTestCase {
 
         let trialPeriod = try XCTUnwrap(metadata.first(where: { $0["key"] as? String == "_subscription_trial_period"}))
         XCTAssertEqual(trialPeriod["value"] as? String, "month")
+
+        let oneTimeShipping = try XCTUnwrap(metadata.first(where: { $0["key"] as? String == "_subscription_one_time_shipping"}))
+        XCTAssertEqual(oneTimeShipping["value"] as? String, "yes")
     }
 
     func test_it_does_not_encode_meta_data_without_subscription() throws {

--- a/Networking/NetworkingTests/Encoder/ProductVariationEncoderTests.swift
+++ b/Networking/NetworkingTests/Encoder/ProductVariationEncoderTests.swift
@@ -10,7 +10,8 @@ final class ProductVariationEncoderTests: XCTestCase {
                                                price: "99",
                                                signUpFee: "25",
                                                trialLength: "1",
-                                               trialPeriod: .month)
+                                               trialPeriod: .month,
+                                               oneTimeShipping: true)
         let variation = ProductVariation.fake().copy(subscription: subscription)
 
         // When

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -382,6 +382,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.signUpFee, "")
         XCTAssertEqual(subscriptionSettings.trialLength, "1")
         XCTAssertEqual(subscriptionSettings.trialPeriod, .week)
+        XCTAssertTrue(subscriptionSettings.oneTimeShipping)
     }
 
     /// Test that `subscription` is nil when parsing non-subscription product response

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -62,6 +62,7 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.signUpFee, "")
         XCTAssertEqual(subscriptionSettings.trialLength, "0")
         XCTAssertEqual(subscriptionSettings.trialPeriod, .month)
+        XCTAssertFalse(subscriptionSettings.oneTimeShipping)
     }
 
     /// Test that the fields for variations of a subscription product are properly parsed when missing fields.
@@ -79,6 +80,7 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.signUpFee, "0")
         XCTAssertEqual(subscriptionSettings.trialLength, "0")
         XCTAssertEqual(subscriptionSettings.trialPeriod, .month)
+        XCTAssertFalse(subscriptionSettings.oneTimeShipping)
     }
 
     /// Test that subscription is nil when parsing non-subscription product response

--- a/Networking/NetworkingTests/Responses/product-subscription.json
+++ b/Networking/NetworkingTests/Responses/product-subscription.json
@@ -154,7 +154,7 @@
             {
                 "id": 4222,
                 "key": "_subscription_one_time_shipping",
-                "value": "no"
+                "value": "yes"
             }
         ],
         "stock_status": "outofstock",

--- a/WooCommerce/Classes/Extensions/ProductSubscription+Empty.swift
+++ b/WooCommerce/Classes/Extensions/ProductSubscription+Empty.swift
@@ -11,6 +11,7 @@ extension ProductSubscription {
               price: "",
               signUpFee: "",
               trialLength: "",
-              trialPeriod: .day)
+              trialPeriod: .day,
+              oneTimeShipping: false)
     }()
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/Expiry/SubscriptionExpiryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/Expiry/SubscriptionExpiryViewController.swift
@@ -105,7 +105,8 @@ struct SubscriptionExpiryView_Previews: PreviewProvider {
                                                                            price: "1",
                                                                            signUpFee: "1",
                                                                            trialLength: "12",
-                                                                           trialPeriod: .day),
+                                                                           trialPeriod: .day,
+                                                                           oneTimeShipping: false),
                                                        completion: { _, _  in } )
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/Trial/SubscriptionTrialViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/Trial/SubscriptionTrialViewController.swift
@@ -100,7 +100,8 @@ struct SubscriptionTrialView_Previews: PreviewProvider {
                                                                           price: "1",
                                                                           signUpFee: "1",
                                                                           trialLength: "12",
-                                                                          trialPeriod: .day),
+                                                                          trialPeriod: .day,
+                                                                          oneTimeShipping: false),
                                                       completion: { _, _, _  in } )
 
 

--- a/Yosemite/Yosemite/Model/Storage/ProductSubscription+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductSubscription+ReadOnlyConvertible.swift
@@ -27,6 +27,8 @@ extension Storage.ProductSubscription: ReadOnlyConvertible {
                                    price: price ?? "",
                                    signUpFee: signUpFee ?? "",
                                    trialLength: trialLength ?? "0",
-                                   trialPeriod: SubscriptionPeriod(rawValue: trialPeriod ?? "day") ?? .day)
+                                   trialPeriod: SubscriptionPeriod(rawValue: trialPeriod ?? "day") ?? .day,
+                                   // TODO: 11178 - Read `oneTimeShipping` from storage
+                                   oneTimeShipping: false)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11178 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We need to show the one-time shipping field in the shipping section of the product form. 

This PR parses the `_subscription_one_time_shipping` field from the meta data fields of the product's JSON response. 

## Testing instructions
CI passing is enough.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
