### PR TITLE
[Scan to Update Inventory] Feature flag + scan product

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -82,7 +82,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .customLoginUIForAccountCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .subscriptionProducts:
+        case .scanToUpdateInventory:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -84,6 +84,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .customLoginUIForAccountCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .subscriptionProducts:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -11,8 +11,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         let isUITesting = CommandLine.arguments.contains("-ui_testing")
 
         switch featureFlag {
-        case .barcodeScanner:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInOrdersTab:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -179,4 +179,8 @@ public enum FeatureFlag: Int {
     /// Enables creating Subscription products
     ///
     case subscriptionProducts
+
+    /// Enables the Scan to Update Inventory feature.
+    ///
+    case scanToUpdateInventory
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -509,15 +509,6 @@ extension WooAnalyticsEvent {
             case variation
         }
 
-        enum BarcodeScanningSource: String {
-            case orderCreation = "order_creation"
-            case orderList = "order_list"
-        }
-
-        enum BarcodeScanningFailureReason: String {
-            case cameraAccessNotPermitted = "camera_access_not_permitted"
-        }
-
         enum OrderProductAdditionVia: String {
             case scanning
             case manually
@@ -565,8 +556,6 @@ extension WooAnalyticsEvent {
             static let addedVia = "added_via"
             static let isFilterActive = "is_filter_active"
             static let searchFilter = "search_filter"
-            static let barcodeFormat = "barcode_format"
-            static let reason = "reason"
             static let couponsCount = "coupons_count"
             static let type = "type"
             static let usesGiftCard = "use_gift_card"
@@ -627,33 +616,6 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreationProductBarcodeScanningTapped, properties: [:])
         }
 
-        static func barcodeScanningSuccess(from source: BarcodeScanningSource) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .barcodeScanningSuccess, properties: [Keys.source: source.rawValue])
-        }
-
-        static func barcodeScanningFailure(from source: BarcodeScanningSource, reason: BarcodeScanningFailureReason) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .barcodeScanningFailure, properties: [Keys.source: source.rawValue,
-                                                                              Keys.reason: reason.rawValue])
-        }
-
-        static func orderProductSearchViaSKUSuccess(from source: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderProductSearchViaSKUSuccess, properties: [Keys.source: source])
-        }
-
-        static func orderProductSearchViaSKUFailure(from source: String,
-                                                    symbology: BarcodeSymbology? = nil,
-                                                    reason: String) -> WooAnalyticsEvent {
-
-            var properties = [Keys.source: source,
-                              Keys.reason: reason]
-
-            if let symbology = symbology {
-                properties[Keys.barcodeFormat] = symbology.rawValue
-            }
-
-            return WooAnalyticsEvent(statName: .orderProductSearchViaSKUFailure, properties: properties)
-        }
-
         static func orderEditButtonTapped(hasMultipleShippingLines: Bool, hasMultipleFeeLines: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderEditButtonTapped, properties: [
                 Keys.hasMultipleShippingLines: hasMultipleShippingLines,
@@ -662,7 +624,7 @@ extension WooAnalyticsEvent {
         }
 
         static func orderProductAdd(flow: Flow,
-                                    source: BarcodeScanningSource,
+                                    source: BarcodeScanning.Source,
                                     addedVia: OrderProductAdditionVia,
                                     productCount: Int = 1,
                                     includesBundleProductConfiguration: Bool) -> WooAnalyticsEvent {
@@ -2834,6 +2796,56 @@ extension WooAnalyticsEvent {
                                 Keys.entityName.rawValue: entityName
                               ].compactMapValues { $0 },
                               error: error)
+        }
+    }
+}
+
+// MARK: - Barcode Scanning
+//
+extension WooAnalyticsEvent {
+    enum BarcodeScanning {
+        private enum Keys {
+            static let barcodeFormat = "barcode_format"
+            static let reason = "reason"
+            static let source = "source"
+        }
+
+        enum Source: String {
+            case orderCreation = "order_creation"
+            case orderList = "order_list"
+            case productList = "product_list"
+        }
+
+        enum BarcodeScanningFailureReason: String {
+            case cameraAccessNotPermitted = "camera_access_not_permitted"
+        }
+
+
+        static func barcodeScanningSuccess(from source: BarcodeScanning.Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .barcodeScanningSuccess, properties: [Keys.source: source.rawValue])
+        }
+
+        static func barcodeScanningFailure(from source: BarcodeScanning.Source, reason: BarcodeScanningFailureReason) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .barcodeScanningFailure, properties: [Keys.source: source.rawValue,
+                                                                              Keys.reason: reason.rawValue])
+        }
+
+        static func productSearchViaSKUSuccess(from source: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderProductSearchViaSKUSuccess, properties: [Keys.source: source])
+        }
+
+        static func productSearchViaSKUFailure(from source: String,
+                                                    symbology: BarcodeSymbology? = nil,
+                                                    reason: String) -> WooAnalyticsEvent {
+
+            var properties = [Keys.source: source,
+                              Keys.reason: reason]
+
+            if let symbology = symbology {
+                properties[Keys.barcodeFormat] = symbology.rawValue
+            }
+
+            return WooAnalyticsEvent(statName: .orderProductSearchViaSKUFailure, properties: properties)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2820,7 +2820,6 @@ extension WooAnalyticsEvent {
             case cameraAccessNotPermitted = "camera_access_not_permitted"
         }
 
-
         static func barcodeScanningSuccess(from source: BarcodeScanning.Source) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .barcodeScanningSuccess, properties: [Keys.source: source.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -615,6 +615,7 @@ public enum WooAnalyticsStat: String {
     case productListAddProductTapped = "product_list_add_product_button_tapped"
     case productListClearFiltersTapped = "product_list_clear_filters_button_tapped"
     case productListShareButtonTapped = "product_list_share_button_tapped"
+    case productListProductBarcodeScanningTapped = "product_list_product_barcode_scanning_tapped"
 
     // MARK: Product List Bulk Editing Events
     //

--- a/WooCommerce/Classes/Extensions/UINavigationItem+Configuration.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationItem+Configuration.swift
@@ -1,0 +1,14 @@
+import UIKit
+import Foundation
+
+extension UINavigationItem {
+    /// Assigns a loading indicator to the `leftBarButtonItem`
+    /// This is useful when the action that follows a tap on the button is still performing, thus blocking another tap.
+    /// 
+    func configureLeftBarButtonItemAsLoader() {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = .navigationBarLoadingIndicator
+        indicator.startAnimating()
+        leftBarButtonItem = UIBarButtonItem(customView: indicator)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -2039,7 +2039,7 @@ extension EditableOrderViewModel {
     /// Attempts to add a Product to the current Order by SKU search
     ///
     func addScannedProductToOrder(barcode: ScannedBarcode, onCompletion: @escaping (Result<Void, Error>) -> Void, onRetryRequested: @escaping () -> Void) {
-        analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningSuccess(from: .orderCreation))
+        analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningSuccess(from: .orderCreation))
         mapScannedBarcodetoBaseItem(barcode: barcode) { [weak self] result in
             guard let self = self else { return }
             switch result {
@@ -2071,7 +2071,7 @@ extension EditableOrderViewModel {
     }
 
     func trackBarcodeScanningNotPermitted() {
-        analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningFailure(from: .orderCreation, reason: .cameraAccessNotPermitted))
+        analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningFailure(from: .orderCreation, reason: .cameraAccessNotPermitted))
     }
 
     /// Attempts to map SKU to Product

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -211,7 +211,7 @@ final class OrdersRootViewController: UIViewController {
 
         let productSKUBarcodeScannerCoordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                                                       onSKUBarcodeScanned: { [weak self] scannedBarcode in
-            self?.analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningSuccess(from: .orderList))
+            self?.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningSuccess(from: .orderList))
 
             self?.navigationItem.configureLeftBarButtonItemAsLoader()
             self?.handleScannedBarcode(scannedBarcode) { [weak self] result in
@@ -229,7 +229,7 @@ final class OrdersRootViewController: UIViewController {
                 }
             }
         }, onPermissionsDenied: { [weak self] in
-            self?.analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningFailure(from: .orderList, reason: .cameraAccessNotPermitted))
+            self?.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningFailure(from: .orderList, reason: .cameraAccessNotPermitted))
         })
         barcodeScannerCoordinator = productSKUBarcodeScannerCoordinator
         productSKUBarcodeScannerCoordinator.start()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -213,7 +213,7 @@ final class OrdersRootViewController: UIViewController {
                                                                                       onSKUBarcodeScanned: { [weak self] scannedBarcode in
             self?.analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningSuccess(from: .orderList))
 
-            self?.configureLeftButtonItemAsLoader()
+            self?.navigationItem.configureLeftBarButtonItemAsLoader()
             self?.handleScannedBarcode(scannedBarcode) { [weak self] result in
                 guard let self = self else { return }
                 self.configureLeftButtonItemAsProductScanningButton()
@@ -348,13 +348,6 @@ private extension OrdersRootViewController {
 
     func configureLeftButtonItemAsProductScanningButton() {
         navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
-    }
-
-    func configureLeftButtonItemAsLoader() {
-        let indicator = UIActivityIndicatorView(style: .medium)
-        indicator.color = .navigationBarLoadingIndicator
-        indicator.startAnimating()
-        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: indicator)
     }
 
     func configureFiltersBar() {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
@@ -41,7 +41,7 @@ final class ProductSelectorViewModelTracker {
             return
         }
 
-        analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUSuccess(from: Constants.orderProductSearchViaSKUSuccessSource))
+        analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaSKUSuccess(from: Constants.orderProductSearchViaSKUSuccessSource))
     }
 
     func trackSearchFailureIfNecessary(with error: Error) {
@@ -49,7 +49,7 @@ final class ProductSelectorViewModelTracker {
             return
         }
 
-        analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUFailure(from: Constants.orderProductSearchViaSKUSuccessSource,
+        analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaSKUFailure(from: Constants.orderProductSearchViaSKUSuccessSource,
                                                                                         reason: error.localizedDescription))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -168,7 +168,7 @@ class ProductListViewModel {
 
     func handleScannedBarcode(_ scannedBarcode: ScannedBarcode) async {
         do {
-            let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .orderList)
+            let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .productList)
             DDLogInfo("SKU search succesfully finished with result: \(result)")
             // TODO: Show product inventory screen
         } catch {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -17,11 +17,15 @@ class ProductListViewModel {
 
     private var wooSubscriptionProductsEligibilityChecker: WooSubscriptionProductsEligibilityCheckerProtocol
 
+    private let barcodeSKUScannerItemFinder: BarcodeSKUScannerItemFinder
+
     init(siteID: Int64,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         barcodeSKUScannerItemFinder: BarcodeSKUScannerItemFinder = BarcodeSKUScannerItemFinder()) {
         self.siteID = siteID
         self.stores = stores
         self.wooSubscriptionProductsEligibilityChecker = WooSubscriptionProductsEligibilityChecker(siteID: siteID)
+        self.barcodeSKUScannerItemFinder = barcodeSKUScannerItemFinder
     }
 
     var selectedProductsCount: Int {
@@ -160,5 +164,16 @@ class ProductListViewModel {
     ///
     var isEligibleForSubscriptions: Bool {
         wooSubscriptionProductsEligibilityChecker.isSiteEligible()
+    }
+
+    func handleScannedBarcode(_ scannedBarcode: ScannedBarcode) async {
+        do {
+            let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .orderList)
+            DDLogInfo("SKU search succesfully finished with result: \(result)")
+            // TODO: Show product inventory screen
+        } catch {
+            DDLogInfo("SKU search failed with error: \(error)")
+            // TODO: Show error notice
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -169,7 +169,7 @@ class ProductListViewModel {
     func handleScannedBarcode(_ scannedBarcode: ScannedBarcode) async {
         do {
             let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .productList)
-            DDLogInfo("SKU search succesfully finished with result: \(result)")
+            DDLogInfo("SKU search successfully finished with result: \(result)")
             // TODO: Show product inventory screen
         } catch {
             DDLogInfo("SKU search failed with error: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -500,14 +500,14 @@ private extension ProductsViewController {
             comment: "Title that appears on top of the Product List screen (plural form of the word Product)."
         )
 
+        configureNavigationBarLeftButtonItems()
         configureNavigationBarRightButtonItems()
     }
 
-    func configureNavigationBarRightButtonItems() {
-        var rightBarButtonItems = [UIBarButtonItem]()
-        rightBarButtonItems.append(addProductButton)
+    func configureNavigationBarLeftButtonItems() {
+        navigationItem.leftBarButtonItem = nil
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.barcodeScanner) && UIImagePickerController.isSourceTypeAvailable(.camera) {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory) && UIImagePickerController.isSourceTypeAvailable(.camera) {
             let buttonItem: UIBarButtonItem = {
                 let button = UIBarButtonItem(image: .scanImage,
                                              style: .plain,
@@ -523,8 +523,14 @@ private extension ProductsViewController {
 
                 return button
             }()
-            rightBarButtonItems.append(buttonItem)
+
+            navigationItem.leftBarButtonItem = buttonItem
         }
+    }
+
+    func configureNavigationBarRightButtonItems() {
+        var rightBarButtonItems = [UIBarButtonItem]()
+        rightBarButtonItems.append(addProductButton)
 
         let searchItem: UIBarButtonItem = {
             let button = UIBarButtonItem(image: .searchBarButtonItemImage,
@@ -556,7 +562,7 @@ private extension ProductsViewController {
         }()
         rightBarButtonItems.append(bulkEditItem)
 
-        navigationItem.leftBarButtonItem = nil
+
         navigationItem.rightBarButtonItems = rightBarButtonItems
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -278,7 +278,7 @@ private extension ProductsViewController {
     }
 
     @objc func scanProducts() {
-        //analytics.track(event: WooAnalyticsEvent.Orders.orderAddNewFromBarcodeScanningTapped())
+        ServiceLocator.analytics.track(.productListProductBarcodeScanningTapped)
 
         guard let navigationController = navigationController else {
             return
@@ -286,7 +286,7 @@ private extension ProductsViewController {
 
         let productSKUBarcodeScannerCoordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                                                       onSKUBarcodeScanned: { [weak self] scannedBarcode in
-            //self?.analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningSuccess(from: .orderList))
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningSuccess(from: .productList))
 
             self?.navigationItem.configureLeftBarButtonItemAsLoader()
 
@@ -295,8 +295,8 @@ private extension ProductsViewController {
                 self?.configureLeftBarBarButtomItemAsScanningButtonIfApplicable()
             }
 
-        }, onPermissionsDenied: { [weak self] in
-            //self?.analytics.track(event: WooAnalyticsEvent.Orders.barcodeScanningFailure(from: .orderList, reason: .cameraAccessNotPermitted))
+        }, onPermissionsDenied: {
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningFailure(from: .productList, reason: .cameraAccessNotPermitted))
         })
         barcodeScannerCoordinator = productSKUBarcodeScannerCoordinator
         productSKUBarcodeScannerCoordinator.start()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -296,7 +296,8 @@ private extension ProductsViewController {
             }
 
         }, onPermissionsDenied: {
-            ServiceLocator.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningFailure(from: .productList, reason: .cameraAccessNotPermitted))
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningFailure(from: .productList,
+                                                                                                           reason: .cameraAccessNotPermitted))
         })
         barcodeScannerCoordinator = productSKUBarcodeScannerCoordinator
         productSKUBarcodeScannerCoordinator.start()

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerItemFinder.swift
@@ -13,14 +13,14 @@ struct BarcodeSKUScannerItemFinder {
         self.analytics = analytics
     }
 
-    func searchBySKU(from barcode: ScannedBarcode, siteID: Int64, source: WooAnalyticsEvent.Orders.BarcodeScanningSource) async throws -> SKUSearchResult {
+    func searchBySKU(from barcode: ScannedBarcode, siteID: Int64, source: WooAnalyticsEvent.BarcodeScanning.Source) async throws -> SKUSearchResult {
         do {
             let result = try await search(by: barcode.payloadStringValue, siteID: siteID)
-            analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUSuccess(from: source.rawValue))
+            analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaSKUSuccess(from: source.rawValue))
 
             return result
         } catch {
-            analytics.track(event: WooAnalyticsEvent.Orders.orderProductSearchViaSKUFailure(from: source.rawValue,
+            analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaSKUFailure(from: source.rawValue,
                                                                                             symbology: barcode.symbology,
                                                                                             reason: trackingReason(for: error)))
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1733,6 +1733,7 @@
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
 		B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */; };
 		B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */; };
+		B98C6D502B149C3900A243E1 /* UINavigationItem+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */; };
 		B98D425B2AF9374400973C76 /* LargeHeightLeftImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98D425A2AF9374400973C76 /* LargeHeightLeftImageTableViewCell.swift */; };
 		B98D425D2AF9400900973C76 /* LargeHeightLeftImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B98D425C2AF9400900973C76 /* LargeHeightLeftImageTableViewCell.xib */; };
 		B98FF4402AAA096200326D16 /* AddressWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98FF43F2AAA096200326D16 /* AddressWooTests.swift */; };
@@ -4312,6 +4313,7 @@
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModelTests.swift; sourceTree = "<group>"; };
 		B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSection.swift; sourceTree = "<group>"; };
+		B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Configuration.swift"; sourceTree = "<group>"; };
 		B98D425A2AF9374400973C76 /* LargeHeightLeftImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeHeightLeftImageTableViewCell.swift; sourceTree = "<group>"; };
 		B98D425C2AF9400900973C76 /* LargeHeightLeftImageTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LargeHeightLeftImageTableViewCell.xib; sourceTree = "<group>"; };
 		B98FF43F2AAA096200326D16 /* AddressWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressWooTests.swift; sourceTree = "<group>"; };
@@ -10044,6 +10046,7 @@
 				864213012AE77C730036E5A6 /* UIImage+Resizing.swift */,
 				DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */,
 				DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */,
+				B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -13699,6 +13702,7 @@
 				DE74F2A327E41D650002FE59 /* EnableAnalyticsViewModel.swift in Sources */,
 				AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */,
 				EE5B5BB32AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift in Sources */,
+				B98C6D502B149C3900A243E1 /* UINavigationItem+Configuration.swift in Sources */,
 				0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */,
 				262EB5AE298C70EF009DCC36 /* SupportFormViewModel.swift in Sources */,
 				45B4F0262860BD0A00F3B16E /* WCShipCTAView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerProductFinderTests.swift
@@ -33,7 +33,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
 
     func test_findProduct_when_there_is_an_error_then_passes_and_tracks_it() async {
         // Given
-        let source = WooAnalyticsEvent.Orders.BarcodeScanningSource.orderCreation
+        let source = WooAnalyticsEvent.BarcodeScanning.Source.orderCreation
         let productNotFoundError = ProductLoadError.notFound
         let symbology = BarcodeSymbology.aztec
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
@@ -63,7 +63,7 @@ final class BarcodeSKUScannerItemFinderTests: XCTestCase {
 
     func test_findProduct_when_sku_matches_barcode_then_returns_product() async {
         // Given
-        let source = WooAnalyticsEvent.Orders.BarcodeScanningSource.orderList
+        let source = WooAnalyticsEvent.BarcodeScanning.Source.orderList
         let returningProduct = Product.fake()
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11289 and #11217 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add a feature flag for the Scan to Update Inventory project and implement the first part, scanning a barcode and searching for its SKU to get a product/variation. Furthermore, I refactored the related events codebase to include the product list source.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to products
2. Tap the navigation bar left button. The event should be tracked `product_list_product_barcode_scanning_tapped`
3. Accept the camera permissions if prompted
4. Scan a barcode linked to a product. You should see the tracked event `barcode_scanning_success` with the `"source": "product_list" `property
5. The camera should be dismissed. The left button should show a loading indicator. The SKU Search event should be tracked `product_search_via_sku_success` (sometimes we also track before `product_search_via_sku_failure`, for instance when correcting the SKU numbers for EAN13 barcodes and trying again) with the `"source": "product_list" `property
6. The log with the success result should be logged in the console: `SKU search successfully finished with result: product(Networking.Product(siteID: 214354650,...`

Try with a barcode that is not linked to any product in your store. You should see the  `product_search_via_sku_failure` with the `"source": "product_list" `property tracked event, and the log `SKU search failed with error: notFound`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/42685dd5-77ed-4c5b-b1f8-4dec37f00ad9



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
