### PR TITLE
[Bundle products in order] Make child items in product bundle read-only

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -168,35 +168,33 @@ private struct CollapsibleProductRowCard: View {
         }, content: {
             Divider()
 
-            SimplifiedProductRow(viewModel: viewModel)
-            HStack {
-                Text(Localization.priceLabel)
-                CollapsibleProductCardPriceSummary(viewModel: viewModel)
-            }
-            .padding(.bottom)
-            HStack {
-                discountRow
-            }
-            HStack {
-                Text(Localization.priceAfterDiscountLabel)
-                Spacer()
-                Text(viewModel.totalPriceAfterDiscountLabel ?? "")
+            Group {
+                SimplifiedProductRow(viewModel: viewModel)
+                HStack {
+                    Text(Localization.priceLabel)
+                    CollapsibleProductCardPriceSummary(viewModel: viewModel)
+                }
+                HStack {
+                    discountRow
+                }
+                HStack {
+                    Text(Localization.priceAfterDiscountLabel)
+                    Spacer()
+                    Text(viewModel.totalPriceAfterDiscountLabel ?? "")
+                }
+                .renderedIf(viewModel.hasDiscount)
             }
             .padding(.top)
-            .renderedIf(viewModel.hasDiscount)
-
-            Divider()
-                .padding()
 
             Group {
+                Divider()
+                    .padding()
+
                 Button(Localization.configureBundleProduct) {
                     viewModel.configure?()
                     ServiceLocator.analytics.track(event: .Orders.orderFormBundleProductConfigureCTATapped(flow: flow, source: .productCard))
                 }
                 .buttonStyle(IconButtonStyle(icon: .cogImage))
-
-                Divider()
-                    .padding()
             }
             .renderedIf(viewModel.isConfigurable)
             .onAppear {
@@ -207,19 +205,22 @@ private struct CollapsibleProductRowCard: View {
                 hasTrackedBundleProductConfigureCTAShownEvent = true
             }
 
+            Group {
+                Divider()
+                    .padding()
 
-            Button(Localization.removeProductLabel) {
-                if let removeProductIntent = viewModel.removeProductIntent {
-                    removeProductIntent()
+                Button(Localization.removeProductLabel) {
+                    if let removeProductIntent = viewModel.removeProductIntent {
+                        removeProductIntent()
+                    }
                 }
-            }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .center)
-            .foregroundColor(Color(.error))
-            .overlay {
-                TooltipView(toolTipTitle: Localization.discountTooltipTitle,
-                            toolTipDescription: Localization.discountTooltipDescription, offset: nil)
-                .renderedIf(shouldShowInfoTooltip)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .foregroundColor(Color(.error))
+                .overlay {
+                    TooltipView(toolTipTitle: Localization.discountTooltipTitle,
+                                toolTipDescription: Localization.discountTooltipDescription, offset: nil)
+                    .renderedIf(shouldShowInfoTooltip)
+                }
             }
         })
         .onTapGesture {
@@ -360,14 +361,18 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
         let childViewModels = [ProductRowViewModel(id: 2, product: product, canChangeQuantity: true, hasParentProduct: true),
                                ProductRowViewModel(id: 3, product: product, canChangeQuantity: true, hasParentProduct: true)]
-        let parentViewModel = ProductRowViewModel(id: 1, product: product, canChangeQuantity: true, childProductRows: childViewModels)
+        let bundleParentViewModel = ProductRowViewModel(id: 1,
+                                                  product: product.copy(productTypeKey: ProductType.bundle.rawValue, bundledItems: [.swiftUIPreviewSample()]),
+                                                  canChangeQuantity: true,
+                                                  childProductRows: childViewModels,
+                                                  configure: {})
         VStack {
             CollapsibleProductCard(viewModel: viewModel,
                                       flow: .creation,
                                       shouldDisableDiscountEditing: false,
                                       shouldDisallowDiscounts: false,
                                       onAddDiscount: { _ in })
-            CollapsibleProductCard(viewModel: parentViewModel,
+            CollapsibleProductCard(viewModel: bundleParentViewModel,
                                       flow: .creation,
                                       shouldDisableDiscountEditing: false,
                                       shouldDisallowDiscounts: false,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -170,6 +170,7 @@ private struct CollapsibleProductRowCard: View {
 
             Group {
                 SimplifiedProductRow(viewModel: viewModel)
+                    .renderedIf(!viewModel.isReadOnly)
                 HStack {
                     Text(Localization.priceLabel)
                     CollapsibleProductCardPriceSummary(viewModel: viewModel)
@@ -177,12 +178,13 @@ private struct CollapsibleProductRowCard: View {
                 HStack {
                     discountRow
                 }
+                .renderedIf(!viewModel.isReadOnly)
                 HStack {
                     Text(Localization.priceAfterDiscountLabel)
                     Spacer()
                     Text(viewModel.totalPriceAfterDiscountLabel ?? "")
                 }
-                .renderedIf(viewModel.hasDiscount)
+                .renderedIf(viewModel.hasDiscount && !viewModel.isReadOnly)
             }
             .padding(.top)
 
@@ -222,6 +224,7 @@ private struct CollapsibleProductRowCard: View {
                     .renderedIf(shouldShowInfoTooltip)
                 }
             }
+            .renderedIf(!viewModel.isReadOnly)
         })
         .onTapGesture {
             dismissTooltip()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -16,8 +16,6 @@ struct SimplifiedProductRow: View {
             ProductStepper(viewModel: viewModel)
                 .renderedIf(viewModel.canChangeQuantity)
         }
-        .padding(.top)
-        .padding(.bottom)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -13,6 +13,11 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     let canChangeQuantity: Bool
 
+    /// Whether the product row is read-only. Defaults to `false`.
+    ///
+    /// Used to remove product editing controls for read-only order items (e.g. child items of a product bundle).
+    private(set) var isReadOnly: Bool = false
+
     /// Unique ID for the view model.
     ///
     let id: Int64
@@ -397,6 +402,12 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         && configure != nil
 
         let productTypeLabel: String? = isConfigurable ? product.productType.description: nil
+
+        if product.productType == .bundle {
+            for child in childProductRows {
+                child.isReadOnly = true // Can't edit child bundle items separate from bundle configuration
+            }
+        }
 
         self.init(id: id,
                   productOrVariationID: product.productID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -739,6 +739,49 @@ final class ProductRowViewModelTests: XCTestCase {
             XCTAssertFalse(viewModel.isConfigurable)
         }
     }
+
+    // MARK: - `isReadOnly`
+
+    func test_isReadOnly_is_false_for_products_by_default() {
+        // Given
+        let product = Product.fake()
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
+
+        // Then
+        XCTAssertFalse(viewModel.isReadOnly, "Product should not be read only")
+    }
+
+    func test_isReadOnly_is_false_for_non_bundle_parent_and_child_items() throws {
+        // Given
+        let parent = Product.fake()
+        let children: [ProductRowViewModel] = [.init(product: .fake(), canChangeQuantity: true),
+                                               .init(productVariation: .fake(), name: "Variation", canChangeQuantity: true, displayMode: .stock)]
+
+        // When
+        let viewModel = ProductRowViewModel(product: parent, canChangeQuantity: true, childProductRows: children)
+
+        // Then
+        XCTAssertFalse(viewModel.isReadOnly, "Parent product should not be read only")
+        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).isReadOnly, "Child product should not be read only")
+        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[1]).isReadOnly, "Child product variation should not be read only")
+    }
+
+    func test_isReadOnly_is_false_for_bundle_parent_and_true_for_bundle_child_items() throws {
+        // Given
+        let parent = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue)
+        let children: [ProductRowViewModel] = [.init(product: .fake(), canChangeQuantity: false),
+                                               .init(productVariation: .fake(), name: "Variation", canChangeQuantity: false, displayMode: .stock)]
+
+        // When
+        let viewModel = ProductRowViewModel(product: parent, canChangeQuantity: true, childProductRows: children)
+
+        // Then
+        XCTAssertFalse(viewModel.isReadOnly, "Parent product should not be read only")
+        XCTAssertTrue(try XCTUnwrap(viewModel.childProductRows[0]).isReadOnly, "Child product should be read only")
+        XCTAssertTrue(try XCTUnwrap(viewModel.childProductRows[1]).isReadOnly, "Child product variation should be read only")
+    }
 }
 
 private extension ProductRowViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: https://github.com/woocommerce/woocommerce-ios/issues/11250
Part of: https://github.com/woocommerce/woocommerce-ios/issues/10428
⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/11298 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
For child items in a product bundle, we want to make them expandable but read-only (no option to add a discount or remove the child item from the order).

## How
To prepare for read-only child items, there are some updates to the `CollapsibleProductRowCard` layout. This makes the padding and dividers consistent for each view in the layout, so if a view is removed from the layout (not rendered) the padding and dividers related to that view are also removed as expected. (These changes also remove some excess padding that was around the "remove product" button.)

Then, to handle the read-only setting, we add a property `isReadOnly` to `ProductRowViewModel` and set it to `false` by default. If a row is the child of a product bundle, we set that property to `true`. In `CollapsibleProductRowCard`, we check that property and don't render the order item quantity stepper, discount row, or "remove product" options if the row is read-only.

## Testing instructions
Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and tap a bundle product from the prerequisite
- Configure the bundle and add it to the order
- On the order form, expand each card and confirm the bundle child items are read-only (showing only the top product details section and expanded price row) while other cards look and behave as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Design-After-ProductBundle-Expanded](https://github.com/woocommerce/woocommerce-ios/assets/8658164/020a1347-a5e4-43da-9911-4ffaf575f951)|![ReadOnly-After-Expanded](https://github.com/woocommerce/woocommerce-ios/assets/8658164/8de0b9a2-230f-45af-828b-2f6af1e636fe)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
