### PR TITLE
Product Subscriptions: Store payment sync date info

### DIFF
--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -5,6 +5,8 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 ## Model 103 (Release 16.5.0.0)
 - @selanthiraiyan 2023-11-27
     - Added `oneTimeShipping` attribute to `ProductSubscription` entity.
+- @selanthiraiyan 2023-11-28
+    - Added `paymentSyncDate` attribute to `ProductSubscription` entity.
 
 ## Model 102 (Release 16.2.0.0)
 - @jaclync 2023-11-15

--- a/Storage/Storage/Model/ProductSubscription+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductSubscription+CoreDataProperties.swift
@@ -18,6 +18,8 @@ extension ProductSubscription {
     @NSManaged public var product: Product?
     @NSManaged public var productVariation: ProductVariation?
     @NSManaged public var oneTimeShipping: Bool
+    @NSManaged public var paymentSyncDate: String?
+
 }
 
 extension ProductSubscription: Identifiable {

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 103.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 103.xcdatamodel/contents
@@ -608,6 +608,7 @@
     <entity name="ProductSubscription" representedClassName="ProductSubscription" syncable="YES">
         <attribute name="length" attributeType="String" defaultValueString=""/>
         <attribute name="oneTimeShipping" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="paymentSyncDate" attributeType="String" defaultValueString=""/>
         <attribute name="period" attributeType="String" defaultValueString=""/>
         <attribute name="periodInterval" attributeType="String" defaultValueString=""/>
         <attribute name="price" attributeType="String" defaultValueString=""/>

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -2399,6 +2399,34 @@ final class MigrationTests: XCTestCase {
         let oneTimeShipping = try XCTUnwrap(migratedProductSubscriptionEntity.value(forKey: "oneTimeShipping") as? Bool)
         XCTAssertFalse(oneTimeShipping, "Confirm expected property exists, and is false by default.")
     }
+
+    func test_migrating_from_102_to_103_adds_new_paymentSyncDate_attribute() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 102")
+        let sourceContext = sourceContainer.viewContext
+
+        let productSubscription = insertProductSubscription(to: sourceContext)
+        try sourceContext.save()
+
+        XCTAssertNil(productSubscription.entity.attributesByName["paymentSyncDate"], "Precondition. Property does not exist.")
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 103")
+
+        // Then
+        let targetContext = targetContainer.viewContext
+        let migratedProductSubscriptionEntity = try XCTUnwrap(targetContext.first(entityName: "ProductSubscription"))
+
+        let paymentSyncDate = try XCTUnwrap(migratedProductSubscriptionEntity.value(forKey: "paymentSyncDate") as? String)
+        XCTAssertEqual(paymentSyncDate, "", "Confirm expected property exists, and is empty by default.")
+
+        // When
+        migratedProductSubscriptionEntity.setValue("30", forKey: "paymentSyncDate")
+        try targetContext.save()
+
+        // Then
+        XCTAssertEqual(migratedProductSubscriptionEntity.value(forKey: "paymentSyncDate") as? String, "30")
+    }
 }
 
 // MARK: - Persistent Store Setup and Migrations

--- a/Yosemite/Yosemite/Model/Storage/ProductSubscription+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductSubscription+ReadOnlyConvertible.swift
@@ -17,6 +17,7 @@ extension Storage.ProductSubscription: ReadOnlyConvertible {
         trialLength = subscription.trialLength
         trialPeriod = subscription.trialPeriod.rawValue
         oneTimeShipping = subscription.oneTimeShipping
+        paymentSyncDate = subscription.paymentSyncDate
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -30,7 +31,6 @@ extension Storage.ProductSubscription: ReadOnlyConvertible {
                                    trialLength: trialLength ?? "0",
                                    trialPeriod: SubscriptionPeriod(rawValue: trialPeriod ?? "day") ?? .day,
                                    oneTimeShipping: oneTimeShipping,
-                                   // TODO: 11178 - Read `paymentSyncDate` from storage
-                                   paymentSyncDate: "")
+                                   paymentSyncDate: paymentSyncDate ?? "0")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11178 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We need to show the one-time shipping field in the shipping section of the product form. We need payment sync date information to enable/disable the toggle. 

This PR updates the `ProductSubscription` entity in Storage layer with the new attribute `paymentSyncDate`.


## Testing instructions
- Build and run the app after initially running it from trunk - the app should still run and should not crash.
- CI should pass.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
