### PR TITLE
Lightweight Storefront: Themes option in Settings

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -84,6 +84,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .customLoginUIForAccountCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .lightweightStorefront:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -179,4 +179,8 @@ public enum FeatureFlag: Int {
     /// Enables creating Subscription products
     ///
     case subscriptionProducts
+
+    /// Enables lightweight storefront project
+    ///
+    case lightweightStorefront
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -825,7 +825,8 @@ private extension SettingsViewController {
         )
 
         static let themes = NSLocalizedString(
-            "Themes",
+            "settingsViewController.themesRow",
+            value: "Themes",
             comment: "Navigates to Themes screen."
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -146,6 +146,8 @@ private extension SettingsViewController {
             configureDomain(cell: cell)
         case let cell as BasicTableViewCell where row == .installJetpack:
             configureInstallJetpack(cell: cell)
+        case let cell as BasicTableViewCell where row == .themes:
+            configureThemes(cell: cell)
         case let cell as SwitchTableViewCell where row == .storeSetupList:
             configureStoreSetupList(cell: cell)
         case let cell as BasicTableViewCell where row == .storeName:
@@ -213,6 +215,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.installJetpack
+    }
+
+    func configureThemes(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = Localization.themes
     }
 
     func configureStoreSetupList(cell: SwitchTableViewCell) {
@@ -688,6 +696,7 @@ extension SettingsViewController {
         case installJetpack
         case storeSetupList
         case storeName
+        case themes
 
         // Help & Feedback
         case support
@@ -756,6 +765,8 @@ extension SettingsViewController {
                 return BasicTableViewCell.self
             case .storeName:
                 return BasicTableViewCell.self
+            case .themes:
+                return BasicTableViewCell.self
             }
         }
 
@@ -811,6 +822,11 @@ private extension SettingsViewController {
         static let installJetpack = NSLocalizedString(
             "Install Jetpack",
             comment: "Navigates to Install Jetpack screen."
+        )
+
+        static let themes = NSLocalizedString(
+            "Themes",
+            comment: "Navigates to Themes screen."
         )
 
         static let storeSetupList = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -287,7 +287,7 @@ private extension SettingsViewModel {
                     rows.append(.installJetpack)
                 }
 
-                let themesUseCase = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
+                let themesUseCase = ThemeEligibilityUseCase()
                 if themesUseCase.isEligible(site: site) {
                     rows.append(.themes)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -287,6 +287,10 @@ private extension SettingsViewModel {
                 rows.append(.installJetpack)
             }
 
+            if featureFlagService.isFeatureFlagEnabled(.lightweightStorefront) {
+                rows.append(.themes)
+            }
+
             if !defaults.completedAllStoreOnboardingTasks,
                 featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList) {
                 rows.append(.storeSetupList)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -280,15 +280,17 @@ private extension SettingsViewModel {
         let storeSettingsSection: Section? = {
             var rows: [Row] = [.storeName]
 
-            let site = stores.sessionManager.defaultSite
-            if site?.isJetpackCPConnected == true ||
-                (site?.isNonJetpackSite == true &&
-                 featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)) {
-                rows.append(.installJetpack)
-            }
+            if let site = stores.sessionManager.defaultSite {
+                if site.isJetpackCPConnected == true ||
+                    (site.isNonJetpackSite == true &&
+                     featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)) {
+                    rows.append(.installJetpack)
+                }
 
-            if featureFlagService.isFeatureFlagEnabled(.lightweightStorefront) {
-                rows.append(.themes)
+                let themesUseCase = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
+                if themesUseCase.isEligible(site: site) {
+                    rows.append(.themes)
+                }
             }
 
             if !defaults.completedAllStoreOnboardingTasks,

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesEligibilityUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Yosemite
+import Experiments
+
+/// Checks whether a store is eligible for Lightweight Storefront feature.
+final class ThemeEligibilityUseCase {
+    private let featureFlagService: FeatureFlagService
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.featureFlagService = featureFlagService
+    }
+
+    func isEligible(site: Site) -> Bool {
+        guard featureFlagService.isFeatureFlagEnabled(.lightweightStorefront) else {
+            return false
+        }
+
+        return site.isWordPressComStore
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1456,6 +1456,7 @@
 		80F9176D2A28638C00890A83 /* products_add_new_grouped_2130.json in Resources */ = {isa = PBXBuildFile; fileRef = 80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */; };
 		8194A48313C34FE1782D51BC /* Pods_StoreWidgetsExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2886DE5218EEA78ABAF0BE67 /* Pods_StoreWidgetsExtension.framework */; };
 		86023FAA2B15CAD800A28F07 /* ThemesEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86023FA92B15CAD800A28F07 /* ThemesEligibilityUseCase.swift */; };
+		86023FAD2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86023FAC2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift */; };
 		860B85F12ADE3A0E00E85884 /* BulletPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860B85F02ADE3A0E00E85884 /* BulletPointView.swift */; };
 		864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864213012AE77C730036E5A6 /* UIImage+Resizing.swift */; };
 		86558EA82AD91B7800E10EDF /* BlazeCampaignIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86558EA72AD91B7800E10EDF /* BlazeCampaignIntroView.swift */; };
@@ -4010,6 +4011,7 @@
 		80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterScreen.swift; sourceTree = "<group>"; };
 		80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = products_add_new_grouped_2130.json; sourceTree = "<group>"; };
 		86023FA92B15CAD800A28F07 /* ThemesEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesEligibilityUseCase.swift; sourceTree = "<group>"; };
+		86023FAC2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEligibilityUseCaseTests.swift; sourceTree = "<group>"; };
 		860B85F02ADE3A0E00E85884 /* BulletPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulletPointView.swift; sourceTree = "<group>"; };
 		864213012AE77C730036E5A6 /* UIImage+Resizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resizing.swift"; sourceTree = "<group>"; };
 		86558EA72AD91B7800E10EDF /* BlazeCampaignIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignIntroView.swift; sourceTree = "<group>"; };
@@ -8450,6 +8452,14 @@
 			path = Themes;
 			sourceTree = "<group>";
 		};
+		86023FAB2B16D80E00A28F07 /* Themes */ = {
+			isa = PBXGroup;
+			children = (
+				86023FAC2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift */,
+			);
+			path = Themes;
+			sourceTree = "<group>";
+		};
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -10568,6 +10578,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				86023FAB2B16D80E00A28F07 /* Themes */,
 				EE45E2C02A42C9C70085F227 /* Feature Highlight */,
 				024D4E952A2EC6790090E0E6 /* Blaze */,
 				02CA3C9829F8EB580079E2FF /* BottomSheet */,
@@ -14131,6 +14142,7 @@
 				DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */,
 				B935D35F2A9F4EDA0067B927 /* WPAdminTaxSettingsURLProviderTests.swift in Sources */,
 				02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */,
+				86023FAD2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift in Sources */,
 				45C8B25B231521510002FA77 /* CustomerNoteTableViewCellTests.swift in Sources */,
 				B5980A6721AC91AA00EBF596 /* BundleWooTests.swift in Sources */,
 				EED0286A2A7B640300C5DE03 /* StoreCreationChallengesQuestionViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1455,6 +1455,7 @@
 		80ECB4E229D2A51A00C62EEC /* ProductFilterScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */; };
 		80F9176D2A28638C00890A83 /* products_add_new_grouped_2130.json in Resources */ = {isa = PBXBuildFile; fileRef = 80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */; };
 		8194A48313C34FE1782D51BC /* Pods_StoreWidgetsExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2886DE5218EEA78ABAF0BE67 /* Pods_StoreWidgetsExtension.framework */; };
+		86023FAA2B15CAD800A28F07 /* ThemesEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86023FA92B15CAD800A28F07 /* ThemesEligibilityUseCase.swift */; };
 		860B85F12ADE3A0E00E85884 /* BulletPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860B85F02ADE3A0E00E85884 /* BulletPointView.swift */; };
 		864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864213012AE77C730036E5A6 /* UIImage+Resizing.swift */; };
 		86558EA82AD91B7800E10EDF /* BlazeCampaignIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86558EA72AD91B7800E10EDF /* BlazeCampaignIntroView.swift */; };
@@ -4008,6 +4009,7 @@
 		80E7E7F22AF4AD3E00AA52D3 /* AddCustomerDetailsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCustomerDetailsScreen.swift; sourceTree = "<group>"; };
 		80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterScreen.swift; sourceTree = "<group>"; };
 		80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = products_add_new_grouped_2130.json; sourceTree = "<group>"; };
+		86023FA92B15CAD800A28F07 /* ThemesEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesEligibilityUseCase.swift; sourceTree = "<group>"; };
 		860B85F02ADE3A0E00E85884 /* BulletPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulletPointView.swift; sourceTree = "<group>"; };
 		864213012AE77C730036E5A6 /* UIImage+Resizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resizing.swift"; sourceTree = "<group>"; };
 		86558EA72AD91B7800E10EDF /* BlazeCampaignIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignIntroView.swift; sourceTree = "<group>"; };
@@ -8440,6 +8442,14 @@
 			path = Payments;
 			sourceTree = "<group>";
 		};
+		86023FA82B15CA8D00A28F07 /* Themes */ = {
+			isa = PBXGroup;
+			children = (
+				86023FA92B15CAD800A28F07 /* ThemesEligibilityUseCase.swift */,
+			);
+			path = Themes;
+			sourceTree = "<group>";
+		};
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -8815,6 +8825,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				86023FA82B15CA8D00A28F07 /* Themes */,
 				DED91DF72AD78A0C00CDCC53 /* Blaze */,
 				EE45E2AB2A409B4C0085F227 /* Feature Highlight */,
 				02B1AA6329A4704C00D54FCB /* FilterTabBar */,
@@ -13779,6 +13790,7 @@
 				4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */,
 				02A723282AB2E1C2003AEC7E /* GiftCardInputViewModel.swift in Sources */,
 				45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */,
+				86023FAA2B15CAD800A28F07 /* ThemesEligibilityUseCase.swift in Sources */,
 				DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */,
 				B9B0391628A6824200DC1C83 /* PermanentNoticePresenter.swift in Sources */,
 				45693189265403A1009ED69D /* ShippingLabelCarriersViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,6 +21,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let productCreationAI: Bool
     private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
+    private let isLightweightStorefrontEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -40,7 +41,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          betterCustomerSelectionInOrder: Bool = false,
          productCreationAI: Bool = false,
          productBundles: Bool = false,
-         productBundlesInOrderForm: Bool = false) {
+         productBundlesInOrderForm: Bool = false,
+         isLightweightStorefrontEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -60,6 +62,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.productCreationAI = productCreationAI
         self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
+        self.isLightweightStorefrontEnabled = isLightweightStorefrontEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -100,6 +103,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return productBundles
         case .productBundlesInOrderForm:
             return productBundlesInOrderForm
+        case .lightweightStorefront:
+            return isLightweightStorefrontEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemeEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemeEligibilityUseCaseTests.swift
@@ -14,7 +14,6 @@ class ThemeEligibilityUseCaseTests: XCTestCase {
         let isEligibleForLightweightStorefront = checker.isEligible(site: site)
 
         // Then
-
         XCTAssertFalse(isEligibleForLightweightStorefront)
     }
 
@@ -28,7 +27,6 @@ class ThemeEligibilityUseCaseTests: XCTestCase {
         let isEligibleForLightweightStorefront = checker.isEligible(site: site)
 
         // Then
-
         XCTAssertFalse(isEligibleForLightweightStorefront)
     }
 
@@ -42,7 +40,6 @@ class ThemeEligibilityUseCaseTests: XCTestCase {
         let isEligibleForLightweightStorefront = checker.isEligible(site: site)
 
         // Then
-
         XCTAssertTrue(isEligibleForLightweightStorefront)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemeEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemeEligibilityUseCaseTests.swift
@@ -1,0 +1,48 @@
+import Experiments
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+class ThemeEligibilityUseCaseTests: XCTestCase {
+    func test_site_not_eligible_for_lightweight_storefront_if_feature_flag_disabled() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: false)
+        let checker = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
+        let site = Site.fake().copy(isWordPressComStore: true)
+
+        // When
+        let isEligibleForLightweightStorefront = checker.isEligible(site: site)
+
+        // Then
+
+        XCTAssertFalse(isEligibleForLightweightStorefront)
+    }
+
+    func test_site_not_eligible_for_lightweight_storefront_if_feature_flag_enabled_but_is_not_wpcom_store() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: true)
+        let checker = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
+        let site = Site.fake().copy(isWordPressComStore: false)
+
+        // When
+        let isEligibleForLightweightStorefront = checker.isEligible(site: site)
+
+        // Then
+
+        XCTAssertFalse(isEligibleForLightweightStorefront)
+    }
+
+    func test_site_eligible_for_lightweight_storefront_if_feature_flag_enabled_and_is_wpcom_store() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: true)
+        let checker = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
+        let site = Site.fake().copy(isWordPressComStore: true)
+
+        // When
+        let isEligibleForLightweightStorefront = checker.isEligible(site: site)
+
+        // Then
+
+        XCTAssertTrue(isEligibleForLightweightStorefront)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11303, #11304
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR:
- Adds feature flag for lightweight storefront,
- Adds a use case for checking lightweight storefront eligiblity,
- Adds a "Themes" setting in Settings > Store Settings area for eligible sites.

The "Themes" setting will not do anything yet, waiting for the themes selection flow to be built first.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Use a WordPress.com site (can be regular Atomic site or Woo Express)
2. Go to Settings, ensure "Themes" is listed in "Store Settings".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/266376/e5a1d71c-2b96-4898-baf2-1f488d6c7255" width="42%" />

