### PR TITLE
[Bundle products in order] Move validation error to a notice at the bottom

### DIFF
--- a/WooCommerce/Classes/Extensions/Publisher+WithPrevious.swift
+++ b/WooCommerce/Classes/Extensions/Publisher+WithPrevious.swift
@@ -1,0 +1,14 @@
+import Combine
+
+extension Publisher {
+    /// Includes the current element as well as the previous element from the upstream publisher in a tuple where the previous element is optional.
+    /// The first time the upstream publisher emits an element, the previous element will be `nil`.
+    /// Reference: https://stackoverflow.com/a/67133582/9185596
+    ///
+    /// - Returns: A publisher of a tuple of the previous and current elements from the upstream publisher.
+    func withPrevious() -> AnyPublisher<(previous: Output?, current: Output), Failure> {
+        scan(Optional<(Output?, Output)>.none) { ($0?.1, $1) }
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemView.swift
@@ -26,11 +26,6 @@ struct ConfigurableBundleItemView: View {
                 ProductRow(viewModel: viewModel.productRowViewModel)
             }
 
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .errorStyle()
-            }
-
             HStack(spacing: 0) {
                 // Indentation from the checkmark image.
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -211,12 +211,12 @@ private extension ConfigurableBundleItemViewModel {
                 }
 
                 guard selectedVariation != nil else {
-                    return Localization.ErrorMessage.missingVariation
+                    return String(format: Localization.ErrorMessage.missingVariationFormat, product.name)
                 }
 
                 let variationAttributes = (selectedVariation?.attributes ?? []) + selectableVariationAttributeViewModels.compactMap { $0.selectedAttribute }
                 guard variationAttributes.count == product.attributesForVariations.count else {
-                    return Localization.ErrorMessage.variationMissingAttributes
+                    return String(format: Localization.ErrorMessage.variationMissingAttributesFormat, product.name)
                 }
 
                 return nil
@@ -268,9 +268,9 @@ private extension ConfigurableBundleItemViewModel {
         let minQuantityString = NumberFormatter.localizedString(from: bundleItem.minQuantity as NSDecimalNumber, number: .decimal)
         if let maxQuantity = bundleItem.maxQuantity {
             let maxQuantityString = NumberFormatter.localizedString(from: maxQuantity as NSDecimalNumber, number: .decimal)
-            return String(format: Localization.ErrorMessage.invalidQuantityWithMinAndMaxQuantityRules, minQuantityString, maxQuantityString)
+            return String(format: Localization.ErrorMessage.invalidQuantityWithMinAndMaxQuantityRulesFormat, product.name, minQuantityString, maxQuantityString)
         } else {
-            return String(format: Localization.ErrorMessage.invalidQuantityWithMinQuantityRule, minQuantityString)
+            return String(format: Localization.ErrorMessage.invalidQuantityWithMinQuantityRuleFormat, product.name, minQuantityString)
         }
     }
 }
@@ -278,25 +278,29 @@ private extension ConfigurableBundleItemViewModel {
 private extension ConfigurableBundleItemViewModel {
     enum Localization {
         enum ErrorMessage {
-            static let invalidQuantityWithMinQuantityRule = NSLocalizedString(
-                "configureBundleItemError.invalidQuantityWithMinQuantityRule",
-                value: "The quantity needs to be at least %1$@",
-                comment: "Error message when setting a bundle item's quantity with a minimum quantity rule."
+            static let invalidQuantityWithMinQuantityRuleFormat = NSLocalizedString(
+                "configureBundleItemError.invalidQuantityWithMinQuantityRuleFormat",
+                value: "The quantity of %1$@ needs to be at least %2$@.",
+                comment: "Error message when setting a bundle item's quantity with a minimum quantity rule. " +
+                "%1$@ is the variable product name. %2$@ is the minimum quantity."
             )
-            static let invalidQuantityWithMinAndMaxQuantityRules = NSLocalizedString(
-                "configureBundleItemError.invalidQuantityWithMinAndMaxQuantityRules",
-                value: "The quantity needs to be within %1$@ and %2$@",
-                comment: "Error message when setting a bundle item's quantity with minimum and maximum quantity rules."
+            static let invalidQuantityWithMinAndMaxQuantityRulesFormat = NSLocalizedString(
+                "configureBundleItemError.invalidQuantityWithMinAndMaxQuantityRulesFormat",
+                value: "The quantity of %1$@ needs to be within %2$@ and %3$@.",
+                comment: "Error message when setting a bundle item's quantity with minimum and maximum quantity rules. " +
+                "%1$@ is the variable product name. %2$@ is the minimum quantity, and %3$@ is the maximum quantity"
             )
-            static let missingVariation = NSLocalizedString(
-                "configureBundleItemError.missingVariation",
-                value: "Please select a variation",
-                comment: "Error message when a variable bundle item is missing a variation."
+            static let missingVariationFormat = NSLocalizedString(
+                "configureBundleItemError.missingVariationFormat",
+                value: "Choose a variation for %1$@.",
+                comment: "Error message format when a variable bundle item is missing a variation. " +
+                "%1$@ is the variable product name."
             )
-            static let variationMissingAttributes = NSLocalizedString(
-                "configureBundleItemError.variationMissingAttributes",
-                value: "Please select an option for all variation attributes",
-                comment: "Error message when a variable bundle item is missing some attributes."
+            static let variationMissingAttributesFormat = NSLocalizedString(
+                "configureBundleItemError.variationMissingAttributesFormat",
+                value: "Choose an option for all variation attributes for %1$@.",
+                comment: "Error message format when a variable bundle item is missing some attributes. " +
+                "%1$@ is the variable product name."
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -282,13 +282,13 @@ private extension ConfigurableBundleItemViewModel {
                 "configureBundleItemError.invalidQuantityWithMinQuantityRuleFormat",
                 value: "The quantity of %1$@ needs to be at least %2$@.",
                 comment: "Error message when setting a bundle item's quantity with a minimum quantity rule. " +
-                "%1$@ is the variable product name. %2$@ is the minimum quantity."
+                "%1$@ is the product name. %2$@ is the minimum quantity."
             )
             static let invalidQuantityWithMinAndMaxQuantityRulesFormat = NSLocalizedString(
                 "configureBundleItemError.invalidQuantityWithMinAndMaxQuantityRulesFormat",
                 value: "The quantity of %1$@ needs to be within %2$@ and %3$@.",
                 comment: "Error message when setting a bundle item's quantity with minimum and maximum quantity rules. " +
-                "%1$@ is the variable product name. %2$@ is the minimum quantity, and %3$@ is the maximum quantity"
+                "%1$@ is the product name. %2$@ is the minimum quantity, and %3$@ is the maximum quantity"
             )
             static let missingVariationFormat = NSLocalizedString(
                 "configureBundleItemError.missingVariationFormat",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleNoticeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleNoticeView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// A notice that is shown when the bundle configuration is invalid or becomes valid.
+struct ConfigurableBundleNoticeView: View {
+    /// Contains a message to be shown for the validation error.
+    struct ValidationError: Error, Equatable {
+        let message: String
+    }
+
+    let validationState: Result<Void, ValidationError>
+
+    private var backgroundColor: Color {
+        validationState.isSuccess ?
+        Color(.withColorStudio(.green, shade: .shade5)):
+        Color(.withColorStudio(.blue, shade: .shade10))
+    }
+
+    private var title: String {
+        validationState.isSuccess ? Localization.validationSuccessTitle: Localization.validationErrorTitle
+    }
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                Text(title)
+                    .bold()
+
+                if let error = validationState.failure {
+                    Text(error.message)
+                }
+            }
+            Spacer()
+        }
+        .padding(.init(top: Layout.defaultPadding, leading: Layout.defaultPadding, bottom: Layout.defaultPadding, trailing: Layout.defaultPadding))
+        .background(
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(backgroundColor.opacity(0.5))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(backgroundColor, lineWidth: 1)
+        )
+    }
+}
+
+// MARK: Constants
+private extension ConfigurableBundleNoticeView {
+    enum Layout {
+        static let verticalSpacing: CGFloat = 4
+        static let defaultPadding: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
+    }
+
+    enum Localization {
+        static let validationErrorTitle = NSLocalizedString(
+            "configureBundleProductValidationError.title",
+            value: "Configuration required",
+            comment: "Title of the error notice when the bundle configuration is currently invalid in the bundle product configuration screen."
+        )
+        static let validationSuccessTitle = NSLocalizedString(
+            "configureBundleProductValidationSuccess.title",
+            value: "Configuration complete",
+            comment: "Title of the error notice when the bundle configuration is currently valid in the bundle product configuration screen."
+        )
+    }
+}
+
+struct ConfigurableBundleNoticeView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            // Short message.
+            ConfigurableBundleNoticeView(validationState: .failure(.init(message: "Choose a variation for Caipi.")))
+            // Long message.
+            ConfigurableBundleNoticeView(validationState: .failure(.init(
+                message: "This bundle requires a total count of 2. Add 1 more of any product to continue."
+            )))
+            ConfigurableBundleNoticeView(validationState: .success(()))
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleProductView.swift
@@ -13,17 +13,9 @@ struct ConfigurableBundleProductView: View {
 
     var body: some View {
         NavigationView {
-            VStack {
+            VStack(alignment: .leading) {
                 ScrollView {
                     VStack(spacing: Layout.noSpacing) {
-                        if let validationErrorMessage = viewModel.validationErrorMessage {
-                            Group {
-                                Text(validationErrorMessage)
-                                    .errorStyle()
-                            }
-                            .padding()
-                        }
-
                         if let loadProductsErrorMessage = viewModel.loadProductsErrorMessage {
                             Group {
                                 Text(loadProductsErrorMessage)
@@ -55,6 +47,10 @@ struct ConfigurableBundleProductView: View {
                         .renderedIf(viewModel.bundleItemViewModels.isEmpty && viewModel.loadProductsErrorMessage == nil)
                     }
                 }
+
+                ConfigurableBundleNoticeView(validationState: viewModel.validationState)
+                    .padding(.horizontal, insets: .init(top: 0, leading: Layout.defaultPadding, bottom: 0, trailing: Layout.defaultPadding))
+                    .renderedIf(viewModel.showsValidationNotice)
 
                 Button(Localization.save) {
                     viewModel.configure()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -238,6 +238,8 @@
 		025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678C025773236009D7E6C /* Collection+ShippingLabel.swift */; };
 		025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
+		0258B4D82B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B4D72B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift */; };
+		0258B4DA2B159A0F008FEA07 /* Publisher+WithPrevious.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */; };
 		0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */; };
 		0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D5F82581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift */; };
 		0259D5FF2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D5FE2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift */; };
@@ -2814,6 +2816,8 @@
 		025678C025773236009D7E6C /* Collection+ShippingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+ShippingLabel.swift"; sourceTree = "<group>"; };
 		025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+ShippingLabelTests.swift"; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
+		0258B4D72B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleNoticeView.swift; sourceTree = "<group>"; };
+		0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithPrevious.swift"; sourceTree = "<group>"; };
 		0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModelTests.swift; sourceTree = "<group>"; };
 		0259D5F82581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionView.swift; sourceTree = "<group>"; };
 		0259D5FE2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionsViewController.swift; sourceTree = "<group>"; };
@@ -9558,6 +9562,7 @@
 				022266BB2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift */,
 				02038C572AF0D0F400CD36D9 /* ConfigurableVariableBundleAttributePicker.swift */,
 				02038C5B2AF0E7FC00CD36D9 /* ConfigurableVariableBundleAttributePickerViewModel.swift */,
+				0258B4D72B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift */,
 			);
 			path = ProductsSection;
 			sourceTree = "<group>";
@@ -10044,6 +10049,7 @@
 				864213012AE77C730036E5A6 /* UIImage+Resizing.swift */,
 				DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */,
 				DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */,
+				0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -12927,6 +12933,7 @@
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,
 				03B9E5272A14EA89005C77F5 /* CardReaderSupportDeterminer.swift in Sources */,
 				DEF8CF1629A8C2EB00800A60 /* AdminRoleRequiredView.swift in Sources */,
+				0258B4D82B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift in Sources */,
 				DE69C54D27BB719A000BB888 /* CouponRestrictions.swift in Sources */,
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
@@ -13078,6 +13085,7 @@
 				45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */,
 				02A410F52583A84C005E2925 /* SpacerTableViewCell.swift in Sources */,
 				02BBD6EB29A316FB00243BE2 /* StoreOnboardingCoordinator.swift in Sources */,
+				0258B4DA2B159A0F008FEA07 /* Publisher+WithPrevious.swift in Sources */,
 				D881FE062579DC78008DE6F2 /* NotWPAccountViewModel.swift in Sources */,
 				311D21ED264AF0E700102316 /* CardReaderSettingsAlerts.swift in Sources */,
 				02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
@@ -60,7 +60,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isConfigureEnabled)
     }
 
-    func test_validationErrorMessage_is_nil_when_bundle_size_matches() throws {
+    func test_validation_is_success_when_bundle_size_matches() throws {
         // Given
         // The bundle size has to be 5.
         let product = Product.fake().copy(productID: 1, bundleMinSize: 5, bundleMaxSize: 5, bundledItems: [
@@ -91,7 +91,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.isConfigureEnabled)
-        XCTAssertNil(viewModel.validationErrorMessage)
+        XCTAssertTrue(viewModel.validationState.isSuccess)
     }
 
     func test_validationErrorMessage_is_set_when_bundle_size_exceeds_max() throws {
@@ -126,7 +126,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.isConfigureEnabled)
-        XCTAssertNotNil(viewModel.validationErrorMessage)
+        XCTAssertTrue(viewModel.validationState.isFailure)
     }
 
     func test_validationErrorMessage_is_set_when_bundle_size_smaller_than_min() throws {
@@ -152,7 +152,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.isConfigureEnabled)
-        XCTAssertNotNil(viewModel.validationErrorMessage)
+        XCTAssertTrue(viewModel.validationState.isFailure)
     }
 
     // MARK: - `loadProductsErrorMessage`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
@@ -23,7 +23,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
 
     // MARK: - Validation
 
-    func test_isConfigureEnabled_is_false_when_bundle_item_is_invalid() throws {
+    func test_validation_is_failure_when_bundle_item_is_invalid() throws {
         // Given
         // The bundle size has to be 5.
         let product = Product.fake().copy(productID: 1, bundleMinSize: nil, bundleMaxSize: 5, bundledItems: [
@@ -82,7 +82,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         }
 
         XCTAssertFalse(viewModel.isConfigureEnabled)
-        XCTAssertNotNil(viewModel.validationErrorMessage)
+        XCTAssertTrue(viewModel.validationState.isFailure)
 
         // Optional non-selected bundle item quantity is not counted for the bundle size.
         let optionalItem = try XCTUnwrap(viewModel.bundleItemViewModels[0])
@@ -97,7 +97,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.validationState.isSuccess)
     }
 
-    func test_validationErrorMessage_is_nil_when_default_bundle_size_matches() throws {
+    func test_validation_is_success_when_default_bundle_size_matches() throws {
         // Given
         // The bundle size has to be 5.
         let product = Product.fake().copy(productID: 1, bundleMinSize: 5, bundleMaxSize: 5, bundledItems: [
@@ -119,10 +119,10 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         }
 
         XCTAssertTrue(viewModel.isConfigureEnabled)
-        XCTAssertNil(viewModel.validationErrorMessage)
+        XCTAssertTrue(viewModel.validationState.isSuccess)
     }
 
-    func test_validationErrorMessage_is_set_when_bundle_size_exceeds_max() throws {
+    func test_validation_is_failure_when_bundle_size_exceeds_max() throws {
         // Given
         let product = Product.fake().copy(productID: 1, bundleMaxSize: 5, bundledItems: [
             // One optional item
@@ -157,7 +157,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.validationState.isFailure)
     }
 
-    func test_validationErrorMessage_is_set_when_bundle_size_smaller_than_min() throws {
+    func test_validation_is_failure_when_bundle_size_smaller_than_min() throws {
         // Given
         let product = Product.fake().copy(productID: 1, bundleMinSize: 5, bundledItems: [
             .fake().copy(productID: 2)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11259
⚠️ Please review https://github.com/woocommerce/woocommerce-ios/pull/11292 first
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From the design review w3JBReW1UJesCf02sj43kR-fi-984_9201, we'd like to move any validation error from either the top (bundle level) or inline (bundle item level) error message to a notice at the bottom.

The design looks like:
<img width="478" alt="Screenshot 2023-11-28 at 4 05 14 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/67f3aabe-f81d-4817-ae56-d52c86e72cae">

Please note that there are still some further enhancements we can make to match the design 100%:
- Update the bundle-level error message to match the design like `This bundle requires a total count of 2. Add 1 more of any product to continue.`. I personally found it a bit verbose and would like to get your thought on whether it's worth making this change
- Hide the notice when the bundle becomes valid, like after 1 second - I'll think about how to implement this

## How

A notice view is shown when:

- The bundle configuration is invalid
- The bundle configuration **becomes** valid
  - In order to implement this state change, I added `Publisher.withPrevious` publisher to observe the current & previous values of the validation state

In `ConfigurableBundleItemView` and `ConfigurableBundleProductView`, the error message text was removed. The new notice view is `ConfigurableBundleNoticeView`, which depends on a validation state `Result<Void, ValidationError>` from the view model `ConfigurableBundleProductViewModel`. I chose to only show the first error message so that the notice height doesn't take up a lot of vertical space when there are multiple errors.

For each item level validation error message in `ConfigurableBundleItemViewModel`, the product name is now included for the merchant to know which item to update.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product **with a bundle size rule** and **at least 1 optional variable item** with non-empty variations and **at least 1 non-variable item**.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite --> a notice should be shown if the default quantities don't match the bundle size rule
- Configure the non-variable items so that they are valid --> the Save CTA should be enabled, and a green notice should be shown
- Tap the circle to select the variable item --> the Save CTA should be disabled while a notice with an error message appears
- Tap `Choose variation` to choose a variation
- In the configuration form, the attributes should be shown that look like the expected design
- Configure the variable item so that it's valid --> the Save CTA should be enabled, and a green notice should be shown
- Tap `Save Configuration`
- Tap `1 Product Selected` --> the bundle product should be added to the order with the expected configuration

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

bundle level error | valid state - light mode | item level error | valid state - dark mode
-- | -- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/93c930e7-a475-4f76-9d43-45b283beca09" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/193fab1f-8c4a-4b42-8515-02a86d7ec8cf" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/4fbe02a8-1e60-4863-8e03-088ed709bba5" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/4e7d19b3-ad84-4275-ba7e-992ef34ad2d1" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.