### PR TITLE
Make Blaze section on Dashboard dismissable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 16.5
 -----
 - [**] Shipping Labels: Fixed issue presenting the printing view for customs forms. [https://github.com/woocommerce/woocommerce-ios/pull/11288]
+- [**] My Store: The Blaze section is now dismissible. [https://github.com/woocommerce/woocommerce-ios/pull/11308]
 
 
 16.4

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -59,9 +59,14 @@ extension WooAnalyticsEvent {
                               properties: [Key.source: source.rawValue])
         }
 
-        /// Tracked when then intro screen for Blaze is displayed.
+        /// Tracked when the intro screen for Blaze is displayed.
         static func blazeIntroDisplayed() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeIntroDisplayed, properties: [:])
+        }
+
+        /// Tracked when an entry point to Blaze is dismissed.
+        static func blazeViewDismissed(source: BlazeSource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeViewDismissed, properties: [Key.source: source.analyticsValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -183,6 +183,7 @@ public enum WooAnalyticsStat: String {
     case blazeCampaignListEntryPointSelected = "blaze_campaign_list_entry_point_selected"
     case blazeCampaignDetailSelected = "blaze_campaign_detail_selected"
     case blazeIntroDisplayed = "blaze_intro_displayed"
+    case blazeViewDismissed = "blaze_view_dismissed"
 
     // MARK: Products Onboarding Events
     //

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -28,17 +28,23 @@ final class BlazeWebViewModel {
     private var isCompleted: Bool = false
 
     private let source: BlazeSource
+    private let siteID: Int64
     private let siteURL: String
     private let productID: Int64?
+    private let userDefaults: UserDefaults
     private let onCampaignCreated: (() -> Void)?
 
-    init(source: BlazeSource,
+    init(siteID: Int64,
+         source: BlazeSource,
          siteURL: String,
          productID: Int64?,
+         userDefaults: UserDefaults = .standard,
          onCampaignCreated: (() -> Void)? = nil) {
+        self.siteID = siteID
         self.source = source
         self.siteURL = siteURL
         self.productID = productID
+        self.userDefaults = userDefaults
         self.onCampaignCreated = onCampaignCreated
         self.initialURL = {
             let url = siteURL.trimHTTPScheme()
@@ -82,6 +88,7 @@ extension BlazeWebViewModel: AuthenticatedWebViewModel {
         if currentStep == Constants.completionStep {
             ServiceLocator.analytics.track(event: .Blaze.blazeFlowCompleted(source: source, step: currentStep))
             isCompleted = true
+            userDefaults.restoreBlazeSectionOnMyStore(for: siteID)
             onCampaignCreated?()
         }
     }

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -45,6 +45,9 @@ extension UserDefaults {
 
         // Celebration view after Blaze campaign creation
         case hasDisplayedTipAfterBlazeCampaignCreation
+
+        // Whether the Blaze section on My Store screen has been dismissed
+        case hasDismissedBlazeSectionOnMyStore
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -172,6 +172,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.storeProfilerAnswers] = nil
         defaults[.aiPromptTone] = nil
         defaults[.hasDisplayedTipAfterBlazeCampaignCreation] = nil
+        defaults[.hasDismissedBlazeSectionOnMyStore] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -33,7 +33,10 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
         super.init(rootView: BlazeCampaignListView(viewModel: viewModel))
 
         rootView.onCreateCampaign = { [weak self] in
-            let webViewModel = BlazeWebViewModel(source: .campaignList, siteURL: viewModel.siteURL, productID: nil) {
+            let webViewModel = BlazeWebViewModel(siteID: viewModel.siteID,
+                                                 source: .campaignList,
+                                                 siteURL: viewModel.siteURL,
+                                                 productID: nil) {
                 self?.handlePostCreation()
             }
             let webViewController = AuthenticatedWebViewController(viewModel: webViewModel)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -26,7 +26,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
     /// Tracks whether the intro view has been presented.
     private var didShowIntroView = false
 
-    private let siteID: Int64
+    let siteID: Int64
     let siteURL: String
     private let stores: StoresManager
     private let storageManager: StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -230,7 +230,6 @@ private extension BlazeCampaignDashboardView {
 
 private extension BlazeCampaignDashboardView {
     enum Layout {
-        static let margin: CGFloat = 16
         static let verticalSpacing: CGFloat = 16
         enum HeadingBlock {
             static let verticalSpacing: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -85,6 +85,7 @@ struct BlazeCampaignDashboardView: View {
 
     @ObservedObject private var viewModel: BlazeCampaignDashboardViewModel
     @State private var selectedProductID: Int64?
+    @State private var showingOptions: Bool = false
 
     init(viewModel: BlazeCampaignDashboardViewModel) {
         self.viewModel = viewModel
@@ -142,10 +143,33 @@ struct BlazeCampaignDashboardView: View {
                 viewModel.shouldShowIntroView = false
             })
         }
+        .overlay {
+            topRightMenu
+        }
     }
 }
 
 private extension BlazeCampaignDashboardView {
+    var topRightMenu: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Button {
+                    showingOptions = true
+                } label: {
+                    Image(uiImage: .ellipsisImage)
+                }
+                .confirmationDialog("", isPresented: $showingOptions) {
+                    Button(Localization.hideBlaze) {
+                        // TODO
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding(Layout.insets)
+    }
+
     var createCampaignButton: some View {
         Button {
             viewModel.checkIfIntroViewIsNeeded()
@@ -205,6 +229,7 @@ private extension BlazeCampaignDashboardView {
 
 private extension BlazeCampaignDashboardView {
     enum Layout {
+        static let margin: CGFloat = 16
         static let verticalSpacing: CGFloat = 16
         enum HeadingBlock {
             static let verticalSpacing: CGFloat = 8
@@ -237,6 +262,12 @@ private extension BlazeCampaignDashboardView {
         static let done = NSLocalizedString("Done", comment: "Button to dismiss the Blaze campaign detail view")
 
         static let detailTitle = NSLocalizedString("Campaign Details", comment: "Title of the Blaze campaign details view.")
+
+        static let hideBlaze = NSLocalizedString(
+            "blazeCampaignDashboardView.hideBlazeButton",
+            value: "Hide Blaze",
+            comment: "Button to dismiss the Blaze campaign section on the My Store screen."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -88,7 +88,6 @@ struct BlazeCampaignDashboardView: View {
 
     @ObservedObject private var viewModel: BlazeCampaignDashboardViewModel
     @State private var selectedProductID: Int64?
-    @State private var showingOptions: Bool = false
 
     init(viewModel: BlazeCampaignDashboardViewModel) {
         self.viewModel = viewModel
@@ -158,15 +157,13 @@ private extension BlazeCampaignDashboardView {
         VStack {
             HStack {
                 Spacer()
-                Button {
-                    showingOptions = true
-                } label: {
-                    Image(uiImage: .ellipsisImage)
-                }
-                .confirmationDialog("", isPresented: $showingOptions) {
+                Menu {
                     Button(Localization.hideBlaze) {
                         viewModel.dismissBlazeSection()
                     }
+                } label: {
+                    Image(uiImage: .ellipsisImage)
+                        .foregroundColor(Color(.textTertiary))
                 }
             }
             Spacer()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -42,7 +42,10 @@ final class BlazeCampaignDashboardViewHostingController: SelfSizingHostingContro
 private extension BlazeCampaignDashboardViewHostingController {
     /// Handles navigation to the campaign creation web view
     func navigateToCampaignCreation(source: BlazeSource, productID: Int64? = nil) {
-        let webViewModel = BlazeWebViewModel(source: source, siteURL: viewModel.siteURL, productID: productID) { [weak self] in
+        let webViewModel = BlazeWebViewModel(siteID: viewModel.siteID,
+                                             source: source,
+                                             siteURL: viewModel.siteURL,
+                                             productID: productID) { [weak self] in
             self?.handlePostCreation()
         }
         let webViewController = AuthenticatedWebViewController(viewModel: webViewModel)
@@ -145,6 +148,7 @@ struct BlazeCampaignDashboardView: View {
         }
         .overlay {
             topRightMenu
+                .renderedIf(viewModel.shouldRedactView == false)
         }
     }
 }
@@ -161,7 +165,7 @@ private extension BlazeCampaignDashboardView {
                 }
                 .confirmationDialog("", isPresented: $showingOptions) {
                     Button(Localization.hideBlaze) {
-                        // TODO
+                        viewModel.dismissBlazeSection()
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -6,7 +6,7 @@ import protocol Storage.StorageManagerType
 /// View model for `BlazeCampaignDashboardView`.
 final class BlazeCampaignDashboardViewModel: ObservableObject {
     /// UI state of the Blaze campaign view in dashboard.
-    enum State {
+    enum State: Equatable {
         /// Shows placeholder views in redacted state.
         case loading
         /// Shows info about the latest Blaze campaign
@@ -205,10 +205,6 @@ private extension BlazeCampaignDashboardViewModel {
     }
 
     func updateResults() {
-        guard !userDefaults.hasDismissedBlazeSectionOnMyStore(for: siteID) else {
-            update(state: .empty)
-            return
-        }
         if let campaign = blazeCampaignResultsController.fetchedObjects.first {
             update(state: .showCampaign(campaign: campaign))
         } else if let product = latestPublishedProduct {
@@ -261,6 +257,7 @@ private extension BlazeCampaignDashboardViewModel {
             .store(in: &subscriptions)
 
         userDefaults.hasDismissedBlazeSectionOnMyStorePublisher
+            .dropFirst() // ignores first event because data is already loaded initially.
             .removeDuplicates()
             .sink { [weak self] hasDismissed in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -256,8 +256,14 @@ private extension BlazeCampaignDashboardViewModel {
             }
             .store(in: &subscriptions)
 
-        userDefaults.hasDismissedBlazeSectionOnMyStorePublisher
+        userDefaults.publisher(for: \.hasDismissedBlazeSectionOnMyStore)
             .dropFirst() // ignores first event because data is already loaded initially.
+            .map { [weak self] hasDismissed -> Bool in
+                guard let self else {
+                    return false
+                }
+                return self.userDefaults.hasDismissedBlazeSectionOnMyStore(for: self.siteID)
+            }
             .removeDuplicates()
             .sink { [weak self] hasDismissed in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -143,6 +143,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
     func dismissBlazeSection() {
         userDefaults.setDismissedBlazeSectionOnMyStore(for: siteID)
+        analytics.track(event: .Blaze.blazeViewDismissed(source: .myStoreSection))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -143,6 +143,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
     func dismissBlazeSection() {
         userDefaults.setDismissedBlazeSectionOnMyStore(for: siteID)
+        update(state: .empty)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -259,7 +259,7 @@ private extension BlazeCampaignDashboardViewModel {
 
         userDefaults.publisher(for: \.hasDismissedBlazeSectionOnMyStore)
             .dropFirst() // ignores first event because data is already loaded initially.
-            .map { [weak self] hasDismissed -> Bool in
+            .map { [weak self] _ -> Bool in
                 guard let self else {
                     return false
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/UserDefaults+Blaze.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/UserDefaults+Blaze.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Combine
+
+extension UserDefaults {
+
+    /// Publisher to observe the changes to the dismissal state of the Blaze section on My Store screen.
+    var hasDismissedBlazeSectionOnMyStorePublisher: AnyPublisher<Bool, Never> {
+        ServiceLocator.stores.site
+            .combineLatest(self.publisher(for: \.hasDismissedBlazeSectionOnMyStore))
+            .map { [weak self] (site, hasDismissed) -> Bool in
+                guard let self, let site else {
+                    return false
+                }
+                return self.hasDismissedBlazeSectionOnMyStore(for: site.siteID)
+            }
+            .eraseToAnyPublisher()
+    }
+
+    /// Expose value for `hasDismissedBlazeSectionOnMyStore` to be observable through KVO.
+    @objc private var hasDismissedBlazeSectionOnMyStore: Bool {
+        get {
+            bool(forKey: Key.hasDismissedBlazeSectionOnMyStore.rawValue)
+        }
+        set {
+            set(newValue, forKey: Key.hasDismissedBlazeSectionOnMyStore.rawValue)
+        }
+    }
+
+    /// Checks if the Blaze section on My Store has been dismissed for a site.
+    ///
+    func hasDismissedBlazeSectionOnMyStore(for siteID: Int64) -> Bool {
+        let hasDismissed = self[.hasDismissedBlazeSectionOnMyStore] as? [String: Bool]
+        let idAsString = "\(siteID)"
+        return hasDismissed?[idAsString] == true
+    }
+
+    /// Marks the Blaze section on My Store as **not** dismissed for a site.
+    ///
+    func restoreBlazeSectionOnMyStore(for siteID: Int64) {
+        let idAsString = "\(siteID)"
+        guard var hasDismissed = self[.hasDismissedBlazeSectionOnMyStore] as? [String: Bool] else {
+            return
+        }
+        hasDismissed[idAsString] = false
+        self[.hasDismissedBlazeSectionOnMyStore] = hasDismissed
+    }
+
+    /// Marks the Blaze section on My Store as dismissed for a site.
+    ///
+    func setDismissedBlazeSectionOnMyStore(for siteID: Int64) {
+        let idAsString = "\(siteID)"
+        if var hasDismissed = self[.hasDismissedBlazeSectionOnMyStore] as? [String: Bool] {
+            hasDismissed[idAsString] = true
+            self[.hasDismissedBlazeSectionOnMyStore] = hasDismissed
+        } else {
+            self[.hasDismissedBlazeSectionOnMyStore] = [idAsString: true]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/UserDefaults+Blaze.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/UserDefaults+Blaze.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Combine
 
 extension UserDefaults {
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/UserDefaults+Blaze.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/UserDefaults+Blaze.swift
@@ -3,21 +3,8 @@ import Combine
 
 extension UserDefaults {
 
-    /// Publisher to observe the changes to the dismissal state of the Blaze section on My Store screen.
-    var hasDismissedBlazeSectionOnMyStorePublisher: AnyPublisher<Bool, Never> {
-        ServiceLocator.stores.site
-            .combineLatest(self.publisher(for: \.hasDismissedBlazeSectionOnMyStore))
-            .map { [weak self] (site, hasDismissed) -> Bool in
-                guard let self, let site else {
-                    return false
-                }
-                return self.hasDismissedBlazeSectionOnMyStore(for: site.siteID)
-            }
-            .eraseToAnyPublisher()
-    }
-
     /// Expose value for `hasDismissedBlazeSectionOnMyStore` to be observable through KVO.
-    @objc private var hasDismissedBlazeSectionOnMyStore: Bool {
+    @objc var hasDismissedBlazeSectionOnMyStore: Bool {
         get {
             bool(forKey: Key.hasDismissedBlazeSectionOnMyStore.rawValue)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1130,7 +1130,10 @@ private extension ProductFormViewController {
     }
 
     private func navigateToBlazeCampaignCreation(siteUrl: String, source: BlazeSource) {
-        let blazeViewModel = BlazeWebViewModel(source: source, siteURL: siteUrl, productID: product.productID)
+        let blazeViewModel = BlazeWebViewModel(siteID: viewModel.productModel.siteID,
+                                               source: source,
+                                               siteURL: siteUrl,
+                                               productID: product.productID)
         let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
         navigationController?.show(webViewController, sender: self)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2299,6 +2299,7 @@
 		DED974112AD8F05A00122EB4 /* URL+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED974102AD8F05A00122EB4 /* URL+Identifiable.swift */; };
 		DEDA8D972B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D962B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift */; };
 		DEDA8D992B04643E0076BF0F /* ProductSubscription+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */; };
+		DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4891,6 +4892,7 @@
 		DED974102AD8F05A00122EB4 /* URL+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Identifiable.swift"; sourceTree = "<group>"; };
 		DEDA8D962B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscriptionPeriodPickerUseCaseTests.swift; sourceTree = "<group>"; };
 		DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+Empty.swift"; sourceTree = "<group>"; };
+		DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Blaze.swift"; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -11439,6 +11441,7 @@
 			children = (
 				EEBA02A22ADD6005001FE8E4 /* BlazeCampaignDashboardView.swift */,
 				EEBA02A42ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift */,
+				DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -13887,6 +13890,7 @@
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
 				DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
+				DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */,
 				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2300,6 +2300,7 @@
 		DEDA8D972B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D962B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift */; };
 		DEDA8D992B04643E0076BF0F /* ProductSubscription+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */; };
 		DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */; };
+		DEDA8D9F2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4893,6 +4894,7 @@
 		DEDA8D962B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscriptionPeriodPickerUseCaseTests.swift; sourceTree = "<group>"; };
 		DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+Empty.swift"; sourceTree = "<group>"; };
 		DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Blaze.swift"; sourceTree = "<group>"; };
+		DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsBlazeTests.swift; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -11477,6 +11479,7 @@
 			isa = PBXGroup;
 			children = (
 				EEC5C8D92ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift */,
+				DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -14487,6 +14490,7 @@
 				D88D5A3B230B5D63007B6E01 /* MockAnalyticsProvider.swift in Sources */,
 				B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */,
 				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,
+				DEDA8D9F2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift in Sources */,
 				573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */,
 				DEBAB70D2A7A6F1100743185 /* MockStorePlanSynchronizer.swift in Sources */,
 				DE36E09E2A8A2C6A00B98496 /* StoreCreationProfilerQuestionContainerViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeWebViewModelTests.swift
@@ -3,14 +3,15 @@ import Yosemite
 @testable import WooCommerce
 
 final class BlazeWebViewModelTests: XCTestCase {
-    // MARK: - `initialURL`
+
+    private let sampleSiteID: Int64 = 123
 
     func test_initialURL_includes_source_and_siteURL_and_productID_when_product_is_available() {
         // Given
         let source: BlazeSource = .campaignList
         let siteURL = "https://example.com"
         let productID: Int64? = 134
-        let viewModel = BlazeWebViewModel(source: source, siteURL: siteURL, productID: productID)
+        let viewModel = BlazeWebViewModel(siteID: sampleSiteID, source: source, siteURL: siteURL, productID: productID)
 
         // Then
         XCTAssertEqual(viewModel.initialURL, URL(string: "https://wordpress.com/advertising/example.com?blazepress-widget=post-134&source=campaign_list"))
@@ -20,9 +21,26 @@ final class BlazeWebViewModelTests: XCTestCase {
         // Given
         let source: BlazeSource = .productMoreMenu
         let siteURL = "https://example.com"
-        let viewModel = BlazeWebViewModel(source: source, siteURL: siteURL, productID: nil)
+        let viewModel = BlazeWebViewModel(siteID: sampleSiteID, source: source, siteURL: siteURL, productID: nil)
 
         // Then
         XCTAssertEqual(viewModel.initialURL, URL(string: "https://wordpress.com/advertising/example.com?source=product_more_menu"))
+    }
+
+    func test_hasDismissedBlazeSectionOnMyStore_is_updated_upon_completion() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        userDefaults.setDismissedBlazeSectionOnMyStore(for: sampleSiteID)
+
+        let siteURL = "https://example.com"
+        let viewModel = BlazeWebViewModel(siteID: sampleSiteID, source: .productMoreMenu, siteURL: siteURL, productID: nil, userDefaults: userDefaults)
+
+        // When
+        let path = "https://wordpress.com/advertising/example.com?blazepress-widget#step-5"
+        viewModel.handleRedirect(for: URL(string: path))
+
+        // Then
+        XCTAssertEqual(userDefaults.hasDismissedBlazeSectionOnMyStore(for: sampleSiteID), false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -26,7 +26,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: .fake().copy(siteID: sampleSiteID)))
+        stores = MockStoresManager(sessionManager: .testingInstance)
         storageManager = MockStorageManager()
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
@@ -818,7 +818,6 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     func test_dismissBlazeSection_sets_state_to_empty() async throws {
         // Given
-        ServiceLocator.setStores(stores) // injecting because we need access through service locator in user defaults
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let uuid = UUID().uuidString
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/UserDefaultsBlazeTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/UserDefaultsBlazeTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import WooCommerce
+
+final class UserDefaultsBlazeTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 123
+
+    func test_hasDismissedBlazeSectionOnMyStore_returns_correct_value() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        userDefaults[.hasDismissedBlazeSectionOnMyStore] = ["\(sampleSiteID)": false]
+
+        // When
+        let hasDismissed = userDefaults.hasDismissedBlazeSectionOnMyStore(for: sampleSiteID)
+
+        // Then
+        XCTAssertFalse(hasDismissed)
+    }
+
+    func test_restoreBlazeSectionOnMyStore_sets_the_blaze_section_to_be_not_dismissed() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        userDefaults[.hasDismissedBlazeSectionOnMyStore] = ["\(sampleSiteID)": true]
+
+        // When
+        userDefaults.restoreBlazeSectionOnMyStore(for: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(userDefaults[.hasDismissedBlazeSectionOnMyStore], ["\(sampleSiteID)": false])
+    }
+
+    func test_setDismissedBlazeSectionOnMyStore_sets_the_blaze_section_to_be_dismissed() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        userDefaults[.hasDismissedBlazeSectionOnMyStore] = ["\(sampleSiteID)": false]
+
+        // When
+        userDefaults.setDismissedBlazeSectionOnMyStore(for: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(userDefaults[.hasDismissedBlazeSectionOnMyStore], ["\(sampleSiteID)": true])
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11302 
<!-- Id number of the GitHub issue this PR addresses. -->

## What
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new button on the Blaze section on the My Store screen. This button displays only one option, which is to dismiss the section for the currently selected store. When the user creates a Blaze campaign for the same store, the section will reappear.

## How
- Added a new `UserDefaults` key `hasDismissedBlazeSectionOnMyStore` to keep track of the state of the section on the My Store screen.
- Added an extension of `UserDefaults` to get, set and reset the values for `hasDismissedBlazeSectionOnMyStore`.
- Updated `BlazeWebViewModel` to trigger restoring the Blaze section upon completion of campaign creation.
- Updated `BlazeCampaignDashboardView` to show a button for dismissing the section.
- Updated `BlazeCampaignDashboardViewModel` to handle dismissing the section and observing the state of its visibility.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store that is eligible for creating Blaze campaigns.
- Notice that the Blaze section is initially displayed below the Stats section, with an ellipsis menu on the top right.
- Tap the ellipsis button, notice that an option to hide the section is displayed.
- Tap Hide Blaze, the section should be dismissed. Confirm that the following event is tracked: `blaze_view_dismissed`, Properties: {"source":"my_store_section"}.
- Relaunch the app, the Blaze section should still be hidden. 
- Switch to another store eligible for Blaze if you account has access to one. Notice that the Blaze section is still available for this store.
- Switch back to the initial store and create a Blaze campaign. After completion, the Blaze campaign should be displayed again on the My Store screen.
- Dismiss the section and again and log out of your account.
- Log back in, the Blaze section should be visible on the My Store screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/5700782c-015f-43a1-ae95-fef6f68fe534" width=320 /> <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/2b6d0f18-706f-4eec-b6c8-1bc2129ea815" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
