### PR TITLE
Product Subscriptions: One time shipping setting

### DIFF
--- a/Fakes/Fakes/Products/ProductFactory.swift
+++ b/Fakes/Fakes/Products/ProductFactory.swift
@@ -48,7 +48,8 @@ public enum ProductFactory {
                             shippingClass: "standard",
                             shippingClassID: 123,
                             categories: [.fake()],
-                            tags: [.fake()])
+                            tags: [.fake()],
+                            subscription: .fake())
     }
 
     /// Returns a simple product that is ready to test the product form actions

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -71,7 +71,7 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
 
             return stringValue == Constants.yes
         }()
-        paymentSyncDate = try container.decodeIfPresent(String.self, forKey: .paymentSyncDate) ?? "0"
+        paymentSyncDate = (try? container.decodeIfPresent(String.self, forKey: .paymentSyncDate)) ?? "0"
     }
 
     func toKeyValuePairs() -> [KeyValuePair] {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 16.5
 -----
 - [**] Shipping Labels: Fixed issue presenting the printing view for customs forms. [https://github.com/woocommerce/woocommerce-ios/pull/11288]
-- [*] Now, merchants can manage "One time shipping" setting for a subscription product. [https://github.com/woocommerce/woocommerce-ios/issues/11310]
+- [*] Now, merchants can manage "One time shipping" setting for a subscription product. [https://github.com/woocommerce/woocommerce-ios/pull/11310]
 
 
 16.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 16.5
 -----
 - [**] Shipping Labels: Fixed issue presenting the printing view for customs forms. [https://github.com/woocommerce/woocommerce-ios/pull/11288]
+- [*] Now, merchants can manage "One time shipping" setting for a subscription products. [https://github.com/woocommerce/woocommerce-ios/issues/11310]
 
 
 16.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 16.5
 -----
 - [**] Shipping Labels: Fixed issue presenting the printing view for customs forms. [https://github.com/woocommerce/woocommerce-ios/pull/11288]
-- [*] Now, merchants can manage "One time shipping" setting for a subscription products. [https://github.com/woocommerce/woocommerce-ios/issues/11310]
+- [*] Now, merchants can manage "One time shipping" setting for a subscription product. [https://github.com/woocommerce/woocommerce-ios/issues/11310]
 
 
 16.4

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -665,11 +665,11 @@ private extension DefaultProductFormTableViewModel {
 extension DefaultProductFormTableViewModel {
     enum Localization {
         // Subscription Free Trial
-        static let subscriptionFreeTrialTitle = NSLocalizedString("defaultProductFormTableViewModel.noFreeTrial",
+        static let subscriptionFreeTrialTitle = NSLocalizedString("defaultProductFormTableViewModel.freeTrialRow.title",
                                                                   value: "Free Trial",
                                                                   comment: "Title for Subscription Free Trial row in the product form screen.")
 
-        static let noTrialPeriod = NSLocalizedString("defaultProductFormTableViewModel.noFreeTrial",
+        static let noTrialPeriod = NSLocalizedString("defaultProductFormTableViewModel.freeTrialRow.noTrialPeriod",
                                                      value: "No trial period",
                                                      comment: "Display label when a subscription has no trial period.")
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1462,9 +1462,10 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func editShippingSettings() {
         let shippingSettingsViewController = ProductShippingSettingsViewController(product: product) {
-            [weak self] (weight, dimensions, shippingClass, shippingClassID, hasUnsavedChanges) in
+            [weak self] (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
             self?.onEditShippingSettingsCompletion(weight: weight,
                                                    dimensions: dimensions,
+                                                   oneTimeShipping: oneTimeShipping,
                                                    shippingClass: shippingClass,
                                                    shippingClassID: shippingClassID,
                                                    hasUnsavedChanges: hasUnsavedChanges)
@@ -1474,6 +1475,7 @@ private extension ProductFormViewController {
 
     func onEditShippingSettingsCompletion(weight: String?,
                                           dimensions: ProductDimensions,
+                                          oneTimeShipping: Bool?,
                                           shippingClass: String?,
                                           shippingClassID: Int64?,
                                           hasUnsavedChanges: Bool) {
@@ -1485,7 +1487,11 @@ private extension ProductFormViewController {
         guard hasUnsavedChanges else {
             return
         }
-        viewModel.updateShippingSettings(weight: weight, dimensions: dimensions, shippingClass: shippingClass, shippingClassID: shippingClassID)
+        viewModel.updateShippingSettings(weight: weight,
+                                         dimensions: dimensions,
+                                         oneTimeShipping: oneTimeShipping,
+                                         shippingClass: shippingClass,
+                                         shippingClassID: shippingClassID)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -393,11 +393,17 @@ extension ProductFormViewModel {
                                                                      soldIndividually: soldIndividually))
     }
 
-    func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: String?, shippingClassID: Int64?) {
+    func updateShippingSettings(weight: String?,
+                                dimensions: ProductDimensions,
+                                oneTimeShipping: Bool?,
+                                shippingClass: String?,
+                                shippingClassID: Int64?) {
+        let subscription = product.subscription?.copy(oneTimeShipping: oneTimeShipping)
         product = EditableProductModel(product: product.product.copy(weight: weight,
                                                                      dimensions: dimensions,
                                                                      shippingClass: shippingClass ?? "",
-                                                                     shippingClassID: shippingClassID ?? 0))
+                                                                     shippingClassID: shippingClassID ?? 0,
+                                                                     subscription: subscription))
     }
 
     func updateProductCategories(_ categories: [ProductCategory]) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -509,8 +509,21 @@ extension ProductFormViewModel {
     }
 
     func updateSubscriptionFreeTrialSettings(trialLength: String, trialPeriod: SubscriptionPeriod) {
+        let oneTimeShipping: Bool? = {
+            guard let subscription = product.subscription else {
+                return nil
+            }
+
+            // One time shipping can be turned on only if there is no Free trial
+            guard trialLength.isEmpty || trialLength == "0" else {
+                return false
+            }
+
+            return subscription.oneTimeShipping
+        }()
         let subscription = product.subscription?.copy(trialLength: trialLength,
-                                                      trialPeriod: trialPeriod)
+                                                      trialPeriod: trialPeriod,
+                                                      oneTimeShipping: oneTimeShipping ?? nil)
         product = EditableProductModel(product: product.product.copy(subscription: subscription))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -119,7 +119,11 @@ protocol ProductFormViewModelProtocol {
 
     func updateProductType(productType: BottomSheetProductType)
 
-    func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: String?, shippingClassID: Int64?)
+    func updateShippingSettings(weight: String?,
+                                dimensions: ProductDimensions,
+                                oneTimeShipping: Bool?,
+                                shippingClass: String?,
+                                shippingClassID: Int64?)
 
     func updateProductCategories(_ categories: [ProductCategory])
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -278,11 +278,17 @@ extension ProductVariationFormViewModel {
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
-    func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: String?, shippingClassID: Int64?) {
+    func updateShippingSettings(weight: String?,
+                                dimensions: ProductDimensions,
+                                // `oneTimeShipping` is ignored as this setting is not applicable for variation
+                                // this needs to be set on the parent product
+                                oneTimeShipping: Bool?,
+                                shippingClass: String?,
+                                shippingClassID: Int64?) {
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(weight: weight,
-                                                 dimensions: dimensions,
-                                                 shippingClass: shippingClass ?? "",
-                                                 shippingClassID: shippingClassID ?? 0),
+                                                                                                                  dimensions: dimensions,
+                                                                                                                  shippingClass: shippingClass ?? "",
+                                                                                                                  shippingClassID: shippingClassID ?? 0),
                                                          parentProductType: productVariation.productType,
                                                          allAttributes: allAttributes,
                                                          parentProductSKU: parentProductSKU,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -12,10 +12,11 @@ final class ProductShippingSettingsViewController: UIViewController {
     private var hasRetrievedShippingClassIfNeeded: Bool = false
 
     typealias Completion = (_ weight: String?,
-        _ dimensions: ProductDimensions,
-        _ shippingClassSlug: String?,
-        _ shippingClassID: Int64?,
-        _ hasUnsavedChanges: Bool) -> Void
+                            _ dimensions: ProductDimensions,
+                            _ oneTimeShipping: Bool?,
+                            _ shippingClassSlug: String?,
+                            _ shippingClassID: Int64?,
+                            _ hasUnsavedChanges: Bool) -> Void
     private let onCompletion: Completion
 
     private let viewModel: ProductShippingSettingsViewModelOutput & ProductShippingSettingsActionHandler

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -265,6 +265,7 @@ extension ProductShippingSettingsViewController {
         case width
         case height
         case shippingClass
+        case oneTimeShipping
 
         fileprivate var type: UITableViewCell.Type {
             switch self {
@@ -272,6 +273,8 @@ extension ProductShippingSettingsViewController {
                 return UnitInputTableViewCell.self
             case .shippingClass:
                 return TitleAndValueTableViewCell.self
+            case .oneTimeShipping:
+                return SwitchTableViewCell.self
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -201,6 +201,8 @@ private extension ProductShippingSettingsViewController {
             configureHeight(cell: cell)
         case let cell as TitleAndValueTableViewCell where row == .shippingClass:
             configureShippingClass(cell: cell)
+        case let cell as SwitchTableViewCell where row == .oneTimeShipping:
+            configureOneTimeShipping(cell: cell)
         default:
             fatalError()
         }
@@ -242,6 +244,18 @@ private extension ProductShippingSettingsViewController {
         let title = NSLocalizedString("Shipping class", comment: "Title of the cell in Product Shipping Settings > Shipping class")
         cell.updateUI(title: title, value: viewModel.shippingClass?.name)
         cell.accessoryType = .disclosureIndicator
+    }
+
+    func configureOneTimeShipping(cell: SwitchTableViewCell) {
+        cell.title = Localization.OneTimeShipping.title
+        cell.subtitle = {
+            viewModel.supportsOneTimeShipping ? Localization.OneTimeShipping.subtitle : Localization.OneTimeShipping.subtitleDisabled
+        }()
+        cell.isOn = viewModel.oneTimeShipping ?? false
+        cell.isUserInteractionEnabled = viewModel.supportsOneTimeShipping
+        cell.onChange = { [weak self] newValue in
+            self?.viewModel.handleOneTimeShippingChange(newValue)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -280,3 +280,29 @@ extension ProductShippingSettingsViewController {
         }
     }
 }
+
+// MARK: Localization
+
+private extension ProductShippingSettingsViewController {
+    enum Localization {
+        enum OneTimeShipping {
+            static let title = NSLocalizedString(
+                "productShippingSettings.oneTimeShipping.title",
+                value: "One time shipping",
+                comment: "Title for the One time shipping product shipping setting."
+            )
+
+            static let subtitle = NSLocalizedString(
+                "productShippingSettings.oneTimeShipping.subtitle",
+                value: "Enable this to charge shipping once on the initial order.",
+                comment: "Subtitle for the One time shipping product shipping setting."
+            )
+
+            static let subtitleDisabled = NSLocalizedString(
+                "productShippingSettings.oneTimeShipping.subtitleDisabled",
+                value: "For this setting to be enabled the subscription must not have a free trial or a synced renewal date.",
+                comment: "Subtitle for the One time shipping product shipping setting when it is disabled."
+            )
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -217,6 +217,7 @@ extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler
                                            height: height ?? "")
         onCompletion(weight,
                      dimensions,
+                     oneTimeShipping,
                      shippingClassSlug,
                      shippingClassID,
                      hasUnsavedChanges())

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -135,8 +135,9 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
         case is EditableProductModel:
             sections = [
                 Section(rows: [.weight, .length, .width, .height]),
-                Section(rows: [.shippingClass])
-            ]
+                Section(rows: [.shippingClass]),
+                product.subscription.map { _ in Section(rows: [.oneTimeShipping]) }
+            ].compactMap { $0 }
         case is EditableProductVariationModel:
             sections = [
                 Section(rows: [.weight, .length, .width, .height])

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -147,6 +147,11 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
         }
 
         configureResultsController()
+
+        // If `oneTimeShipping` is `true` when there is no support for one time shipping set it as `false`
+        if !supportsOneTimeShipping && oneTimeShipping == true {
+            oneTimeShipping = false
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -227,6 +227,7 @@ extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler
             || length != product.dimensions.length
             || width != product.dimensions.width
             || height != product.dimensions.height
+            || oneTimeShipping != product.subscription?.oneTimeShipping
             || shippingClass != originalShippingClass
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// Provides data needed for shipping settings.
 ///
@@ -49,6 +50,7 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
     let sections: [Section]
     let product: ProductFormDataModel
 
+    private let storageManager: StorageManagerType
     // Localizes weight and package dimensions
     //
     private let shippingValueLocalizer: ShippingValueLocalizer
@@ -85,8 +87,10 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
     private var originalShippingClass: ProductShippingClass?
 
     init(product: ProductFormDataModel,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
          shippingValueLocalizer: ShippingValueLocalizer = DefaultShippingValueLocalizer()) {
         self.product = product
+        self.storageManager = storageManager
         self.shippingValueLocalizer = shippingValueLocalizer
         weight = product.weight
         length = product.dimensions.length

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -16,6 +16,9 @@ protocol ProductShippingSettingsViewModelOutput {
     var localizedWidth: String? { get }
     var localizedHeight: String? { get }
 
+    var oneTimeShipping: Bool? { get }
+    var supportsOneTimeShipping: Bool { get }
+
     /// Only for UI display and list selector
     /// Nil and not editable until the shipping class is synced at a later point.
     var shippingClass: ProductShippingClass? { get }
@@ -29,6 +32,7 @@ protocol ProductShippingSettingsActionHandler {
     func handleLengthChange(_ length: String?)
     func handleWidthChange(_ width: String?)
     func handleHeightChange(_ height: String?)
+    func handleOneTimeShippingChange(_ oneTimeShipping: Bool)
     func handleShippingClassChange(_ shippingClass: ProductShippingClass?)
 
     /// If the product has a shipping class (slug & ID), the shipping class is synced to get the name and for list selector.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -182,3 +182,10 @@ extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler
             || shippingClass != originalShippingClass
     }
 }
+
+private extension ProductSubscription {
+    var supportsOneTimeShipping: Bool {
+        (trialLength.isEmpty || trialLength == "0")
+        && (paymentSyncDate.isEmpty || paymentSyncDate == "0")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -86,6 +86,14 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
     private(set) var shippingClass: ProductShippingClass?
     private var originalShippingClass: ProductShippingClass?
 
+    /// Product Variations Controller.
+    ///
+    private lazy var productVariationsResultsController: ResultsController<StorageProductVariation> = {
+        let predicate = NSPredicate(format: "siteID == %lld AND productID == %lld", product.siteID, product.productID)
+        let resultsController = ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [])
+        return resultsController
+    }()
+
     init(product: ProductFormDataModel,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          shippingValueLocalizer: ShippingValueLocalizer = DefaultShippingValueLocalizer()) {
@@ -112,6 +120,18 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
             ]
         default:
             fatalError("Unsupported product type: \(product)")
+        }
+
+        configureResultsController()
+    }
+}
+
+private extension ProductShippingSettingsViewModel {
+    func configureResultsController() {
+        do {
+            try productVariationsResultsController.performFetch()
+        } catch {
+            DDLogError("⛔️ Error fetching product variations from shipping settings screen: \(error)")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -64,6 +64,28 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
     private var shippingClassSlug: String?
     private var shippingClassID: Int64
 
+    /// Subscription related
+    ///
+    private(set) var oneTimeShipping: Bool?
+
+    var supportsOneTimeShipping: Bool {
+        switch product.productType {
+        case .subscription:
+            guard let subscription = product.subscription else {
+                return false
+            }
+
+            return subscription.supportsOneTimeShipping
+        case .variableSubscription:
+            let variations = productVariationsResultsController.fetchedObjects
+            let allVariationsSupportOneTimeShipping = variations
+                .allSatisfy { $0.subscription?.supportsOneTimeShipping == true }
+            return allVariationsSupportOneTimeShipping
+        default:
+            return false
+        }
+    }
+
     // Localized values
     //
     var localizedWeight: String? {
@@ -106,6 +128,7 @@ final class ProductShippingSettingsViewModel: ProductShippingSettingsViewModelOu
         height = product.dimensions.height
         shippingClassSlug = product.shippingClass
         shippingClassID = product.shippingClassID
+        oneTimeShipping = product.subscription?.oneTimeShipping
 
         // TODO-2580: re-enable shipping class for `ProductVariation` when the API issue is fixed.
         switch product {
@@ -170,6 +193,10 @@ extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler
         }
 
         self.height = shippingValueLocalizer.unLocalized(shippingValue: height) ?? height
+    }
+
+    func handleOneTimeShippingChange(_ oneTimeShipping: Bool) {
+        self.oneTimeShipping = oneTimeShipping
     }
 
     func handleShippingClassChange(_ shippingClass: ProductShippingClass?) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ValidationErrorRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ValidationErrorRow.swift
@@ -19,7 +19,7 @@ struct ValidationErrorRow: View {
         Text(errorMessage)
             .errorStyle()
             .padding(.vertical, Constants.verticalSpacing)
-            .padding(.horizontal, Constants.horizontalSpacing)
+            .padding(.horizontal, horizontalPadding)
             .frame(maxWidth: .infinity, minHeight: Constants.rowHeight, alignment: .leading)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Shipping/ProductShippingSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Shipping/ProductShippingSettingsViewModelTests.swift
@@ -11,7 +11,8 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         // Arrange
         let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
         let product = Product.fake()
-            .copy(weight: "1.6",
+            .copy(productTypeKey: "subscription",
+                  weight: "1.6",
                   dimensions: dimensions,
                   shippingClass: "60-day",
                   shippingClassID: 2)
@@ -42,11 +43,14 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         // Arrange
         let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
         let product = Product.fake()
-            .copy(weight: "1.6",
+            .copy(productTypeKey: "subscription",
+                  weight: "1.6",
                   dimensions: dimensions,
                   shippingClass: "60-day",
                   shippingClassID: 2,
-                  subscription: .fake().copy(oneTimeShipping: true))
+                  subscription: .fake().copy(trialLength: "0",
+                                             oneTimeShipping: true,
+                                             paymentSyncDate: "0"))
         let model = EditableProductModel(product: product)
 
         // Act
@@ -69,11 +73,14 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         // Arrange
         let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
         let product = Product.fake()
-            .copy(weight: "1.6",
+            .copy(productTypeKey: "subscription",
+                  weight: "1.6",
                   dimensions: dimensions,
                   shippingClass: "60-day",
                   shippingClassID: 2,
-                  subscription: .fake().copy(oneTimeShipping: true))
+                  subscription: .fake().copy(trialLength: "0",
+                                             oneTimeShipping: true,
+                                             paymentSyncDate: "0"))
         let model = EditableProductModel(product: product)
 
         // Act

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Shipping/ProductShippingSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Shipping/ProductShippingSettingsViewModelTests.swift
@@ -45,16 +45,18 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
             .copy(weight: "1.6",
                   dimensions: dimensions,
                   shippingClass: "60-day",
-                  shippingClassID: 2)
+                  shippingClassID: 2,
+                  subscription: .fake().copy(oneTimeShipping: true))
         let model = EditableProductModel(product: product)
 
         // Act
         let viewModel = ProductShippingSettingsViewModel(product: model)
         waitForExpectation { expectation in
-            viewModel.completeUpdating { (weight, dimensions, shippingClass, shippingClassID, hasUnsavedChanges) in
+            viewModel.completeUpdating { (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
                 // Assert
                 XCTAssertEqual(weight, product.weight)
                 XCTAssertEqual(dimensions, product.dimensions)
+                XCTAssertEqual(oneTimeShipping, product.subscription?.oneTimeShipping)
                 XCTAssertEqual(shippingClass, product.shippingClass)
                 XCTAssertEqual(shippingClassID, product.shippingClassID)
                 XCTAssertFalse(hasUnsavedChanges)
@@ -70,7 +72,8 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
             .copy(weight: "1.6",
                   dimensions: dimensions,
                   shippingClass: "60-day",
-                  shippingClassID: 2)
+                  shippingClassID: 2,
+                  subscription: .fake().copy(oneTimeShipping: true))
         let model = EditableProductModel(product: product)
 
         // Act
@@ -78,10 +81,11 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         let retrievedShippingClass = ProductShippingClass(count: 0, descriptionHTML: nil, name: "60 Days", shippingClassID: 2, siteID: 0, slug: "90-day")
         viewModel.onShippingClassRetrieved(shippingClass: retrievedShippingClass)
         waitForExpectation { expectation in
-            viewModel.completeUpdating { (weight, dimensions, shippingClass, shippingClassID, hasUnsavedChanges) in
+            viewModel.completeUpdating { (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
                 // Assert
                 XCTAssertEqual(weight, product.weight)
                 XCTAssertEqual(dimensions, product.dimensions)
+                XCTAssertEqual(oneTimeShipping, product.subscription?.oneTimeShipping)
                 XCTAssertEqual(shippingClass, product.shippingClass)
                 XCTAssertEqual(shippingClassID, product.shippingClassID)
                 XCTAssertFalse(hasUnsavedChanges)
@@ -97,7 +101,8 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
             .copy(weight: "1.6",
                   dimensions: dimensions,
                   shippingClass: "60-day",
-                  shippingClassID: 2)
+                  shippingClassID: 2,
+                  subscription: .fake().copy(oneTimeShipping: false))
         let model = EditableProductModel(product: product)
 
         // Act
@@ -106,12 +111,14 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         viewModel.handleWidthChange("3.2")
         viewModel.handleHeightChange("9.888")
         viewModel.handleLengthChange("")
+        viewModel.handleOneTimeShippingChange(true)
         viewModel.handleShippingClassChange(nil)
         waitForExpectation { expectation in
-            viewModel.completeUpdating { (weight, dimensions, shippingClass, shippingClassID, hasUnsavedChanges) in
+            viewModel.completeUpdating { (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
                 // Assert
                 XCTAssertEqual(weight, "-1.2")
                 XCTAssertEqual(dimensions, ProductDimensions(length: "", width: "3.2", height: "9.888"))
+                XCTAssertEqual(oneTimeShipping, true)
                 XCTAssertEqual(shippingClass, nil)
                 XCTAssertEqual(shippingClassID, 0)
                 XCTAssertTrue(hasUnsavedChanges)
@@ -188,5 +195,135 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertTrue(hasUnsavedChanges)
+    }
+
+    // MARK: `oneTimeShipping`
+
+    func test_updating_with_the_same_oneTimeShipping_value_has_no_unsaved_changes() {
+        // Arrange
+        let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
+        let product = Product.fake()
+            .copy(weight: "1.6",
+                  dimensions: dimensions,
+                  shippingClass: "60-day",
+                  shippingClassID: 2,
+                  subscription: .fake().copy(oneTimeShipping: true))
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductShippingSettingsViewModel(product: model)
+        viewModel.handleOneTimeShippingChange(true)
+        let hasUnsavedChanges = viewModel.hasUnsavedChanges()
+
+        // Assert
+        XCTAssertFalse(hasUnsavedChanges)
+    }
+
+    func test_updating_with_different_oneTimeShipping_value_has_unsaved_changes() {
+        // Arrange
+        let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
+        let product = Product.fake()
+            .copy(weight: "1.6",
+                  dimensions: dimensions,
+                  shippingClass: "60-day",
+                  shippingClassID: 2,
+                  subscription: .fake().copy(oneTimeShipping: true))
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductShippingSettingsViewModel(product: model)
+        viewModel.handleOneTimeShippingChange(false)
+        let hasUnsavedChanges = viewModel.hasUnsavedChanges()
+
+        // Assert
+        XCTAssertTrue(hasUnsavedChanges)
+    }
+
+    func test_oneTimeShipping_row_is_added_for_product() {
+        // Given
+        let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
+        let product = Product.fake()
+            .copy(weight: "1.6",
+                  dimensions: dimensions,
+                  shippingClass: "60-day",
+                  shippingClassID: 2,
+                  subscription: .fake().copy(oneTimeShipping: true))
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductShippingSettingsViewModel(product: model)
+
+        // Then
+        XCTAssertTrue(viewModel.sections.flatMap({ $0.rows }).contains(where: { $0 == .oneTimeShipping}))
+    }
+
+    func test_oneTimeShipping_row_is_not_added_for_product_variation() {
+        // Given
+        let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
+        let product = ProductVariation.fake()
+            .copy(weight: "1.6",
+                  dimensions: dimensions,
+                  shippingClass: "60-day",
+                  shippingClassID: 2,
+                  subscription: .fake().copy(oneTimeShipping: true))
+        let model = EditableProductVariationModel(productVariation: product)
+        let viewModel = ProductShippingSettingsViewModel(product: model)
+
+        // Then
+        XCTAssertFalse(viewModel.sections.flatMap({ $0.rows }).contains(where: { $0 == .oneTimeShipping}))
+    }
+
+    // MARK: `supportsOneTimeShipping`
+
+    func test_supportsOneTimeShipping_is_true_when_no_free_trial_or_payment_sync_date_available() {
+        // Given
+        let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
+        let product = Product.fake()
+            .copy(productTypeKey: "subscription",
+                  weight: "1.6",
+                  dimensions: dimensions,
+                  shippingClass: "60-day",
+                  shippingClassID: 2,
+                  subscription: .fake().copy(trialLength: "0",
+                                             paymentSyncDate: "0"))
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductShippingSettingsViewModel(product: model)
+
+        // Then
+        XCTAssertTrue(viewModel.supportsOneTimeShipping)
+    }
+
+    func test_supportsOneTimeShipping_is_false_when_free_trial_available() {
+        // Given
+        let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
+        let product = Product.fake()
+            .copy(productTypeKey: "subscription",
+                  weight: "1.6",
+                  dimensions: dimensions,
+                  shippingClass: "60-day",
+                  shippingClassID: 2,
+                  subscription: .fake().copy(trialLength: "1",
+                                             paymentSyncDate: "0"))
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductShippingSettingsViewModel(product: model)
+
+        // Then
+        XCTAssertFalse(viewModel.supportsOneTimeShipping)
+    }
+
+    func test_supportsOneTimeShipping_is_false_when_payment_sync_date_available() {
+        // Given
+        let dimensions = ProductDimensions(length: "2.9", width: "", height: "1116")
+        let product = Product.fake()
+            .copy(productTypeKey: "subscription",
+                  weight: "1.6",
+                  dimensions: dimensions,
+                  shippingClass: "60-day",
+                  shippingClassID: 2,
+                  subscription: .fake().copy(trialLength: "0",
+                                             paymentSyncDate: "10"))
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductShippingSettingsViewModel(product: model)
+
+        // Then
+        XCTAssertFalse(viewModel.supportsOneTimeShipping)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -384,4 +384,48 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let subscription = try XCTUnwrap(viewModel.productModel.subscription)
         XCTAssertEqual(subscription.length, "5")
     }
+
+    // MARK: Free trial
+
+    func test_updateSubscriptionFreeTrialSettings_changes_oneTimeShipping_to_false_when_there_is_free_trial() throws {
+        // Given
+        let product = Product.fake().copy(subscription: .fake().copy(period: .week,
+                                                                     periodInterval: "1",
+                                                                     trialLength: "0",
+                                                                     trialPeriod: .month,
+                                                                     oneTimeShipping: true))
+        let model = EditableProductModel(product: product)
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
+        let viewModel = ProductFormViewModel(product: model,
+                                    formType: .edit,
+                                    productImageActionHandler: productImageActionHandler)
+
+        // When
+        viewModel.updateSubscriptionFreeTrialSettings(trialLength: "1", trialPeriod: .month)
+
+        // Then
+        let subscription = try XCTUnwrap(viewModel.productModel.subscription)
+        XCTAssertFalse(subscription.oneTimeShipping)
+    }
+
+    func test_updateSubscriptionFreeTrialSettings_does_not_change_oneTimeShipping_when_there_is_no_free_trial() throws {
+        // Given
+        let product = Product.fake().copy(subscription: .fake().copy(period: .week,
+                                                                     periodInterval: "1",
+                                                                     trialLength: "0",
+                                                                     trialPeriod: .month,
+                                                                     oneTimeShipping: true))
+        let model = EditableProductModel(product: product)
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
+        let viewModel = ProductFormViewModel(product: model,
+                                    formType: .edit,
+                                    productImageActionHandler: productImageActionHandler)
+
+        // When
+        viewModel.updateSubscriptionFreeTrialSettings(trialLength: "0", trialPeriod: .year)
+
+        // Then
+        let subscription = try XCTUnwrap(viewModel.productModel.subscription)
+        XCTAssertTrue(subscription.oneTimeShipping)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -74,6 +74,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
                                           stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight,
                                          dimensions: product.dimensions,
+                                         oneTimeShipping: product.subscription?.oneTimeShipping,
                                          shippingClass: product.shippingClass,
                                          shippingClassID: product.shippingClassID)
         viewModel.updateProductCategories(product.categories)
@@ -244,6 +245,19 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         // When
         viewModel.updateShippingSettings(weight: "88888",
                                          dimensions: product.dimensions,
+                                         oneTimeShipping: product.subscription?.oneTimeShipping,
+                                         shippingClass: product.shippingClass,
+                                         shippingClassID: product.shippingClassID)
+
+        // Then
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func test_product_has_unsaved_changes_from_editing_oneTimeShipping() {
+        // When
+        viewModel.updateShippingSettings(weight: product.weight,
+                                         dimensions: product.dimensions,
+                                         oneTimeShipping: true,
                                          shippingClass: product.shippingClass,
                                          shippingClassID: product.shippingClassID)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -107,6 +107,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                           stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight,
                                          dimensions: product.dimensions,
+                                         oneTimeShipping: product.subscription?.oneTimeShipping,
                                          shippingClass: product.shippingClass,
                                          shippingClassID: product.shippingClassID)
         viewModel.updateProductCategories(product.categories)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -43,7 +43,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
 
     func testUpdatingShippingSettings() {
         // Arrange
-        let product = Product.fake()
+        let subscription = ProductSubscription.fake()
+        let product = Product.fake().copy(subscription: subscription)
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -61,6 +61,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
                                                     slug: "2-days")
         viewModel.updateShippingSettings(weight: newWeight,
                                          dimensions: newDimensions,
+                                         oneTimeShipping: true,
                                          shippingClass: newShippingClass.slug,
                                          shippingClassID: newShippingClass.shippingClassID)
 
@@ -69,6 +70,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.name, product.name)
         XCTAssertEqual(viewModel.productModel.weight, newWeight)
         XCTAssertEqual(viewModel.productModel.dimensions, newDimensions)
+        XCTAssertEqual(viewModel.productModel.subscription?.oneTimeShipping, true)
         XCTAssertEqual(viewModel.productModel.shippingClass, newShippingClass.slug)
         XCTAssertEqual(viewModel.productModel.shippingClassID, newShippingClass.shippingClassID)
         XCTAssertEqual(viewModel.productModel.shippingClass, newShippingClass.slug)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -58,7 +58,11 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
                                           stockQuantity: productVariation.stockQuantity,
                                           backordersSetting: model.backordersSetting,
                                           stockStatus: productVariation.stockStatus)
-        viewModel.updateShippingSettings(weight: productVariation.weight, dimensions: productVariation.dimensions, shippingClass: nil, shippingClassID: nil)
+        viewModel.updateShippingSettings(weight: productVariation.weight,
+                                         dimensions: productVariation.dimensions,
+                                         oneTimeShipping: nil,
+                                         shippingClass: nil,
+                                         shippingClassID: nil)
 
         // Assert
         XCTAssertFalse(viewModel.hasUnsavedChanges())
@@ -162,7 +166,11 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
 
     func test_product_variation_has_unsaved_changes_from_editing_shipping_settings() {
         // Action
-        viewModel.updateShippingSettings(weight: "88888", dimensions: productVariation.dimensions, shippingClass: nil, shippingClassID: nil)
+        viewModel.updateShippingSettings(weight: "88888",
+                                         dimensions: productVariation.dimensions,
+                                         oneTimeShipping: nil,
+                                         shippingClass: nil,
+                                         shippingClassID: nil)
 
         // Assert
         XCTAssertTrue(viewModel.hasUnsavedChanges())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -69,7 +69,11 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
                                           stockQuantity: productVariation.stockQuantity,
                                           backordersSetting: model.backordersSetting,
                                           stockStatus: productVariation.stockStatus)
-        viewModel.updateShippingSettings(weight: productVariation.weight, dimensions: productVariation.dimensions, shippingClass: nil, shippingClassID: nil)
+        viewModel.updateShippingSettings(weight: productVariation.weight,
+                                         dimensions: productVariation.dimensions,
+                                         oneTimeShipping: nil,
+                                         shippingClass: nil,
+                                         shippingClassID: nil)
     }
 
     func testObservablesFromUploadingAnImage() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -38,6 +38,7 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
                                                     slug: "2-days")
         viewModel.updateShippingSettings(weight: newWeight,
                                          dimensions: newDimensions,
+                                         oneTimeShipping: nil,
                                          shippingClass: newShippingClass.slug,
                                          shippingClassID: newShippingClass.shippingClassID)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11178 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR adds a new toggle setting to the product's shipping settings screen to manage "One time shipping" setting.

I have also included a fix to remove extra padding from an error view. [Commit](https://github.com/woocommerce/woocommerce-ios/commit/99a28dc0f0ba834ba055e54aee32a332acfba640)

🗒️ 
Thanks, @hichamboushaba, for the detailed notes and testing instructions. 

## Testing instructions

#### Simple subscription product
##### Normal path
1. Open a subscription product.
2. Confirm the shipping option is shown for the product. (Under "+ Add more details")
3. Click on it.
5. Edit the "one time shipping" option.
6. Go back to the product, then save.
7. Confirm the option was saved.

##### Subscription with free trial
1. Open a subscription product.
2. Add a free trial.
3. Open shipping options.
4. Confirm the "one time shipping" option is disabled.

##### Subscription with synced renewals
1. Enable synced renewals option from the plugin's settings (https://woo.com/document/subscriptions/renewal-synchronisation/#section-2)
2. Open the product in wp-admin, and enable synced renewals for the subscription.
3. Open the subscription in the app.
4. Open the shipping options.
5. Confirm the "one time shipping" option is disabled.

#### Variable subscription product

##### Normal path
1. Open a variable subscription product.
2. Confirm the shipping option is shown for the product.
3. Click on it.
5. Edit the "one-time shipping" option.
6. Go back to the product then save.
7. Confirm the option was saved.

##### Variation with a free trial
1. Open a variable subscription product.
2. Add free trial to one of its variations.
3. Go back to the parent product details.
4. Open shipping options.
5. Confirm the "one time shipping" option is disabled.

##### Variation with synced renewals
1. Enable synced renewals option from the plugin's settings (https://woo.com/document/subscriptions/renewal-synchronisation/#section-2)
2. Open a variable subscription in wp-admin, and enable synced renewals for one of its variants.
3. Open the product in the app.
4. Click on the variations to confirm that they are fetched.
5. Go back to the product details.
6. Open the shipping options.
7. Confirm the "one time shipping" option is disabled.

## Screenshots
| User cannot interact | User can change setting |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-11-28 at 20 06 32](https://github.com/woocommerce/woocommerce-ios/assets/524475/b9424970-1b8d-44b2-aed4-9e813cb25c14) | ![Simulator Screenshot - iPhone 14 Pro - 2023-11-28 at 20 07 42](https://github.com/woocommerce/woocommerce-ios/assets/524475/2973273c-bc7c-4d59-868f-fd7c2f55620d) | 


#### Free trial error view
| Before | After |
|--------|--------|
| ![Cell](https://github.com/woocommerce/woocommerce-ios/assets/5533851/fd2698c5-73b1-47e3-96cf-750c454240af) | ![Simulator Screenshot - iPhone 14 Pro - 2023-11-28 at 21 02 09](https://github.com/woocommerce/woocommerce-ios/assets/524475/095d16c1-aeec-4528-8fd0-5c07a7401d22) | 
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
