### PR TITLE
Use raw value for filter list event instead of the localized value

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductListFilter.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductListFilter.swift
@@ -24,7 +24,7 @@ extension WooAnalyticsEvent {
         }
 
         static func productFilterListExploreButtonTapped(type: PromotableProductType) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productFilterListExploreButtonTapped, properties: [Key.type: type.description])
+            WooAnalyticsEvent(statName: .productFilterListExploreButtonTapped, properties: [Key.type: type.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
@@ -40,6 +40,13 @@ extension ProductStatus: FilterType {
 }
 
 extension PromotableProductType: FilterType {
+
+    /// Raw value, used for analytics.
+    ///
+    var rawValue: String {
+        productType.rawValue
+    }
+
     var description: String {
         productType.description
     }


### PR DESCRIPTION
# Why

It was reported in slack C02KUCFCSFP-slack-p1701190164959879 that the `product_filter_list_explore_button_tapped` event was being recorded with the localized for the type property.

This PR adds a new `rawValue` property to `PromotableProductType` so it can be used safely in tracks.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
