### PR TITLE
[Scan to Update Inventory] Inventory Screen UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Media/Product+Media.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/Product+Media.swift
@@ -14,8 +14,19 @@ extension Product {
 
     /// Returns the URL of the first image, if available. Otherwise, nil is returned.
     var imageURL: URL? {
-        guard let productImageURLString = images.first?.src,
-              let encodedProductImageURLString = productImageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+        images.first?.imageURL
+    }
+}
+
+extension ProductVariation {
+    var imageURL: URL? {
+        image?.imageURL
+    }
+}
+
+private extension ProductImage {
+    var imageURL: URL? {
+        guard let encodedProductImageURLString = src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
             return nil
         }
         return URL(string: encodedProductImageURLString)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -168,14 +168,9 @@ class ProductListViewModel {
 
     func handleScannedBarcode(_ scannedBarcode: ScannedBarcode) async throws -> SKUSearchResult {
         do {
-            let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .productList)
-            DDLogInfo("SKU search successfully finished with result: \(result)")
-
-            return result
-            // TODO: Show product inventory screen
+            return try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .productList)
         } catch {
             DDLogInfo("SKU search failed with error: \(error)")
-
             throw error
             // TODO: Show error notice
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -166,13 +166,17 @@ class ProductListViewModel {
         wooSubscriptionProductsEligibilityChecker.isSiteEligible()
     }
 
-    func handleScannedBarcode(_ scannedBarcode: ScannedBarcode) async {
+    func handleScannedBarcode(_ scannedBarcode: ScannedBarcode) async throws -> SKUSearchResult {
         do {
             let result = try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .productList)
             DDLogInfo("SKU search successfully finished with result: \(result)")
+
+            return result
             // TODO: Show product inventory screen
         } catch {
             DDLogInfo("SKU search failed with error: \(error)")
+
+            throw error
             // TODO: Show error notice
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 import WordPressUI
 import Yosemite
 import Combine
@@ -293,6 +294,7 @@ private extension ProductsViewController {
             Task {
                 await self?.viewModel.handleScannedBarcode(scannedBarcode)
                 self?.configureLeftBarBarButtomItemAsScanningButtonIfApplicable()
+                self?.present(UIHostingController(rootView: UpdateProductInventoryView()), animated: true)
             }
 
         }, onPermissionsDenied: {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -297,8 +297,9 @@ private extension ProductsViewController {
 
                 do {
                     let scannedItem = try await self.viewModel.handleScannedBarcode(scannedBarcode)
-                    let viewModel = UpdateProductInventoryViewModel(inventoryItem: scannedItem.inventoryItem, siteID: self.viewModel.siteID)
-                    self.present(UIHostingController(rootView: UpdateProductInventoryView(viewModel: viewModel)), animated: true)
+                    self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem,
+                                                                                          siteID: self.viewModel.siteID)),
+                                 animated: true)
                 } catch {
                     // TODO: Show error notices
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -297,7 +297,7 @@ private extension ProductsViewController {
 
                 do {
                     let scannedItem = try await self.viewModel.handleScannedBarcode(scannedBarcode)
-                    let viewModel = UpdateProductInventoryViewModel(inventoryItem: scannedItem.inventoryItem)
+                    let viewModel = UpdateProductInventoryViewModel(inventoryItem: scannedItem.inventoryItem, siteID: self.viewModel.siteID)
                     self.present(UIHostingController(rootView: UpdateProductInventoryView(viewModel: viewModel)), animated: true)
                 } catch {
                     // TODO: Show error notices

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -775,7 +775,7 @@ private extension ProductsViewController {
                 self?.tableView.updateHeaderHeight()
             },
             onTroubleshootButtonPressed: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
             },

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -88,6 +88,7 @@ struct UpdateProductInventoryView: View {
                         .padding(.bottom)
                     }
                     .frame(minHeight: geometry.size.height)
+                    .frame(width: geometry.size.width)
                     .padding()
                     .navigationBarTitle(Localization.navigationBarTitle, displayMode: .inline)
                     .navigationBarItems(leading: Button(Localization.cancelButtonTitle) {
@@ -96,7 +97,6 @@ struct UpdateProductInventoryView: View {
                     .onReceive(Publishers.keyboardHeight) { keyboardHeight in
                         isKeyboardVisible = keyboardHeight > 0
                     }
-                    .frame(width: geometry.size.width)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -50,8 +50,10 @@ struct UpdateProductInventoryView: View {
                             Text(Localization.productQuantityTitle)
                             Spacer()
                             TextField("", text: $viewModel.quantity)
-                            .keyboardType(.numberPad)
-                            .multilineTextAlignment(.trailing)
+                                .textFieldStyle(.roundedBorder)
+                                .keyboardType(.numberPad)
+                                .multilineTextAlignment(.trailing)
+                                .fixedSize()
                         }
                         .padding([.top, .bottom], Layout.mediumSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -3,8 +3,7 @@ import Combine
 import WooFoundation
 
 struct UpdateProductInventoryView: View {
-    @State private var quantity: Int = 2000
-    @ObservedObject private(set) var viewModel = UpdateProductInventoryViewModel()
+    @ObservedObject private(set) var viewModel: UpdateProductInventoryViewModel
 
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
@@ -12,27 +11,28 @@ struct UpdateProductInventoryView: View {
     @Environment(\.presentationMode) var presentationMode
 
     @State private var isKeyboardVisible = false
+    @State private var buttonTitle: String = Localization.IncreaseStockOnceButtonTitle
 
     var body: some View {
         NavigationView {
             VStack(alignment: .center, spacing: 0) {
-                    AsyncImage(url: URL(string: "https://picsum.photos/160")) { image in
-                        image.resizable()
-                    } placeholder: {
-                        Rectangle()
-                            .foregroundColor(.gray)
-                    }
-                    .frame(width: Layout.imageDimensionsSize * scale, height: Layout.imageDimensionsSize * scale)
-                    .cornerRadius(Layout.imageCornerRadius)
-                    .padding(.bottom, Layout.largeVerticalSpacing)
-                    .renderedIf(!isKeyboardVisible)
+                AsyncImage(url: viewModel.imageURL) { image in
+                    image.resizable()
+                } placeholder: {
+                    Rectangle()
+                        .foregroundColor(.gray)
+                }
+                .frame(width: Layout.imageDimensionsSize * scale, height: Layout.imageDimensionsSize * scale)
+                .cornerRadius(Layout.imageCornerRadius)
+                .padding(.bottom, Layout.largeVerticalSpacing)
+                .renderedIf(!isKeyboardVisible)
 
-                Text(Localization.ProductNameTitle)
+                Text(viewModel.name)
                     .headlineStyle()
                     .padding(.bottom, Layout.smallVerticalSpacing)
 
 
-                Text("123-SKU-456")
+                Text(viewModel.sku)
                     .subheadlineStyle()
                     .padding(.bottom, Layout.largeVerticalSpacing)
 
@@ -41,9 +41,11 @@ struct UpdateProductInventoryView: View {
                 HStack {
                     Text(Localization.ProductQuantityTitle)
                     Spacer()
-                    TextField("", text: $viewModel.quantity)
-                        .keyboardType(.numberPad)
-                        .multilineTextAlignment(.trailing)
+                    TextField("", text: $viewModel.quantity, onEditingChanged: { _ in
+                        buttonTitle = Localization.UpdateQuantityButtonTitle
+                    })
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.trailing)
                 }
                 .padding([.top, .bottom], Layout.mediumVerticalSpacing)
 
@@ -51,7 +53,7 @@ struct UpdateProductInventoryView: View {
 
                 Spacer()
 
-                Button("Quantity + 1") {
+                Button(buttonTitle) {
 
                 }
                 .buttonStyle(PrimaryButtonStyle())
@@ -91,22 +93,22 @@ extension UpdateProductInventoryView {
                                                         value: "Product Name",
                                                         comment: "Product name label in the update product inventory view.")
         static let ProductQuantityTitle = NSLocalizedString("updateProductInventoryView.productQuantityTitle",
-                                                        value: "Product Name",
-                                                        comment: "Product quantity label in the update product inventory view.")
+                                                            value: "Quantity",
+                                                            comment: "Product quantity label in the update product inventory view.")
         static let ViewProductDetailsButtonTitle = NSLocalizedString("updateProductInventoryView.viewProductDetailsButtonTitle",
-                                                        value: "View Product Details",
-                                                        comment: "Product detailsl button title.")
+                                                                     value: "View Product Details",
+                                                                     comment: "Product detailsl button title.")
         static let NavigationBarTitle = NSLocalizedString("updateProductInventoryView.navigationBarTitle",
-                                                        value: "Product",
-                                                        comment: "Navigation bar title of the update product inventory view.")
+                                                          value: "Product",
+                                                          comment: "Navigation bar title of the update product inventory view.")
         static let CancelButtonTitle = NSLocalizedString("updateProductInventoryView.cancelButtonTitle",
-                                                        value: "Cancel",
-                                                        comment: "Cancel button title on the update product inventory view.")
-    }
-}
-
-struct UpdateProductInventoryView_Previews: PreviewProvider {
-    static var previews: some View {
-        UpdateProductInventoryView()
+                                                         value: "Cancel",
+                                                         comment: "Cancel button title on the update product inventory view.")
+        static let IncreaseStockOnceButtonTitle = NSLocalizedString("updateProductInventoryView.quantityButton.increaseStockOnceButtonTitle",
+                                                                    value: "Quantity + 1",
+                                                                    comment: "Stock quantity button when a tap increases the stock once.")
+        static let UpdateQuantityButtonTitle = NSLocalizedString("updateProductInventoryView.quantityButton.updateQuantityButtonTitle",
+                                                                 value: "Update quantity",
+                                                                 comment: "Stock quantity button when the user adds a custom quantity.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -53,6 +53,7 @@ struct UpdateProductInventoryView: View {
                                 .textFieldStyle(.roundedBorder)
                                 .keyboardType(.numberPad)
                                 .multilineTextAlignment(.trailing)
+                                .frame(maxWidth: 200, alignment: .trailing)
                                 .fixedSize()
                         }
                         .padding([.top, .bottom], Layout.mediumSpacing)
@@ -72,6 +73,7 @@ struct UpdateProductInventoryView: View {
                                 .renderedIf(viewModel.updateQuantityButtonMode == .increaseOnce)
 
                         }
+                        .disabled(!viewModel.enableQuantityButton)
                         .padding(.bottom, Layout.mediumSpacing)
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -11,7 +11,6 @@ struct UpdateProductInventoryView: View {
     @Environment(\.presentationMode) var presentationMode
 
     @State private var isKeyboardVisible = false
-    @State private var updateInventoryButtonTitle: String = Localization.IncreaseStockOnceButtonTitle
 
     var body: some View {
         NavigationView {
@@ -48,11 +47,9 @@ struct UpdateProductInventoryView: View {
                             .padding(.trailing, -Layout.mediumSpacing)
 
                         HStack {
-                            Text(Localization.ProductQuantityTitle)
+                            Text(Localization.productQuantityTitle)
                             Spacer()
-                            TextField("", text: $viewModel.quantity, onEditingChanged: { _ in
-                                updateInventoryButtonTitle = Localization.UpdateQuantityButtonTitle
-                            })
+                            TextField("", text: $viewModel.quantity)
                             .keyboardType(.numberPad)
                             .multilineTextAlignment(.trailing)
                         }
@@ -63,11 +60,20 @@ struct UpdateProductInventoryView: View {
 
                         Spacer()
 
-                        Button(updateInventoryButtonTitle) {}
-                            .buttonStyle(PrimaryButtonStyle())
-                            .padding(.bottom, Layout.mediumSpacing)
+                        Group {
+                            Button(Localization.updateQuantityButtonTitle) {}
+                                .buttonStyle(PrimaryButtonStyle())
+                                .renderedIf(viewModel.updateQuantityButtonMode == .customQuantity)
 
-                        Button(Localization.ViewProductDetailsButtonTitle) {
+                            Button(Localization.increaseStockOnceButtonTitle) {}
+                                .buttonStyle(PrimaryButtonStyle())
+                                .renderedIf(viewModel.updateQuantityButtonMode == .increaseOnce)
+
+                        }
+                        .padding(.bottom, Layout.mediumSpacing)
+
+
+                        Button(Localization.viewProductDetailsButtonTitle) {
 
                         }
                         .buttonStyle(SecondaryButtonStyle())
@@ -75,8 +81,8 @@ struct UpdateProductInventoryView: View {
                     }
                     .frame(minHeight: geometry.size.height)
                     .padding()
-                    .navigationBarTitle(Localization.NavigationBarTitle, displayMode: .inline)
-                    .navigationBarItems(leading: Button(Localization.CancelButtonTitle) {
+                    .navigationBarTitle(Localization.navigationBarTitle, displayMode: .inline)
+                    .navigationBarItems(leading: Button(Localization.cancelButtonTitle) {
                         presentationMode.wrappedValue.dismiss()
                     })
                     .onReceive(Publishers.keyboardHeight) { keyboardHeight in
@@ -99,25 +105,25 @@ extension UpdateProductInventoryView {
     }
 
     enum Localization {
-        static let ProductNameTitle = NSLocalizedString("updateProductInventoryView.productNameTitle",
+        static let productNameTitle = NSLocalizedString("updateProductInventoryView.productNameTitle",
                                                         value: "Product Name",
                                                         comment: "Product name label in the update product inventory view.")
-        static let ProductQuantityTitle = NSLocalizedString("updateProductInventoryView.productQuantityTitle",
+        static let productQuantityTitle = NSLocalizedString("updateProductInventoryView.productQuantityTitle",
                                                             value: "Quantity",
                                                             comment: "Product quantity label in the update product inventory view.")
-        static let ViewProductDetailsButtonTitle = NSLocalizedString("updateProductInventoryView.viewProductDetailsButtonTitle",
+        static let viewProductDetailsButtonTitle = NSLocalizedString("updateProductInventoryView.viewProductDetailsButtonTitle",
                                                                      value: "View Product Details",
                                                                      comment: "Product detailsl button title.")
-        static let NavigationBarTitle = NSLocalizedString("updateProductInventoryView.navigationBarTitle",
+        static let navigationBarTitle = NSLocalizedString("updateProductInventoryView.navigationBarTitle",
                                                           value: "Product",
                                                           comment: "Navigation bar title of the update product inventory view.")
-        static let CancelButtonTitle = NSLocalizedString("updateProductInventoryView.cancelButtonTitle",
+        static let cancelButtonTitle = NSLocalizedString("updateProductInventoryView.cancelButtonTitle",
                                                          value: "Cancel",
                                                          comment: "Cancel button title on the update product inventory view.")
-        static let IncreaseStockOnceButtonTitle = NSLocalizedString("updateProductInventoryView.quantityButton.increaseStockOnceButtonTitle",
+        static let increaseStockOnceButtonTitle = NSLocalizedString("updateProductInventoryView.quantityButton.increaseStockOnceButtonTitle",
                                                                     value: "Quantity + 1",
                                                                     comment: "Stock quantity button when a tap increases the stock once.")
-        static let UpdateQuantityButtonTitle = NSLocalizedString("updateProductInventoryView.quantityButton.updateQuantityButtonTitle",
+        static let updateQuantityButtonTitle = NSLocalizedString("updateProductInventoryView.quantityButton.updateQuantityButtonTitle",
                                                                  value: "Update quantity",
                                                                  comment: "Stock quantity button when the user adds a custom quantity.")
     }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -57,14 +57,12 @@ struct UpdateProductInventoryView: View {
 
                 }
                 .buttonStyle(PrimaryButtonStyle())
-                .accessibilityIdentifier("")
                 .padding(.bottom, Layout.mediumVerticalSpacing)
 
                 Button(Localization.ViewProductDetailsButtonTitle) {
 
                 }
                 .buttonStyle(SecondaryButtonStyle())
-                .accessibilityIdentifier("")
                 .padding(.bottom)
             }
             .padding()
@@ -73,7 +71,7 @@ struct UpdateProductInventoryView: View {
                 presentationMode.wrappedValue.dismiss()
             })
             .onReceive(Publishers.keyboardHeight) { keyboardHeight in
-                self.isKeyboardVisible = keyboardHeight > 0
+                isKeyboardVisible = keyboardHeight > 0
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import Combine
+import WooFoundation
+
+struct UpdateProductInventoryView: View {
+    @State private var quantity: Int = 2000
+    @ObservedObject private(set) var viewModel = UpdateProductInventoryViewModel()
+
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    @Environment(\.presentationMode) var presentationMode
+
+    @State private var isKeyboardVisible = false
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .center, spacing: 0) {
+                    AsyncImage(url: URL(string: "https://picsum.photos/160")) { image in
+                        image.resizable()
+                    } placeholder: {
+                        Rectangle()
+                            .foregroundColor(.gray)
+                    }
+                    .frame(width: Layout.imageDimensionsSize * scale, height: Layout.imageDimensionsSize * scale)
+                    .cornerRadius(Layout.imageCornerRadius)
+                    .padding(.bottom, Layout.largeVerticalSpacing)
+                    .renderedIf(!isKeyboardVisible)
+
+                Text(Localization.ProductNameTitle)
+                    .headlineStyle()
+                    .padding(.bottom, Layout.smallVerticalSpacing)
+
+
+                Text("123-SKU-456")
+                    .subheadlineStyle()
+                    .padding(.bottom, Layout.largeVerticalSpacing)
+
+                Divider()
+
+                HStack {
+                    Text(Localization.ProductQuantityTitle)
+                    Spacer()
+                    TextField("", text: $viewModel.quantity)
+                        .keyboardType(.numberPad)
+                        .multilineTextAlignment(.trailing)
+                }
+                .padding([.top, .bottom], Layout.mediumVerticalSpacing)
+
+                Divider()
+
+                Spacer()
+
+                Button("Quantity + 1") {
+
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .accessibilityIdentifier("")
+                .padding(.bottom, Layout.mediumVerticalSpacing)
+
+                Button(Localization.ViewProductDetailsButtonTitle) {
+
+                }
+                .buttonStyle(SecondaryButtonStyle())
+                .accessibilityIdentifier("")
+                .padding(.bottom)
+            }
+            .padding()
+            .navigationBarTitle(Localization.NavigationBarTitle, displayMode: .inline)
+            .navigationBarItems(leading: Button(Localization.CancelButtonTitle) {
+                presentationMode.wrappedValue.dismiss()
+            })
+            .onReceive(Publishers.keyboardHeight) { keyboardHeight in
+                self.isKeyboardVisible = keyboardHeight > 0
+            }
+        }
+    }
+}
+
+extension UpdateProductInventoryView {
+    enum Layout {
+        static let imageDimensionsSize: CGFloat = 160
+        static let imageCornerRadius: CGFloat = 8
+        static let largeVerticalSpacing: CGFloat = 32
+        static let mediumVerticalSpacing: CGFloat = 16
+        static let smallVerticalSpacing: CGFloat = 8
+    }
+
+    enum Localization {
+        static let ProductNameTitle = NSLocalizedString("updateProductInventoryView.productNameTitle",
+                                                        value: "Product Name",
+                                                        comment: "Product name label in the update product inventory view.")
+        static let ProductQuantityTitle = NSLocalizedString("updateProductInventoryView.productQuantityTitle",
+                                                        value: "Product Name",
+                                                        comment: "Product quantity label in the update product inventory view.")
+        static let ViewProductDetailsButtonTitle = NSLocalizedString("updateProductInventoryView.viewProductDetailsButtonTitle",
+                                                        value: "View Product Details",
+                                                        comment: "Product detailsl button title.")
+        static let NavigationBarTitle = NSLocalizedString("updateProductInventoryView.navigationBarTitle",
+                                                        value: "Product",
+                                                        comment: "Navigation bar title of the update product inventory view.")
+        static let CancelButtonTitle = NSLocalizedString("updateProductInventoryView.cancelButtonTitle",
+                                                        value: "Cancel",
+                                                        comment: "Cancel button title on the update product inventory view.")
+    }
+}
+
+struct UpdateProductInventoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        UpdateProductInventoryView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -8,7 +8,7 @@ struct UpdateProductInventoryView: View {
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) private var dismiss
 
     @State private var isKeyboardVisible = false
 
@@ -91,7 +91,7 @@ struct UpdateProductInventoryView: View {
                     .padding()
                     .navigationBarTitle(Localization.navigationBarTitle, displayMode: .inline)
                     .navigationBarItems(leading: Button(Localization.cancelButtonTitle) {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                     })
                     .onReceive(Publishers.keyboardHeight) { keyboardHeight in
                         isKeyboardVisible = keyboardHeight > 0

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -12,6 +12,10 @@ struct UpdateProductInventoryView: View {
 
     @State private var isKeyboardVisible = false
 
+    init(inventoryItem: InventoryItem, siteID: Int64) {
+        viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, siteID: siteID)
+    }
+
     var body: some View {
         NavigationView {
             GeometryReader { geometry in

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -11,67 +11,74 @@ struct UpdateProductInventoryView: View {
     @Environment(\.presentationMode) var presentationMode
 
     @State private var isKeyboardVisible = false
-    @State private var buttonTitle: String = Localization.IncreaseStockOnceButtonTitle
+    @State private var updateInventoryButtonTitle: String = Localization.IncreaseStockOnceButtonTitle
 
     var body: some View {
         NavigationView {
-            VStack(alignment: .center, spacing: 0) {
-                AsyncImage(url: viewModel.imageURL) { image in
-                    image.resizable()
-                } placeholder: {
-                    Rectangle()
-                        .foregroundColor(.gray)
-                }
-                .frame(width: Layout.imageDimensionsSize * scale, height: Layout.imageDimensionsSize * scale)
-                .cornerRadius(Layout.imageCornerRadius)
-                .padding(.bottom, Layout.largeVerticalSpacing)
-                .renderedIf(!isKeyboardVisible)
+            GeometryReader { geometry in
+                ScrollView {
+                    VStack(alignment: .center, spacing: 0) {
+                        AsyncImage(url: viewModel.imageURL) { image in
+                            image.resizable()
+                        } placeholder: {
+                            Rectangle()
+                                .foregroundColor(.gray)
+                        }
+                        .frame(width: Layout.imageDimensionsSize * scale, height: Layout.imageDimensionsSize * scale)
+                        .cornerRadius(Layout.imageCornerRadius)
+                        .padding(.bottom, Layout.largeSpacing)
+                        .padding(.top, Layout.mediumSpacing)
+                        .renderedIf(!isKeyboardVisible)
 
-                Text(viewModel.name)
-                    .headlineStyle()
-                    .padding(.bottom, Layout.smallVerticalSpacing)
+                        Text(viewModel.name)
+                            .headlineStyle()
+                            .padding(.bottom, Layout.smallSpacing)
 
 
-                Text(viewModel.sku)
-                    .subheadlineStyle()
-                    .padding(.bottom, Layout.largeVerticalSpacing)
+                        Text(viewModel.sku)
+                            .subheadlineStyle()
+                            .padding(.bottom, Layout.largeSpacing)
 
-                Divider()
+                        Divider()
+                            .padding(.trailing, -Layout.mediumSpacing)
 
-                HStack {
-                    Text(Localization.ProductQuantityTitle)
-                    Spacer()
-                    TextField("", text: $viewModel.quantity, onEditingChanged: { _ in
-                        buttonTitle = Localization.UpdateQuantityButtonTitle
+                        HStack {
+                            Text(Localization.ProductQuantityTitle)
+                            Spacer()
+                            TextField("", text: $viewModel.quantity, onEditingChanged: { _ in
+                                updateInventoryButtonTitle = Localization.UpdateQuantityButtonTitle
+                            })
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                        }
+                        .padding([.top, .bottom], Layout.mediumSpacing)
+
+                        Divider()
+                            .padding(.trailing, -Layout.mediumSpacing)
+
+                        Spacer()
+
+                        Button(updateInventoryButtonTitle) {}
+                            .buttonStyle(PrimaryButtonStyle())
+                            .padding(.bottom, Layout.mediumSpacing)
+
+                        Button(Localization.ViewProductDetailsButtonTitle) {
+
+                        }
+                        .buttonStyle(SecondaryButtonStyle())
+                        .padding(.bottom)
+                    }
+                    .frame(minHeight: geometry.size.height)
+                    .padding()
+                    .navigationBarTitle(Localization.NavigationBarTitle, displayMode: .inline)
+                    .navigationBarItems(leading: Button(Localization.CancelButtonTitle) {
+                        presentationMode.wrappedValue.dismiss()
                     })
-                    .keyboardType(.numberPad)
-                    .multilineTextAlignment(.trailing)
+                    .onReceive(Publishers.keyboardHeight) { keyboardHeight in
+                        isKeyboardVisible = keyboardHeight > 0
+                    }
+                    .frame(width: geometry.size.width)
                 }
-                .padding([.top, .bottom], Layout.mediumVerticalSpacing)
-
-                Divider()
-
-                Spacer()
-
-                Button(buttonTitle) {
-
-                }
-                .buttonStyle(PrimaryButtonStyle())
-                .padding(.bottom, Layout.mediumVerticalSpacing)
-
-                Button(Localization.ViewProductDetailsButtonTitle) {
-
-                }
-                .buttonStyle(SecondaryButtonStyle())
-                .padding(.bottom)
-            }
-            .padding()
-            .navigationBarTitle(Localization.NavigationBarTitle, displayMode: .inline)
-            .navigationBarItems(leading: Button(Localization.CancelButtonTitle) {
-                presentationMode.wrappedValue.dismiss()
-            })
-            .onReceive(Publishers.keyboardHeight) { keyboardHeight in
-                isKeyboardVisible = keyboardHeight > 0
             }
         }
     }
@@ -81,9 +88,9 @@ extension UpdateProductInventoryView {
     enum Layout {
         static let imageDimensionsSize: CGFloat = 160
         static let imageCornerRadius: CGFloat = 8
-        static let largeVerticalSpacing: CGFloat = 32
-        static let mediumVerticalSpacing: CGFloat = 16
-        static let smallVerticalSpacing: CGFloat = 8
+        static let largeSpacing: CGFloat = 32
+        static let mediumSpacing: CGFloat = 16
+        static let smallSpacing: CGFloat = 8
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -30,10 +30,15 @@ struct UpdateProductInventoryView: View {
                         .padding(.top, Layout.mediumSpacing)
                         .renderedIf(!isKeyboardVisible)
 
-                        Text(viewModel.name)
-                            .headlineStyle()
-                            .padding(.bottom, Layout.smallSpacing)
+                        Group {
+                            Text(viewModel.name)
+                                .headlineStyle()
+                                .renderedIf(!viewModel.showLoadingName)
 
+                            ProgressView()
+                                .renderedIf(viewModel.showLoadingName)
+                        }
+                        .padding(.bottom, Layout.smallSpacing)
 
                         Text(viewModel.sku)
                             .subheadlineStyle()

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -87,9 +87,9 @@ struct UpdateProductInventoryView: View {
                         .buttonStyle(SecondaryButtonStyle())
                         .padding(.bottom)
                     }
+                    .padding()
                     .frame(minHeight: geometry.size.height)
                     .frame(width: geometry.size.width)
-                    .padding()
                     .navigationBarTitle(Localization.navigationBarTitle, displayMode: .inline)
                     .navigationBarItems(leading: Button(Localization.cancelButtonTitle) {
                         dismiss()

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -61,10 +61,12 @@ final class UpdateProductInventoryViewModel: ObservableObject {
 
         Task { @MainActor in
             name = try await inventoryItem.retrieveName(with: stores, siteID: siteID)
+            showLoadingName = false
         }
     }
 
     @Published var quantity: String = ""
+    @Published var showLoadingName: Bool = true
     @Published var name: String = Localization.productNamePlaceholder
 
     var sku: String {

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -72,15 +72,19 @@ final class UpdateProductInventoryViewModel: ObservableObject {
 
     @Published var quantity: String = "" {
         didSet {
-            guard quantity != oldValue,
-                    let decimalValue = Decimal(string: quantity) else {
+            guard quantity != oldValue else { return }
+
+            guard let decimalValue = Decimal(string: quantity) else {
+                enableQuantityButton = false
                 return
             }
 
+            enableQuantityButton = true
             updateQuantityButtonMode = decimalValue == inventoryItem.stockQuantity ? .increaseOnce : .customQuantity
         }
     }
 
+    @Published var enableQuantityButton: Bool = true
     @Published var showLoadingName: Bool = true
     @Published var name: String = Localization.productNamePlaceholder
     @Published var updateQuantityButtonMode: UpdateQuantityButtonMode = .increaseOnce

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -97,11 +97,3 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         inventoryItem.imageURL
     }
 }
-
-extension UpdateProductInventoryViewModel {
-    enum Localization {
-        static let productNamePlaceholder = NSLocalizedString("updateProductInventoryViewModel.productName.placeholder",
-                                                              value: "Product Name",
-                                                              comment: "Placeholder of the product name title.")
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -1,5 +1,53 @@
 import Combine
+import Yosemite
+
+typealias InventoryProductTypeAlias = SKUSearchResult
+
+protocol InventoryItem {
+    var manageStock: Bool { get }
+    var stockQuantity: Decimal? { get }
+    var sku: String? { get }
+    var name: String { get }
+    var imageURL: URL? { get }
+}
+
+extension SKUSearchResult {
+    var inventoryItem: InventoryItem {
+        switch self {
+        case .product(let product):
+            return product
+        case .variation(let variation):
+            return variation
+        }
+    }
+}
+
+extension Product: InventoryItem {}
+extension ProductVariation: InventoryItem {
+    var name: String {
+        attributes.map { $0.name }.joined(separator: " • ")
+    }
+}
 
 final class UpdateProductInventoryViewModel: ObservableObject {
-    @Published var quantity = "2000"
+    let inventoryItem: InventoryItem
+
+    init(inventoryItem: InventoryItem) {
+        self.inventoryItem = inventoryItem
+
+        quantity = inventoryItem.stockQuantity?.formatted() ?? ""
+    }
+
+    @Published var quantity: String = ""
+    var name: String {
+        inventoryItem.name
+    }
+
+    var sku: String {
+        inventoryItem.sku ?? ""
+    }
+
+    var imageURL: URL? {
+        inventoryItem.imageURL
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -30,6 +30,7 @@ extension Product: InventoryItem {
 }
 extension ProductVariation: InventoryItem {
     func retrieveName(with stores: StoresManager, siteID: Int64) async throws -> String {
+        // Let's retrieve the parent product's name
         return try await withCheckedThrowingContinuation { continuation in
             let action = ProductAction.retrieveProduct(siteID: siteID,
                                                        productID: productID) { result in

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -50,6 +50,11 @@ extension ProductVariation: InventoryItem {
 }
 
 final class UpdateProductInventoryViewModel: ObservableObject {
+    enum UpdateQuantityButtonMode {
+        case increaseOnce
+        case customQuantity
+    }
+
     let inventoryItem: InventoryItem
 
     init(inventoryItem: InventoryItem,
@@ -65,9 +70,20 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         }
     }
 
-    @Published var quantity: String = ""
+    @Published var quantity: String = "" {
+        didSet {
+            guard quantity != oldValue,
+                    let decimalValue = Decimal(string: quantity) else {
+                return
+            }
+
+            updateQuantityButtonMode = decimalValue == inventoryItem.stockQuantity ? .increaseOnce : .customQuantity
+        }
+    }
+
     @Published var showLoadingName: Bool = true
     @Published var name: String = Localization.productNamePlaceholder
+    @Published var updateQuantityButtonMode: UpdateQuantityButtonMode = .increaseOnce
 
     var sku: String {
         inventoryItem.sku ?? ""

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -1,0 +1,5 @@
+import Combine
+
+final class UpdateProductInventoryViewModel: ObservableObject {
+    @Published var quantity = "2000"
+}

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -86,7 +86,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
 
     @Published var enableQuantityButton: Bool = true
     @Published var showLoadingName: Bool = true
-    @Published var name: String = Localization.productNamePlaceholder
+    @Published var name: String = ""
     @Published var updateQuantityButtonMode: UpdateQuantityButtonMode = .increaseOnce
 
     var sku: String {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1746,6 +1746,7 @@
 		B998DF4A2A98AE4200D1C6E8 /* TaxEducationalDialogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B998DF492A98AE4200D1C6E8 /* TaxEducationalDialogViewModel.swift */; };
 		B99B30CD2A85200D0066743D /* AddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99B30CC2A85200D0066743D /* AddressFormViewModel.swift */; };
 		B99B87A72AEFCF0A006B8AB1 /* Order+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99B87A62AEFCF0A006B8AB1 /* Order+Empty.swift */; };
+		B9A0F7A62B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A0F7A52B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift */; };
 		B9B0391628A6824200DC1C83 /* PermanentNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B0391528A6824200DC1C83 /* PermanentNoticePresenter.swift */; };
 		B9B0391828A6838400DC1C83 /* PermanentNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B0391728A6838400DC1C83 /* PermanentNoticeView.swift */; };
 		B9B0391A28A68ADE00DC1C83 /* ConstraintsUpdatingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B0391928A68ADE00DC1C83 /* ConstraintsUpdatingHostingController.swift */; };
@@ -4328,6 +4329,7 @@
 		B998DF492A98AE4200D1C6E8 /* TaxEducationalDialogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModel.swift; sourceTree = "<group>"; };
 		B99B30CC2A85200D0066743D /* AddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressFormViewModel.swift; sourceTree = "<group>"; };
 		B99B87A62AEFCF0A006B8AB1 /* Order+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Empty.swift"; sourceTree = "<group>"; };
+		B9A0F7A52B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryViewModelTests.swift; sourceTree = "<group>"; };
 		B9B0391528A6824200DC1C83 /* PermanentNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermanentNoticePresenter.swift; sourceTree = "<group>"; };
 		B9B0391728A6838400DC1C83 /* PermanentNoticeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermanentNoticeView.swift; sourceTree = "<group>"; };
 		B9B0391928A68ADE00DC1C83 /* ConstraintsUpdatingHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintsUpdatingHostingController.swift; sourceTree = "<group>"; };
@@ -5847,6 +5849,7 @@
 		0269177E23260090002AFC20 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				B9A0F7A42B17359A0035A153 /* UpdateInventory */,
 				EEBDF7E02A2F684D00EFEF47 /* ShareProduct */,
 				26F94E32267AA3DD00DB6CCF /* Addons */,
 				02077F70253816B1005A78EF /* Actions Factory */,
@@ -9373,6 +9376,14 @@
 				B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */,
 			);
 			path = Taxes;
+			sourceTree = "<group>";
+		};
+		B9A0F7A42B17359A0035A153 /* UpdateInventory */ = {
+			isa = PBXGroup;
+			children = (
+				B9A0F7A52B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift */,
+			);
+			path = UpdateInventory;
 			sourceTree = "<group>";
 		};
 		B9B0391B28A690DA00DC1C83 /* PermanentNotice */ = {
@@ -14374,6 +14385,7 @@
 				0968B80C27CFB2EF0021210A /* BulkUpdateOptionsModelTests.swift in Sources */,
 				DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */,
 				0277AE9B256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift in Sources */,
+				B9A0F7A62B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift in Sources */,
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				31AD0B1326E95998000B6391 /* CardPresentModalConnectingFailedTests.swift in Sources */,
 				E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1729,8 +1729,10 @@
 		B958B4DA2983E3F40010286B /* OrderDurationRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */; };
 		B95A45E92A77AE2C0073A91F /* CustomerSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95A45E82A77AE2C0073A91F /* CustomerSelectorViewModel.swift */; };
 		B95A45EC2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95A45EB2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift */; };
+		B95B15C92B15EBA000A54044 /* UpdateProductInventoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95B15C82B15EBA000A54044 /* UpdateProductInventoryViewModel.swift */; };
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
+		B97C6E562B15E51A008A2BF2 /* UpdateProductInventoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */; };
 		B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */; };
 		B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */; };
 		B98C6D502B149C3900A243E1 /* UINavigationItem+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */; };
@@ -4309,8 +4311,10 @@
 		B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDurationRecorder.swift; sourceTree = "<group>"; };
 		B95A45E82A77AE2C0073A91F /* CustomerSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSelectorViewModel.swift; sourceTree = "<group>"; };
 		B95A45EB2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSelectorViewModelTests.swift; sourceTree = "<group>"; };
+		B95B15C82B15EBA000A54044 /* UpdateProductInventoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryViewModel.swift; sourceTree = "<group>"; };
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
+		B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryView.swift; sourceTree = "<group>"; };
 		B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModelTests.swift; sourceTree = "<group>"; };
 		B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSection.swift; sourceTree = "<group>"; };
 		B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Configuration.swift"; sourceTree = "<group>"; };
@@ -8273,6 +8277,7 @@
 		74EC34A3225FE1F3004BBC2E /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				B97C6E542B15E4EE008A2BF2 /* UpdateInventory */,
 				EEBDF7D62A2EF65D00EFEF47 /* ShareProduct */,
 				02EAF5BC29FA04660058071C /* AI */,
 				DE4FB771280E758D003D20D6 /* ProductSelector */,
@@ -9322,6 +9327,15 @@
 				B95A45EB2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift */,
 			);
 			path = CustomerSection;
+			sourceTree = "<group>";
+		};
+		B97C6E542B15E4EE008A2BF2 /* UpdateInventory */ = {
+			isa = PBXGroup;
+			children = (
+				B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */,
+				B95B15C82B15EBA000A54044 /* UpdateProductInventoryViewModel.swift */,
+			);
+			path = UpdateInventory;
 			sourceTree = "<group>";
 		};
 		B98968542A98F1DF007A2FBE /* PaymentSection */ = {
@@ -12587,6 +12601,7 @@
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */,
 				269B46622A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift in Sources */,
+				B95B15C92B15EBA000A54044 /* UpdateProductInventoryViewModel.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
 				DE157E1A2B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift in Sources */,
 				31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */,
@@ -13264,6 +13279,7 @@
 				E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */,
 				26E7EE7229301EBC00793045 /* AnalyticsProductCardViewModel.swift in Sources */,
 				027A2E142513124E00DA6ACB /* Keychain+Entries.swift in Sources */,
+				B97C6E562B15E51A008A2BF2 /* UpdateProductInventoryView.swift in Sources */,
 				268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */,
 				4535EE7E281BE04A004212B4 /* CouponAmountInputFormatter.swift in Sources */,
 				209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+import Yosemite
+import Fakes
+@testable import WooCommerce
+
+final class UpdateProductInventoryViewModelTests: XCTestCase {
+    private var viewModel: UpdateProductInventoryViewModel!
+    let siteID: Int64 = 1
+
+    func test_quantity_when_we_pass_a_product_it_shows_right_quantity() {
+        // Given
+        let stockQuantity = Decimal(12)
+        let product = Product.fake().copy(siteID: siteID, stockQuantity: stockQuantity)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(viewModel.quantity, stockQuantity.formatted())
+    }
+
+    func test_quantity_when_we_pass_a_variation_it_shows_right_quantity() {
+        // Given
+        let stockQuantity = Decimal(12)
+        let variation = ProductVariation.fake().copy(siteID: siteID, stockQuantity: stockQuantity)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(viewModel.quantity, stockQuantity.formatted())
+    }
+
+    func test_sku_when_we_pass_a_product_it_shows_right_sku() {
+        // Given
+        let sku = "test-sku"
+        let product = Product.fake().copy(siteID: siteID, sku: sku)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(viewModel.sku, sku)
+    }
+
+    func test_sku_when_we_pass_a_variation_it_shows_right_sku() {
+        // Given
+        let sku = "test-sku"
+        let variation = ProductVariation.fake().copy(siteID: siteID, sku: sku)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(viewModel.sku, sku)
+    }
+
+    func test_imageURL_when_we_pass_a_product_it_shows_right_url() {
+        // Given
+        let url = "www.picture.com"
+        let product = Product.fake().copy(siteID: siteID, images: [ProductImage.fake().copy(src: url)])
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(viewModel.imageURL?.absoluteString, url)
+    }
+
+    func test_imageURL_when_we_pass_a_variation_it_shows_right_url() {
+        // Given
+        let url = "www.picture.com"
+        let variation = ProductVariation.fake().copy(siteID: siteID, image: ProductImage.fake().copy(src: url))
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(viewModel.imageURL?.absoluteString, url)
+    }
+
+    func test_name_when_we_pass_a_product_it_shows_right_name() {
+        // Given
+        let name = "test-name"
+        let product = Product.fake().copy(siteID: siteID, name: name)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+
+        waitUntil {
+            viewModel.name == name
+        }
+    }
+
+    func test_name_when_we_pass_a_variation_it_shows_the_parent_product_name() {
+        // Given
+        let parentProductID: Int64 = 12345
+        let name = "test-name"
+        let parentProduct = Product.fake().copy(siteID: siteID, productID: parentProductID, name: name)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: ProductAction.self) { [weak self ]action in
+            guard let self = self else { return }
+            switch action {
+            case let .retrieveProduct(passingSiteID, productID, onCompletion):
+                if passingSiteID == self.siteID,
+                   productID == parentProductID {
+                    onCompletion(.success(parentProduct))
+                }
+            default:
+                break
+            }
+        }
+
+        let product = ProductVariation.fake().copy(siteID: siteID, productID: parentProductID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID, stores: stores)
+
+        waitUntil {
+            viewModel.name == name
+        }
+    }
+}

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		9FA5113235035AC9A6079B0D /* Pods_WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1733C61561AE3A1AD3C16B7 /* Pods_WooFoundation.framework */; };
 		AE948D0A28CF67CF009F3246 /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */; };
 		AE948D0D28CF6D50009F3246 /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE948D0C28CF6D50009F3246 /* DateStartAndEndTests.swift */; };
+		B95B15CB2B15FA3A00A54044 /* Publishers+KeyboardHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95B15CA2B15FA3A00A54044 /* Publishers+KeyboardHeight.swift */; };
 		B97190D1292CF3BC0065E413 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97190D0292CF3BC0065E413 /* Result+Extensions.swift */; };
 		B987B06F284540D300C53CF6 /* CurrencyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B987B06E284540D300C53CF6 /* CurrencyCode.swift */; };
 		B99686DE2A13B38B00D1AF62 /* FullScreenCoverClearBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99686DD2A13B38B00D1AF62 /* FullScreenCoverClearBackgroundView.swift */; };
@@ -106,6 +107,7 @@
 		A21D73D352B4162AB096E276 /* Pods-WooFoundationTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationTests.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		AE948D0C28CF6D50009F3246 /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
+		B95B15CA2B15FA3A00A54044 /* Publishers+KeyboardHeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publishers+KeyboardHeight.swift"; sourceTree = "<group>"; };
 		B97190D0292CF3BC0065E413 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		B987B06E284540D300C53CF6 /* CurrencyCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrencyCode.swift; sourceTree = "<group>"; };
 		B99686DD2A13B38B00D1AF62 /* FullScreenCoverClearBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCoverClearBackgroundView.swift; sourceTree = "<group>"; };
@@ -296,6 +298,7 @@
 				B99BC2112A1FAE5100E6008A /* CIImage+ImageCombination.swift */,
 				B99BC2132A1FAEBC00E6008A /* URL+QRCodeGeneration.swift */,
 				B99BC2152A1FB21700E6008A /* UIImage+Background.swift */,
+				B95B15CA2B15FA3A00A54044 /* Publishers+KeyboardHeight.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -550,6 +553,7 @@
 				B9C9C660283E71F4001B879F /* Double+Woo.swift in Sources */,
 				689D11D02891B3A300F6A83F /* CrashLogger.swift in Sources */,
 				26AF1F5928B9011100937BA9 /* WooStyleModifiers.swift in Sources */,
+				B95B15CB2B15FA3A00A54044 /* Publishers+KeyboardHeight.swift in Sources */,
 				686BE912288EE0D300967C86 /* TypedPredicates.swift in Sources */,
 				B9C9C65E283E71C8001B879F /* CurrencySettings.swift in Sources */,
 				26AF1F5528B8362800937BA9 /* UIColor+ColorStudio.swift in Sources */,

--- a/WooFoundation/WooFoundation/Extensions/Publishers+KeyboardHeight.swift
+++ b/WooFoundation/WooFoundation/Extensions/Publishers+KeyboardHeight.swift
@@ -1,0 +1,24 @@
+import Combine
+import Foundation
+import UIKit
+
+public extension Publishers {
+    /// This publisher provides the height of the keyboard
+    ///
+    static var keyboardHeight: AnyPublisher<CGFloat, Never> {
+        let willShow = NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .map { $0.keyboardHeight }
+
+        let willHide = NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .map { _ in CGFloat(0) }
+
+        return MergeMany(willShow, willHide)
+            .eraseToAnyPublisher()
+    }
+}
+
+private extension Notification {
+    var keyboardHeight: CGFloat {
+        return (userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height ?? 0
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11307 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the UI of the update inventory screen:

- Layout
- Strictly layout logic: when showing the keyboard the first item, we change the button title. Anytime the keyboard is on screen, the image is hidden
- View model:  populate the layout with the inventory item. Here the challenge was to abstract the screen for products and variations, which have a slightly different structure.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to products
2. Scan a product whose inventory can be managed (`manageStock` property to true). The Inventory Update screen should appear.
3. Tap on the quantity, and make sure that the button title changes and the image disappears while the keyboard is onscreen.

Repeat with a product variation. See that the name is updated after a while (we have to retrieve the parent's product name)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/3e72e4c7-61ba-44ca-9809-9703d5949e55

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
