### PR TITLE
11203 Fix excessive memory use on Dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Now, merchants can manage "One time shipping" setting for a subscription product. [https://github.com/woocommerce/woocommerce-ios/pull/11310]
 - [**] My Store: The Blaze section is now dismissible. [https://github.com/woocommerce/woocommerce-ios/pull/11308]
 - [internal] Product Subscriptions: Handle yearly Synchronise renewals case while enabling One time shipping setting. [https://github.com/woocommerce/woocommerce-ios/pull/11312]
+- [internal] Update Shimmer dependency to avoid high CPU and memory use crashing the app when built with Xcode 15 [https://github.com/woocommerce/woocommerce-ios/pull/11320]
 
 16.4
 -----

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/markiv/SwiftUI-Shimmer",
         "state": {
           "branch": null,
-          "revision": "61411771350a5a4e96666a8a202ae4b2be327a2b",
-          "version": "1.0.1"
+          "revision": "1f3a620e4abe890d00008cb2af7023d810b433a7",
+          "version": "1.4.0"
         }
       },
       {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11203
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Xcode 15 builds previously would crash after about 30s on the dashboard, due to excessive memory use.

@jaclync identified that this was due to the shimmer modifier on the TopPerformersView.

There’s a newer version of the Shimmer library which appears to fix the issue; this commit updates to that version.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Use Xcode 15+ to build and launch the app
2. Wait on the dashboard for 30s-1m
3. Observe Xcode's memory inspector while the app is running – it should remain relatively stable. 
4. The app should not crash or use excessive memory (previously it went up to 2-3GB, depending on your device)
5. The CPU usage should also remain low; on my test device it hovers at 3%


When you've checked this, check that the TopPerformersView and other views in the app still shimmer as expected when loading.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
