### PR TITLE
[Bundle products in order] Display bundle child item prices according to whether they are priced individually

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Now, merchants can manage "One time shipping" setting for a subscription product. [https://github.com/woocommerce/woocommerce-ios/pull/11310]
 - [**] My Store: The Blaze section is now dismissible. [https://github.com/woocommerce/woocommerce-ios/pull/11308]
 - [internal] Product Subscriptions: Handle yearly Synchronise renewals case while enabling One time shipping setting. [https://github.com/woocommerce/woocommerce-ios/pull/11312]
+- [internal] Order form: Updated design for product bundles and their bundled items in order creation/editing, to more clearly show the hierarchy and bundled item prices. [https://github.com/woocommerce/woocommerce-ios/pull/11321]
 
 16.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -59,7 +59,7 @@ struct CollapsibleProductCard: View {
                                               flow: flow,
                                               shouldDisableDiscountEditing: shouldDisableDiscountEditing,
                                               shouldDisallowDiscounts: shouldDisallowDiscounts,
-                                              onAddDiscount: onAddDiscount) // TODO: #11250 Update design of child items in product bundle
+                                              onAddDiscount: onAddDiscount)
                     Divider().padding(.horizontal)
                 }
             }
@@ -156,8 +156,7 @@ private struct CollapsibleProductRowCard: View {
                             .font(.subheadline)
                             .foregroundColor(Color(.text))
                             .renderedIf(!isCollapsed)
-                        CollapsibleProductCardPriceSummary(viewModel: viewModel)
-                            .font(.subheadline)
+                        CollapsibleProductCardPriceSummary(viewModel: viewModel, font: .subheadline)
                             .renderedIf(isCollapsed)
                     }
                 }
@@ -299,19 +298,24 @@ struct CollapsibleProductCardPriceSummary: View {
 
     @ObservedObject var viewModel: ProductRowViewModel
 
-    init(viewModel: ProductRowViewModel) {
+    /// Font must be passed into `AttributedText` because font modifiers won't work on it.
+    let font: UIFont
+
+    init(viewModel: ProductRowViewModel,
+         font: UIFont = .body) {
         self.viewModel = viewModel
+        self.font = font
     }
 
     var body: some View {
         HStack {
             HStack {
-                Text(viewModel.priceQuantityLine)
-                    .foregroundColor(.secondary)
+                AttributedText(viewModel.priceQuantityLine(font: font))
                 Spacer()
             }
             if let price = viewModel.priceBeforeDiscountsLabel {
                 Text(price)
+                    .font(Font(font))
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -156,7 +156,8 @@ private struct CollapsibleProductRowCard: View {
                             .font(.subheadline)
                             .foregroundColor(Color(.text))
                             .renderedIf(!isCollapsed)
-                        CollapsibleProductCardPriceSummary(viewModel: viewModel, font: .subheadline)
+                        CollapsibleProductCardPriceSummary(viewModel: viewModel)
+                            .font(.subheadline)
                             .renderedIf(isCollapsed)
                     }
                 }
@@ -298,24 +299,19 @@ struct CollapsibleProductCardPriceSummary: View {
 
     @ObservedObject var viewModel: ProductRowViewModel
 
-    /// Font must be passed into `AttributedText` because font modifiers won't work on it.
-    let font: UIFont
-
-    init(viewModel: ProductRowViewModel,
-         font: UIFont = .body) {
+    init(viewModel: ProductRowViewModel) {
         self.viewModel = viewModel
-        self.font = font
     }
 
     var body: some View {
         HStack {
             HStack {
-                AttributedText(viewModel.priceQuantityLine(font: font))
+                Text(viewModel.priceQuantityLine)
+                    .foregroundColor(.secondary)
                 Spacer()
             }
             if let price = viewModel.priceBeforeDiscountsLabel {
                 Text(price)
-                    .font(Font(font))
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -312,6 +312,9 @@ struct CollapsibleProductCardPriceSummary: View {
             }
             if let price = viewModel.priceBeforeDiscountsLabel {
                 Text(price)
+                    .if(!viewModel.pricedIndividually) {
+                        $0.foregroundColor(.secondary)
+                    }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -119,9 +119,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         guard let price = price else {
             return nil
         }
-        guard pricedIndividually else {
-            return currencyFormatter.formatAmount(Decimal.zero)
-        }
         let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
         return currencyFormatter.formatAmount(productSubtotal)
     }
@@ -180,7 +177,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     var priceQuantityLine: String {
         let quantity = quantity.formatted()
-        let price = ( pricedIndividually ? priceLabel : currencyFormatter.formatAmount(Decimal.zero) ) ?? "-"
+        let price = priceLabel ?? "-"
         return String.localizedStringWithFormat(Localization.priceQuantityLine, quantity, price)
     }
 
@@ -372,6 +369,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         let price: String?
         if product.productType == .variable {
             price = nil
+        } else if !pricedIndividually {
+            price = "0"
         } else {
             price = product.price
         }
@@ -474,7 +473,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   productOrVariationID: productVariation.productVariationID,
                   name: name,
                   sku: productVariation.sku,
-                  price: productVariation.price,
+                  price: pricedIndividually ? productVariation.price : "0",
                   discount: discount,
                   stockStatusKey: productVariation.stockStatus.rawValue,
                   stockQuantity: productVariation.stockQuantity,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -178,26 +178,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Formatted price label based on a product's price, quantity, and whether it is priced individually.
     /// Reads as '8 x $10.00'
     ///
-    func priceQuantityLine(font: UIFont = .body) -> NSAttributedString {
+    var priceQuantityLine: String {
         let quantity = quantity.formatted()
-        let price = priceLabel ?? "-"
-        let attributedString = NSMutableAttributedString(
-            string: String.localizedStringWithFormat(Localization.priceQuantityLine, quantity, price),
-            attributes: [.font: font,
-                         .foregroundColor: UIColor.textSubtle]
-        )
-
-        guard !pricedIndividually else {
-            return attributedString
-        }
-
-        // Add strikethrough to price label
-        let bundledPrice = NSAttributedString(string: price, attributes: [.strikethroughStyle: NSUnderlineStyle.single.rawValue,
-                                                                          .font: font,
-                                                                          .foregroundColor: UIColor.textSubtle])
-        attributedString.replaceFirstOccurrence(of: price, with: bundledPrice)
-
-        return attributedString
+        let price = ( pricedIndividually ? priceLabel : currencyFormatter.formatAmount(Decimal.zero) ) ?? "-"
+        return String.localizedStringWithFormat(Localization.priceQuantityLine, quantity, price)
     }
 
     private(set) var discount: Decimal?

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -56,7 +56,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Whether the product is priced individually. Defaults to `true`.
     ///
-    /// Used when a product is part of a bundle, to control how the price is displayed (as part of the bundle price or in addition to it).
+    /// Used to control how the price is displayed, e.g. when a product is part of a bundle.
     ///
     let pricedIndividually: Bool
 
@@ -172,7 +172,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     }
 
-    /// Formatted price label based on a product's price, quantity, and whether it is priced individually.
+    /// Formatted price label based on a product's price and quantity.
     /// Reads as '8 x $10.00'
     ///
     var priceQuantityLine: String {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3136,6 +3136,27 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(newBundleOrderItem.bundleConfiguration, [.fake().copy(bundledItemID: 2, productID: 5, quantity: 5, isOptionalAndSelected: false)])
         XCTAssertEqual(newBundleOrderItem.quantity, 1)
     }
+
+    func test_createProductRowViewModel_correctly_sets_pricedIndividually_for_product_bundle_row() throws {
+        // Given
+        let bundledItems = [ProductBundleItem.fake().copy(productID: 2, pricedIndividually: false),
+                            ProductBundleItem.fake().copy(productID: 3, pricedIndividually: true)]
+        let product = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: sampleProductID, bundleItems: bundledItems)
+        storageManager.insertProducts([Product.fake().copy(siteID: sampleSiteID, productID: 2),
+                                       Product.fake().copy(siteID: sampleSiteID, productID: 3)])
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // When
+        let orderItem = OrderItem.fake().copy(productID: product.productID, quantity: 1)
+        let childItems = [OrderItem.fake().copy(productID: 2, quantity: 1),
+                          OrderItem.fake().copy(productID: 3, quantity: 1)]
+        let productRow = viewModel.createProductRowViewModel(for: orderItem, childItems: childItems, canChangeQuantity: true)
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(productRow).pricedIndividually)
+        XCTAssertFalse(try XCTUnwrap(productRow?.childProductRows[0]).pricedIndividually)
+        XCTAssertTrue(try XCTUnwrap(productRow?.childProductRows[1]).pricedIndividually)
+    }
 }
 
 private extension EditableOrderViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -627,7 +627,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: true)
 
         // Then
-        assertEqual("8 × $10.71", viewModel.priceQuantityLine().string)
+        assertEqual("8 × $10.71", viewModel.priceQuantityLine)
     }
 
     func test_priceQuantityLine_returns_properly_formatted_priceQuantityLine_for_product_not_pricedIndividually() throws {
@@ -640,16 +640,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: false, pricedIndividually: false)
 
         // Then
-        let expectedString = "8 × $10.71"
-        let attributedString = viewModel.priceQuantityLine(font: .subheadline)
-        assertEqual(expectedString, attributedString.string)
-
-        // Confirm the attributed string has the expected attributes
-        var effectiveRange = NSRange()
-        let rangeUpToPrice = NSRange(expectedString.startIndex..<(try XCTUnwrap(expectedString.range(of: "$")).lowerBound), in: expectedString)
-        let attributesAtPrice = attributedString.attributes(at: rangeUpToPrice.upperBound, effectiveRange: &effectiveRange)
-        assertEqual(NSUnderlineStyle.single.rawValue, try XCTUnwrap(attributesAtPrice[.strikethroughStyle] as? Int))
-        assertEqual(.subheadline, try XCTUnwrap(attributesAtPrice[.font] as? UIFont))
+        assertEqual("8 × $0.00", viewModel.priceQuantityLine)
     }
 
     func test_priceBeforeDiscountsLabel_returns_expected_price_for_product_pricedIndividually() {
@@ -709,7 +700,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: true)
 
         // Then
-        assertEqual("8 × -", viewModel.priceQuantityLine().string)
+        assertEqual("8 × -", viewModel.priceQuantityLine)
     }
 
     // MARK: - `isConfigurable`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -652,7 +652,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, pricedIndividually: true)
 
         // Then
-        assertEqual("$10.71", viewModel.priceBeforeDiscountsLabel)
+        assertEqual(price, viewModel.price)
     }
 
     func test_priceBeforeDiscountsLabel_returns_expected_price_for_product_not_pricedIndividually() {
@@ -664,7 +664,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, pricedIndividually: false)
 
         // Then
-        assertEqual("$0.00", viewModel.priceBeforeDiscountsLabel)
+        assertEqual("0", viewModel.price)
     }
 
     func test_totalPriceAfterDiscountLabel_when_product_row_has_one_item_and_discount_then_returns_properly_formatted_price_after_discount() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -630,7 +630,7 @@ final class ProductRowViewModelTests: XCTestCase {
         assertEqual("8 × $10.71", viewModel.priceQuantityLine)
     }
 
-    func test_priceQuantityLine_returns_properly_formatted_priceQuantityLine_for_product_not_pricedIndividually() throws {
+    func test_priceQuantityLine_returns_properly_formatted_priceQuantityLine_for_product_not_pricedIndividually() {
         // Given
         let price = "10.71"
         let quantity: Decimal = 8

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -627,7 +627,53 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: true)
 
         // Then
-        assertEqual("8 × $10.71", viewModel.priceQuantityLine)
+        assertEqual("8 × $10.71", viewModel.priceQuantityLine().string)
+    }
+
+    func test_priceQuantityLine_returns_properly_formatted_priceQuantityLine_for_product_not_pricedIndividually() throws {
+        // Given
+        let price = "10.71"
+        let quantity: Decimal = 8
+        let product = Product.fake().copy(price: price)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: false, pricedIndividually: false)
+
+        // Then
+        let expectedString = "8 × $10.71"
+        let attributedString = viewModel.priceQuantityLine(font: .subheadline)
+        assertEqual(expectedString, attributedString.string)
+
+        // Confirm the attributed string has the expected attributes
+        var effectiveRange = NSRange()
+        let rangeUpToPrice = NSRange(expectedString.startIndex..<(try XCTUnwrap(expectedString.range(of: "$")).lowerBound), in: expectedString)
+        let attributesAtPrice = attributedString.attributes(at: rangeUpToPrice.upperBound, effectiveRange: &effectiveRange)
+        assertEqual(NSUnderlineStyle.single.rawValue, try XCTUnwrap(attributesAtPrice[.strikethroughStyle] as? Int))
+        assertEqual(.subheadline, try XCTUnwrap(attributesAtPrice[.font] as? UIFont))
+    }
+
+    func test_priceBeforeDiscountsLabel_returns_expected_price_for_product_pricedIndividually() {
+        // Given
+        let price = "10.71"
+        let product = Product.fake().copy(price: price)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, pricedIndividually: true)
+
+        // Then
+        assertEqual("$10.71", viewModel.priceBeforeDiscountsLabel)
+    }
+
+    func test_priceBeforeDiscountsLabel_returns_expected_price_for_product_not_pricedIndividually() {
+        // Given
+        let price = "10.71"
+        let product = Product.fake().copy(price: price)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, pricedIndividually: false)
+
+        // Then
+        assertEqual("$0.00", viewModel.priceBeforeDiscountsLabel)
     }
 
     func test_totalPriceAfterDiscountLabel_when_product_row_has_one_item_and_discount_then_returns_properly_formatted_price_after_discount() {
@@ -663,7 +709,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: true)
 
         // Then
-        assertEqual("8 × -", viewModel.priceQuantityLine)
+        assertEqual("8 × -", viewModel.priceQuantityLine().string)
     }
 
     // MARK: - `isConfigurable`


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11250
⚠️ Depends on #11316 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
If child items aren't priced individually, we want to set the price to $0.00 with a grey text colour.

Note: We discussed in pe5pgL-42P-p2#comment-3289 using the regular price for the unit price, and displaying it with a strikethrough. However, when I tried this (see ba9f724f663cba46bcd6d2933ee59cbb66b7a15c) it both added a lot of complexity using attributed strings and changed the line height for the price line because of how we create the `AttributedText` view in SwiftUI. I'd suggest we stick with the $0.00 price for the unit price for now, but I'm interested in your perspective on whether it's worth doing the strikethrough.

## How
Using the `pricedIndividually` property added in #11316:

* We add `pricedIndividually` to `ProductRowViewModel`. If a product or variation is not priced individually, the `price` is set to `"0"`.
* In `EditableOrderViewModel` we set `pricedIndividually` when the `ProductRowViewModels` are created, based on whether the bundle items that correspond to each child item in the order are priced individually.
* In `CollapsibleProductCardPriceSummary` we use `ProductRowViewModel.pricedIndividually` to make all of the price text grey if the row is not priced individually.

## Testing instructions
Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with at least one bundled item priced individually and one bundled item _not_ priced individually.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and tap a non-bundle product
- Tap a bundle product from the prerequisite
- Configure the bundle
- Add the products to the order
- On the order form, confirm the parent bundle and any child items that are priced individually show the regular price as before, while any child items _not_ priced individually show a $0.00 price in grey.

## Screenshots
Before|After
-|-
![Before-Collapsed](https://github.com/woocommerce/woocommerce-ios/assets/8658164/1f413bad-df0e-4253-869b-9ba69df329a7)|![After-Collapsed](https://github.com/woocommerce/woocommerce-ios/assets/8658164/00dc248f-7194-4dd1-a581-50f6db6a76e8)
![Before-Expanded](https://github.com/woocommerce/woocommerce-ios/assets/8658164/836e316a-3793-4937-b497-824e6b08bf6a)|![After-Expanded](https://github.com/woocommerce/woocommerce-ios/assets/8658164/207014ab-91e3-4fab-bf33-339407ad6796)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.