### PR TITLE
Networking: Fetch suggested themes based on hardcoded theme IDs

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2298,7 +2298,6 @@ extension Networking.WordPressTheme {
     ///
     public static func fake() -> Networking.WordPressTheme {
         .init(
-            author: .fake(),
             id: .fake(),
             description: .fake(),
             name: .fake(),

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2293,3 +2293,16 @@ extension Networking.WordPressMedia {
         )
     }
 }
+extension Networking.WordPressTheme {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WordPressTheme {
+        .init(
+            author: .fake(),
+            id: .fake(),
+            description: .fake(),
+            name: .fake(),
+            demoURI: .fake()
+        )
+    }
+}

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -867,6 +867,7 @@
 		DEDA8DA52B1839320076BF0F /* theme-list-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DEDA8DA42B1839320076BF0F /* theme-list-success.json */; };
 		DEDA8DA72B18399D0076BF0F /* WordPressThemeListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */; };
 		DEDA8DA92B183D5D0076BF0F /* WordPressThemeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */; };
+		DEDA8DAB2B18407D0076BF0F /* WordPressThemeRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1885,6 +1886,7 @@
 		DEDA8DA42B1839320076BF0F /* theme-list-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-list-success.json"; sourceTree = "<group>"; };
 		DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapperTests.swift; sourceTree = "<group>"; };
 		DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemote.swift; sourceTree = "<group>"; };
+		DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemoteTests.swift; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -2231,6 +2233,7 @@
 			children = (
 				B5969E1420A47F99005E9DF1 /* RemoteTests.swift */,
 				DED91DE62AD64ED500CDCC53 /* BlazeRemoteTests.swift */,
+				DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */,
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				2685C101263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift */,
@@ -4508,6 +4511,7 @@
 				45152815257A83DD0076B03C /* ProductAttributesRemoteTests.swift in Sources */,
 				0286981629ED315000853B88 /* GenerativeContentRemoteTests.swift in Sources */,
 				CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */,
+				DEDA8DAB2B18407D0076BF0F /* WordPressThemeRemoteTests.swift in Sources */,
 				B505F6D720BEE58800BB1B69 /* AccountRemoteTests.swift in Sources */,
 				DE42F9632967C8B900D514C2 /* ReportOrderTotalsMapperTests.swift in Sources */,
 				DED91DE32AD63EE300CDCC53 /* BlazeCampaignListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -865,6 +865,7 @@
 		DEDA8DA12B182E850076BF0F /* WordPressTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */; };
 		DEDA8DA32B18323E0076BF0F /* WordPressThemeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */; };
 		DEDA8DA52B1839320076BF0F /* theme-list-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DEDA8DA42B1839320076BF0F /* theme-list-success.json */; };
+		DEDA8DA72B18399D0076BF0F /* WordPressThemeListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1881,6 +1882,7 @@
 		DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressTheme.swift; sourceTree = "<group>"; };
 		DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapper.swift; sourceTree = "<group>"; };
 		DEDA8DA42B1839320076BF0F /* theme-list-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-list-success.json"; sourceTree = "<group>"; };
+		DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapperTests.swift; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -3246,6 +3248,7 @@
 				EEA1E2012AC18CD700A37ADD /* AIProductMapperTests.swift */,
 				EE078D922AD2F1E500C1199E /* JWTokenMapperTests.swift */,
 				DED91DE22AD63EE300CDCC53 /* BlazeCampaignListMapperTests.swift */,
+				DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -4544,6 +4547,7 @@
 				028F3F942B0DF9A800F8E227 /* OrderEncoderTests.swift in Sources */,
 				9387A6F0226E3F15001B53D7 /* AccountSettingsMapperTests.swift in Sources */,
 				2685C102263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift in Sources */,
+				DEDA8DA72B18399D0076BF0F /* WordPressThemeListMapperTests.swift in Sources */,
 				02616F8C292132800095BC00 /* SiteRemoteTests.swift in Sources */,
 				EEFAA579295D2FC7003583BE /* RESTRequestTests.swift in Sources */,
 				B57B1E6721C916850046E764 /* NetworkErrorTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -864,6 +864,7 @@
 		DEDA8D9B2B05BEF80076BF0F /* CreateProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9A2B05BEF80076BF0F /* CreateProductVariationTests.swift */; };
 		DEDA8DA12B182E850076BF0F /* WordPressTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */; };
 		DEDA8DA32B18323E0076BF0F /* WordPressThemeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */; };
+		DEDA8DA52B1839320076BF0F /* theme-list-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DEDA8DA42B1839320076BF0F /* theme-list-success.json */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1879,6 +1880,7 @@
 		DEDA8D9A2B05BEF80076BF0F /* CreateProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProductVariationTests.swift; sourceTree = "<group>"; };
 		DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressTheme.swift; sourceTree = "<group>"; };
 		DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapper.swift; sourceTree = "<group>"; };
+		DEDA8DA42B1839320076BF0F /* theme-list-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-list-success.json"; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -2572,6 +2574,7 @@
 			isa = PBXGroup;
 			children = (
 				DED91DDE2AD63C2800CDCC53 /* blaze-campaigns-success.json */,
+				DEDA8DA42B1839320076BF0F /* theme-list-success.json */,
 				EE28C7D72AC17960004A69F4 /* generate-product-failure.json */,
 				EE28C7D82AC17961004A69F4 /* generate-product-invalid-token.json */,
 				EE28C7D92AC17961004A69F4 /* generate-product-success.json */,
@@ -3779,6 +3782,7 @@
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
+				DEDA8DA52B1839320076BF0F /* theme-list-success.json in Resources */,
 				EE84D62B2B0B46E7008EA80A /* product-variation-subscription-incomplete.json in Resources */,
 				029B86902A6FBBE000E944D1 /* wcpay-account-null-isLive.json in Resources */,
 				02AED9D82AA03F3F006DC460 /* order-with-all-addon-types.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -866,6 +866,7 @@
 		DEDA8DA32B18323E0076BF0F /* WordPressThemeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */; };
 		DEDA8DA52B1839320076BF0F /* theme-list-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DEDA8DA42B1839320076BF0F /* theme-list-success.json */; };
 		DEDA8DA72B18399D0076BF0F /* WordPressThemeListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */; };
+		DEDA8DA92B183D5D0076BF0F /* WordPressThemeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1883,6 +1884,7 @@
 		DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapper.swift; sourceTree = "<group>"; };
 		DEDA8DA42B1839320076BF0F /* theme-list-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-list-success.json"; sourceTree = "<group>"; };
 		DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapperTests.swift; sourceTree = "<group>"; };
+		DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemote.swift; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -2437,6 +2439,7 @@
 				EE2C09BB29AF0AAD009396F9 /* StoreOnboardingTasksRemote.swift */,
 				0286981329ED2D6400853B88 /* GenerativeContentRemote.swift */,
 				DED91DE42AD64B2900CDCC53 /* BlazeRemote.swift */,
+				DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -4112,6 +4115,7 @@
 				74046E1F217A6B70007DD7BF /* SiteSettingsMapper.swift in Sources */,
 				31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */,
 				02BE0A7B274B695F001176D2 /* WordPressMediaMapper.swift in Sources */,
+				DEDA8DA92B183D5D0076BF0F /* WordPressThemeRemote.swift in Sources */,
 				45150A9A268340D2006922EA /* Country.swift in Sources */,
 				DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */,
 				CC33754E29C884000006A538 /* ProductCompositeComponent.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -862,6 +862,7 @@
 		DED91DE52AD64B2900CDCC53 /* BlazeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DE42AD64B2900CDCC53 /* BlazeRemote.swift */; };
 		DED91DE72AD64ED500CDCC53 /* BlazeRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DE62AD64ED500CDCC53 /* BlazeRemoteTests.swift */; };
 		DEDA8D9B2B05BEF80076BF0F /* CreateProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9A2B05BEF80076BF0F /* CreateProductVariationTests.swift */; };
+		DEDA8DA12B182E850076BF0F /* WordPressTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1875,6 +1876,7 @@
 		DED91DE42AD64B2900CDCC53 /* BlazeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeRemote.swift; sourceTree = "<group>"; };
 		DED91DE62AD64ED500CDCC53 /* BlazeRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeRemoteTests.swift; sourceTree = "<group>"; };
 		DEDA8D9A2B05BEF80076BF0F /* CreateProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProductVariationTests.swift; sourceTree = "<group>"; };
+		DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressTheme.swift; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -2559,6 +2561,7 @@
 				B990FA912AA1EBC600496375 /* TaxRate.swift */,
 				EE078D8E2AD2E65400C1199E /* JWToken.swift */,
 				DED91DDC2AD62DCB00CDCC53 /* BlazeCampaign.swift */,
+				DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -4309,6 +4312,7 @@
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,
 				261C466B2A6738EE00734070 /* AppicationPasswordEncoder.swift in Sources */,
+				DEDA8DA12B182E850076BF0F /* WordPressTheme.swift in Sources */,
 				2665032A261F41510079A159 /* ProductAddOn.swift in Sources */,
 				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,
 				0359EA1327AAC6D00048DE2D /* WCPayCardPaymentDetails.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -863,6 +863,7 @@
 		DED91DE72AD64ED500CDCC53 /* BlazeRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DE62AD64ED500CDCC53 /* BlazeRemoteTests.swift */; };
 		DEDA8D9B2B05BEF80076BF0F /* CreateProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9A2B05BEF80076BF0F /* CreateProductVariationTests.swift */; };
 		DEDA8DA12B182E850076BF0F /* WordPressTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */; };
+		DEDA8DA32B18323E0076BF0F /* WordPressThemeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1877,6 +1878,7 @@
 		DED91DE62AD64ED500CDCC53 /* BlazeRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeRemoteTests.swift; sourceTree = "<group>"; };
 		DEDA8D9A2B05BEF80076BF0F /* CreateProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProductVariationTests.swift; sourceTree = "<group>"; };
 		DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressTheme.swift; sourceTree = "<group>"; };
+		DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapper.swift; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -3079,6 +3081,7 @@
 				B9CFF6512AB2118900C2F616 /* TaxRateMapper.swift */,
 				EE839C252ABEF9C900049545 /* AIProductMapper.swift */,
 				EE078D902AD2EFBA00C1199E /* JWTokenMapper.swift */,
+				DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -4380,6 +4383,7 @@
 				B59325D5217E4206000B0E8E /* NoteRange.swift in Sources */,
 				458C6DE425AC72A1009B300D /* StoredProductSettings.swift in Sources */,
 				0359EA1927AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift in Sources */,
+				DEDA8DA32B18323E0076BF0F /* WordPressThemeListMapper.swift in Sources */,
 				45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */,
 				AEF9458B27297FF6001DCCFB /* IgnoringResponseMapper.swift in Sources */,
 				B59325C7217E22FC000B0E8E /* Note.swift in Sources */,

--- a/Networking/Networking/Mapper/WordPressThemeListMapper.swift
+++ b/Networking/Networking/Mapper/WordPressThemeListMapper.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Mapper: `WordPressTheme` List
+///
+struct WordPressThemeListMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into `[WordPressTheme]`.
+    ///
+    func map(response: Data) throws -> [WordPressTheme] {
+        let decoder = JSONDecoder()
+        return try decoder.decode(WordPressThemeListEnvelope.self, from: response).themes
+    }
+}
+
+
+/// WordPressThemeEnvelope Disposable Entity.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct WordPressThemeListEnvelope: Decodable {
+    let themes: [WordPressTheme]
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3102,20 +3102,17 @@ extension Networking.WordPressMedia {
 
 extension Networking.WordPressTheme {
     public func copy(
-        author: CopiableProp<String> = .copy,
         id: CopiableProp<String> = .copy,
         description: CopiableProp<String> = .copy,
         name: CopiableProp<String> = .copy,
         demoURI: CopiableProp<String> = .copy
     ) -> Networking.WordPressTheme {
-        let author = author ?? self.author
         let id = id ?? self.id
         let description = description ?? self.description
         let name = name ?? self.name
         let demoURI = demoURI ?? self.demoURI
 
         return Networking.WordPressTheme(
-            author: author,
             id: id,
             description: description,
             name: name,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3099,3 +3099,27 @@ extension Networking.WordPressMedia {
         )
     }
 }
+
+extension Networking.WordPressTheme {
+    public func copy(
+        author: CopiableProp<String> = .copy,
+        id: CopiableProp<String> = .copy,
+        description: CopiableProp<String> = .copy,
+        name: CopiableProp<String> = .copy,
+        demoURI: CopiableProp<String> = .copy
+    ) -> Networking.WordPressTheme {
+        let author = author ?? self.author
+        let id = id ?? self.id
+        let description = description ?? self.description
+        let name = name ?? self.name
+        let demoURI = demoURI ?? self.demoURI
+
+        return Networking.WordPressTheme(
+            author: author,
+            id: id,
+            description: description,
+            name: name,
+            demoURI: demoURI
+        )
+    }
+}

--- a/Networking/Networking/Model/WordPressTheme.swift
+++ b/Networking/Networking/Model/WordPressTheme.swift
@@ -26,4 +26,23 @@ public struct WordPressTheme: Decodable, Equatable, GeneratedCopiable, Generated
         self.name = name
         self.demoURI = demoURI
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        description = try container.decode(String.self, forKey: .description)
+        name = try container.decode(String.self, forKey: .name)
+        demoURI = try container.decodeIfPresent(String.self, forKey: .demoURI) ??
+        (try container.decodeIfPresent(String.self, forKey: .themeURI)) ?? ""
+    }
+}
+
+private extension WordPressTheme {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case description
+        case name
+        case demoURI = "demo_uri"
+        case themeURI = "theme_uri"
+    }
 }

--- a/Networking/Networking/Model/WordPressTheme.swift
+++ b/Networking/Networking/Model/WordPressTheme.swift
@@ -32,8 +32,7 @@ public struct WordPressTheme: Decodable, Equatable, GeneratedCopiable, Generated
         id = try container.decode(String.self, forKey: .id)
         description = try container.decode(String.self, forKey: .description)
         name = try container.decode(String.self, forKey: .name)
-        demoURI = try container.decodeIfPresent(String.self, forKey: .demoURI) ??
-        (try container.decodeIfPresent(String.self, forKey: .themeURI)) ?? ""
+        demoURI = try container.decodeIfPresent(String.self, forKey: .demoURI) ?? ""
     }
 }
 
@@ -43,6 +42,5 @@ private extension WordPressTheme {
         case description
         case name
         case demoURI = "demo_uri"
-        case themeURI = "theme_uri"
     }
 }

--- a/Networking/Networking/Model/WordPressTheme.swift
+++ b/Networking/Networking/Model/WordPressTheme.swift
@@ -32,6 +32,8 @@ public struct WordPressTheme: Decodable, Equatable, GeneratedCopiable, Generated
         id = try container.decode(String.self, forKey: .id)
         description = try container.decode(String.self, forKey: .description)
         name = try container.decode(String.self, forKey: .name)
+        /// We want to reuse the response for WPCom V1.1 themes/mine/ which doesn't have `demo_uri`
+        /// so this is decoding can fail silently with an empty string as the default value.
         demoURI = try container.decodeIfPresent(String.self, forKey: .demoURI) ?? ""
     }
 }

--- a/Networking/Networking/Model/WordPressTheme.swift
+++ b/Networking/Networking/Model/WordPressTheme.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Codegen
+
+/// Details of a WordPress theme
+///
+public struct WordPressTheme: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+
+    /// Name of the theme's author
+    public let author: String
+
+    /// ID of the theme
+    public let id: String
+
+    /// Description of the theme
+    public let description: String
+
+    /// Name of the theme
+    public let name: String
+
+    /// URI of the demo site for the theme
+    public let demoURI: String
+
+    public init(author: String,
+                id: String,
+                description: String,
+                name: String,
+                demoURI: String) {
+        self.author = author
+        self.id = id
+        self.description = description
+        self.name = name
+        self.demoURI = demoURI
+    }
+}

--- a/Networking/Networking/Model/WordPressTheme.swift
+++ b/Networking/Networking/Model/WordPressTheme.swift
@@ -5,9 +5,6 @@ import Codegen
 ///
 public struct WordPressTheme: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
 
-    /// Name of the theme's author
-    public let author: String
-
     /// ID of the theme
     public let id: String
 
@@ -20,12 +17,10 @@ public struct WordPressTheme: Decodable, Equatable, GeneratedCopiable, Generated
     /// URI of the demo site for the theme
     public let demoURI: String
 
-    public init(author: String,
-                id: String,
+    public init(id: String,
                 description: String,
                 name: String,
                 demoURI: String) {
-        self.author = author
         self.id = id
         self.description = description
         self.name = name

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for `WordPressThemeRemote` mainly used for mocking.
+///
+public protocol WordPressThemeRemoteProtocol {
+    /// Loads suggested themes.
+    ///
+    func loadSuggestedThemes() async throws -> [WordPressTheme]
+}
+
+/// WordPressThemes: Remote Endpoints
+///
+public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
+
+    public func loadSuggestedThemes() async throws -> [WordPressTheme] {
+        let path = Paths.suggestedThemes
+        let parameters: [String: Any] = [
+            Keys.filter: Values.suggestedThemeFilter,
+            Keys.number: Values.maximumThemeCount
+        ]
+        let request = DotcomRequest(wordpressApiVersion: .mark1_2, method: .get, path: path, parameters: parameters)
+        let mapper = WordPressThemeListMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+}
+
+private extension WordPressThemeRemote {
+    enum Paths {
+        // https://public-api.wordpress.com/rest/v1.2/themes?filter=subject:store&number=100
+        static let suggestedThemes = "themes"
+    }
+
+    enum Keys {
+        static let filter = "filter"
+        static let number =  "number"
+    }
+
+    enum Values {
+        static let suggestedThemeFilter = "subject:store"
+        static let maximumThemeCount = 100
+    }
+}

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -21,6 +21,9 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
         let request = DotcomRequest(wordpressApiVersion: .mark1_2, method: .get, path: path, parameters: parameters)
         let mapper = WordPressThemeListMapper()
         return try await enqueue(request, mapper: mapper)
+            .filter { theme in
+                Values.filteredThemeIDs.contains(theme.id)
+            }
     }
 }
 
@@ -38,5 +41,6 @@ private extension WordPressThemeRemote {
     enum Values {
         static let suggestedThemeFilter = "subject:store"
         static let maximumThemeCount = 100
+        static let filteredThemeIDs = ["tsubaki", "tazza", "amulet", "zaino", "thriving-artist", "attar"]
     }
 }

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -14,11 +14,7 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
 
     public func loadSuggestedThemes() async throws -> [WordPressTheme] {
         let path = Paths.suggestedThemes
-        let parameters: [String: Any] = [
-            Keys.filter: Values.suggestedThemeFilter,
-            Keys.number: Values.maximumThemeCount
-        ]
-        let request = DotcomRequest(wordpressApiVersion: .mark1_2, method: .get, path: path, parameters: parameters)
+        let request = DotcomRequest(wordpressApiVersion: .mark1_2, method: .get, path: path)
         let mapper = WordPressThemeListMapper()
         return try await enqueue(request, mapper: mapper)
             .filter { theme in
@@ -29,18 +25,10 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
 
 private extension WordPressThemeRemote {
     enum Paths {
-        // https://public-api.wordpress.com/rest/v1.2/themes?filter=subject:store&number=100
-        static let suggestedThemes = "themes"
-    }
-
-    enum Keys {
-        static let filter = "filter"
-        static let number =  "number"
+        static let suggestedThemes = "themes?filter=subject:store&number=100"
     }
 
     enum Values {
-        static let suggestedThemeFilter = "subject:store"
-        static let maximumThemeCount = 100
         static let filteredThemeIDs = ["tsubaki", "tazza", "amulet", "zaino", "thriving-artist", "attar"]
     }
 }

--- a/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
@@ -13,7 +13,7 @@ final class WordPressThemeListMapperTests: XCTestCase {
         XCTAssertEqual(item.id, "tsubaki")
         XCTAssertEqual(item.name, "Tsubaki")
         // swiftlint:disable:next line_length
-        XCTAssertEqual(item.description, "Tsubaki")
+        XCTAssertEqual(item.description, "Tsubaki puts the spotlight on your products and your customers.  This theme leverages WooCommerce to provide you with intuitive product navigation and the patterns you need to master digital merchandising.")
         XCTAssertEqual(item.demoURI, "https://tsubakidemo.wpcomstaging.com/")
     }
 }

--- a/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
@@ -10,11 +10,11 @@ final class WordPressThemeListMapperTests: XCTestCase {
         XCTAssertEqual(themes.count, 2)
 
         let item = try XCTUnwrap(themes.first)
-        XCTAssertEqual(item.id, "organic-stax")
-        XCTAssertEqual(item.name, "STAX")
+        XCTAssertEqual(item.id, "tsubaki")
+        XCTAssertEqual(item.name, "Tsubaki")
         // swiftlint:disable:next line_length
-        XCTAssertEqual(item.description, "STAX is a premium block theme for the WordPress full-site editor. The design is clean, versatile, and totally customizable. Additionally, the setup wizard provides a super simple installation process — so your site will appear exactly as the demo within moments of activation. ")
-        XCTAssertEqual(item.demoURI, "https://stax.organicthemes.com/")
+        XCTAssertEqual(item.description, "Tsubaki")
+        XCTAssertEqual(item.demoURI, "https://tsubakidemo.wpcomstaging.com/")
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Networking
+
+final class WordPressThemeListMapperTests: XCTestCase {
+
+    /// Verifies that the whole list is parsed.
+    ///
+    func test_WordPressThemeListMapper_parses_all_contents_in_response() throws {
+        let themes = try mapLoadWordPressThemeListResponse()
+        XCTAssertEqual(themes.count, 2)
+
+        let item = try XCTUnwrap(themes.first)
+        XCTAssertEqual(item.id, "organic-stax")
+        XCTAssertEqual(item.name, "STAX")
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(item.description, "STAX is a premium block theme for the WordPress full-site editor. The design is clean, versatile, and totally customizable. Additionally, the setup wizard provides a super simple installation process — so your site will appear exactly as the demo within moments of activation. ")
+        XCTAssertEqual(item.demoURI, "https://stax.organicthemes.com/")
+    }
+}
+
+// MARK: - Test Helpers
+///
+private extension WordPressThemeListMapperTests {
+
+    /// Returns the WordPressThemeListMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapWordPressThemeList(from filename: String) throws -> [WordPressTheme] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try WordPressThemeListMapper().map(response: response)
+    }
+
+    /// Returns the WordPressThemeListMapper output from `theme-list-success.json`
+    ///
+    func mapLoadWordPressThemeListResponse() throws -> [WordPressTheme] {
+        return try mapWordPressThemeList(from: "theme-list-success")
+    }
+}

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -25,7 +25,7 @@ final class BlazeRemoteTests: XCTestCase {
 
     /// Verifies that loadCampaign properly parses the response.
     ///
-    func test_loadCampaigns_returns_parsed_coupons() async throws {
+    func test_loadCampaigns_returns_parsed_campaigns() async throws {
         // Given
         let remote = BlazeRemote(network: network)
 

--- a/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Networking
+
+final class WordPressThemeRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - loadSuggestedThemes tests
+
+    func test_loadSuggestedThemes_returns_parsed_campaigns() async throws {
+        // Given
+        let remote = WordPressThemeRemote(network: network)
+
+        let suffix = "themes?filter=subject:store&number=100"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "theme-list-success")
+
+        // When
+        let results = try await remote.loadSuggestedThemes()
+
+        // Then
+        XCTAssertEqual(results.count, 1)
+        let item = try XCTUnwrap(results.first)
+        XCTAssertEqual(item.id, "tsubaki")
+        XCTAssertEqual(item.name, "Tsubaki")
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(item.description, "Tsubaki puts the spotlight on your products and your customers.  This theme leverages WooCommerce to provide you with intuitive product navigation and the patterns you need to master digital merchandising.")
+        XCTAssertEqual(item.demoURI, "https://tsubakidemo.wpcomstaging.com/")
+    }
+
+    func test_loadSuggestedThemes_properly_relays_networking_errors() async {
+        // Given
+        let remote = WordPressThemeRemote(network: network)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        let suffix = "themes?filter=subject:store&number=100"
+        network.simulateError(requestUrlSuffix: suffix, error: expectedError)
+
+        do {
+            // When
+            _ = try await remote.loadSuggestedThemes()
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/theme-list-success.json
+++ b/Networking/NetworkingTests/Responses/theme-list-success.json
@@ -1,49 +1,67 @@
 {
     "themes": [
         {
-            "menu_order": -110,
-            "author": "Organic Themes",
-            "id": "organic-stax",
-            "description": "STAX is a premium block theme for the WordPress full-site editor. The design is clean, versatile, and totally customizable. Additionally, the setup wizard provides a super simple installation process — so your site will appear exactly as the demo within moments of activation. ",
-            "stylesheet": "organic-stax",
-            "name": "STAX",
-            "author_uri": "https://organicthemes.com/",
-            "demo_uri": "https://stax.organicthemes.com/",
-            "screenshot": "https://theme.files.wordpress.com/2023/02/stax-featured.jpg",
-            "theme_type": "managed-external",
-            "product_details": [
-                {
-                    "product_id": 10025,
-                    "product_slug": "wp_mp_theme_organic_stax_yearly"
-                },
-                {
-                    "product_id": 10026,
-                    "product_slug": "wp_mp_theme_organic_stax_monthly"
-                }
-            ],
+            "menu_order": -57,
+            "author": "Automattic",
+            "id": "tsubaki",
+            "description": "Tsubaki puts the spotlight on your products and your customers.  This theme leverages WooCommerce to provide you with intuitive product navigation and the patterns you need to master digital merchandising.",
+            "stylesheet": "premium/tsubaki",
+            "name": "Tsubaki",
+            "author_uri": "https://automattic.com/",
+            "demo_uri": "https://tsubakidemo.wpcomstaging.com/",
+            "screenshot": "https://i0.wp.com/s2.wp.com/wp-content/themes/premium/tsubaki/screenshot.png?ssl=1",
+            "theme_type": "hosted-internal",
+            "download_uri": "https://public-api.wordpress.com/rest/v1/themes/download/tsubaki.zip",
+            "price": "US$50",
             "taxonomies": {
+                "theme_subject": [
+                    {
+                        "name": "Business",
+                        "slug": "business",
+                        "term_id": "179"
+                    },
+                    {
+                        "name": "Store",
+                        "slug": "store",
+                        "term_id": "40550"
+                    }
+                ],
+                "theme_style": [
+                    {
+                        "name": "Clean",
+                        "slug": "clean",
+                        "term_id": "9519"
+                    },
+                    {
+                        "name": "Modern",
+                        "slug": "modern",
+                        "term_id": "4690"
+                    }
+                ],
+                "theme_color": [
+                    {
+                        "name": "Black",
+                        "slug": "black",
+                        "term_id": "59007"
+                    },
+                    {
+                        "name": "White",
+                        "slug": "white",
+                        "term_id": "7052"
+                    }
+                ],
                 "theme_column": [
                     {
                         "name": "One Column",
                         "slug": "one-column",
                         "term_id": "1450969"
-                    },
-                    {
-                        "name": "Two Columns",
-                        "slug": "two-columns",
-                        "term_id": "2600855"
                     }
                 ],
                 "theme_feature": [
                     {
-                        "name": "Custom Menu",
-                        "slug": "custom-menu",
-                        "term_id": "4349195"
-                    },
-                    {
-                        "name": "Full Width Template",
-                        "slug": "full-width-template",
-                        "term_id": "43438937"
+                        "name": "Custom Colors",
+                        "slug": "custom-colors",
+                        "term_id": "2184596"
                     },
                     {
                         "name": "RTL Language Support",
@@ -56,16 +74,6 @@
                         "term_id": "3895381"
                     },
                     {
-                        "name": "Accessibility Ready",
-                        "slug": "accessibility-ready",
-                        "term_id": "158289315"
-                    },
-                    {
-                        "name": "Threaded Comments",
-                        "slug": "threaded-comments",
-                        "term_id": "5371426"
-                    },
-                    {
                         "name": "Block Editor Styles",
                         "slug": "block-editor-styles",
                         "term_id": "685452039"
@@ -76,18 +84,11 @@
                         "term_id": "686035051"
                     }
                 ],
-                "theme_mobile-friendly": [
+                "theme_software_set": [
                     {
-                        "name": "Mobile-Friendly",
-                        "slug": "mobile-friendly",
-                        "term_id": "350456"
-                    }
-                ],
-                "theme_subject": [
-                    {
-                        "name": "Store",
-                        "slug": "store",
-                        "term_id": "40550"
+                        "name": "woo-on-plans",
+                        "slug": "woo-on-plans",
+                        "term_id": "755216234"
                     }
                 ]
             },

--- a/Networking/NetworkingTests/Responses/theme-list-success.json
+++ b/Networking/NetworkingTests/Responses/theme-list-success.json
@@ -1,0 +1,211 @@
+{
+    "themes": [
+        {
+            "menu_order": -110,
+            "author": "Organic Themes",
+            "id": "organic-stax",
+            "description": "STAX is a premium block theme for the WordPress full-site editor. The design is clean, versatile, and totally customizable. Additionally, the setup wizard provides a super simple installation process — so your site will appear exactly as the demo within moments of activation. ",
+            "stylesheet": "organic-stax",
+            "name": "STAX",
+            "author_uri": "https://organicthemes.com/",
+            "demo_uri": "https://stax.organicthemes.com/",
+            "screenshot": "https://theme.files.wordpress.com/2023/02/stax-featured.jpg",
+            "theme_type": "managed-external",
+            "product_details": [
+                {
+                    "product_id": 10025,
+                    "product_slug": "wp_mp_theme_organic_stax_yearly"
+                },
+                {
+                    "product_id": 10026,
+                    "product_slug": "wp_mp_theme_organic_stax_monthly"
+                }
+            ],
+            "taxonomies": {
+                "theme_column": [
+                    {
+                        "name": "One Column",
+                        "slug": "one-column",
+                        "term_id": "1450969"
+                    },
+                    {
+                        "name": "Two Columns",
+                        "slug": "two-columns",
+                        "term_id": "2600855"
+                    }
+                ],
+                "theme_feature": [
+                    {
+                        "name": "Custom Menu",
+                        "slug": "custom-menu",
+                        "term_id": "4349195"
+                    },
+                    {
+                        "name": "Full Width Template",
+                        "slug": "full-width-template",
+                        "term_id": "43438937"
+                    },
+                    {
+                        "name": "RTL Language Support",
+                        "slug": "rtl-language-support",
+                        "term_id": "23177744"
+                    },
+                    {
+                        "name": "Featured Images",
+                        "slug": "featured-images",
+                        "term_id": "3895381"
+                    },
+                    {
+                        "name": "Accessibility Ready",
+                        "slug": "accessibility-ready",
+                        "term_id": "158289315"
+                    },
+                    {
+                        "name": "Threaded Comments",
+                        "slug": "threaded-comments",
+                        "term_id": "5371426"
+                    },
+                    {
+                        "name": "Block Editor Styles",
+                        "slug": "block-editor-styles",
+                        "term_id": "685452039"
+                    },
+                    {
+                        "name": "Full Site Editing",
+                        "slug": "full-site-editing",
+                        "term_id": "686035051"
+                    }
+                ],
+                "theme_mobile-friendly": [
+                    {
+                        "name": "Mobile-Friendly",
+                        "slug": "mobile-friendly",
+                        "term_id": "350456"
+                    }
+                ],
+                "theme_subject": [
+                    {
+                        "name": "Store",
+                        "slug": "store",
+                        "term_id": "40550"
+                    }
+                ]
+            },
+            "style_variations": [],
+            "soft_launched": false
+        },
+        {
+            "menu_order": -63,
+            "author": "Themes Kingdom",
+            "id": "nokul",
+            "description": "Nokul is a tasty block WordPress theme that will help your pastries and doughs take center stage and get the attention they deserve. Thanks to Nokul’s seamless design, your website visitors will enjoy adding your products to cart and will keep coming back.",
+            "stylesheet": "nokul",
+            "name": "Nokul",
+            "author_uri": "https://themeskingdom.com/",
+            "demo_uri": "https://nokul.themeskingdom.com/",
+            "screenshot": "https://theme.files.wordpress.com/2023/03/nokul2.jpg",
+            "theme_type": "managed-external",
+            "product_details": [
+                {
+                    "product_id": 10046,
+                    "product_slug": "wp_mp_theme_nokul_yearly"
+                },
+                {
+                    "product_id": 10047,
+                    "product_slug": "wp_mp_theme_nokul_monthly"
+                }
+            ],
+            "taxonomies": {
+                "theme_column": [
+                    {
+                        "name": "One Column",
+                        "slug": "one-column",
+                        "term_id": "1450969"
+                    },
+                    {
+                        "name": "Two Columns",
+                        "slug": "two-columns",
+                        "term_id": "2600855"
+                    },
+                    {
+                        "name": "Three Columns",
+                        "slug": "three-columns",
+                        "term_id": "5624304"
+                    },
+                    {
+                        "name": "Four Columns",
+                        "slug": "four-columns",
+                        "term_id": "6130973"
+                    },
+                    {
+                        "name": "Left Sidebar",
+                        "slug": "left-sidebar",
+                        "term_id": "1637027"
+                    },
+                    {
+                        "name": "Right Sidebar",
+                        "slug": "right-sidebar",
+                        "term_id": "1637034"
+                    }
+                ],
+                "theme_feature": [
+                    {
+                        "name": "Custom Colors",
+                        "slug": "custom-colors",
+                        "term_id": "2184596"
+                    },
+                    {
+                        "name": "Custom Menu",
+                        "slug": "custom-menu",
+                        "term_id": "4349195"
+                    },
+                    {
+                        "name": "Full Width Template",
+                        "slug": "full-width-template",
+                        "term_id": "43438937"
+                    },
+                    {
+                        "name": "RTL Language Support",
+                        "slug": "rtl-language-support",
+                        "term_id": "23177744"
+                    },
+                    {
+                        "name": "Featured Images",
+                        "slug": "featured-images",
+                        "term_id": "3895381"
+                    },
+                    {
+                        "name": "Threaded Comments",
+                        "slug": "threaded-comments",
+                        "term_id": "5371426"
+                    },
+                    {
+                        "name": "Site Logo",
+                        "slug": "site-logo",
+                        "term_id": "7533351"
+                    },
+                    {
+                        "name": "Block Editor Styles",
+                        "slug": "block-editor-styles",
+                        "term_id": "685452039"
+                    },
+                    {
+                        "name": "Full Site Editing",
+                        "slug": "full-site-editing",
+                        "term_id": "686035051"
+                    }
+                ],
+                "theme_subject": [
+                    {
+                        "name": "Store",
+                        "slug": "store",
+                        "term_id": "40550"
+                    }
+                ]
+            },
+            "style_variations": [],
+            "soft_launched": false
+        }
+    ],
+    "found": 2
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11322 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds support for fetching suggested WP themes for a site. Changes include:
- Added a new model `WordPressTheme`.
- Added a new mapper `WordPressThemeListMapper`.
- Added a new remote `WordPressThemeRemote`
- Added tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The remote hasn't been integrated yet so just CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
