### PR TITLE
Yosemite: Support loading suggested themes

### DIFF
--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -99,7 +99,10 @@ class AuthenticatedState: StoresManagerState {
 
 
         if case .wpcom = credentials {
-            services.append(AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network))
+            services.append(contentsOf: [
+                AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+                WordPressThemeStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+            ])
         } else {
             DDLogInfo("No WordPress.com auth token found. AccountStore is not initialized.")
         }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -427,6 +427,7 @@
 		DED91DF22AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */; };
 		DED91DF42AD67E9400CDCC53 /* BlazeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */; };
 		DED91DF62AD67F8F00CDCC53 /* MockBlazeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF52AD67F8F00CDCC53 /* MockBlazeRemote.swift */; };
+		DEDA8DAD2B1846FF0076BF0F /* WordPressThemeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
@@ -900,6 +901,7 @@
 		DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeCampaign+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStoreTests.swift; sourceTree = "<group>"; };
 		DED91DF52AD67F8F00CDCC53 /* MockBlazeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBlazeRemote.swift; sourceTree = "<group>"; };
+		DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeAction.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1805,6 +1807,7 @@
 				DE2E8EA42953F77A002E4B14 /* WordPressSiteAction.swift */,
 				EEB4E2CA29B04A1200371C3C /* StoreOnboardingTasksAction.swift */,
 				0286A1B92A0CBE1B0099EF94 /* FeatureFlagAction.swift */,
+				DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -2136,6 +2139,7 @@
 				5758EB3024DC7791009ED8A6 /* InAppFeedbackCardVisibilityUseCase.swift in Sources */,
 				7471401321877A8B009A11CC /* NotificationStore.swift in Sources */,
 				74D42DBA221C978D00B4977D /* ShipmentTracking+ReadOnlyType.swift in Sources */,
+				DEDA8DAD2B1846FF0076BF0F /* WordPressThemeAction.swift in Sources */,
 				AEF945892729766D001DCCFB /* TelemetryStore.swift in Sources */,
 				AEF945872729760F001DCCFB /* TelemetryAction.swift in Sources */,
 				B5DC3CB120D1B8720063AC41 /* AccountAction.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		DED91DF42AD67E9400CDCC53 /* BlazeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */; };
 		DED91DF62AD67F8F00CDCC53 /* MockBlazeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF52AD67F8F00CDCC53 /* MockBlazeRemote.swift */; };
 		DEDA8DAD2B1846FF0076BF0F /* WordPressThemeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */; };
+		DEDA8DAF2B1847C80076BF0F /* WordPressThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAE2B1847C80076BF0F /* WordPressThemeStore.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
@@ -902,6 +903,7 @@
 		DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStoreTests.swift; sourceTree = "<group>"; };
 		DED91DF52AD67F8F00CDCC53 /* MockBlazeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBlazeRemote.swift; sourceTree = "<group>"; };
 		DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeAction.swift; sourceTree = "<group>"; };
+		DEDA8DAE2B1847C80076BF0F /* WordPressThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeStore.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1545,6 +1547,7 @@
 				02EF1665292DB65000D90AD6 /* PaymentStore.swift */,
 				EEB4E2C829B0489800371C3C /* StoreOnboardingTasksStore.swift */,
 				0286A1B72A0CBDC40099EF94 /* FeatureFlagStore.swift */,
+				DEDA8DAE2B1847C80076BF0F /* WordPressThemeStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -2355,6 +2358,7 @@
 				B9AECD402850FE4600E78584 /* Order+CardPresentPayment.swift in Sources */,
 				7492FADB217FAE4D00ED2C69 /* SiteSetting+ReadOnlyType.swift in Sources */,
 				209AD3CE2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift in Sources */,
+				DEDA8DAF2B1847C80076BF0F /* WordPressThemeStore.swift in Sources */,
 				03EB99902907B97800F06A39 /* JustInTimeMessage.swift in Sources */,
 				031C1EAA27B1702800298699 /* WCPayCharge+ReadOnlyConvertible.swift in Sources */,
 				D8652E0D26303A8B00350F37 /* ReceiptAction.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		DEDA8DAD2B1846FF0076BF0F /* WordPressThemeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */; };
 		DEDA8DAF2B1847C80076BF0F /* WordPressThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAE2B1847C80076BF0F /* WordPressThemeStore.swift */; };
 		DEDA8DB12B184A660076BF0F /* MockWordPressThemeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DB02B184A660076BF0F /* MockWordPressThemeRemote.swift */; };
+		DEDA8DB32B184B950076BF0F /* WordPressThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DB22B184B950076BF0F /* WordPressThemeStoreTests.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
@@ -906,6 +907,7 @@
 		DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeAction.swift; sourceTree = "<group>"; };
 		DEDA8DAE2B1847C80076BF0F /* WordPressThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeStore.swift; sourceTree = "<group>"; };
 		DEDA8DB02B184A660076BF0F /* MockWordPressThemeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWordPressThemeRemote.swift; sourceTree = "<group>"; };
+		DEDA8DB22B184B950076BF0F /* WordPressThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeStoreTests.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1619,6 +1621,7 @@
 				EEB4E2CE29B04D7900371C3C /* StoreOnboardingTasksStoreTests.swift */,
 				0391C13C29CC5E14008A3E86 /* OrderCardPresentPaymentEligibilityStoreTests.swift */,
 				0286A1BB2A0CC4120099EF94 /* FeatureFlagStoreTests.swift */,
+				DEDA8DB22B184B950076BF0F /* WordPressThemeStoreTests.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -2436,6 +2439,7 @@
 				DEDA8DB12B184A660076BF0F /* MockWordPressThemeRemote.swift in Sources */,
 				0391C13D29CC5E14008A3E86 /* OrderCardPresentPaymentEligibilityStoreTests.swift in Sources */,
 				B5C9DE222087FF20006B910A /* DispatcherTests.swift in Sources */,
+				DEDA8DB32B184B950076BF0F /* WordPressThemeStoreTests.swift in Sources */,
 				45182D2327B55F9C00B4C05C /* InboxNotesStoreTests.swift in Sources */,
 				03FBDA2A263296C400ACE257 /* CouponStoreTests.swift in Sources */,
 				02E7FFD92562234F00C53030 /* MockShippingLabelRemote.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		DED91DF62AD67F8F00CDCC53 /* MockBlazeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF52AD67F8F00CDCC53 /* MockBlazeRemote.swift */; };
 		DEDA8DAD2B1846FF0076BF0F /* WordPressThemeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */; };
 		DEDA8DAF2B1847C80076BF0F /* WordPressThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAE2B1847C80076BF0F /* WordPressThemeStore.swift */; };
+		DEDA8DB12B184A660076BF0F /* MockWordPressThemeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DB02B184A660076BF0F /* MockWordPressThemeRemote.swift */; };
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
@@ -904,6 +905,7 @@
 		DED91DF52AD67F8F00CDCC53 /* MockBlazeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBlazeRemote.swift; sourceTree = "<group>"; };
 		DEDA8DAC2B1846FF0076BF0F /* WordPressThemeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeAction.swift; sourceTree = "<group>"; };
 		DEDA8DAE2B1847C80076BF0F /* WordPressThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeStore.swift; sourceTree = "<group>"; };
+		DEDA8DB02B184A660076BF0F /* MockWordPressThemeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWordPressThemeRemote.swift; sourceTree = "<group>"; };
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1295,6 +1297,7 @@
 		578CE78A2475E79300492EBF /* Remote */ = {
 			isa = PBXGroup;
 			children = (
+				DEDA8DB02B184A660076BF0F /* MockWordPressThemeRemote.swift */,
 				578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */,
 				578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */,
 				578CE7912475EC9200492EBF /* MockProductsRemote.swift */,
@@ -2430,6 +2433,7 @@
 				02E262C0238CE80100B79588 /* StorageShippingSettingsServiceTests.swift in Sources */,
 				45AB8B1E24AB363D00B5B36E /* ProductTagStoreTests.swift in Sources */,
 				02616F922921E1530095BC00 /* SiteStoreTests.swift in Sources */,
+				DEDA8DB12B184A660076BF0F /* MockWordPressThemeRemote.swift in Sources */,
 				0391C13D29CC5E14008A3E86 /* OrderCardPresentPaymentEligibilityStoreTests.swift in Sources */,
 				B5C9DE222087FF20006B910A /* DispatcherTests.swift in Sources */,
 				45182D2327B55F9C00B4C05C /* InboxNotesStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
@@ -8,8 +8,8 @@ public enum WordPressThemeAction: Action {
     /// Retrieves the suggested themes for a site.
     ///
     /// - `onCompletion`: invoked when the sync operation finishes.
-    ///     - `result.success(Bool)`: value indicates whether there are further pages to retrieve.
-    ///     - `result.failure(Error)`: error indicates issues syncing the specified page.
+    ///     - `result.success([WordPressTheme])`: list of suggested themes.
+    ///     - `result.failure(Error)`: error indicates issues loading themes.
     ///
-    case fetchSuggestedThemes(onCompletion: (Result<[WordPressTheme], Error>) -> Void)
+    case loadSuggestedThemes(onCompletion: (Result<[WordPressTheme], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
@@ -1,0 +1,15 @@
+import Foundation
+import struct Networking.WordPressTheme
+
+// MARK: - WordPressThemeAction: Defines all of the Actions supported by the WordPressThemeStore.
+//
+public enum WordPressThemeAction: Action {
+
+    /// Retrieves the suggested themes for a site.
+    ///
+    /// - `onCompletion`: invoked when the sync operation finishes.
+    ///     - `result.success(Bool)`: value indicates whether there are further pages to retrieve.
+    ///     - `result.failure(Error)`: error indicates issues syncing the specified page.
+    ///
+    case fetchSuggestedThemes(onCompletion: (Result<[WordPressTheme], Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -189,6 +189,7 @@ public typealias WooPaymentsDepositInterval = Networking.WooPaymentsDepositInter
 public typealias WooPaymentsDepositStatus = Networking.WooPaymentsDepositStatus
 public typealias StoreOnboardingTask = Networking.StoreOnboardingTask
 public typealias WCAnalyticsCustomer = Networking.WCAnalyticsCustomer
+public typealias WordPressTheme = Networking.WordPressTheme
 
 // MARK: - Exported Storage Symbols
 

--- a/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
@@ -41,7 +41,7 @@ public final class WordPressThemeStore: Store {
     ///
     override public func onAction(_ action: Action) {
         guard let action = action as? WordPressThemeAction else {
-            assertionFailure("BlazeStore received an unsupported action")
+            assertionFailure("WordPressThemeStore received an unsupported action")
             return
         }
 

--- a/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Networking
+import Storage
+
+// MARK: - WordPressThemeStore
+//
+public final class WordPressThemeStore: Store {
+    private let remote: WordPressThemeRemoteProtocol
+
+    init(dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         network: Network,
+         remote: WordPressThemeRemoteProtocol) {
+        self.remote = remote
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    /// Initializes a new WordPressThemeStore.
+    /// - Parameters:
+    ///   - dispatcher: The dispatcher used to subscribe to `WordPressThemeAction`.
+    ///   - network: The network layer used to fetch theme details
+    ///
+    public convenience override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        self.init(dispatcher: dispatcher,
+                  storageManager: storageManager,
+                  network: network,
+                  remote: WordPressThemeRemote(network: network))
+    }
+
+    // MARK: - Actions
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: BlazeAction.self)
+    }
+
+    /// Receives and executes Actions.
+    /// - Parameters:
+    ///   - action: An action to handle. Must be a `WordPressThemeAction`
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? WordPressThemeAction else {
+            assertionFailure("BlazeStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case .loadSuggestedThemes(let onCompletion):
+            loadSuggestedThemes(onCompletion: onCompletion)
+        }
+    }
+}
+
+private extension WordPressThemeStore {
+
+    func loadSuggestedThemes(onCompletion: @escaping (Result<[WordPressTheme], Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let themes = try await remote.loadSuggestedThemes()
+                onCompletion(.success(themes))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+}

--- a/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
@@ -32,7 +32,7 @@ public final class WordPressThemeStore: Store {
     /// Registers for supported Actions.
     ///
     override public func registerSupportedActions(in dispatcher: Dispatcher) {
-        dispatcher.register(processor: self, for: BlazeAction.self)
+        dispatcher.register(processor: self, for: WordPressThemeAction.self)
     }
 
     /// Receives and executes Actions.

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import Networking
+
+/// Mock for `WordPressThemeRemote`.
+///
+final class MockWordPressThemeRemote {
+    private var stubbedThemes: [WordPressTheme] = []
+    private var stubbedError: Error?
+
+    func whenLoadingSuggestedTheme(thenReturn result: Result<[Networking.WordPressTheme], Error>) {
+        switch result {
+        case .success(let themes):
+            stubbedThemes = themes
+        case .failure(let error):
+            stubbedError = error
+        }
+    }
+}
+
+extension MockWordPressThemeRemote: WordPressThemeRemoteProtocol {
+    func loadSuggestedThemes() async throws -> [Networking.WordPressTheme] {
+        if let stubbedError {
+            throw stubbedError
+        }
+        return stubbedThemes
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Networking
+@testable import Yosemite
+@testable import Storage
+
+final class WordPressThemeStoreTests: XCTestCase {
+
+    private var dispatcher: Dispatcher!
+
+    private var network: MockNetwork!
+
+    private var remote: MockWordPressThemeRemote!
+
+    private var storageManager: MockStorageManager!
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+        dispatcher = Dispatcher()
+        remote = MockWordPressThemeRemote()
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        network = nil
+        dispatcher = nil
+        remote = nil
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_loadSuggestedThemes_returns_themes_on_success() throws {
+        // Given
+        remote.whenLoadingSuggestedTheme(thenReturn: .success([.fake().copy(id: "tsubaki")]))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.loadSuggestedThemes(onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let themes = try result.get()
+        XCTAssertEqual(themes.count, 1)
+        XCTAssertEqual(themes.first?.id, "tsubaki")
+    }
+
+    func test_loadSuggestedThemes_returns_error_on_failure() throws {
+        // Given
+        remote.whenLoadingSuggestedTheme(thenReturn: .failure(NetworkError.timeout()))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.loadSuggestedThemes(onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11322 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Yosemite layer to add new store and action for loading suggested WordPress themes.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The action hasn't been integrated yet so just CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
