### PR TITLE
[Bundle products in order form] Fix validation error after selecting options for "Any" variation attributes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -222,8 +222,8 @@ private extension ConfigurableBundleItemViewModel {
                     return String(format: Localization.ErrorMessage.missingVariationFormat, product.name)
                 }
 
-                let variationAttributesCount = (selectedVariation?.attributes ?? []).count + selectableVariationOptionsByName.values.compactMap { $0 }.count
-                guard variationAttributesCount == product.attributesForVariations.count else {
+                let variationAttributes = (selectedVariation?.attributes ?? []) + selectableVariationOptionsByName.compactMap { $0.value }
+                guard variationAttributes.count == product.attributesForVariations.count else {
                     return String(format: Localization.ErrorMessage.variationMissingAttributesFormat, product.name)
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableVariableBundleAttributePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableVariableBundleAttributePickerViewModel.swift
@@ -17,12 +17,7 @@ final class ConfigurableVariableBundleAttributePickerViewModel: ObservableObject
     @Published var selectedOption: String
 
     /// Optionally selected variation attribute from the picker UI.
-    var selectedAttribute: ProductVariationAttribute? {
-        guard attribute.options.contains(selectedOption) else {
-            return nil
-        }
-        return .init(id: attribute.attributeID, name: attribute.name, option: selectedOption)
-    }
+    @Published private(set) var selectedAttribute: ProductVariationAttribute?
 
     /// Provides the view info about the attribute, like the name and options.
     private let attribute: ProductAttribute
@@ -30,5 +25,14 @@ final class ConfigurableVariableBundleAttributePickerViewModel: ObservableObject
     init(attribute: ProductAttribute, selectedOption: String?) {
         self.attribute = attribute
         self.selectedOption = selectedOption ?? ""
+
+        $selectedOption
+            .compactMap { selectedOption in
+                guard attribute.options.contains(selectedOption) else {
+                    return nil
+                }
+                return .init(id: attribute.attributeID, name: attribute.name, option: selectedOption)
+            }
+            .assign(to: &$selectedAttribute)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11329 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As Rachel discovered in https://github.com/woocommerce/woocommerce-ios/pull/11306#pullrequestreview-1752606349, the validation error on a variable item with "Any"/selectable attributes can't be cleared even after selecting an option for all of them. After some debugging, the cause was the same SwiftUI behavior where state property changes on nested elements (`selectableVariationAttributeViewModels: [ConfigurableVariableBundleAttributePickerViewModel]`) don't trigger updates in the array's observation for the validation error.

## How

I followed the workaround as in the SwiftUI workarounds page P91TBi-7F9-p2#observing-state-property-changes-from-nested-elements to observe each nested element's observable state (`selectedAttribute`) separately when the array changes. `selectedAttribute` was updated to an observable property, because `selectedOption` can have an initial value as an empty string. Then, `selectableVariationOptionsByName: [String: ProductVariationAttribute?]` dictionary was added to track the selected options manually under the assumption that variation attributes have unique names (I tested in core by adding an attribute of the same name and it overwrote the previous one).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with 1 variable item with at least one variation with "Any" attributes.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products`
- Search/select the bundle product in the prerequisite
- Tap to select the variable item in the prerequisite if it's optional --> the Save CTA is disabled
- Tap to select an option for all attributes --> the Save CTA should be enabled

⚠️ 🗒️ I noticed another issue when creating an order with a bundle product with a variable item with "any" attributes (this doesn't happen when updating an order), the variable order item is later shown as "Any *" in order details (same in core). I'll look into this separately.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/28bf6bcf-244a-4427-9391-80006a6ab4d9



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
