### PR TITLE
Networking & Yosemite: Support fetching theme for current site

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -870,6 +870,7 @@
 		DEDA8DAB2B18407D0076BF0F /* WordPressThemeRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */; };
 		DEDA8DB52B187DE40076BF0F /* WordPressThemeMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */; };
 		DEDA8DB72B187E770076BF0F /* theme-mine-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DEDA8DB62B187E770076BF0F /* theme-mine-success.json */; };
+		DEDA8DB92B187EC90076BF0F /* WordPressThemeMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DB82B187EC90076BF0F /* WordPressThemeMapperTests.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1891,6 +1892,7 @@
 		DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemoteTests.swift; sourceTree = "<group>"; };
 		DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeMapper.swift; sourceTree = "<group>"; };
 		DEDA8DB62B187E770076BF0F /* theme-mine-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-mine-success.json"; sourceTree = "<group>"; };
+		DEDA8DB82B187EC90076BF0F /* WordPressThemeMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeMapperTests.swift; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -3261,6 +3263,7 @@
 				EE078D922AD2F1E500C1199E /* JWTokenMapperTests.swift */,
 				DED91DE22AD63EE300CDCC53 /* BlazeCampaignListMapperTests.swift */,
 				DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */,
+				DEDA8DB82B187EC90076BF0F /* WordPressThemeMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -4460,6 +4463,7 @@
 				4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */,
 				025F9A252B020F1900B91F1D /* MockURLProtocol.swift in Sources */,
 				45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */,
+				DEDA8DB92B187EC90076BF0F /* WordPressThemeMapperTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
 				020D0C03291504DE00BB3DCE /* UnauthenticatedRequestTests.swift in Sources */,
 				24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -868,6 +868,7 @@
 		DEDA8DA72B18399D0076BF0F /* WordPressThemeListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */; };
 		DEDA8DA92B183D5D0076BF0F /* WordPressThemeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */; };
 		DEDA8DAB2B18407D0076BF0F /* WordPressThemeRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */; };
+		DEDA8DB52B187DE40076BF0F /* WordPressThemeMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1887,6 +1888,7 @@
 		DEDA8DA62B18399D0076BF0F /* WordPressThemeListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeListMapperTests.swift; sourceTree = "<group>"; };
 		DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemote.swift; sourceTree = "<group>"; };
 		DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemoteTests.swift; sourceTree = "<group>"; };
+		DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeMapper.swift; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -3093,6 +3095,7 @@
 				EE839C252ABEF9C900049545 /* AIProductMapper.swift */,
 				EE078D902AD2EFBA00C1199E /* JWTokenMapper.swift */,
 				DEDA8DA22B18323E0076BF0F /* WordPressThemeListMapper.swift */,
+				DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -4406,6 +4409,7 @@
 				029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */,
 				0359EA0D27AAC5F80048DE2D /* WCPayChargeStatus.swift in Sources */,
 				CE430674234BA6AD0073CBFF /* RefundMapper.swift in Sources */,
+				DEDA8DB52B187DE40076BF0F /* WordPressThemeMapper.swift in Sources */,
 				2676F4CE290AE6BB00C7A15B /* EntityIDMapper.swift in Sources */,
 				CE0A0F1B223989670075ED8D /* ProductsRemote.swift in Sources */,
 				0359EA1527AAC7460048DE2D /* WCPayCardBrand.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -869,6 +869,7 @@
 		DEDA8DA92B183D5D0076BF0F /* WordPressThemeRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */; };
 		DEDA8DAB2B18407D0076BF0F /* WordPressThemeRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */; };
 		DEDA8DB52B187DE40076BF0F /* WordPressThemeMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */; };
+		DEDA8DB72B187E770076BF0F /* theme-mine-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DEDA8DB62B187E770076BF0F /* theme-mine-success.json */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */; };
@@ -1889,6 +1890,7 @@
 		DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemote.swift; sourceTree = "<group>"; };
 		DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeRemoteTests.swift; sourceTree = "<group>"; };
 		DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressThemeMapper.swift; sourceTree = "<group>"; };
+		DEDA8DB62B187E770076BF0F /* theme-mine-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-mine-success.json"; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEEF8E6729C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneTimeApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
@@ -2583,6 +2585,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEDA8DB62B187E770076BF0F /* theme-mine-success.json */,
 				DED91DDE2AD63C2800CDCC53 /* blaze-campaigns-success.json */,
 				DEDA8DA42B1839320076BF0F /* theme-list-success.json */,
 				EE28C7D72AC17960004A69F4 /* generate-product-failure.json */,
@@ -3736,6 +3739,7 @@
 				EEA6583E2966B41E00112DF0 /* products-load-all-without-data.json in Resources */,
 				68F48B1328E3E5750045C15B /* wc-analytics-customers.json in Resources */,
 				D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */,
+				DEDA8DB72B187E770076BF0F /* theme-mine-success.json in Resources */,
 				74C947862193A6C70024CB60 /* comment-moderate-unapproved.json in Resources */,
 				3105472C262E303400C5C02B /* wcpay-payment-intent-unknown-status.json in Resources */,
 				B559EBAA20A0B5CD00836CD4 /* orders-load-all.json in Resources */,

--- a/Networking/Networking/Mapper/WordPressThemeMapper.swift
+++ b/Networking/Networking/Mapper/WordPressThemeMapper.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Mapper: `WordPressTheme`
+///
+struct WordPressThemeMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into `WordPressTheme`.
+    ///
+    func map(response: Data) throws -> WordPressTheme {
+        let decoder = JSONDecoder()
+        return try decoder.decode(WordPressTheme.self, from: response)
+    }
+}

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -6,6 +6,10 @@ public protocol WordPressThemeRemoteProtocol {
     /// Loads suggested themes.
     ///
     func loadSuggestedThemes() async throws -> [WordPressTheme]
+
+    /// Loads the current theme for the site with the specified ID.
+    ///
+    func loadCurrentTheme(siteID: Int64) async throws -> WordPressTheme
 }
 
 /// WordPressThemes: Remote Endpoints
@@ -21,11 +25,20 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
                 Values.filteredThemeIDs.contains(theme.id)
             }
     }
+
+    public func loadCurrentTheme(siteID: Int64) async throws -> WordPressTheme {
+        let path = Paths.currentThemePath(for: siteID)
+        let request = DotcomRequest(wordpressApiVersion: .mark1_2, method: .get, path: path)
+        return try await enqueue(request, mapper: WordPressThemeMapper())
+    }
 }
 
 private extension WordPressThemeRemote {
     enum Paths {
         static let suggestedThemes = "themes?filter=subject:store&number=100"
+        static func currentThemePath(for siteID: Int64) -> String {
+            "sites/\(siteID)/themes/mine"
+        }
     }
 
     enum Values {

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -28,7 +28,7 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
 
     public func loadCurrentTheme(siteID: Int64) async throws -> WordPressTheme {
         let path = Paths.currentThemePath(for: siteID)
-        let request = DotcomRequest(wordpressApiVersion: .mark1_2, method: .get, path: path)
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path)
         return try await enqueue(request, mapper: WordPressThemeMapper())
     }
 }

--- a/Networking/NetworkingTests/Mapper/WordPressThemeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressThemeMapperTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Networking
+
+final class WordPressThemeMapperTests: XCTestCase {
+
+    /// Verifies that the object is parsed.
+    ///
+    func test_WordPressThemeMapper_parses_all_contents_in_response() throws {
+        let theme = try XCTUnwrap(mapLoadWordPressThemeResponse())
+
+        XCTAssertEqual(theme.id, "maywood")
+        XCTAssertEqual(theme.name, "Maywood")
+        XCTAssertEqual(theme.description, "Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.")
+        XCTAssertEqual(theme.demoURI, "")
+    }
+
+}
+
+// MARK: - Test Helpers
+//
+private extension WordPressThemeMapperTests {
+
+    /// Returns the WordPressThemeMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapWordPressTheme(from filename: String) throws -> WordPressTheme? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try WordPressThemeMapper().map(response: response)
+    }
+
+    /// Returns the WordPressThemeMapper output from `theme-mine-success.json`
+    ///
+    func mapLoadWordPressThemeResponse() throws -> WordPressTheme? {
+        return try mapWordPressTheme(from: "theme-mine-success")
+    }
+}

--- a/Networking/NetworkingTests/Responses/theme-mine-success.json
+++ b/Networking/NetworkingTests/Responses/theme-mine-success.json
@@ -1,0 +1,25 @@
+{
+    "id": "maywood",
+    "screenshot": "//i0.wp.com/example.com/wp-content/themes/maywood/screenshot.png?ssl=1",
+    "name": "Maywood",
+    "theme_uri": "https://wordpress.com/theme/maywood",
+    "description": "Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.",
+    "tags": [
+        "one-column",
+        "flexible-header",
+        "accessibility-ready",
+        "custom-colors",
+        "custom-menu",
+        "custom-logo",
+        "editor-style",
+        "featured-images",
+        "footer-widgets",
+        "rtl-language-support",
+        "sticky-post",
+        "threaded-comments",
+        "translation-ready",
+        "auto-loading-homepage",
+        "wpcom-fse",
+        "jetpack-global-styles"
+    ]
+}

--- a/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
@@ -12,4 +12,12 @@ public enum WordPressThemeAction: Action {
     ///     - `result.failure(Error)`: error indicates issues loading themes.
     ///
     case loadSuggestedThemes(onCompletion: (Result<[WordPressTheme], Error>) -> Void)
+
+    /// Retrieves the current theme for a site.
+    /// - `siteID`: ID of the current site.
+    /// - `onCompletion`: invoked when the sync operation finishes.
+    ///     - `result.success(WordPressTheme)`: the current theme's details.
+    ///     - `result.failure(Error)`: error indicates issues loading themes.
+    ///
+    case loadCurrentTheme(siteID: Int64, onCompletion: (Result<WordPressTheme, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
@@ -48,6 +48,8 @@ public final class WordPressThemeStore: Store {
         switch action {
         case .loadSuggestedThemes(let onCompletion):
             loadSuggestedThemes(onCompletion: onCompletion)
+        case let .loadCurrentTheme(siteID, onCompletion):
+            loadCurrentTheme(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -59,6 +61,17 @@ private extension WordPressThemeStore {
             do {
                 let themes = try await remote.loadSuggestedThemes()
                 onCompletion(.success(themes))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func loadCurrentTheme(siteID: Int64, onCompletion: @escaping (Result<WordPressTheme, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let theme = try await remote.loadCurrentTheme(siteID: siteID)
+                onCompletion(.success(theme))
             } catch {
                 onCompletion(.failure(error))
             }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
@@ -4,24 +4,46 @@ import Foundation
 /// Mock for `WordPressThemeRemote`.
 ///
 final class MockWordPressThemeRemote {
-    private var stubbedThemes: [WordPressTheme] = []
-    private var stubbedError: Error?
+    private var stubbedSuggestedThemes: [WordPressTheme] = []
+    private var stubbedSuggestedThemeError: Error?
+
+    private var stubbedCurrentTheme: WordPressTheme?
+    private var stubbedCurrentThemeError: Error?
 
     func whenLoadingSuggestedTheme(thenReturn result: Result<[Networking.WordPressTheme], Error>) {
         switch result {
         case .success(let themes):
-            stubbedThemes = themes
+            stubbedSuggestedThemes = themes
         case .failure(let error):
-            stubbedError = error
+            stubbedSuggestedThemeError = error
+        }
+    }
+
+    func whenLoadingCurrentTheme(thenReturn result: Result<Networking.WordPressTheme, Error>) {
+        switch result {
+        case .success(let theme):
+            stubbedCurrentTheme = theme
+        case .failure(let error):
+            stubbedCurrentThemeError = error
         }
     }
 }
 
 extension MockWordPressThemeRemote: WordPressThemeRemoteProtocol {
     func loadSuggestedThemes() async throws -> [Networking.WordPressTheme] {
-        if let stubbedError {
-            throw stubbedError
+        if let stubbedSuggestedThemeError {
+            throw stubbedSuggestedThemeError
         }
-        return stubbedThemes
+        return stubbedSuggestedThemes
+    }
+
+    func loadCurrentTheme(siteID: Int64) async throws -> WordPressTheme {
+        if let stubbedCurrentThemeError {
+            throw stubbedCurrentThemeError
+        }
+        guard let stubbedCurrentTheme else {
+            throw NetworkError.notFound()
+        }
+        return stubbedCurrentTheme
     }
 }

--- a/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
@@ -29,6 +29,8 @@ final class WordPressThemeStoreTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - loadSuggestedThemes tests
+
     func test_loadSuggestedThemes_returns_themes_on_success() throws {
         // Given
         remote.whenLoadingSuggestedTheme(thenReturn: .success([.fake().copy(id: "tsubaki")]))
@@ -62,6 +64,49 @@ final class WordPressThemeStoreTests: XCTestCase {
         // When
         let result = waitFor { promise in
             store.onAction(WordPressThemeAction.loadSuggestedThemes(onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
+
+    // MARK: - loadCurrentTheme tests
+
+    func test_loadCurrentTheme_returns_theme_on_success() throws {
+        // Given
+        remote.whenLoadingCurrentTheme(thenReturn: .success(.fake().copy(name: "Tsubaki")))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.loadCurrentTheme(siteID: 123, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let theme = try result.get()
+        XCTAssertEqual(theme.name, "Tsubaki")
+    }
+
+    func test_loadCurrentTheme_returns_error_on_failure() throws {
+        // Given
+        remote.whenLoadingCurrentTheme(thenReturn: .failure(NetworkError.timeout()))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.loadCurrentTheme(siteID: 123, onCompletion: { result in
                 promise(result)
             }))
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11324 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates Networking and Yosemite layers to support fetching theme details for the current site. Changes include:
- Added new mapper `WordPressThemeMapper` for decoding single theme details.
- Updated `WordPressThemeRemote` with a new endpoint to load the current theme for a site.
- Updated `WordPressThemeAction` and store to support loading current theme details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The new action hasn't been used yet so just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
