### PR TITLE
[Bundle products in order] Update product details in order creation to show bundle product type and variation attributes

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -6,6 +6,8 @@ import Codegen
 public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, GeneratedCopiable {
     public let itemID: Int64
     public let name: String
+
+    /// The product ID of a product order item, or the ID of the parent product if the order item is a product variation.
     public let productID: Int64
     public let variationID: Int64
     public let quantity: Decimal
@@ -31,6 +33,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
     /// Item ID of parent `OrderItem`, if any.
     ///
     /// An `OrderItem` can have a parent if, for example, it is a bundled item within a product bundle.
+    /// Note that this reflects a parent-child relationship between items in an order; it is not the parent product of a product variation in an order.
     ///
     public let parent: Int64?
 

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -7,7 +7,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
     public let itemID: Int64
     public let name: String
 
-    /// The product ID of a product order item, or the ID of the parent product if the order item is a product variation.
+    /// The product ID of a product order item, or the ID of the variable product if the order item is a product variation.
     public let productID: Int64
     public let variationID: Int64
     public let quantity: Decimal
@@ -33,7 +33,7 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
     /// Item ID of parent `OrderItem`, if any.
     ///
     /// An `OrderItem` can have a parent if, for example, it is a bundled item within a product bundle.
-    /// Note that this reflects a parent-child relationship between items in an order; it is not the parent product of a product variation in an order.
+    /// Note that this reflects a parent-child relationship between items in an order; it is not the parent variable product of a product variation in an order.
     ///
     public let parent: Int64?
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -149,7 +149,7 @@ private struct CollapsibleProductRowCard: View {
                         Text(viewModel.name)
                             .font(viewModel.hasParentProduct ? .subheadline : .none)
                             .foregroundColor(Color(.text))
-                        Text(viewModel.stockQuantityLabel)
+                        Text(viewModel.orderProductDetailsLabel)
                             .font(.subheadline)
                             .foregroundColor(isCollapsed ? Color(.textSubtle) : Color(.text))
                         Text(viewModel.skuLabel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -583,8 +583,8 @@ final class EditableOrderViewModel: ObservableObject {
 
         if item.variationID != 0,
             let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {
-            let parent = allProducts.first(where: { $0.productID == item.productID })
-            let attributes = ProductVariationFormatter().generateAttributes(for: variation, from: parent?.attributes ?? [])
+            let variableProduct = allProducts.first(where: { $0.productID == item.productID })
+            let attributes = ProductVariationFormatter().generateAttributes(for: variation, from: variableProduct?.attributes ?? [])
             return ProductRowViewModel(id: item.itemID,
                                        productVariation: variation,
                                        discount: passingDiscountValue,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -583,7 +583,7 @@ final class EditableOrderViewModel: ObservableObject {
 
         if item.variationID != 0,
             let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {
-            let parent = allProducts.first(where: { $0.productID == item.parent })
+            let parent = allProducts.first(where: { $0.productID == item.productID })
             let attributes = ProductVariationFormatter().generateAttributes(for: variation, from: parent?.attributes ?? [])
             return ProductRowViewModel(id: item.itemID,
                                        productVariation: variation,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -213,11 +213,18 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             .joined(separator: " • ")
     }
 
-    /// Label showing product details for a product in an order. Can include product type (if the row is configurable) and stock status.
+    /// Label showing product details for a product in an order.
+    /// Can include product type (if the row is configurable), variation attributes (if available), and stock status.
     ///
     var orderProductDetailsLabel: String {
+        let attributesLabel: String? = {
+            guard case let .attributes(attributes) = self.variationDisplayMode else {
+                return nil
+            }
+            return createAttributesText(from: attributes)
+        }()
         let stockLabel = createStockText()
-        return [productTypeLabel, stockLabel]
+        return [productTypeLabel, attributesLabel, stockLabel]
             .compactMap({ $0 })
             .filter { $0.isNotEmpty }
             .joined(separator: " • ")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -218,7 +218,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     var orderProductDetailsLabel: String {
         let attributesLabel: String? = {
-            guard case let .attributes(attributes) = self.variationDisplayMode else {
+            guard case let .attributes(attributes) = variationDisplayMode else {
                 return nil
             }
             return createAttributesText(from: attributes)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -213,6 +213,16 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             .joined(separator: " • ")
     }
 
+    /// Label showing product details for a product in an order. Can include product type (if the row is configurable) and stock status.
+    ///
+    var orderProductDetailsLabel: String {
+        let stockLabel = createStockText()
+        return [productTypeLabel, stockLabel]
+            .compactMap({ $0 })
+            .filter { $0.isNotEmpty }
+            .joined(separator: " • ")
+    }
+
     private let productTypeLabel: String?
 
     /// Label showing product SKU

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -310,6 +310,32 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.secondaryProductDetailsLabel, ProductType.bundle.description)
     }
 
+    func test_orderProductDetailsLabel_is_stock_status_for_non_configurable_product() {
+        // Given
+        let stockStatus = ProductStockStatus.inStock
+        let product = Product.fake().copy(stockStatusKey: stockStatus.rawValue)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+
+        // Then
+        assertEqual(stockStatus.description, viewModel.orderProductDetailsLabel)
+    }
+
+    func test_orderProductDetailsLabel_contains_product_type_and_stock_status_for_configurable_bundle_product() {
+        // Given
+        let stockStatus = ProductStockStatus.inStock
+        let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, stockStatusKey: stockStatus.rawValue, bundledItems: [.fake()])
+        let featureFlagService = MockFeatureFlagService(productBundlesInOrderForm: true)
+
+        // When
+        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, featureFlagService: featureFlagService, configure: {})
+
+        // Then
+        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(ProductType.bundle.description), "Label should contain product type (Bundle)")
+        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(stockStatus.description), "Label should contain stock status")
+    }
+
     func test_increment_and_decrement_quantity_have_step_value_of_one() {
         // Given
         let product = Product.fake()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -322,6 +322,22 @@ final class ProductRowViewModelTests: XCTestCase {
         assertEqual(stockStatus.description, viewModel.orderProductDetailsLabel)
     }
 
+    func test_orderProductDetailsLabel_contains_attributes_and_stock_status_for_non_configurable_product_variation() {
+        // Given
+        let stockStatus = ProductStockStatus.inStock
+        let variationAttribute = "Blue"
+        let variation = ProductVariation.fake().copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: variationAttribute)],
+                                                     stockStatus: stockStatus)
+        let attributes = [VariationAttributeViewModel(name: "Color", value: "Blue"), VariationAttributeViewModel(name: "Size")]
+
+        // When
+        let viewModel = ProductRowViewModel(productVariation: variation, name: "", canChangeQuantity: true, displayMode: .attributes(attributes))
+
+        // Then
+        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(variationAttribute), "Label should contain variation attribute")
+        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(stockStatus.description), "Label should contain stock status")
+    }
+
     func test_orderProductDetailsLabel_contains_product_type_and_stock_status_for_configurable_bundle_product() {
         // Given
         let stockStatus = ProductStockStatus.inStock


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11251
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
This includes two changes to the product details displayed in order creation:

1. When there is a product bundle in the order, it adds "Bundle" (the product type) to the parent product details.
2. I noticed that the designs also include variation attributes in the product details, but we haven't been displaying those. Now we display attributes for all variations in an order (whether or not they are part of a product bundle).

## How
This adds a new `orderProductDetailsLabel` to `ProductRowViewModel`, which includes the product type (for configurable products), variation attributes (when provided for a product variation), and stock status.

To add the variation attributes, there's also a fix in `EditableOrderViewModel` to use the item's `productID` instead of `parent` to generate the attributes. I added documentation to `OrderItem` to clarify the difference between these two properties. Let me know if you think there's a better way to explain that; it can be confusing that we use the term parent to describe two different parent/child relationships (parent product/child product variation and parent order item/child order item e.g. for bundled or composite products in an order).

## Testing instructions
Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and select a non-bundle product and a non-bundle product variation
- Select a bundle product from the prerequisite
- Configure the bundle
- Add the products to the order
- On the order form, confirm the product details include a "Bundle" label for the parent bundle product and the variation attributes for any selected product variations. Confirm non-bundle, non-variation products in the order show only the stock status on that line.

## Screenshots
Before|After
-|-
![Labels-Before](https://github.com/woocommerce/woocommerce-ios/assets/8658164/938fcd82-c7f2-4928-9685-f5c1aa7c0be6)|![Labels-After](https://github.com/woocommerce/woocommerce-ios/assets/8658164/1cbe9c65-f4fc-46b9-80eb-fee0432bfc99)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
