### PR TITLE
[Scan to Update Inventory M1] Quick Inventory Update Business Logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -74,7 +74,6 @@ struct UpdateProductInventoryView: View {
                                     dismiss()
                                 }
                             }
-
                             .renderedIf(viewModel.updateQuantityButtonMode == .customQuantity)
 
                             Button(Localization.increaseStockOnceButtonTitle) {

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -58,15 +58,18 @@ struct UpdateProductInventoryView: View {
 
                         Spacer()
 
-                        Button(updateInventoryButtonTitle) {}
-                            .buttonStyle(PrimaryButtonStyle())
-                            .padding(.bottom, Layout.mediumSpacing)
-
-                        Button(Localization.ViewProductDetailsButtonTitle) {
-
+                        Button(updateInventoryButtonTitle) {
+                            Task {
+                                await viewModel.onTapUpdateStockQuantity()
+                                presentationMode.wrappedValue.dismiss()
+                            }
                         }
-                        .buttonStyle(SecondaryButtonStyle())
-                        .padding(.bottom)
+                        .buttonStyle(PrimaryButtonStyle())
+                        .padding(.bottom, Layout.mediumSpacing)
+
+                        Button(Localization.ViewProductDetailsButtonTitle) {}
+                            .buttonStyle(SecondaryButtonStyle())
+                            .padding(.bottom)
                     }
                     .frame(minHeight: geometry.size.height)
                     .padding()

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -68,14 +68,27 @@ struct UpdateProductInventoryView: View {
                         Spacer()
 
                         Group {
-                            Button(Localization.updateQuantityButtonTitle) {}
-                                .buttonStyle(PrimaryButtonStyle())
-                                .renderedIf(viewModel.updateQuantityButtonMode == .customQuantity)
+                            Button(Localization.updateQuantityButtonTitle) {
+                                Task { @MainActor in
+                                    await viewModel.onTapUpdateStockQuantity()
+                                    dismiss()
+                                }
+                            }
 
-                            Button(Localization.increaseStockOnceButtonTitle) {}
-                                .buttonStyle(PrimaryButtonStyle())
-                                .renderedIf(viewModel.updateQuantityButtonMode == .increaseOnce)
+                            .renderedIf(viewModel.updateQuantityButtonMode == .customQuantity)
+
+                            Button(Localization.increaseStockOnceButtonTitle) {
+                                Task { @MainActor in
+                                    await viewModel.onTapIncreaseStockQuantityOnce()
+                                    dismiss()
+                                }
+                            }
+                            .renderedIf(viewModel.updateQuantityButtonMode == .increaseOnce)
+
+                            ProgressView()
+                                .renderedIf(viewModel.updateQuantityButtonMode == .loading)
                         }
+                        .buttonStyle(PrimaryButtonStyle())
                         .disabled(!viewModel.enableQuantityButton)
                         .padding(.bottom, Layout.mediumSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -83,11 +83,8 @@ struct UpdateProductInventoryView: View {
                                 }
                             }
                             .renderedIf(viewModel.updateQuantityButtonMode == .increaseOnce)
-
-                            ProgressView()
-                                .renderedIf(viewModel.updateQuantityButtonMode == .loading)
                         }
-                        .buttonStyle(PrimaryButtonStyle())
+                        .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isPrimaryButtonLoading))
                         .disabled(!viewModel.enableQuantityButton)
                         .padding(.bottom, Layout.mediumSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -10,6 +10,7 @@ protocol InventoryItem {
     var imageURL: URL? { get }
 
     func retrieveName(with stores: StoresManager, siteID: Int64) async throws -> String
+    func updateStockQuantity(with newQuantity: Decimal, stores: StoresManager) async throws
 }
 
 extension SKUSearchResult {
@@ -27,7 +28,27 @@ extension Product: InventoryItem {
     func retrieveName(with stores: StoresManager, siteID: Int64) async throws -> String {
         name
     }
+
+    func updateStockQuantity(with newQuantity: Decimal, stores: StoresManager) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            let newProduct = copy(stockQuantity: newQuantity)
+
+            let action = ProductAction.updateProduct(product: newProduct) { result in
+                switch result {
+                case .success(_):
+                    continuation.resume(with: .success(()))
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
+        }
+    }
 }
+
 extension ProductVariation: InventoryItem {
     func retrieveName(with stores: StoresManager, siteID: Int64) async throws -> String {
         // Let's retrieve the parent product's name
@@ -47,15 +68,36 @@ extension ProductVariation: InventoryItem {
             }
         }
     }
+
+    func updateStockQuantity(with newQuantity: Decimal, stores: StoresManager) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            let newProductVaiation = copy(stockQuantity: newQuantity)
+
+            let action = ProductVariationAction.updateProductVariation(productVariation: newProductVaiation) { result in
+                switch result {
+                case .success(_):
+                    continuation.resume(with: .success(()))
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
+        }
+    }
 }
 
 final class UpdateProductInventoryViewModel: ObservableObject {
-    let inventoryItem: InventoryItem
+    var inventoryItem: InventoryItem
+    private let stores: StoresManager
 
     init(inventoryItem: InventoryItem,
          siteID: Int64,
          stores: StoresManager = ServiceLocator.stores) {
         self.inventoryItem = inventoryItem
+        self.stores = stores
 
         quantity = inventoryItem.stockQuantity?.formatted() ?? ""
 
@@ -73,6 +115,15 @@ final class UpdateProductInventoryViewModel: ObservableObject {
 
     var imageURL: URL? {
         inventoryItem.imageURL
+    }
+
+    func onTapUpdateStockQuantity() async {
+        guard let quantityDecimal = Decimal(string: quantity) else {
+            return
+        }
+
+        // TODO: Handle error
+        try? await inventoryItem.updateStockQuantity(with: quantityDecimal, stores: stores)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -94,7 +94,6 @@ final class UpdateProductInventoryViewModel: ObservableObject {
     enum UpdateQuantityButtonMode {
         case increaseOnce
         case customQuantity
-        case loading
     }
 
     let inventoryItem: InventoryItem
@@ -128,6 +127,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         }
     }
 
+    @Published var isPrimaryButtonLoading: Bool = false
     @Published var enableQuantityButton: Bool = true
     @Published var showLoadingName: Bool = true
     @Published var name: String = ""
@@ -163,11 +163,12 @@ final class UpdateProductInventoryViewModel: ObservableObject {
 
 private extension UpdateProductInventoryViewModel {
     func updateStockQuantity(with newQuantity: Decimal) async throws {
-        updateQuantityButtonMode = .loading
+        isPrimaryButtonLoading = true
 
         // TODO: Handle error
         try? await inventoryItem.updateStockQuantity(with: newQuantity, stores: stores)
 
+        isPrimaryButtonLoading = false
         updateQuantityButtonMode = .increaseOnce
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -89,10 +89,12 @@ extension ProductVariation: InventoryItem {
     }
 }
 
+@MainActor
 final class UpdateProductInventoryViewModel: ObservableObject {
     enum UpdateQuantityButtonMode {
         case increaseOnce
         case customQuantity
+        case loading
     }
 
     let inventoryItem: InventoryItem
@@ -139,12 +141,33 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         inventoryItem.imageURL
     }
 
+    func onTapIncreaseStockQuantityOnce() async {
+        guard let quantityDecimal = Decimal(string: quantity) else {
+            return
+        }
+
+        let newQuantity = quantityDecimal + 1
+        quantity = newQuantity.formatted()
+
+        try? await updateStockQuantity(with: newQuantity)
+    }
+
     func onTapUpdateStockQuantity() async {
         guard let quantityDecimal = Decimal(string: quantity) else {
             return
         }
 
+        try? await updateStockQuantity(with: quantityDecimal)
+    }
+}
+
+private extension UpdateProductInventoryViewModel {
+    func updateStockQuantity(with newQuantity: Decimal) async throws {
+        updateQuantityButtonMode = .loading
+
         // TODO: Handle error
-        try? await inventoryItem.updateStockQuantity(with: quantityDecimal, stores: stores)
+        try? await inventoryItem.updateStockQuantity(with: newQuantity, stores: stores)
+
+        updateQuantityButtonMode = .increaseOnce
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11315 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the logic for updating the stock inventory of a product or variation when requested. We have two different actions depending on the button mode, increase the stock quantity once, or adds a custom quantity.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Products
2. Tap on the barcode button to scan a barcode
3. Scan the barcode of a product. The quick inventory screen should open.
4. Tap on Quantity + 1. A loading indicator should replace the button, and once the quantity is updated remotely, the screen should be dismissed.
5. Scan the same barcode again, and check that the stock quantity was indeed updated. Try now adding your custom stock quantity into the text field. Tap on Update Quantity. See that it's dismissed as the above case.
6. Scan the barcode again, and check that the stock quantity was indeed updated.

As the flow has slightly different implementation details for product variations, repeat the above process with a product variation.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/5695a81c-057e-4539-a6f7-c50025e413d9

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
