### PR TITLE
[Xcode 15] Prevent infinite loop in `scrollVerticallyIfNeeded` to fix Set up Tap to Pay screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [**] My Store: The Blaze section is now dismissible. [https://github.com/woocommerce/woocommerce-ios/pull/11308]
 - [internal] Product Subscriptions: Handle yearly Synchronise renewals case while enabling One time shipping setting. [https://github.com/woocommerce/woocommerce-ios/pull/11312]
 - [internal] Update Shimmer dependency to avoid high CPU and memory use crashing the app when built with Xcode 15 [https://github.com/woocommerce/woocommerce-ios/pull/11320]
+- [internal] Fix issue with scrolling some views when built from Xcode 15 [https://github.com/woocommerce/woocommerce-ios/pull/11335]
 
 16.4
 -----

--- a/WooCommerce/Classes/View Modifiers/View+ScrollModifiers.swift
+++ b/WooCommerce/Classes/View Modifiers/View+ScrollModifiers.swift
@@ -1,52 +1,59 @@
 import SwiftUI
 
-/// View modifier that conditionally wraps the `content` in a `Scrollview` if the `content` height exceeds the view height.
+/// Preference key for communicating sizes
+struct SizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize? = nil
+
+    static func reduce(value: inout CGSize?, nextValue: () -> CGSize?) {
+        // Take the response of the first child which updates the key. Disallow further updates from its children.
+        value = value ?? nextValue()
+    }
+}
+
+/// View modifier that conditionally wraps the `content` in a `ScrollView` if the `content` height exceeds the view height.
 ///
 struct ConditionalVerticalScrollModifier: ViewModifier {
-
-    /// Keeps track of the `content` rendered size
-    ///
-    @State private var contentSize: CGSize = .zero
-
     /// Defines if the content should scroll or not.
-    ///
     @State private var shouldScroll: Bool = false
-
 
     func body(content: Content) -> some View {
         GeometryReader { parentGeometry in
-            if shouldScroll {
-                ScrollView(.vertical, showsIndicators: false) {
-                    contentGeometryListener(content: content, parentGeometry: parentGeometry)
+            Group {
+                if shouldScroll {
+                    ScrollView(.vertical, showsIndicators: false) {
+                        contentGeometryListener(content: content)
+                    }
+                } else {
+                    contentGeometryListener(content: content)
                 }
-            } else {
-                contentGeometryListener(content: content, parentGeometry: parentGeometry)
+            }
+            .onPreferenceChange(SizePreferenceKey.self) { contentSize in
+                /// Using `onPreferenceChange` avoid changing state (`shouldScroll`) during a layout pass.
+                /// Changing state that's used to layout the view during layout can cause an infinite loop and make the screen unresponsive.
+                if let contentSize = contentSize {
+                    shouldScroll = contentSize.height > parentGeometry.size.height
+                }
             }
         }
-        .frame(maxHeight: contentSize.height)
     }
 
-    /// Updates the `contentSize` property by adding a clear background to the `content` that has a `GeometryReader` attached to it.
-    /// Updates the `shouldScroll` property when the content vertical geometry is greater than the parent vertical geometry.
+    /// Updates the `SizePreferenceKey` by adding a clear background to the `content` that has a `GeometryReader` attached to it.
+    /// This is used in the parent to update the `shouldScroll` property when the content vertical geometry is greater than the parent vertical geometry.
     ///
-    private func contentGeometryListener(content: Content, parentGeometry: GeometryProxy) -> some View {
+    private func contentGeometryListener(content: Content) -> some View {
         content
             .background(
-                GeometryReader { contentGeometry -> Color in
-                    DispatchQueue.main.async {
-                        contentSize = contentGeometry.size
-                        shouldScroll = contentGeometry.size.height > parentGeometry.size.height
-                    }
-                    return .clear
-                }
-            )
+                GeometryReader { geometry in
+                    Color.clear
+                        .preference(key: SizePreferenceKey.self, value: geometry.size)
+                })
     }
 }
 
 // MARK: View Extensions
 
 extension View {
-    /// Allows the view to scroll vertically when the content height is greater than it's parent height.
+    /// Allows the view to scroll vertically when the content height is greater than its parent height.
     ///
     func scrollVerticallyIfNeeded() -> some View {
         self.modifier(ConditionalVerticalScrollModifier())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11334 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The Set up Tap to Pay screen was broken, when used in certain devices (such as an iPhone 15!) and built from Xcode 15. 

### Cause and fix
Previously, we checked the size of the content within the body of the scrollVerticallyIfNeeded view modifier, and set the `shouldScroll` state according to the size compared against the parent’s size.

Since it was in `body`, this comparison happened during the layout pass, and because it resulted in a change of state which the same view depended on, it would result in a re-render of the view.

For some sizes, particularly where `contentSize` was very close/equal to `parentGeometry.size`, this re-render would change the `shouldScroll` state back to its previous value, and thus invalidate the view again. That was the cause of the infinite layout loop.

In this commit, we move the comparison out of the `body`, so we’re never changing `State` _during_ a layout pass, but instead we change it in response to a preference key change. `PreferenceKey` is a convenient way to pass data from child views to parent views.

### Not just Xcode 15

There's nothing about this bug which is specific to Xcode 15, it could have happened previously, but we have no examples where it has been an issue.

Other screens where this is used:

- `EnableAnalyticsView`
- The What's New screen, via `ReportList`
- `JCPJetpackInstallIntroView`
- `JCPJetpackInstallStepsView`
- `JetpackBenefitsView`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. Launch the app from Xcode 15, on an iPhone 15 or iPhone 15 simulator (if using a simulator, ensure you enable the simulated card reader in the scheme options before you build.)
2. Switch to a US or UK WooPayments store
3. Navigate to Menu > Payments > Set up Tap to Pay on iPhone
4. Observe that on the screen which is presented, you **can** tap the CTA button or the Learn More link.


Test further by increasing/decreasing dynamic type size to change whether a scrollview is required. Also try landscape views.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
