### PR TITLE
Settings: Navigate to theme settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -430,7 +430,11 @@ private extension SettingsViewController {
     }
 
     func showThemeSettings() {
-        // TODO
+        guard let site = stores.sessionManager.defaultSite else {
+            return
+        }
+        let controller = ThemeSettingHostingController(siteID: site.siteID)
+        present(controller, animated: true)
     }
 
     func privacyWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -429,6 +429,10 @@ private extension SettingsViewController {
         present(controller, animated: true)
     }
 
+    func showThemeSettings() {
+        // TODO
+    }
+
     func privacyWasPressed() {
         ServiceLocator.analytics.track(.settingsPrivacySettingsTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
@@ -637,6 +641,8 @@ extension SettingsViewController: UITableViewDelegate {
             accountSettingsWasPressed()
         case .logout:
             logoutWasPressed()
+        case .themes:
+            showThemeSettings()
         default:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -2,7 +2,12 @@ import SwiftUI
 
 final class ThemeSettingHostingController: UIHostingController<ThemeSettingView> {
     init(siteID: Int64) {
-        super.init(rootView: ThemeSettingView())
+        let viewModel = ThemeSettingViewModel(siteID: siteID)
+        super.init(rootView: ThemeSettingView(viewModel: viewModel))
+
+        rootView.onDismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -13,6 +18,17 @@ final class ThemeSettingHostingController: UIHostingController<ThemeSettingView>
 /// View for selecting a new theme for the current site.
 ///
 struct ThemeSettingView: View {
+
+    @ObservedObject private var viewModel: ThemeSettingViewModel
+
+    /// Triggered when the Cancel button is tapped.
+    /// To be update from the hosting controller.
+    var onDismiss: () -> Void = {}
+
+    init(viewModel: ThemeSettingViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         NavigationView {
             Form {
@@ -35,9 +51,7 @@ struct ThemeSettingView: View {
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(Localization.cancelButton) {
-                        // TODO: dismiss view
-                    }
+                    Button(Localization.cancelButton, action: onDismiss)
                 }
             }
             .navigationTitle(Localization.title)
@@ -83,8 +97,6 @@ private extension ThemeSettingView {
 struct ThemeSettingView_Previews: PreviewProvider {
 
     static var previews: some View {
-        Group {
-            ThemeSettingView()
-        }
+        ThemeSettingView(viewModel: .init(siteID: 123))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -36,7 +36,7 @@ struct ThemeSettingView: View {
         NavigationView {
             Form {
                 Section(Localization.currentSection) {
-                    HStack {
+                    AdaptiveStack(horizontalAlignment: .leading) {
                         Text(Localization.themeRow)
                             .bodyStyle()
                         Spacer()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// View for selecting a new theme for the current site.
+///
+struct ThemeSettingView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct ThemeSettingView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        Group {
+            ThemeSettingView()
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -1,10 +1,48 @@
 import SwiftUI
 
+final class ThemeSettingHostingController: UIHostingController<ThemeSettingView> {
+    init(siteID: Int64) {
+        super.init(rootView: ThemeSettingView())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// View for selecting a new theme for the current site.
 ///
 struct ThemeSettingView: View {
     var body: some View {
-        Text("Hello, World!")
+        NavigationView {
+            Form {
+                Section(Localization.currentSection) {
+                    HStack {
+                        Text(Localization.themeRow)
+                            .bodyStyle()
+                        Spacer()
+                        Text("Tsubaki")
+                            .secondaryBodyStyle()
+                    }
+                }
+
+                Section(Localization.tryOtherLook) {
+                    VStack {
+                        // TODO: add slider here
+                        Spacer()
+                    }
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        // TODO: dismiss view
+                    }
+                }
+            }
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -8,6 +8,40 @@ struct ThemeSettingView: View {
     }
 }
 
+private extension ThemeSettingView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "themeSettingView.title",
+            value: "Themes",
+            comment: "Title for the theme settings screen"
+        )
+
+        static let currentSection = NSLocalizedString(
+            "themeSettingView.currentSection",
+            value: "Current",
+            comment: "Title for the Current section on the theme settings screen"
+        )
+
+        static let themeRow = NSLocalizedString(
+            "themeSettingView.themeRow",
+            value: "Theme",
+            comment: "Title for the Theme row on the theme settings screen"
+        )
+
+        static let tryOtherLook = NSLocalizedString(
+            "themeSettingView.tryOtherLookLabel",
+            value: "Try other new look",
+            comment: "Label for the suggested theme section on the theme settings screen"
+        )
+
+        static let cancelButton = NSLocalizedString(
+            "themeSettingView.cancelButton",
+            value: "Cancel",
+            comment: "Button to dismiss the theme settings screen"
+        )
+    }
+}
+
 struct ThemeSettingView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -27,6 +27,9 @@ struct ThemeSettingView: View {
 
     init(viewModel: ThemeSettingViewModel) {
         self.viewModel = viewModel
+        Task {
+            await viewModel.updateCurrentThemeName()
+        }
     }
 
     var body: some View {
@@ -37,8 +40,12 @@ struct ThemeSettingView: View {
                         Text(Localization.themeRow)
                             .bodyStyle()
                         Spacer()
-                        Text("Tsubaki")
-                            .secondaryBodyStyle()
+                        if viewModel.loadingCurrentTheme {
+                            ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                        } else {
+                            Text(viewModel.currentThemeName)
+                                .secondaryBodyStyle()
+                        }
                     }
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -5,15 +5,44 @@ import Yosemite
 /// 
 final class ThemeSettingViewModel: ObservableObject {
 
+    @Published private(set) var currentThemeName: String = ""
+    @Published private(set) var loadingCurrentTheme: Bool = false
+
     private let siteID: Int64
     private let stores: StoresManager
     private let analytics: Analytics
 
-    init(siteID: Int64, 
+    init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.analytics = analytics
+    }
+
+    @MainActor
+    func updateCurrentThemeName() async {
+        loadingCurrentTheme = true
+        currentThemeName = await loadCurrentThemeName()
+        loadingCurrentTheme = false
+    }
+}
+
+private extension ThemeSettingViewModel {
+
+    @MainActor
+    func loadCurrentThemeName() async -> String {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(WordPressThemeAction.loadCurrentTheme(siteID: siteID) { result in
+                switch result {
+                case .success(let theme):
+                    continuation.resume(returning: theme.name)
+                case .failure(let error):
+                    DDLogError("⛔️ Error loading current theme: \(error)")
+                    // TODO: analytics
+                    continuation.resume(returning: "")
+                }
+            })
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -39,7 +39,7 @@ private extension ThemeSettingViewModel {
                     continuation.resume(returning: theme.name)
                 case .failure(let error):
                     DDLogError("⛔️ Error loading current theme: \(error)")
-                    // TODO: analytics
+                    // TODO: #11291 - analytics
                     continuation.resume(returning: "")
                 }
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Yosemite
+
+/// View model for `ThemeSettingView`
+/// 
+final class ThemeSettingViewModel: ObservableObject {
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let analytics: Analytics
+
+    init(siteID: Int64, 
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.stores = stores
+        self.analytics = analytics
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2307,6 +2307,7 @@
 		DEDA8D9F2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */; };
 		DEDA8DBC2B1983570076BF0F /* ThemeSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */; };
 		DEDA8DBE2B19952B0076BF0F /* ThemeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DBD2B19952B0076BF0F /* ThemeSettingViewModel.swift */; };
+		DEDA8DC02B19CDC50076BF0F /* ThemeSettingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DBF2B19CDC50076BF0F /* ThemeSettingViewModelTests.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4907,6 +4908,7 @@
 		DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsBlazeTests.swift; sourceTree = "<group>"; };
 		DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingView.swift; sourceTree = "<group>"; };
 		DEDA8DBD2B19952B0076BF0F /* ThemeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingViewModel.swift; sourceTree = "<group>"; };
+		DEDA8DBF2B19CDC50076BF0F /* ThemeSettingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingViewModelTests.swift; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -11207,6 +11209,7 @@
 				03A6C18128B52ACC00AADF23 /* In-Person Payments */,
 				E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */,
 				DEC51B03276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift */,
+				DEDA8DBF2B19CDC50076BF0F /* ThemeSettingViewModelTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -14394,6 +14397,7 @@
 				021125B82578ECF10075AD2A /* BoldableTextParserTests.swift in Sources */,
 				4569D3F425DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
+				DEDA8DC02B19CDC50076BF0F /* ThemeSettingViewModelTests.swift in Sources */,
 				03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */,
 				EE5B5BB62AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift in Sources */,
 				DE2FE5832924DA2F0018040A /* JetpackSetupRequiredViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2305,6 +2305,7 @@
 		DEDA8D992B04643E0076BF0F /* ProductSubscription+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */; };
 		DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */; };
 		DEDA8D9F2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */; };
+		DEDA8DBC2B1983570076BF0F /* ThemeSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4903,6 +4904,7 @@
 		DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+Empty.swift"; sourceTree = "<group>"; };
 		DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Blaze.swift"; sourceTree = "<group>"; };
 		DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsBlazeTests.swift; sourceTree = "<group>"; };
+		DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingView.swift; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -10305,6 +10307,7 @@
 		CE85FD5820F7A59E0080B73E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				DEDA8DBA2B19833E0076BF0F /* Themes */,
 				DE68979D2A8F7C8C00154588 /* AccountSettings */,
 				02ACD2592852E11700EC928E /* CloseAccountCoordinator.swift */,
 				0239305F2918F35600B2632F /* Domains */,
@@ -11087,6 +11090,14 @@
 				DED9740C2AD7D27000122EB4 /* BlazeCampaignListViewModel.swift */,
 			);
 			path = BlazeCampaignList;
+			sourceTree = "<group>";
+		};
+		DEDA8DBA2B19833E0076BF0F /* Themes */ = {
+			isa = PBXGroup;
+			children = (
+				DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */,
+			);
+			path = Themes;
 			sourceTree = "<group>";
 		};
 		DEE4BBCA27FED9390002C818 /* ProductListSelector */ = {
@@ -13637,6 +13648,7 @@
 				03582BE2299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift in Sources */,
 				02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */,
 				B9DA153C280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift in Sources */,
+				DEDA8DBC2B1983570076BF0F /* ThemeSettingView.swift in Sources */,
 				03825FE92A97B63800363BDA /* AdaptiveImage.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,
 				CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2306,6 +2306,7 @@
 		DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */; };
 		DEDA8D9F2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */; };
 		DEDA8DBC2B1983570076BF0F /* ThemeSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */; };
+		DEDA8DBE2B19952B0076BF0F /* ThemeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDA8DBD2B19952B0076BF0F /* ThemeSettingViewModel.swift */; };
 		DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */; };
 		DEDAE30D2A12091500F9635F /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */; };
 		DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */; };
@@ -4905,6 +4906,7 @@
 		DEDA8D9C2B1609DE0076BF0F /* UserDefaults+Blaze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Blaze.swift"; sourceTree = "<group>"; };
 		DEDA8D9E2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsBlazeTests.swift; sourceTree = "<group>"; };
 		DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingView.swift; sourceTree = "<group>"; };
+		DEDA8DBD2B19952B0076BF0F /* ThemeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingViewModel.swift; sourceTree = "<group>"; };
 		DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationTests.swift; sourceTree = "<group>"; };
 		DEDAE30C2A12091500F9635F /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		DEDB2D252845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModel.swift; sourceTree = "<group>"; };
@@ -11096,6 +11098,7 @@
 			isa = PBXGroup;
 			children = (
 				DEDA8DBB2B1983570076BF0F /* ThemeSettingView.swift */,
+				DEDA8DBD2B19952B0076BF0F /* ThemeSettingViewModel.swift */,
 			);
 			path = Themes;
 			sourceTree = "<group>";
@@ -13097,6 +13100,7 @@
 				AEC12B7A2758D55900845F97 /* OrderStatusList.swift in Sources */,
 				0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */,
 				B958640C2A66847B002C4C6E /* CouponListView.swift in Sources */,
+				DEDA8DBE2B19952B0076BF0F /* ThemeSettingViewModel.swift in Sources */,
 				68C31B712A8617C500AE5C5A /* NewNoteViewModel.swift in Sources */,
 				D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */,
 				02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
@@ -7,7 +7,7 @@ final class ThemeSettingViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 123
 
-    func test_updateCurrentThemeName_updates_currentThemeName_properly() async {
+    func test_updateCurrentThemeName_updates_loadingCurrentTheme_properly() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ThemeSettingViewModel(siteID: 123, stores: stores)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+@MainActor
+final class ThemeSettingViewModelTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 123
+
+    func test_updateCurrentThemeName_updates_currentThemeName_properly() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ThemeSettingViewModel(siteID: 123, stores: stores)
+        XCTAssertFalse(viewModel.loadingCurrentTheme)
+
+        // When
+        stores.whenReceivingAction(ofType: WordPressThemeAction.self) { action in
+            switch action {
+            case let .loadCurrentTheme(_, onCompletion):
+                XCTAssertTrue(viewModel.loadingCurrentTheme)
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+        await viewModel.updateCurrentThemeName()
+
+        // Then
+        XCTAssertFalse(viewModel.loadingCurrentTheme)
+    }
+
+    func test_updateCurrentThemeName_updates_correct_name_from_loaded_theme() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ThemeSettingViewModel(siteID: 123, stores: stores)
+        let expectedName = "Tsubaki"
+
+        // When
+        stores.whenReceivingAction(ofType: WordPressThemeAction.self) { action in
+            switch action {
+            case let .loadCurrentTheme(_, onCompletion):
+                onCompletion(.success(.fake().copy(name: expectedName)))
+            default:
+                break
+            }
+        }
+        await viewModel.updateCurrentThemeName()
+
+        // Then
+        XCTAssertEqual(viewModel.currentThemeName, expectedName)
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 final class MockWordPressThemeRemote {
     private var stubbedSuggestedThemes: [WordPressTheme] = []
-    private var stubbedSuggestedThemeError: Error?
+    private var stubbedSuggestedThemesError: Error?
 
     private var stubbedCurrentTheme: WordPressTheme?
     private var stubbedCurrentThemeError: Error?
@@ -15,7 +15,7 @@ final class MockWordPressThemeRemote {
         case .success(let themes):
             stubbedSuggestedThemes = themes
         case .failure(let error):
-            stubbedSuggestedThemeError = error
+            stubbedSuggestedThemesError = error
         }
     }
 
@@ -31,8 +31,8 @@ final class MockWordPressThemeRemote {
 
 extension MockWordPressThemeRemote: WordPressThemeRemoteProtocol {
     func loadSuggestedThemes() async throws -> [Networking.WordPressTheme] {
-        if let stubbedSuggestedThemeError {
-            throw stubbedSuggestedThemeError
+        if let stubbedSuggestedThemesError {
+            throw stubbedSuggestedThemesError
         }
         return stubbedSuggestedThemes
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11337 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new view to be presented from the Settings screen for picking themes for the current site. The screen contains only the name of the current theme - the theme picker will be added in a future PR.

Changes include:
- Updated `SettingsViewController` to navigate to the new screen upon tapping Themes row.
- Added new file `ThemeSettingView` for picking theme for the current site.
- Added `ThemeSettingViewModel` to handle loading current theme and send the theme name to `ThemeSettingView`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom site and switch to the Menu tab.
- Select Settings > Themes.
- Confirm that a new screen is presented, and the correct name of the current theme is displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/dd0df495-56a1-4c25-bf17-8c529e65bfff" width=320 /> 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
