### PR TITLE
[Payments Menu] Animate presentation of onboarding notice

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [internal] Product Subscriptions: Handle yearly Synchronise renewals case while enabling One time shipping setting. [https://github.com/woocommerce/woocommerce-ios/pull/11312]
 - [internal] Update Shimmer dependency to avoid high CPU and memory use crashing the app when built with Xcode 15 [https://github.com/woocommerce/woocommerce-ios/pull/11320]
 - [internal] Fix issue with scrolling some views when built from Xcode 15 [https://github.com/woocommerce/woocommerce-ios/pull/11335]
+- [*] Animate display of the onboarding notice in the payments menu [https://github.com/woocommerce/woocommerce-ios/pull/11339]
 
 16.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -192,6 +192,7 @@ struct InPersonPaymentsMenu: View {
 
             if let onboardingNotice = viewModel.cardPresentPaymentsOnboardingNotice {
                 PermanentNoticeView(notice: onboardingNotice)
+                    .transition(.opacity.animation(.easeInOut))
                 LazyNavigationLink(destination: HostedSupportForm(viewModel: .init()),
                                    isActive: $viewModel.presentSupport) {
                     EmptyView()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11129
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The UIKit Payments Menu animated the presentation of the background onboarding notice. This PR adds that animation to the SwiftUI Payments Menu – I didn't realise how easy it was!

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Delete the app from your phone
2. Launch it from Xcode
3. Log in to a store which will have incomplete onboarding; e.g. because it's a US store with both WooPayments and Stripe installed, or because you don't have Cash on Delivery set up.
4. Navigate to `Menu > Payments` (quickly)
5. Observe that after a moment, the onboarding notice fades in to view

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/15e1237c-cd7b-4382-b24f-551815e23703



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
