### PR TITLE
Fix Crash on Image Drag & Drop during upload in Product Images

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.6
 -----
-- [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience.
+- [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience. [https://github.com/woocommerce/woocommerce-ios/pull/11350]
 
 16.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.6
 -----
-
+- [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience.
 
 16.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -10,6 +10,12 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
 
     private var productImageStatuses: [ProductImageStatus]
 
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     private let isDeletionEnabled: Bool
     private let productUIImageLoader: ProductUIImageLoader
     private let onDeletion: ProductImagesGalleryViewController.Deletion
@@ -159,6 +165,15 @@ extension ProductImagesCollectionViewController {
 ///
 extension ProductImagesCollectionViewController: UICollectionViewDragDelegate, UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+
+        // If any image is currently being uploaded, display a message to the user and prevent drag & drop operations.
+        guard !productImageStatuses.contains(where: { if case .uploading = $0 { return true }; return false }) else {
+            let notice = Notice(title: Localization.dragAndDropMessageWhileUploading,
+                                feedbackType: .warning)
+            self.noticePresenter.enqueue(notice: notice)
+            return []
+        }
+
         guard let item = productImageStatuses[safe: indexPath.row] else {
             return []
         }
@@ -265,5 +280,14 @@ private extension ProductImagesCollectionViewController {
                                 forCellWithReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier)
         collectionView.register(InProgressProductImageCollectionViewCell.loadNib(),
                                 forCellWithReuseIdentifier: InProgressProductImageCollectionViewCell.reuseIdentifier)
+    }
+}
+
+/// Private data structures
+/// 
+private extension ProductImagesCollectionViewController {
+    enum Localization {
+        static let dragAndDropMessageWhileUploading = NSLocalizedString("Please wait until all uploads are finished before reordering images.",
+                   comment: "Alert message to inform the user that they must wait for all image uploads to complete before they can reorder the images.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -287,7 +287,9 @@ private extension ProductImagesCollectionViewController {
 /// 
 private extension ProductImagesCollectionViewController {
     enum Localization {
-        static let dragAndDropMessageWhileUploading = NSLocalizedString("Please wait until all uploads are finished before reordering images.",
-                   comment: "Alert message to inform the user that they must wait for all image uploads to complete before they can reorder the images.")
+        static let dragAndDropMessageWhileUploading = NSLocalizedString(
+            "productImagesCollectionViewController.notice",
+            value: "Please wait until all uploads are finished before reordering images.",
+            comment: "Alert message to inform the user that they must wait for all image uploads to complete before they can reorder the images.")
     }
 }


### PR DESCRIPTION
Fixes: #11341 

## Description
This PR addresses a crash that occurs when a user attempts to drag and drop images during an image upload process in the Product Images section. The issue arises due to an inconsistency exception: `UIDragSnappingFeedbackGenerator is already being interacted with.`. This is definitively in the top 5 unresolved crashes on iOS. More details: peaMlT-hQ


## Steps to reproduce the crash:
1. Open a product.
2. Tap on images.
3. Upload 3 or more images (suggested for users with a fast connection).
4. While the images are uploading, open the list of images.
5. Start the drag and drop of an image, and keep it while the images are uploading. Release it at the end.
6. After the upload finishes, re-try to drag & drop some images.
7. Crash 💥 

## Resolution
With this fix, the app should no longer crash when the user attempts to drag and drop images during the upload process. Instead, the drag and drop functionality will be disabled until the upload process is complete to ensure the app remains stable and the user experience is not disrupted. A notice will be presented if an image is still uploading.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
