### PR TITLE
[Accessibility] Improve VoiceOver on order form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -29,8 +29,11 @@ struct CustomAmountRowView: View {
                 .frame(width: Layout.editIconImageSize * scale,
                        height: Layout.editIconImageSize * scale)
                 .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                .accessibilityAddTraits(.isButton)
+                .accessibilityLabel(Localization.editButtonAccessibilityLabel)
         }
         .padding(Layout.contentPadding)
+        .contentShape(Rectangle())
         .onTapGesture {
             viewModel.onEditCustomAmount()
         }
@@ -53,5 +56,12 @@ extension CustomAmountRowView {
         static let cornerRadius: CGFloat = 8
         static let borderLineWidth: CGFloat = 0.5
         static let editIconImageSize: CGFloat = 16
+    }
+
+    enum Localization {
+        static let editButtonAccessibilityLabel = NSLocalizedString(
+            "customAmount.edit.button.accessibilityLabel",
+            value: "Edit amount",
+            comment: "Accessibility title for the edit button on a custom amount row.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -545,6 +545,7 @@ private extension ProductsSection {
                 .foregroundColor(Color(.brand))
             }
         })
+        .accessibilityLabel(OrderForm.Localization.scanProductButtonAccessibilityLabel)
         .sheet(isPresented: $showAddProductViaSKUScanner, onDismiss: {
             scroll.scrollTo(addProductViaSKUScannerButton)
         }, content: {
@@ -596,6 +597,10 @@ private extension OrderForm {
                                                                                      "when there is a tax rate stored")
         static let storedTaxRateBottomSheetClearTaxRateButtonTitle = NSLocalizedString("Clear address and stop using this rate",
                                                                                        comment: "Title for the button to clear the stored tax rate")
+        static let scanProductButtonAccessibilityLabel = NSLocalizedString(
+            "orderForm.products.add.scan.button.accessibilityLabel",
+            value: "Scan barcode",
+            comment: "Accessibility label for the barcode scanning button to add product")
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -439,6 +439,7 @@ private struct ProductsSection: View {
                         }) {
                             Image(uiImage: .plusImage)
                         }
+                        .accessibilityLabel(OrderForm.Localization.addProductButtonAccessibilityLabel)
                         .id(addProductButton)
                         .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
                     }
@@ -601,6 +602,11 @@ private extension OrderForm {
             "orderForm.products.add.scan.button.accessibilityLabel",
             value: "Scan barcode",
             comment: "Accessibility label for the barcode scanning button to add product")
+
+        static let addProductButtonAccessibilityLabel = NSLocalizedString(
+            "orderForm.products.add.button.accessibilityLabel",
+            value: "Add product",
+            comment: "Accessibility label for the + button to add product using a form")
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -156,6 +156,7 @@ private extension OrderPaymentSection {
                 Image(systemName: "questionmark.circle")
                     .resizable()
                     .frame(width: Constants.sectionPadding, height: Constants.sectionPadding)
+                    .accessibilityLabel(Localization.couponTooltipInformationAccessibilityLabel)
             }
             .renderedIf(viewModel.shouldRenderCouponsInfoTooltip)
         }
@@ -338,6 +339,7 @@ private extension OrderPaymentSection {
             } label: {
                 Image(systemName: "questionmark.circle")
                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                    .accessibilityLabel(Localization.taxInformationAccessibilityLabel)
             }
             .renderedIf(viewModel.shouldShowTaxesInfoButton)
 
@@ -449,6 +451,14 @@ private extension OrderPaymentSection {
         static let couponsTooltipDescription = NSLocalizedString(
             "To add Coupons, please remove your Product Discounts",
             comment: "Description text for the coupons row informational tooltip")
+        static let taxInformationAccessibilityLabel = NSLocalizedString(
+            "order.form.paymentSection.taxes.moreInfo.accessibilityLabel",
+            value: "Tax information",
+            comment: "An accessibility label for a More info button, rendered as a question mark icon, which shows tax information.")
+        static let couponTooltipInformationAccessibilityLabel = NSLocalizedString(
+            "order.form.paymentSection.coupon.moreInfo.accessibilityLabel",
+            value: "Coupon information",
+            comment: "An accessibility label for a More info button, rendered as a question mark icon, which shows coupon information.")
     }
 
     enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I noticed a few issues with VoiceOver on the Order Form. This PR resolves them.

### Known issue
When creating an order, if you add a coupon or shipping line, then try to edit those before saving the order, you can't do that with voiceover.

It looks like it's to do with the `handleSwipeBackGesture`, from the HostingController the VO double-tap gesture on _just these rows_ is being propagated to `UIViewController.gestureRecognizer(_:shouldBeRequiredToFailBy:)` in `UINavigationController+Woo`, and compared against the swipe back gesture, which triggers the action sheet to confirm navigation away from the view.

We could add some workaround, but anything I can come up with right now has worse side-effects than the existing issue.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Turn on VoiceOver
3. Create or edit an order
4. Explore the screen and make sure that accessibility labels and traits are appropriate. Pay particular attention to buttons.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/1690bdde-681b-4c95-9474-cf8e6799aae9


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
