### PR TITLE
[HACK Week] Other payment methods

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1172,6 +1172,7 @@ extension WooAnalyticsEvent {
             case cash
             case paymentLink = "payment_link"
             case scanToPay = "scan_to_pay"
+            case otherPaymentMethods = "other_payment_methods"
         }
 
         /// Possible view sources

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -488,6 +488,10 @@ public enum WooAnalyticsStat: String {
     //
     case cashPaymentTenderViewOnMarkOrderAsCompleteButtonTapped = "cash_payment_tender_view_on_mark_order_as_complete_button_tapped"
 
+    // MARK: Other Payment Methods View Events
+    //
+    case otherPaymentMethodsNoteAdded = "other_payment_methods_note_added"
+
     // MARK: Shipping Labels Events
     //
     case shippingLabelRefundRequested = "shipping_label_refund_requested"

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -265,6 +265,10 @@ extension UIImage {
         UIImage(systemName: "qrcode.viewfinder")?.withRenderingMode(.alwaysTemplate) ?? .creditCardImage
     }
 
+    static var otherPaymentMethodsIcon: UIImage {
+        UIImage(systemName: "rectangle.and.pencil.and.ellipsis")?.withRenderingMode(.alwaysTemplate) ?? emptyBoxImage
+    }
+
     /// Customize Icon
     ///
     static var customizeImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import Foundation
+import WooFoundation
+
+struct OtherPaymentMethodsView: View {
+    @Environment(\.dismiss) var dismiss
+    @ObservedObject private(set) var viewModel: OtherPaymentMethodsViewModel
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(Layout.backgroundOpacity).edgesIgnoringSafeArea(.all)
+
+            VStack {
+                GeometryReader { geometry in
+                    ScrollView {
+                        VStack(alignment: .center, spacing: Layout.verticalSpacing) {
+                            Text(String.localizedStringWithFormat(Localization.otherPaymentMethodsTitle, viewModel.formattedTotal))
+                                .font(.title3)
+
+                            TextEditor(text: $viewModel.noteText)
+                                .cornerRadius(4)
+                                .border(Color(.separator), width: 0.5)
+                                            .foregroundStyle(.secondary)
+                                            .onTapGesture {
+                                                viewModel.noteText = ""
+                                            }
+
+                            Text(Localization.otherPaymentMethodsFootnote)
+                                .footnoteStyle()
+
+                            Spacer()
+
+                            Button(Localization.markOrderAsCompleteTitle) {
+                                viewModel.onMarkOrderAsCompleteTapped()
+                                dismiss()
+                            }
+                                .buttonStyle(PrimaryButtonStyle())
+                            Button(Localization.cancelButtonTitle) {
+                                dismiss()
+                            }
+                            .buttonStyle(SecondaryButtonStyle())
+
+                        }
+                        .padding(Layout.outterPadding)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .background(Color(.systemBackground))
+                        .cornerRadius(Layout.cornerRadius)
+                        .frame(width: geometry.size.width)      // Make the scroll view full-width
+                        .frame(minHeight: geometry.size.height)
+                    }
+                }
+            }
+            .padding(Layout.outterPadding)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+}
+
+extension OtherPaymentMethodsView {
+    enum Layout {
+        static let verticalSpacing: CGFloat = 16
+        static let backgroundOpacity: CGFloat = 0.5
+        static let cornerRadius: CGFloat = 8
+        static let outterPadding: CGFloat = 24
+    }
+
+    enum Localization {
+        static let otherPaymentMethodsTitle = NSLocalizedString("otherPaymentMethodsView.title",
+                                                        value: "Other Payment Methods: %1$@",
+                                                        comment: "Title for the other payment methods view. Reads like Other Payment Methods: $34.45")
+        static let otherPaymentMethodsFootnote = NSLocalizedString("otherPaymentMethodsView.footnote",
+                                                        value: "Enter an optional note with your custom payment method. The note will be added to the order.",
+                                                        comment: "Explanatory footnote for the other payment methods view.")
+        static let markOrderAsCompleteTitle = NSLocalizedString("otherPaymentMethodsView.markOrderAsCompleteButton.title",
+                                                        value: "Mark order as complete",
+                                                        comment: "Title for the mark order as complete button in the other payment methods view.")
+        static let cancelButtonTitle = NSLocalizedString("otherPaymentMethods.cancelButton",
+                                                        value: "Cancel",
+                                                        comment: "Title for the cancel button in the other payment methods screen.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModel.swift
@@ -7,18 +7,26 @@ final class OtherPaymentMethodsViewModel: ObservableObject {
     @Published var noteText: String = Localization.noteTextPlaceholder
     let formattedTotal: String
     private let onMarkOrderAsComplete: OnMarkOrderAsCompleteCallback
+    private let analytics: Analytics
 
     init(formattedTotal: String,
+         analytics: Analytics = ServiceLocator.analytics,
          onMarkOrderAsComplete: @escaping OnMarkOrderAsCompleteCallback) {
         self.formattedTotal = formattedTotal
+        self.analytics = analytics
         self.onMarkOrderAsComplete = onMarkOrderAsComplete
     }
 
     func onMarkOrderAsCompleteTapped() {
         let noteTextWasAdded = noteText.isNotEmpty && noteText != Localization.noteTextPlaceholder
-        let noteText = noteTextWasAdded ? noteText : nil
 
-        onMarkOrderAsComplete(noteText)
+        var addingNoteText: String?
+        if noteTextWasAdded {
+            addingNoteText = noteText
+            analytics.track(.otherPaymentMethodsNoteAdded)
+        }
+
+        onMarkOrderAsComplete(addingNoteText)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModel.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import Combine
+
+typealias OnMarkOrderAsCompleteCallback = ((_ noteText: String?) -> Void)
+
+final class OtherPaymentMethodsViewModel: ObservableObject {
+    @Published var noteText: String = Localization.noteTextPlaceholder
+    let formattedTotal: String
+    let onMarkOrderAsComplete: OnMarkOrderAsCompleteCallback
+
+    init(formattedTotal: String,
+         onMarkOrderAsComplete: @escaping OnMarkOrderAsCompleteCallback) {
+        self.formattedTotal = formattedTotal
+        self.onMarkOrderAsComplete = onMarkOrderAsComplete
+    }
+
+    func onMarkOrderAsCompleteTapped() {
+        let noteTextWasAdded = noteText.isNotEmpty && noteText != Localization.noteTextPlaceholder
+        let noteText = noteTextWasAdded ? noteText : nil
+
+        onMarkOrderAsComplete(noteText)
+    }
+}
+
+extension OtherPaymentMethodsViewModel {
+    enum Localization {
+        static let noteTextPlaceholder = NSLocalizedString("otherPaymentMethodsViewModel.note.placeholder",
+                                                            value: "Enter optional note",
+                                                            comment: "Placeholder for the text editor when adding a note in the payment methods view.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModel.swift
@@ -6,7 +6,7 @@ typealias OnMarkOrderAsCompleteCallback = ((_ noteText: String?) -> Void)
 final class OtherPaymentMethodsViewModel: ObservableObject {
     @Published var noteText: String = Localization.noteTextPlaceholder
     let formattedTotal: String
-    let onMarkOrderAsComplete: OnMarkOrderAsCompleteCallback
+    private let onMarkOrderAsComplete: OnMarkOrderAsCompleteCallback
 
     init(formattedTotal: String,
          onMarkOrderAsComplete: @escaping OnMarkOrderAsCompleteCallback) {
@@ -22,7 +22,7 @@ final class OtherPaymentMethodsViewModel: ObservableObject {
     }
 }
 
-extension OtherPaymentMethodsViewModel {
+private extension OtherPaymentMethodsViewModel {
     enum Localization {
         static let noteTextPlaceholder = NSLocalizedString("otherPaymentMethodsViewModel.note.placeholder",
                                                             value: "Enter optional note",

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -99,7 +99,7 @@ struct PaymentMethodsView: View {
 
                         MethodRow(icon: .otherPaymentMethodsIcon, title: Localization.otherPaymentMethods, accessibilityID: Accessibility.otherPaymentMethods) {
                             showingOtherPaymentMethodsView = true
-                            // viewModel.trackCollectByScanToPay()
+                            viewModel.trackCollectByScanToPay()
                         }
                     }
                     .padding(.horizontal)

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -99,7 +99,7 @@ struct PaymentMethodsView: View {
 
                         MethodRow(icon: .otherPaymentMethodsIcon, title: Localization.otherPaymentMethods, accessibilityID: Accessibility.otherPaymentMethods) {
                             showingOtherPaymentMethodsView = true
-                            viewModel.trackCollectByScanToPay()
+                            viewModel.trackCollectByOtherPaymentMethods()
                         }
                     }
                     .padding(.horizontal)

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -147,7 +147,9 @@ struct PaymentMethodsView: View {
         }
         .fullScreenCover(isPresented: $showingOtherPaymentMethodsView) {
             OtherPaymentMethodsView(viewModel: OtherPaymentMethodsViewModel(formattedTotal: viewModel.formattedTotal) { noteText in
-
+                viewModel.markOrderAsComplete(with: noteText) {
+                    dismiss()
+                }
             })
                 .background(FullScreenCoverClearBackgroundView())
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -147,7 +147,7 @@ struct PaymentMethodsView: View {
         }
         .fullScreenCover(isPresented: $showingOtherPaymentMethodsView) {
             OtherPaymentMethodsView(viewModel: OtherPaymentMethodsViewModel(formattedTotal: viewModel.formattedTotal) { noteText in
-                viewModel.markOrderAsComplete(with: noteText) {
+                viewModel.markOrderAsPaidWithOtherPaymentMethod(with: noteText) {
                     dismiss()
                 }
             })

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -24,6 +24,8 @@ struct PaymentMethodsView: View {
 
     @State private var showingScanToPayView = false
 
+    @State private var showingOtherPaymentMethodsView = false
+
     private let learnMoreViewModel = LearnMoreViewModel.inPersonPayments(source: .paymentMethods)
 
     ///   Environment safe areas
@@ -92,6 +94,13 @@ struct PaymentMethodsView: View {
                                 viewModel.trackCollectByScanToPay()
                             }
                         }
+
+                        Divider()
+
+                        MethodRow(icon: .otherPaymentMethodsIcon, title: Localization.otherPaymentMethods, accessibilityID: Accessibility.otherPaymentMethods) {
+                            showingOtherPaymentMethodsView = true
+                            // viewModel.trackCollectByScanToPay()
+                        }
                     }
                     .padding(.horizontal)
                     .background(Color(.listForeground(modal: false)))
@@ -134,6 +143,12 @@ struct PaymentMethodsView: View {
                 dismiss()
                 viewModel.performScanToPayFinishedTasks()
             }
+                .background(FullScreenCoverClearBackgroundView())
+        }
+        .fullScreenCover(isPresented: $showingOtherPaymentMethodsView) {
+            OtherPaymentMethodsView(viewModel: OtherPaymentMethodsViewModel(formattedTotal: viewModel.formattedTotal) { noteText in
+
+            })
                 .background(FullScreenCoverClearBackgroundView())
         }
     }
@@ -209,6 +224,9 @@ extension PaymentMethodsView {
                                                 comment: "Tap to Pay on iPhone method title on the select payment method screen")
         static let link = NSLocalizedString("Share Payment Link", comment: "Payment Link method title on the select payment method screen")
         static let scanToPay = NSLocalizedString("Scan to Pay", comment: "Scan to Pay method title on the select payment method screen")
+        static let otherPaymentMethods = NSLocalizedString("paymentMethods.otherPaymentMethods.tyile",
+                                                           value: "Other Payment Methods",
+                                                           comment: "Other payment methods title on the select payment method screen")
         static let markAsPaidTitle = NSLocalizedString("Mark as Paid?", comment: "Alert title when selecting the cash payment method")
         static let markAsPaidButton = NSLocalizedString("Mark as Paid", comment: "Alert button when selecting the cash payment method")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the payment methods screen")
@@ -230,6 +248,7 @@ extension PaymentMethodsView {
         static let tapToPayMethod = "payment-methods-view-tap-to-pay-row"
         static let paymentLink = "payment-methods-view-payment-link-row"
         static let scanToPayMethod = "payment-methods-view-scan-to-pay-row"
+        static let otherPaymentMethods = "payment-methods-other-payment-methods-row"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -274,6 +274,10 @@ final class PaymentMethodsViewModel: ObservableObject {
         trackCollectIntention(method: .scanToPay, cardReaderType: .none)
     }
 
+    func trackCollectByOtherPaymentMethods() {
+        trackCollectIntention(method: .otherPaymentMethods, cardReaderType: .none)
+    }
+
     /// Perform the necesary tasks after a link is shared.
     ///
     func performLinkSharedTasks() {
@@ -305,20 +309,20 @@ private extension PaymentMethodsViewModel {
     ///
     func markOrderAsPaid(onSuccess: @escaping () -> Void) {
         showLoadingIndicator = true
-        
+
         let action = OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: .completed) { [weak self] error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 self.presentNoticeSubject.send(.error(Localization.markAsPaidError))
                 self.trackFlowFailed()
                 return DDLogError("⛔️ Error updating order: \(error)")
             }
-            
+
             self.updateOrderAsynchronously()
-            
+
             onSuccess()
-            
+
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -308,17 +308,17 @@ private extension PaymentMethodsViewModel {
         
         let action = OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: .completed) { [weak self] error in
             guard let self = self else { return }
-
+            
             if let error = error {
                 self.presentNoticeSubject.send(.error(Localization.markAsPaidError))
                 self.trackFlowFailed()
                 return DDLogError("⛔️ Error updating order: \(error)")
             }
-
+            
             self.updateOrderAsynchronously()
-
+            
             onSuccess()
-
+            
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -183,7 +183,6 @@ final class PaymentMethodsViewModel: ObservableObject {
     }
 
     func markOrderAsComplete(with note: String?, onCompletion: @escaping () -> Void) {
-        showLoadingIndicator = true
         markOrderAsPaid { [weak self] in
             guard let self = self,
                   let note else {
@@ -305,6 +304,8 @@ private extension PaymentMethodsViewModel {
     /// Mark an order as paid and notify if successful.
     ///
     func markOrderAsPaid(onSuccess: @escaping () -> Void) {
+        showLoadingIndicator = true
+        
         let action = OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: .completed) { [weak self] error in
             guard let self = self else { return }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1742,6 +1742,7 @@
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
 		B9713D282B1F381100AA899F /* OtherPaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9713D272B1F381100AA899F /* OtherPaymentMethodsView.swift */; };
 		B9713D2A2B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9713D292B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift */; };
+		B9713D2D2B1F436D00AA899F /* OtherPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9713D2C2B1F436D00AA899F /* OtherPaymentMethodsViewModelTests.swift */; };
 		B97C6E562B15E51A008A2BF2 /* UpdateProductInventoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */; };
 		B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */; };
 		B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */; };
@@ -4337,6 +4338,7 @@
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		B9713D272B1F381100AA899F /* OtherPaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherPaymentMethodsView.swift; sourceTree = "<group>"; };
 		B9713D292B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
+		B9713D2C2B1F436D00AA899F /* OtherPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryView.swift; sourceTree = "<group>"; };
 		B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModelTests.swift; sourceTree = "<group>"; };
 		B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSection.swift; sourceTree = "<group>"; };
@@ -6610,6 +6612,7 @@
 		039F373B2860DC12009A2B4C /* Payment Methods */ = {
 			isa = PBXGroup;
 			children = (
+				B9713D2B2B1F434F00AA899F /* Other */,
 				B9001CE22B1E119600EC87B2 /* Cash */,
 				261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */,
 			);
@@ -9399,6 +9402,14 @@
 			children = (
 				B9713D272B1F381100AA899F /* OtherPaymentMethodsView.swift */,
 				B9713D292B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift */,
+			);
+			path = Other;
+			sourceTree = "<group>";
+		};
+		B9713D2B2B1F434F00AA899F /* Other */ = {
+			isa = PBXGroup;
+			children = (
+				B9713D2C2B1F436D00AA899F /* OtherPaymentMethodsViewModelTests.swift */,
 			);
 			path = Other;
 			sourceTree = "<group>";
@@ -14615,6 +14626,7 @@
 				EECB7EE02862115C0028C888 /* MockProductImageUploader.swift in Sources */,
 				022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,
+				B9713D2D2B1F436D00AA899F /* OtherPaymentMethodsViewModelTests.swift in Sources */,
 				DE5FBB932A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift in Sources */,
 				26F94E34267AA42F00DB6CCF /* ProductAddOnViewModelTests.swift in Sources */,
 				AE7C957F27C417FA007E8E12 /* FeeOrDiscountLineDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1740,6 +1740,8 @@
 		B95B15C92B15EBA000A54044 /* UpdateProductInventoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95B15C82B15EBA000A54044 /* UpdateProductInventoryViewModel.swift */; };
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
+		B9713D282B1F381100AA899F /* OtherPaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9713D272B1F381100AA899F /* OtherPaymentMethodsView.swift */; };
+		B9713D2A2B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9713D292B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift */; };
 		B97C6E562B15E51A008A2BF2 /* UpdateProductInventoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */; };
 		B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */; };
 		B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */; };
@@ -4333,6 +4335,8 @@
 		B95B15C82B15EBA000A54044 /* UpdateProductInventoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryViewModel.swift; sourceTree = "<group>"; };
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
+		B9713D272B1F381100AA899F /* OtherPaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherPaymentMethodsView.swift; sourceTree = "<group>"; };
+		B9713D292B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryView.swift; sourceTree = "<group>"; };
 		B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModelTests.swift; sourceTree = "<group>"; };
 		B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSection.swift; sourceTree = "<group>"; };
@@ -6586,6 +6590,7 @@
 		0386CFE52851F58E00134466 /* Payment Methods */ = {
 			isa = PBXGroup;
 			children = (
+				B9713D262B1F37FB00AA899F /* Other */,
 				B9001CDD2B1DD5F700EC87B2 /* Cash */,
 				261AA308275178FA009530FE /* PaymentMethodsView.swift */,
 				261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */,
@@ -9387,6 +9392,15 @@
 				B95A45EB2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift */,
 			);
 			path = CustomerSection;
+			sourceTree = "<group>";
+		};
+		B9713D262B1F37FB00AA899F /* Other */ = {
+			isa = PBXGroup;
+			children = (
+				B9713D272B1F381100AA899F /* OtherPaymentMethodsView.swift */,
+				B9713D292B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift */,
+			);
+			path = Other;
 			sourceTree = "<group>";
 		};
 		B97C6E542B15E4EE008A2BF2 /* UpdateInventory */ = {
@@ -12704,6 +12718,7 @@
 				E15F163126C5117300D3059B /* InPersonPaymentsNoConnectionView.swift in Sources */,
 				CC41E70C29310C1F008B3FB9 /* AnalyticsLineChart.swift in Sources */,
 				456CB50D2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift in Sources */,
+				B9713D2A2B1F3DCA00AA899F /* OtherPaymentMethodsViewModel.swift in Sources */,
 				6827140F28A3988300E6E3F6 /* DismissableNoticeView.swift in Sources */,
 				D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */,
 				B651474527D644FF00C9C4E6 /* CustomerNoteSection.swift in Sources */,
@@ -13003,6 +13018,7 @@
 				021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */,
 				02490D1A284DE664002096EF /* ProductImagesSaver.swift in Sources */,
 				0215320B24231D5A003F2BBD /* UIStackView+Subviews.swift in Sources */,
+				B9713D282B1F381100AA899F /* OtherPaymentMethodsView.swift in Sources */,
 				02F4F50B237AEB8A00E13A9C /* ProductFormTableViewDataSource.swift in Sources */,
 				B57C5C9621B80E5500FF82B2 /* Dictionary+Woo.swift in Sources */,
 				CE27257F21925AE8002B22EB /* ValueOneTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/Other/OtherPaymentMethodsViewModelTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import WooCommerce
+
+class OtherPaymentMethodsViewModelTests: XCTestCase {
+    func test_note_text_on_initialization_then_shows_placeholder() {
+        let viewModel = OtherPaymentMethodsViewModel(formattedTotal: "100.00", onMarkOrderAsComplete: { _ in })
+
+        XCTAssertEqual(viewModel.noteText, Localization.noteTextPlaceholder)
+    }
+
+    func test_onMarkOrderAsCompleteTapped_when_there_is_a_note_then_passes_the_note() {
+
+        var capturedNote: String?
+        let viewModel = OtherPaymentMethodsViewModel(formattedTotal: "100.00", onMarkOrderAsComplete: { note in
+            capturedNote = note
+        })
+
+        viewModel.noteText = "TestNote"
+        viewModel.onMarkOrderAsCompleteTapped()
+
+        XCTAssertEqual(capturedNote, viewModel.noteText)
+    }
+
+    func test_onMarkOrderAsCompleteTapped_when_note_is_empty_then_passes_nil() {
+
+        var capturedNote: String?
+        let viewModel = OtherPaymentMethodsViewModel(formattedTotal: "100.00", onMarkOrderAsComplete: { note in
+            capturedNote = note
+        })
+
+        viewModel.noteText = ""
+        viewModel.onMarkOrderAsCompleteTapped()
+
+        XCTAssertNil(capturedNote)
+    }
+
+    func test_onMarkOrderAsCompleteTapped_when_note_does_not_change_then_passes_nil() {
+        var capturedNote: String?
+        let viewModel = OtherPaymentMethodsViewModel(formattedTotal: "100.00", onMarkOrderAsComplete: { note in
+            capturedNote = note
+        })
+
+        viewModel.onMarkOrderAsCompleteTapped()
+
+        XCTAssertNil(capturedNote)
+    }
+}
+
+extension OtherPaymentMethodsViewModelTests {
+    enum Localization {
+        static let noteTextPlaceholder = NSLocalizedString("otherPaymentMethodsViewModel.note.placeholder",
+                                                           value: "Enter optional note",
+                                                           comment: "Placeholder for the text editor when adding a note in the payment methods view.")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -444,7 +444,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(passedNote, expectedNote)
     }
 
-    func test_markOrderAsComplete_when_passing_note_then_sends_note() {
+    func test_markOrderAsPaidWithOtherPaymentMethod_when_passing_note_then_sends_note() {
         // Given
         let testNote = "testNote"
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -477,7 +477,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
 
         // When
         let onSuccessInvoked: Bool = waitFor { promise in
-            viewModel.markOrderAsComplete(with: testNote, onCompletion: {
+            viewModel.markOrderAsPaidWithOtherPaymentMethod(with: testNote, onCompletion: {
                 promise(true)
             })
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add support for other payment methods, where the merchant can add a note to the order specifying their method. This is useful when they receive a payment with a different method -e.g. checks, gift cards, house accounts, etc- than those currently displayed in the payment methods screen, and they want to add a record of it.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1.  Go to orders
2. Tap on + to create a new order
3. Add products to the order. Tap on create.
4. Tap on Collect Payment
5. Select Other Payment Methods
6. Add a note and mark the order as complete.
7. See that the order is set as complete and the order details are shown.
8. Refresh the order. See that a note is added with the text you entered.

Try also without adding a note (no note should be added to the order).  See that the events are tracked as well: when tapping on the Other Payment Methods row:

`🔵 Tracked payments_flow_collect, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("site_url"): "https://americanwootester.wpcomstaging.com", AnyHashable("order_id"): 1898, AnyHashable("payment_method"): "other_payment_methods", AnyHashable("was_ecommerce_trial"): false, AnyHashable("plan"): "business-bundle", AnyHashable("blog_id"): 214354650, AnyHashable("flow"): "order_payment"]`

`("payment_method"): "other_payment_methods"
`

When adding a note:

`🔵 Tracked other_payment_methods_note_added, properties: [AnyHashable("site_url"): "https://americanwootester.wpcomstaging.com", AnyHashable("was_ecommerce_trial"): false, AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 214354650, AnyHashable("plan"): "business-bundle"]`

Please also check that the event `payments_flow_completed` is tracked with the right payment method.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/fc9f8360-e300-4ab3-8e96-258fea70b768



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
