### PR TITLE
[Order form] Extract ProductStepper from ProductRow, and use it only in views where it is needed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -32,7 +32,7 @@ struct CollapsibleProductCard: View {
     }
 
     var body: some View {
-        if viewModel.rowViewModel.childProductRows.isEmpty {
+        if viewModel.childProductRows.isEmpty {
             CollapsibleProductRowCard(viewModel: viewModel,
                                       flow: flow,
                                       shouldDisableDiscountEditing: shouldDisableDiscountEditing,
@@ -54,7 +54,7 @@ struct CollapsibleProductCard: View {
                     .overlay(Color(.separator))
 
                 // Child products
-                ForEach(viewModel.rowViewModel.childProductRows) { childRow in
+                ForEach(viewModel.childProductRows) { childRow in
                     CollapsibleProductRowCard(viewModel: childRow,
                                               flow: flow,
                                               shouldDisableDiscountEditing: shouldDisableDiscountEditing,
@@ -171,7 +171,7 @@ private struct CollapsibleProductRowCard: View {
 
             Group {
                 SimplifiedProductRow(viewModel: viewModel.stepperViewModel, canChangeQuantity: viewModel.canChangeQuantity)
-                    .renderedIf(!viewModel.rowViewModel.isReadOnly)
+                    .renderedIf(!viewModel.isReadOnly)
                 HStack {
                     Text(Localization.priceLabel)
                     CollapsibleProductCardPriceSummary(viewModel: viewModel.rowViewModel)
@@ -179,13 +179,13 @@ private struct CollapsibleProductRowCard: View {
                 HStack {
                     discountRow
                 }
-                .renderedIf(!viewModel.rowViewModel.isReadOnly)
+                .renderedIf(!viewModel.isReadOnly)
                 HStack {
                     Text(Localization.priceAfterDiscountLabel)
                     Spacer()
                     Text(viewModel.rowViewModel.totalPriceAfterDiscountLabel ?? "")
                 }
-                .renderedIf(viewModel.rowViewModel.hasDiscount && !viewModel.rowViewModel.isReadOnly)
+                .renderedIf(viewModel.rowViewModel.hasDiscount && !viewModel.isReadOnly)
             }
             .padding(.top)
 
@@ -225,7 +225,7 @@ private struct CollapsibleProductRowCard: View {
                     .renderedIf(shouldShowInfoTooltip)
                 }
             }
-            .renderedIf(!viewModel.rowViewModel.isReadOnly)
+            .renderedIf(!viewModel.isReadOnly)
         })
         .onTapGesture {
             dismissTooltip()
@@ -383,13 +383,13 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
         let bundleParentRowViewModel = ProductRowViewModel(id: 1,
                                                            product: product
             .copy(productTypeKey: ProductType.bundle.rawValue, bundledItems: [.swiftUIPreviewSample()]),
-                                                           childProductRows: childViewModels,
                                                            configure: {})
         let bundleParentViewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
                                                                                                 name: "",
                                                                                                 quantityUpdatedCallback: { _ in }),
                                                                         rowViewModel: bundleParentRowViewModel,
-                                                                        canChangeQuantity: true)
+                                                                        canChangeQuantity: true,
+                                                                        childProductRows: childViewModels)
         VStack {
             CollapsibleProductCard(viewModel: viewModel,
                                       flow: .creation,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -365,14 +365,14 @@ private extension CollapsibleProductRowCard {
 struct CollapsibleProductCard_Previews: PreviewProvider {
     static var previews: some View {
         let product = Product.swiftUIPreviewSample()
-        let rowViewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
+        let rowViewModel = ProductRowViewModel(product: product)
         let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
                                                                                     name: "",
                                                                                     quantityUpdatedCallback: { _ in }),
                                                             rowViewModel: rowViewModel,
                                                             canChangeQuantity: true)
-        let childViewModels = [ProductRowViewModel(id: 2, product: product, canChangeQuantity: true, hasParentProduct: true),
-                               ProductRowViewModel(id: 3, product: product, canChangeQuantity: true, hasParentProduct: true)]
+        let childViewModels = [ProductRowViewModel(id: 2, product: product, hasParentProduct: true),
+                               ProductRowViewModel(id: 3, product: product, hasParentProduct: true)]
             .map {
                 ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
                                                                             name: "",
@@ -383,7 +383,6 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
         let bundleParentRowViewModel = ProductRowViewModel(id: 1,
                                                            product: product
             .copy(productTypeKey: ProductType.bundle.rawValue, bundledItems: [.swiftUIPreviewSample()]),
-                                                           canChangeQuantity: true,
                                                            childProductRows: childViewModels,
                                                            configure: {})
         let bundleParentViewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -575,6 +575,7 @@ final class EditableOrderViewModel: ObservableObject {
     func createProductRowViewModel(for item: OrderItem,
                                    childItems: [OrderItem] = [],
                                    canChangeQuantity: Bool,
+                                   isReadOnly: Bool = false,
                                    pricedIndividually: Bool = true) -> ProductWithQuantityStepperViewModel? {
         guard item.quantity > 0 else {
             // Don't render any item with `.zero` quantity.
@@ -617,7 +618,11 @@ final class EditableOrderViewModel: ObservableObject {
                     }
                     return bundledItem.pricedIndividually
                 }()
-                return createProductRowViewModel(for: childItem, canChangeQuantity: canChildItemsChangeQuantity, pricedIndividually: pricedIndividually)
+                let isReadOnly = product.productType == .bundle
+                return createProductRowViewModel(for: childItem,
+                                                 canChangeQuantity: canChildItemsChangeQuantity,
+                                                 isReadOnly: isReadOnly,
+                                                 pricedIndividually: pricedIndividually)
             }
             let rowViewModel = ProductRowViewModel(id: item.itemID,
                                                    product: product,
@@ -625,7 +630,6 @@ final class EditableOrderViewModel: ObservableObject {
                                                    quantity: item.quantity,
                                                    hasParentProduct: item.parent != nil,
                                                    pricedIndividually: pricedIndividually,
-                                                   childProductRows: childProductRows,
                                                    removeProductIntent: { [weak self] in
                 self?.removeItemFromOrder(item)},
                                                    configure: { [weak self] in
@@ -651,7 +655,11 @@ final class EditableOrderViewModel: ObservableObject {
             }, removeProductIntent: { [weak self] in
                 self?.removeItemFromOrder(item)
             })
-            return ProductWithQuantityStepperViewModel(stepperViewModel: stepperViewModel, rowViewModel: rowViewModel, canChangeQuantity: canChangeQuantity)
+            return ProductWithQuantityStepperViewModel(stepperViewModel: stepperViewModel,
+                                                       rowViewModel: rowViewModel,
+                                                       canChangeQuantity: canChangeQuantity,
+                                                       isReadOnly: isReadOnly,
+                                                       childProductRows: childProductRows)
         } else {
             DDLogInfo("No product or variation found. Couldn't create the product row")
             return nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -593,14 +593,9 @@ final class EditableOrderViewModel: ObservableObject {
                                                    discount: passingDiscountValue,
                                                    name: item.name,
                                                    quantity: item.quantity,
-                                                   canChangeQuantity: canChangeQuantity,
                                                    displayMode: .attributes(attributes),
                                                    hasParentProduct: item.parent != nil,
                                                    pricedIndividually: pricedIndividually,
-                                                   quantityUpdatedCallback: { [weak self] _ in
-                guard let self else { return }
-                self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductQuantityChange(flow: self.flow.analyticsFlow))
-            },
                                                    removeProductIntent: { [weak self] in
                 self?.removeItemFromOrder(item)})
             let stepperViewModel = ProductStepperViewModel(quantity: item.quantity,
@@ -628,14 +623,9 @@ final class EditableOrderViewModel: ObservableObject {
                                                    product: product,
                                                    discount: passingDiscountValue,
                                                    quantity: item.quantity,
-                                                   canChangeQuantity: canChangeQuantity,
                                                    hasParentProduct: item.parent != nil,
                                                    pricedIndividually: pricedIndividually,
                                                    childProductRows: childProductRows,
-                                                   quantityUpdatedCallback: { [weak self] _ in
-                guard let self = self else { return }
-                self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductQuantityChange(flow: self.flow.analyticsFlow))
-            },
                                                    removeProductIntent: { [weak self] in
                 self?.removeItemFromOrder(item)},
                                                    configure: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemView.swift
@@ -23,7 +23,7 @@ struct ConfigurableBundleItemView: View {
                 }
                 .disabled(!viewModel.isOptional)
 
-                ProductRow(viewModel: viewModel.productRowViewModel)
+                ProductWithQuantityStepperView(viewModel: viewModel.productWithStepperViewModel)
             }
 
             HStack(spacing: 0) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -107,7 +107,6 @@ final class ConfigurableBundleItemViewModel: ObservableObject, Identifiable {
                                                       quantity: quantity,
                                                       minimumQuantity: bundleItem.minQuantity,
                                                       maximumQuantity: bundleItem.maxQuantity,
-                                                      canChangeQuantity: canChangeQuantity,
                                                       imageURL: product.imageURL,
                                                       hasParentProduct: false,
                                                       isConfigurable: false)
@@ -171,8 +170,6 @@ private extension ConfigurableBundleItemViewModel {
                                                           quantity: self.quantity,
                                                           minimumQuantity: self.bundleItem.minQuantity,
                                                           maximumQuantity: self.bundleItem.maxQuantity,
-                                                          // TODO-jc: remove
-                                                          canChangeQuantity: isOptionalAndSelected,
                                                           imageURL: self.product.imageURL,
                                                           hasParentProduct: false,
                                                           isConfigurable: false)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -31,7 +31,7 @@ final class ConfigurableBundleItemViewModel: ObservableObject, Identifiable {
     }
 
     /// For rendering the product row with the quantity setting UI.
-    @Published private(set) var productRowViewModel: ProductRowViewModel
+    @Published private(set) var productWithStepperViewModel: ProductWithQuantityStepperViewModel
     @Published var quantity: Decimal
     @Published var isOptionalAndSelected: Bool = false
 
@@ -95,21 +95,29 @@ final class ConfigurableBundleItemViewModel: ObservableObject, Identifiable {
         self.variableProductSettings = variableProductSettings
         self.analytics = analytics
         isVariable = product.productType == .variable
-        productRowViewModel = .init(productOrVariationID: bundleItem.productID,
-                                    name: bundleItem.title,
-                                    sku: nil,
-                                    price: nil,
-                                    stockStatusKey: "",
-                                    stockQuantity: nil,
-                                    manageStock: false,
-                                    quantity: quantity,
-                                    minimumQuantity: bundleItem.minQuantity,
-                                    maximumQuantity: bundleItem.maxQuantity,
-                                    canChangeQuantity: !isOptional || isOptionalAndSelected,
-                                    imageURL: product.imageURL,
-                                    hasParentProduct: false,
-                                    isConfigurable: false)
-        productRowViewModel.stepperViewModel.quantityUpdatedCallback = { [weak self] quantity in
+
+        let canChangeQuantity = !isOptional || isOptionalAndSelected
+        let productRowViewModel = ProductRowViewModel(productOrVariationID: bundleItem.productID,
+                                                      name: bundleItem.title,
+                                                      sku: nil,
+                                                      price: nil,
+                                                      stockStatusKey: "",
+                                                      stockQuantity: nil,
+                                                      manageStock: false,
+                                                      quantity: quantity,
+                                                      minimumQuantity: bundleItem.minQuantity,
+                                                      maximumQuantity: bundleItem.maxQuantity,
+                                                      canChangeQuantity: canChangeQuantity,
+                                                      imageURL: product.imageURL,
+                                                      hasParentProduct: false,
+                                                      isConfigurable: false)
+        let stepperViewModel = ProductStepperViewModel(quantity: quantity,
+                                                       name: bundleItem.title,
+                                                       minimumQuantity: bundleItem.minQuantity,
+                                                       maximumQuantity: bundleItem.maxQuantity,
+                                                       quantityUpdatedCallback: { _ in })
+        self.productWithStepperViewModel = .init(stepperViewModel: stepperViewModel, rowViewModel: productRowViewModel, canChangeQuantity: canChangeQuantity)
+        stepperViewModel.quantityUpdatedCallback = { [weak self] quantity in
             guard let self else { return }
             self.quantity = quantity
             self.analytics.track(event: .Orders.orderFormBundleProductConfigurationChanged(changedField: .quantity))
@@ -163,16 +171,21 @@ private extension ConfigurableBundleItemViewModel {
                                                           quantity: self.quantity,
                                                           minimumQuantity: self.bundleItem.minQuantity,
                                                           maximumQuantity: self.bundleItem.maxQuantity,
+                                                          // TODO-jc: remove
                                                           canChangeQuantity: isOptionalAndSelected,
                                                           imageURL: self.product.imageURL,
                                                           hasParentProduct: false,
                                                           isConfigurable: false)
-            productRowViewModel.stepperViewModel.quantityUpdatedCallback = { [weak self] quantity in
+            let stepperViewModel = ProductStepperViewModel(quantity: quantity,
+                                                           name: bundleItem.title,
+                                                           minimumQuantity: bundleItem.minQuantity,
+                                                           maximumQuantity: bundleItem.maxQuantity,
+                                                           quantityUpdatedCallback: { [weak self] quantity in
                 self?.quantity = quantity
-            }
-            return productRowViewModel
+            })
+            return .init(stepperViewModel: stepperViewModel, rowViewModel: productRowViewModel, canChangeQuantity: isOptionalAndSelected)
         }
-        .assign(to: &$productRowViewModel)
+        .assign(to: &$productWithStepperViewModel)
     }
 
     func observeSelectedVariationForSelectableAttributes() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -105,8 +105,6 @@ final class ConfigurableBundleItemViewModel: ObservableObject, Identifiable {
                                                       stockQuantity: nil,
                                                       manageStock: false,
                                                       quantity: quantity,
-                                                      minimumQuantity: bundleItem.minQuantity,
-                                                      maximumQuantity: bundleItem.maxQuantity,
                                                       imageURL: product.imageURL,
                                                       hasParentProduct: false,
                                                       isConfigurable: false)
@@ -168,8 +166,6 @@ private extension ConfigurableBundleItemViewModel {
                                                           stockQuantity: nil,
                                                           manageStock: false,
                                                           quantity: self.quantity,
-                                                          minimumQuantity: self.bundleItem.minQuantity,
-                                                          maximumQuantity: self.bundleItem.maxQuantity,
                                                           imageURL: self.product.imageURL,
                                                           hasParentProduct: false,
                                                           isConfigurable: false)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrder.swift
@@ -143,7 +143,6 @@ struct ProductInOrder_Previews: PreviewProvider {
                                             stockStatusKey: "instock",
                                             stockQuantity: 7,
                                             manageStock: true,
-                                            canChangeQuantity: false,
                                                imageURL: nil,
                                                hasParentProduct: true,
                                                isConfigurable: true)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -143,7 +143,6 @@ struct ProductRow_Previews: PreviewProvider {
                                             stockStatusKey: "instock",
                                             stockQuantity: 7,
                                             manageStock: true,
-                                            canChangeQuantity: true,
                                             imageURL: nil,
                                             hasParentProduct: false,
                                             isConfigurable: true)
@@ -154,7 +153,6 @@ struct ProductRow_Previews: PreviewProvider {
                                                           stockStatusKey: "instock",
                                                           stockQuantity: 7,
                                                           manageStock: true,
-                                                          canChangeQuantity: false,
                                                           imageURL: nil,
                                                           hasParentProduct: true,
                                                           isConfigurable: false)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -59,50 +59,43 @@ struct ProductRow: View {
     }
 
     var body: some View {
-        VStack {
-            AdaptiveStack(horizontalAlignment: .leading) {
-                HStack(alignment: .center) {
-                    if multipleSelectionsEnabled {
-                        if let selectionHandler = onCheckboxSelected {
-                            checkbox.onTapGesture {
-                                selectionHandler()
-                            }
-                        } else {
-                            checkbox
-                        }
+        HStack(alignment: .center) {
+            if multipleSelectionsEnabled {
+                if let selectionHandler = onCheckboxSelected {
+                    checkbox.onTapGesture {
+                        selectionHandler()
                     }
-
-                    // Product image
-                    ProductImageThumbnail(productImageURL: viewModel.imageURL,
-                                          productImageSize: Layout.productImageSize,
-                                          scale: scale,
-                                          productImageCornerRadius: Layout.cornerRadius,
-                                          foregroundColor: Color(UIColor.listSmallIcon))
-
-                    // Product details
-                    VStack(alignment: .leading) {
-                        Text(viewModel.name)
-                            .bodyStyle()
-                        Text(viewModel.productDetailsLabel)
-                            .subheadlineStyle()
-                            .renderedIf(viewModel.productDetailsLabel.isNotEmpty)
-                        Text(viewModel.secondaryProductDetailsLabel)
-                            .subheadlineStyle()
-                            .renderedIf(viewModel.secondaryProductDetailsLabel.isNotEmpty)
-                    }
-                    .multilineTextAlignment(.leading)
+                } else {
+                    checkbox
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
-                .accessibilityElement(children: .ignore)
-                .accessibilityAddTraits(.isButton)
-                .accessibilityLabel(viewModel.productAccessibilityLabel)
-                .accessibilityHint(accessibilityHint)
-
-                ProductStepper(viewModel: viewModel.stepperViewModel)
-                    .renderedIf(viewModel.canChangeQuantity)
             }
+
+            // Product image
+            ProductImageThumbnail(productImageURL: viewModel.imageURL,
+                                  productImageSize: Layout.productImageSize,
+                                  scale: scale,
+                                  productImageCornerRadius: Layout.cornerRadius,
+                                  foregroundColor: Color(UIColor.listSmallIcon))
+
+            // Product details
+            VStack(alignment: .leading) {
+                Text(viewModel.name)
+                    .bodyStyle()
+                Text(viewModel.productDetailsLabel)
+                    .subheadlineStyle()
+                    .renderedIf(viewModel.productDetailsLabel.isNotEmpty)
+                Text(viewModel.secondaryProductDetailsLabel)
+                    .subheadlineStyle()
+                    .renderedIf(viewModel.secondaryProductDetailsLabel.isNotEmpty)
+            }
+            .multilineTextAlignment(.leading)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(viewModel.productAccessibilityLabel)
+        .accessibilityHint(accessibilityHint)
     }
 
     private var checkbox: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -3,18 +3,20 @@ import Kingfisher
 
 struct SimplifiedProductRow: View {
 
-    @ObservedObject var viewModel: ProductRowViewModel
+    @ObservedObject var viewModel: ProductStepperViewModel
+    private let canChangeQuantity: Bool
 
-    init(viewModel: ProductRowViewModel) {
+    init(viewModel: ProductStepperViewModel, canChangeQuantity: Bool) {
         self.viewModel = viewModel
+        self.canChangeQuantity = canChangeQuantity
     }
 
     var body: some View {
         HStack(alignment: .center) {
             Text(Localization.orderCountLabel)
             Spacer()
-            ProductStepper(viewModel: viewModel.stepperViewModel)
-                .renderedIf(viewModel.canChangeQuantity)
+            ProductStepper(viewModel: viewModel)
+                .renderedIf(canChangeQuantity)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -8,11 +8,6 @@ import WooFoundation
 final class ProductRowViewModel: ObservableObject, Identifiable {
     private let currencyFormatter: CurrencyFormatter
 
-    /// Whether the product row is read-only. Defaults to `false`.
-    ///
-    /// Used to remove product editing controls for read-only order items (e.g. child items of a product bundle).
-    private(set) var isReadOnly: Bool = false
-
     /// Unique ID for the view model.
     ///
     let id: Int64
@@ -33,9 +28,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Whether a product in an order item has a parent order item
     let hasParentProduct: Bool
-
-    /// Child product rows, if the product is the parent of child order items
-    @Published private(set) var childProductRows: [ProductWithQuantityStepperViewModel]
 
     /// Whether a product in an order item is configurable
     ///
@@ -290,7 +282,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          selectedState: ProductRow.SelectedState = .notSelected,
          hasParentProduct: Bool,
          pricedIndividually: Bool = true,
-         childProductRows: [ProductWithQuantityStepperViewModel] = [],
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
@@ -311,7 +302,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.imageURL = imageURL
         self.hasParentProduct = hasParentProduct
         self.pricedIndividually = pricedIndividually
-        self.childProductRows = childProductRows
         self.isConfigurable = isConfigurable
         self.currencyFormatter = currencyFormatter
         self.analytics = analytics
@@ -330,7 +320,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      selectedState: ProductRow.SelectedState = .notSelected,
                      hasParentProduct: Bool = false,
                      pricedIndividually: Bool = true,
-                     childProductRows: [ProductWithQuantityStepperViewModel] = [],
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      analytics: Analytics = ServiceLocator.analytics,
                      removeProductIntent: @escaping (() -> Void) = {},
@@ -385,12 +374,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
         let productTypeLabel: String? = isConfigurable ? product.productType.description: nil
 
-        if product.productType == .bundle {
-            for child in childProductRows {
-                child.rowViewModel.isReadOnly = true // Can't edit child bundle items separate from bundle configuration
-            }
-        }
-
         self.init(id: id,
                   productOrVariationID: product.productID,
                   name: product.name,
@@ -407,7 +390,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   selectedState: selectedState,
                   hasParentProduct: hasParentProduct,
                   pricedIndividually: pricedIndividually,
-                  childProductRows: childProductRows,
                   isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
                   analytics: analytics,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -8,8 +8,7 @@ import WooFoundation
 final class ProductRowViewModel: ObservableObject, Identifiable {
     private let currencyFormatter: CurrencyFormatter
 
-    let stepperViewModel: ProductStepperViewModel
-
+    // TODO-jc: remove
     /// Whether the product quantity can be changed.
     /// Controls whether the stepper is rendered.
     ///
@@ -259,7 +258,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     /// Quantity of product in the order. The source of truth is from the the quantity stepper view model `stepperViewModel`.
     ///
-    @Published private(set) var quantity: Decimal
+    @Published var quantity: Decimal
 
     /// Closure to run when the quantity is decremented below the minimum quantity.
     ///
@@ -319,12 +318,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.stockQuantity = stockQuantity
         self.manageStock = manageStock
         self.quantity = quantity
-        self.stepperViewModel = ProductStepperViewModel(quantity: quantity,
-                                                        name: name,
-                                                        minimumQuantity: minimumQuantity,
-                                                        maximumQuantity: maximumQuantity,
-                                                        quantityUpdatedCallback: quantityUpdatedCallback,
-                                                        removeProductIntent: removeProductIntent)
         self.canChangeQuantity = canChangeQuantity
         self.imageURL = imageURL
         self.hasParentProduct = hasParentProduct
@@ -337,8 +330,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.variationDisplayMode = variationDisplayMode
         self.removeProductIntent = removeProductIntent
         self.configure = configure
-
-        observeQuantityFromStepperViewModel()
     }
 
     /// Initialize `ProductRowViewModel` with a `Product`
@@ -539,13 +530,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
     func trackEditDiscountTapped() {
         analytics.track(event: .Orders.productDiscountEditButtonTapped())
-    }
-}
-
-private extension ProductRowViewModel {
-    func observeQuantityFromStepperViewModel() {
-        stepperViewModel.$quantity
-            .assign(to: &$quantity)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -41,7 +41,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     let hasParentProduct: Bool
 
     /// Child product rows, if the product is the parent of child order items
-    @Published private(set) var childProductRows: [ProductRowViewModel]
+    @Published private(set) var childProductRows: [ProductWithQuantityStepperViewModel]
 
     /// Whether a product in an order item is configurable
     ///
@@ -299,7 +299,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          selectedState: ProductRow.SelectedState = .notSelected,
          hasParentProduct: Bool,
          pricedIndividually: Bool = true,
-         childProductRows: [ProductRowViewModel] = [],
+         childProductRows: [ProductWithQuantityStepperViewModel] = [],
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
@@ -342,7 +342,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      selectedState: ProductRow.SelectedState = .notSelected,
                      hasParentProduct: Bool = false,
                      pricedIndividually: Bool = true,
-                     childProductRows: [ProductRowViewModel] = [],
+                     childProductRows: [ProductWithQuantityStepperViewModel] = [],
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      analytics: Analytics = ServiceLocator.analytics,
                      quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
@@ -400,7 +400,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
         if product.productType == .bundle {
             for child in childProductRows {
-                child.isReadOnly = true // Can't edit child bundle items separate from bundle configuration
+                child.rowViewModel.isReadOnly = true // Can't edit child bundle items separate from bundle configuration
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -8,12 +8,6 @@ import WooFoundation
 final class ProductRowViewModel: ObservableObject, Identifiable {
     private let currencyFormatter: CurrencyFormatter
 
-    // TODO-jc: remove
-    /// Whether the product quantity can be changed.
-    /// Controls whether the stepper is rendered.
-    ///
-    let canChangeQuantity: Bool
-
     /// Whether the product row is read-only. Defaults to `false`.
     ///
     /// Used to remove product editing controls for read-only order items (e.g. child items of a product bundle).
@@ -292,7 +286,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          quantity: Decimal = 1,
          minimumQuantity: Decimal = 1,
          maximumQuantity: Decimal? = nil,
-         canChangeQuantity: Bool,
          imageURL: URL?,
          numberOfVariations: Int = 0,
          variationDisplayMode: VariationDisplayMode? = nil,
@@ -303,7 +296,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
-         quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
          removeProductIntent: (() -> Void)? = nil,
          configure: (() -> Void)? = nil) {
         self.id = id ?? Int64(UUID().uuidString.hashValue)
@@ -318,7 +310,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.stockQuantity = stockQuantity
         self.manageStock = manageStock
         self.quantity = quantity
-        self.canChangeQuantity = canChangeQuantity
         self.imageURL = imageURL
         self.hasParentProduct = hasParentProduct
         self.pricedIndividually = pricedIndividually
@@ -338,14 +329,12 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      product: Product,
                      discount: Decimal? = nil,
                      quantity: Decimal = 1,
-                     canChangeQuantity: Bool,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      hasParentProduct: Bool = false,
                      pricedIndividually: Bool = true,
                      childProductRows: [ProductWithQuantityStepperViewModel] = [],
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      analytics: Analytics = ServiceLocator.analytics,
-                     quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
                      removeProductIntent: @escaping (() -> Void) = {},
                      featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
                      configure: (() -> Void)? = nil) {
@@ -415,7 +404,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   stockQuantity: stockQuantity,
                   manageStock: manageStock,
                   quantity: quantity,
-                  canChangeQuantity: canChangeQuantity,
                   imageURL: product.imageURL,
                   numberOfVariations: product.variations.count,
                   selectedState: selectedState,
@@ -425,7 +413,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
                   analytics: analytics,
-                  quantityUpdatedCallback: quantityUpdatedCallback,
                   removeProductIntent: removeProductIntent,
                   configure: configure)
     }
@@ -437,14 +424,12 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      discount: Decimal? = nil,
                      name: String,
                      quantity: Decimal = 1,
-                     canChangeQuantity: Bool,
                      displayMode: VariationDisplayMode,
                      selectedState: ProductRow.SelectedState = .notSelected,
                      hasParentProduct: Bool = false,
                      pricedIndividually: Bool = true,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      analytics: Analytics = ServiceLocator.analytics,
-                     quantityUpdatedCallback: @escaping ((Decimal) -> Void) = { _ in },
                      removeProductIntent: @escaping (() -> Void) = {}) {
         let imageURL: URL?
         if let encodedImageURLString = productVariation.image?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
@@ -463,7 +448,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   stockQuantity: productVariation.stockQuantity,
                   manageStock: productVariation.manageStock,
                   quantity: quantity,
-                  canChangeQuantity: canChangeQuantity,
                   imageURL: imageURL,
                   variationDisplayMode: displayMode,
                   selectedState: selectedState,
@@ -472,7 +456,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   isConfigurable: false,
                   currencyFormatter: currencyFormatter,
                   analytics: analytics,
-                  quantityUpdatedCallback: quantityUpdatedCallback,
                   removeProductIntent: removeProductIntent)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -284,8 +284,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          stockQuantity: Decimal?,
          manageStock: Bool,
          quantity: Decimal = 1,
-         minimumQuantity: Decimal = 1,
-         maximumQuantity: Decimal? = nil,
          imageURL: URL?,
          numberOfVariations: Int = 0,
          variationDisplayMode: VariationDisplayMode? = nil,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -706,7 +706,6 @@ private extension ProductSelectorViewModel {
                 self?.onConfigureProductRow?(product)
             }
             return ProductRowViewModel(product: product,
-                                       canChangeQuantity: false,
                                        selectedState: selectedState,
                                        featureFlagService: featureFlagService,
                                        configure: configure)
@@ -734,7 +733,6 @@ extension ProductSelectorViewModel {
                             stockStatusKey: ProductStockStatus.inStock.rawValue,
                             stockQuantity: 1,
                             manageStock: false,
-                            canChangeQuantity: false,
                             imageURL: nil,
                             hasParentProduct: false,
                             isConfigurable: false)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductStepperViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductStepperViewModel.swift
@@ -45,8 +45,8 @@ final class ProductStepperViewModel: ObservableObject {
 
     init(quantity: Decimal,
          name: String,
-         minimumQuantity: Decimal,
-         maximumQuantity: Decimal?,
+         minimumQuantity: Decimal = 1,
+         maximumQuantity: Decimal? = nil,
          quantityUpdatedCallback: @escaping (Decimal) -> Void,
          removeProductIntent: (() -> Void)? = nil) {
         self.quantity = quantity

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -324,7 +324,6 @@ private extension ProductVariationSelectorViewModel {
                 let selectedState: ProductRow.SelectedState = selectedIDs.contains(variation.productVariationID) ? .selected : .notSelected
                 return ProductRowViewModel(productVariation: variation,
                                            name: ProductVariationFormatter().generateName(for: variation, from: self.productAttributes),
-                                           canChangeQuantity: false,
                                            displayMode: .stock,
                                            selectedState: selectedState)
             }
@@ -352,7 +351,6 @@ extension ProductVariationSelectorViewModel {
                             stockStatusKey: ProductStockStatus.inStock.rawValue,
                             stockQuantity: 1,
                             manageStock: false,
-                            canChangeQuantity: false,
                             imageURL: nil,
                             hasParentProduct: false,
                             isConfigurable: false)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
@@ -15,6 +15,7 @@ struct ProductWithQuantityStepperView: View {
     }
 }
 
+#if canImport(SwiftUI) && DEBUG
 struct ProductWithQuantityStepperView_Previews: PreviewProvider {
     static var previews: some View {
         let stepperViewModel = ProductStepperViewModel(quantity: 2,
@@ -27,3 +28,4 @@ struct ProductWithQuantityStepperView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
@@ -9,14 +9,32 @@ final class ProductWithQuantityStepperViewModel: ObservableObject, Identifiable 
     ///
     @Published private(set) var canChangeQuantity: Bool
 
-    init(stepperViewModel: ProductStepperViewModel, rowViewModel: ProductRowViewModel, canChangeQuantity: Bool) {
+    // TODO: 11357 - move to `CollapsibleProductCard`'s own view model
+    /// Whether the product row is read-only. Defaults to `false`.
+    ///
+    /// Used to remove product editing controls for read-only order items (e.g. child items of a product bundle).
+    let isReadOnly: Bool
+
+    // TODO: 11357 - move to `CollapsibleProductCard`'s own view model
+    /// Child product rows, if the product is the parent of child order items
+    @Published private(set) var childProductRows: [ProductWithQuantityStepperViewModel]
+
+    init(stepperViewModel: ProductStepperViewModel,
+         rowViewModel: ProductRowViewModel,
+         canChangeQuantity: Bool,
+         isReadOnly: Bool = false,
+         childProductRows: [ProductWithQuantityStepperViewModel] = []) {
         self.stepperViewModel = stepperViewModel
         self.rowViewModel = rowViewModel
         self.canChangeQuantity = canChangeQuantity
+        self.isReadOnly = isReadOnly
+        self.childProductRows = childProductRows
 
         observeQuantityFromStepperViewModel()
     }
+}
 
+private extension ProductWithQuantityStepperViewModel {
     func observeQuantityFromStepperViewModel() {
         stepperViewModel.$quantity
             .assign(to: &rowViewModel.$quantity)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+final class ProductWithQuantityStepperViewModel: ObservableObject {
+    let stepperViewModel: ProductStepperViewModel
+    let rowViewModel: ProductRowViewModel
+
+    /// Whether the product quantity can be changed.
+    /// Controls whether the stepper is rendered.
+    ///
+    @Published private(set) var canChangeQuantity: Bool
+
+    init(stepperViewModel: ProductStepperViewModel, rowViewModel: ProductRowViewModel, canChangeQuantity: Bool) {
+        self.stepperViewModel = stepperViewModel
+        self.rowViewModel = rowViewModel
+        self.canChangeQuantity = canChangeQuantity
+
+        observeQuantityFromStepperViewModel()
+    }
+
+    func observeQuantityFromStepperViewModel() {
+        stepperViewModel.$quantity
+            .assign(to: &rowViewModel.$quantity)
+    }
+}
+
+struct ProductWithQuantityStepperView: View {
+    @ObservedObject var viewModel: ProductWithQuantityStepperViewModel
+
+    var body: some View {
+        VStack {
+            AdaptiveStack(horizontalAlignment: .leading) {
+                ProductRow(viewModel: viewModel.rowViewModel)
+                ProductStepper(viewModel: viewModel.stepperViewModel)
+                    .renderedIf(viewModel.canChangeQuantity)
+            }
+        }
+    }
+}
+
+struct ProductWithQuantityStepperView_Previews: PreviewProvider {
+    static var previews: some View {
+        EmptyView()
+        // TODO-jc: fix preview
+//        ProductWithQuantityStepperView(viewModel: <#ProductWithQuantityStepperViewModel#>)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
@@ -1,46 +1,6 @@
 import SwiftUI
 
-final class ProductWithQuantityStepperViewModel: ObservableObject, Identifiable {
-    let stepperViewModel: ProductStepperViewModel
-    let rowViewModel: ProductRowViewModel
-
-    /// Whether the product quantity can be changed.
-    /// Controls whether the stepper is rendered.
-    ///
-    @Published private(set) var canChangeQuantity: Bool
-
-    // TODO: 11357 - move to `CollapsibleProductCard`'s own view model
-    /// Whether the product row is read-only. Defaults to `false`.
-    ///
-    /// Used to remove product editing controls for read-only order items (e.g. child items of a product bundle).
-    let isReadOnly: Bool
-
-    // TODO: 11357 - move to `CollapsibleProductCard`'s own view model
-    /// Child product rows, if the product is the parent of child order items
-    @Published private(set) var childProductRows: [ProductWithQuantityStepperViewModel]
-
-    init(stepperViewModel: ProductStepperViewModel,
-         rowViewModel: ProductRowViewModel,
-         canChangeQuantity: Bool,
-         isReadOnly: Bool = false,
-         childProductRows: [ProductWithQuantityStepperViewModel] = []) {
-        self.stepperViewModel = stepperViewModel
-        self.rowViewModel = rowViewModel
-        self.canChangeQuantity = canChangeQuantity
-        self.isReadOnly = isReadOnly
-        self.childProductRows = childProductRows
-
-        observeQuantityFromStepperViewModel()
-    }
-}
-
-private extension ProductWithQuantityStepperViewModel {
-    func observeQuantityFromStepperViewModel() {
-        stepperViewModel.$quantity
-            .assign(to: &rowViewModel.$quantity)
-    }
-}
-
+/// Displays a product row with an option to change its quantity, mostly used in the order creation/editing context.
 struct ProductWithQuantityStepperView: View {
     @ObservedObject var viewModel: ProductWithQuantityStepperViewModel
 
@@ -57,8 +17,13 @@ struct ProductWithQuantityStepperView: View {
 
 struct ProductWithQuantityStepperView_Previews: PreviewProvider {
     static var previews: some View {
-        EmptyView()
-        // TODO-jc: fix preview
-//        ProductWithQuantityStepperView(viewModel: <#ProductWithQuantityStepperViewModel#>)
+        let stepperViewModel = ProductStepperViewModel(quantity: 2,
+                                                       name: "",
+                                                       quantityUpdatedCallback: { _ in })
+        let rowViewModel = ProductRowViewModel(product: .swiftUIPreviewSample())
+        VStack {
+            ProductWithQuantityStepperView(viewModel: .init(stepperViewModel: stepperViewModel, rowViewModel: rowViewModel, canChangeQuantity: true))
+            ProductWithQuantityStepperView(viewModel: .init(stepperViewModel: stepperViewModel, rowViewModel: rowViewModel, canChangeQuantity: false))
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-final class ProductWithQuantityStepperViewModel: ObservableObject {
+final class ProductWithQuantityStepperViewModel: ObservableObject, Identifiable {
     let stepperViewModel: ProductStepperViewModel
     let rowViewModel: ProductRowViewModel
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductWithQuantityStepperViewModel.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// View model for `ProductWithQuantityStepperView`.
+final class ProductWithQuantityStepperViewModel: ObservableObject, Identifiable {
+    let stepperViewModel: ProductStepperViewModel
+    let rowViewModel: ProductRowViewModel
+
+    /// Whether the product quantity can be changed.
+    /// Controls whether the stepper is rendered.
+    ///
+    @Published private(set) var canChangeQuantity: Bool
+
+    // TODO: 11357 - move to `CollapsibleProductCard`'s own view model
+    /// Whether the product row is read-only. Defaults to `false`.
+    ///
+    /// Used to remove product editing controls for read-only order items (e.g. child items of a product bundle).
+    let isReadOnly: Bool
+
+    // TODO: 11357 - move to `CollapsibleProductCard`'s own view model
+    /// Child product rows, if the product is the parent of child order items
+    @Published private(set) var childProductRows: [ProductWithQuantityStepperViewModel]
+
+    init(stepperViewModel: ProductStepperViewModel,
+         rowViewModel: ProductRowViewModel,
+         canChangeQuantity: Bool,
+         isReadOnly: Bool = false,
+         childProductRows: [ProductWithQuantityStepperViewModel] = []) {
+        self.stepperViewModel = stepperViewModel
+        self.rowViewModel = rowViewModel
+        self.canChangeQuantity = canChangeQuantity
+        self.isReadOnly = isReadOnly
+        self.childProductRows = childProductRows
+
+        observeQuantityFromStepperViewModel()
+    }
+}
+
+private extension ProductWithQuantityStepperViewModel {
+    func observeQuantityFromStepperViewModel() {
+        stepperViewModel.$quantity
+            .assign(to: &rowViewModel.$quantity)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -475,6 +475,7 @@
 		02C37B7D2967B72A00F0CF9E /* FreeStagingDomainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C37B7C2967B72A00F0CF9E /* FreeStagingDomainView.swift */; };
 		02C3FACE282A93020095440A /* WooAnalyticsEvent+Dashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3FACD282A93020095440A /* WooAnalyticsEvent+Dashboard.swift */; };
 		02C3FDEA251091CE009569EE /* ProductFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3FDE9251091CE009569EE /* ProductFactoryTests.swift */; };
+		02C7EE8A2B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C7EE892B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift */; };
 		02C8876D24501FAC00E4470F /* FilterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C8876B24501FAC00E4470F /* FilterListViewController.swift */; };
 		02C8876E24501FAC00E4470F /* FilterListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02C8876C24501FAC00E4470F /* FilterListViewController.xib */; };
 		02C887712450285100E4470F /* BottomButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C887702450285100E4470F /* BottomButtonContainerView.swift */; };
@@ -3072,6 +3073,7 @@
 		02C37B7C2967B72A00F0CF9E /* FreeStagingDomainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeStagingDomainView.swift; sourceTree = "<group>"; };
 		02C3FACD282A93020095440A /* WooAnalyticsEvent+Dashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Dashboard.swift"; sourceTree = "<group>"; };
 		02C3FDE9251091CE009569EE /* ProductFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFactoryTests.swift; sourceTree = "<group>"; };
+		02C7EE892B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductWithQuantityStepperViewModel.swift; sourceTree = "<group>"; };
 		02C8876B24501FAC00E4470F /* FilterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListViewController.swift; sourceTree = "<group>"; };
 		02C8876C24501FAC00E4470F /* FilterListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterListViewController.xib; sourceTree = "<group>"; };
 		02C887702450285100E4470F /* BottomButtonContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonContainerView.swift; sourceTree = "<group>"; };
@@ -10975,6 +10977,7 @@
 				02DFD5032B20486C0048CD70 /* ProductStepper.swift */,
 				02DFD5052B2048C50048CD70 /* ProductStepperViewModel.swift */,
 				02FE734A2B21613D00CD486B /* ProductWithQuantityStepperView.swift */,
+				02C7EE892B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift */,
 			);
 			path = ProductSelector;
 			sourceTree = "<group>";
@@ -13181,6 +13184,7 @@
 				E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */,
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
 				45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */,
+				02C7EE8A2B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift in Sources */,
 				02A410F52583A84C005E2925 /* SpacerTableViewCell.swift in Sources */,
 				02BBD6EB29A316FB00243BE2 /* StoreOnboardingCoordinator.swift in Sources */,
 				0258B4DA2B159A0F008FEA07 /* Publisher+WithPrevious.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		024DF31E23743045006658FE /* TextList+AztecFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF31C23743045006658FE /* TextList+AztecFormatting.swift */; };
 		024DF31F23743045006658FE /* Header+AztecFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF31D23743045006658FE /* Header+AztecFormatting.swift */; };
 		024DF32123744798006658FE /* AztecFormatBarCommandCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF32023744798006658FE /* AztecFormatBarCommandCoordinator.swift */; };
+		024EB5812B21A981009BC2D9 /* ProductWithQuantityStepperViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024EB5802B21A981009BC2D9 /* ProductWithQuantityStepperViewModelTests.swift */; };
 		024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024EFA6823FCC10B00F36918 /* Product+Media.swift */; };
 		024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024F1451250B65A40003030A /* AddProductCoordinatorTests.swift */; };
 		02503C632538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02503C622538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift */; };
@@ -2816,6 +2817,7 @@
 		024DF31C23743045006658FE /* TextList+AztecFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TextList+AztecFormatting.swift"; sourceTree = "<group>"; };
 		024DF31D23743045006658FE /* Header+AztecFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Header+AztecFormatting.swift"; sourceTree = "<group>"; };
 		024DF32023744798006658FE /* AztecFormatBarCommandCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecFormatBarCommandCoordinator.swift; sourceTree = "<group>"; };
+		024EB5802B21A981009BC2D9 /* ProductWithQuantityStepperViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductWithQuantityStepperViewModelTests.swift; sourceTree = "<group>"; };
 		024EFA6823FCC10B00F36918 /* Product+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+Media.swift"; sourceTree = "<group>"; };
 		024F1451250B65A40003030A /* AddProductCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductCoordinatorTests.swift; sourceTree = "<group>"; };
 		02503C622538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormActionsFactory+ReadonlyVariationTests.swift"; sourceTree = "<group>"; };
@@ -9659,6 +9661,7 @@
 				EEB221A629B9B5B300662A12 /* CouponLineDetailsViewModelTests.swift */,
 				B9DC770429F2BE200013B191 /* TopProductsFromCachedOrdersProviderTests.swift */,
 				02DFD5072B205AEF0048CD70 /* ProductStepperViewModelTests.swift */,
+				024EB5802B21A981009BC2D9 /* ProductWithQuantityStepperViewModelTests.swift */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -14192,6 +14195,7 @@
 				267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */,
 				0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,
+				024EB5812B21A981009BC2D9 /* ProductWithQuantityStepperViewModelTests.swift in Sources */,
 				57C5FF7C25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift in Sources */,
 				020BE77723B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift in Sources */,
 				020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 		02FADAA52A607CEE00FE8683 /* MockImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */; };
 		02FADAA72A608F6B00FE8683 /* ImageTextScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA62A608F6B00FE8683 /* ImageTextScannerTests.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
+		02FE734B2B21613D00CD486B /* ProductWithQuantityStepperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE734A2B21613D00CD486B /* ProductWithQuantityStepperView.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FFDDC62A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */; };
 		0300201029C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0300200F29C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift */; };
@@ -3178,6 +3179,7 @@
 		02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageTextScanner.swift; sourceTree = "<group>"; };
 		02FADAA62A608F6B00FE8683 /* ImageTextScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTextScannerTests.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
+		02FE734A2B21613D00CD486B /* ProductWithQuantityStepperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductWithQuantityStepperView.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FFDDC52A31A73D000F5F1C /* WooAnalyticsEvent+Blaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Blaze.swift"; sourceTree = "<group>"; };
 		0300200F29C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderConnectionUnderlyingErrorDisplaying.swift; sourceTree = "<group>"; };
@@ -10969,6 +10971,7 @@
 				68AC9D282ACE598B0042F784 /* ProductImageThumbnail.swift */,
 				02DFD5032B20486C0048CD70 /* ProductStepper.swift */,
 				02DFD5052B2048C50048CD70 /* ProductStepperViewModel.swift */,
+				02FE734A2B21613D00CD486B /* ProductWithQuantityStepperView.swift */,
 			);
 			path = ProductSelector;
 			sourceTree = "<group>";
@@ -13704,6 +13707,7 @@
 				03582BE2299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift in Sources */,
 				02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */,
 				B9DA153C280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift in Sources */,
+				02FE734B2B21613D00CD486B /* ProductWithQuantityStepperView.swift in Sources */,
 				DEDA8DBC2B1983570076BF0F /* ThemeSettingView.swift in Sources */,
 				03825FE92A97B63800363BDA /* AdaptiveImage.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -433,7 +433,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.productRows.map { $0.rowViewModel }.contains(where: { $0.productOrVariationID == product0.productID }))
-        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }.map { $0.id }, [expectedRemainingRow].map { $0.id })
+        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }.map { $0.id }, [expectedRemainingRow].map { $0.rowViewModel }.map { $0.id })
     }
 
     func test_view_model_is_updated_when_product_is_removed_from_order_using_product_row_ID() throws {
@@ -456,7 +456,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.productRows.map { $0.rowViewModel }.contains(where: { $0.productOrVariationID == product0.productID }))
-        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }.map { $0.id }, [expectedRemainingRow].map { $0.id })
+        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }.map { $0.id }, [expectedRemainingRow].map { $0.rowViewModel }.map { $0.id })
     }
 
     func test_createProductRowViewModel_creates_expected_row_for_product() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -285,7 +285,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         productSelectorViewModel.completeMultipleSelection()
 
         // Then
-        XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
+        XCTAssertTrue(viewModel.productRows.map { $0.rowViewModel }.contains(where: { $0.productOrVariationID == sampleProductID }),
+                      "Product rows do not contain expected product")
     }
 
     func test_order_details_are_updated_when_product_quantity_changes() throws {
@@ -308,8 +309,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.productRows[0].stepperViewModel.incrementQuantity()
 
         // Then
-        XCTAssertEqual(viewModel.productRows[safe: 0]?.quantity, 2)
-        XCTAssertEqual(viewModel.productRows[safe: 1]?.quantity, 1)
+        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }[safe: 0]?.quantity, 2)
+        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }[safe: 1]?.quantity, 1)
     }
 
     func test_product_is_removed_when_quantity_is_decremented_below_1() throws {
@@ -322,13 +323,13 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Product quantity is 1
         productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         productSelectorViewModel.completeMultipleSelection()
-        XCTAssertEqual(viewModel.productRows[0].quantity, 1)
+        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }[0].quantity, 1)
 
         // When
         viewModel.productRows[0].stepperViewModel.decrementQuantity()
 
         // Then
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product.productID }))
+        XCTAssertFalse(viewModel.productRows.map { $0.rowViewModel }.contains(where: { $0.productOrVariationID == product.productID }))
     }
 
     func test_bundle_order_item_with_child_items_includes_full_bundle_configuration_when_quantity_is_incremented() throws {
@@ -404,7 +405,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         productSelectorViewModel.completeMultipleSelection()
 
         // When
-        let expectedRow = viewModel.productRows[0]
+        let expectedRow = viewModel.productRows.map { $0.rowViewModel }[0]
         viewModel.selectOrderItem(expectedRow.id)
 
         // Then
@@ -427,12 +428,12 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // When
         let expectedRemainingRow = viewModel.productRows[1]
-        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows.map { $0.rowViewModel }[0].id)
         viewModel.removeItemFromOrder(itemToRemove)
 
         // Then
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product0.productID }))
-        XCTAssertEqual(viewModel.productRows.map { $0.id }, [expectedRemainingRow].map { $0.id })
+        XCTAssertFalse(viewModel.productRows.map { $0.rowViewModel }.contains(where: { $0.productOrVariationID == product0.productID }))
+        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }.map { $0.id }, [expectedRemainingRow].map { $0.id })
     }
 
     func test_view_model_is_updated_when_product_is_removed_from_order_using_product_row_ID() throws {
@@ -450,12 +451,12 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // When
         let expectedRemainingRow = viewModel.productRows[1]
-        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows.map { $0.rowViewModel }[0].id)
         viewModel.removeItemFromOrder(itemToRemove.itemID)
 
         // Then
-        XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product0.productID }))
-        XCTAssertEqual(viewModel.productRows.map { $0.id }, [expectedRemainingRow].map { $0.id })
+        XCTAssertFalse(viewModel.productRows.map { $0.rowViewModel }.contains(where: { $0.productOrVariationID == product0.productID }))
+        XCTAssertEqual(viewModel.productRows.map { $0.rowViewModel }.map { $0.id }, [expectedRemainingRow].map { $0.id })
     }
 
     func test_createProductRowViewModel_creates_expected_row_for_product() {
@@ -469,10 +470,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         let productRow = viewModel.createProductRowViewModel(for: orderItem, canChangeQuantity: true)
 
         // Then
-        let expectedProductRow = ProductRowViewModel(product: product, canChangeQuantity: true)
-        XCTAssertEqual(productRow?.name, expectedProductRow.name)
-        XCTAssertEqual(productRow?.quantity, expectedProductRow.quantity)
-        XCTAssertEqual(productRow?.canChangeQuantity, expectedProductRow.canChangeQuantity)
+        let expectedProductRow = ProductRowViewModel(product: product)
+        XCTAssertEqual(productRow?.rowViewModel.name, expectedProductRow.name)
+        XCTAssertEqual(productRow?.rowViewModel.quantity, expectedProductRow.quantity)
+        XCTAssertEqual(productRow?.canChangeQuantity, true)
     }
 
     func test_createProductRowViewModel_creates_expected_row_for_product_variation() {
@@ -497,12 +498,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         let expectedProductRow = ProductRowViewModel(productVariation: productVariation,
                                                      name: product.name,
                                                      quantity: 2,
-                                                     canChangeQuantity: false,
                                                      displayMode: .stock)
-        XCTAssertEqual(productRow?.name, expectedProductRow.name)
-        XCTAssertEqual(productRow?.skuLabel, expectedProductRow.skuLabel)
-        XCTAssertEqual(productRow?.quantity, expectedProductRow.quantity)
-        XCTAssertEqual(productRow?.canChangeQuantity, expectedProductRow.canChangeQuantity)
+        XCTAssertEqual(productRow?.rowViewModel.name, expectedProductRow.name)
+        XCTAssertEqual(productRow?.rowViewModel.skuLabel, expectedProductRow.skuLabel)
+        XCTAssertEqual(productRow?.rowViewModel.quantity, expectedProductRow.quantity)
+        XCTAssertEqual(productRow?.canChangeQuantity, false)
     }
 
     func test_view_model_is_updated_when_custom_amount_is_added_to_order() {
@@ -1199,7 +1199,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         productSelectorViewModel.completeMultipleSelection()
 
         // When
-        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)
+        let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows.map { $0.rowViewModel }[0].id)
         viewModel.removeItemFromOrder(itemToRemove)
 
         // Then
@@ -2815,10 +2815,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows.count, 1)
 
         let parentOrderItemRow = try XCTUnwrap(viewModel.productRows[0])
-        XCTAssertEqual(parentOrderItemRow.quantity, 2)
+        XCTAssertEqual(parentOrderItemRow.rowViewModel.quantity, 2)
 
-        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.childProductRows[0])
-        XCTAssertEqual(childOrderItemRow.quantity, 1)
+        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.rowViewModel.childProductRows[0])
+        XCTAssertEqual(childOrderItemRow.rowViewModel.quantity, 1)
     }
 
     func test_bundle_child_order_item_has_canChangeQuantity_false() throws {
@@ -2843,7 +2843,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let parentOrderItemRow = try XCTUnwrap(viewModel.productRows[0])
         XCTAssertTrue(parentOrderItemRow.canChangeQuantity)
 
-        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.childProductRows[0])
+        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.rowViewModel.childProductRows[0])
         XCTAssertFalse(childOrderItemRow.canChangeQuantity)
     }
 
@@ -2870,11 +2870,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows.count, 1)
 
         let parentOrderItemRow = try XCTUnwrap(viewModel.productRows[0])
-        XCTAssertEqual(parentOrderItemRow.quantity, 2)
+        XCTAssertEqual(parentOrderItemRow.rowViewModel.quantity, 2)
         XCTAssertTrue(parentOrderItemRow.canChangeQuantity)
 
-        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.childProductRows[0])
-        XCTAssertEqual(childOrderItemRow.quantity, 1)
+        let childOrderItemRow = try XCTUnwrap(parentOrderItemRow.rowViewModel.childProductRows[0])
+        XCTAssertEqual(childOrderItemRow.rowViewModel.quantity, 1)
         XCTAssertTrue(childOrderItemRow.canChangeQuantity)
     }
 
@@ -3153,9 +3153,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         let productRow = viewModel.createProductRowViewModel(for: orderItem, childItems: childItems, canChangeQuantity: true)
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(productRow).pricedIndividually)
-        XCTAssertFalse(try XCTUnwrap(productRow?.childProductRows[0]).pricedIndividually)
-        XCTAssertTrue(try XCTUnwrap(productRow?.childProductRows[1]).pricedIndividually)
+        XCTAssertTrue(try XCTUnwrap(productRow).rowViewModel.pricedIndividually)
+        XCTAssertFalse(try XCTUnwrap(productRow?.rowViewModel.childProductRows[0]).rowViewModel.pricedIndividually)
+        XCTAssertTrue(try XCTUnwrap(productRow?.rowViewModel.childProductRows[1]).rowViewModel.pricedIndividually)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
@@ -431,7 +431,7 @@ final class ConfigurableBundleItemViewModelTests: XCTestCase {
                                                         analytics: analytics)
 
         // When
-        viewModel.productRowViewModel.stepperViewModel.quantityUpdatedCallback(12)
+        viewModel.productWithStepperViewModel.stepperViewModel.quantityUpdatedCallback(12)
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["order_form_bundle_product_configuration_changed"])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -81,14 +81,14 @@ final class ProductRowViewModelTests: XCTestCase {
         let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
                                                                                     name: "",
                                                                                     quantityUpdatedCallback: { _ in }),
-                                                            rowViewModel: .init(product: product,
-                                                                                childProductRows: childProductRows),
-                                                            canChangeQuantity: true)
+                                                            rowViewModel: .init(product: product),
+                                                            canChangeQuantity: true,
+                                                            childProductRows: childProductRows)
 
         // Then
         XCTAssertTrue(viewModel.canChangeQuantity)
-        XCTAssertEqual(viewModel.rowViewModel.childProductRows.count, 2)
-        XCTAssertFalse(try XCTUnwrap(viewModel.rowViewModel.childProductRows[0]).canChangeQuantity)
+        XCTAssertEqual(viewModel.childProductRows.count, 2)
+        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).canChangeQuantity)
     }
 
     func test_view_model_creates_expected_label_for_product_with_managed_stock() {
@@ -650,73 +650,6 @@ final class ProductRowViewModelTests: XCTestCase {
             // Then
             XCTAssertFalse(viewModel.isConfigurable)
         }
-    }
-
-    // MARK: - `isReadOnly`
-
-    func test_isReadOnly_is_false_for_products_by_default() {
-        // Given
-        let product = Product.fake()
-
-        // When
-        let viewModel = ProductRowViewModel(product: product)
-
-        // Then
-        XCTAssertFalse(viewModel.isReadOnly, "Product should not be read only")
-    }
-
-    func test_isReadOnly_is_false_for_non_bundle_parent_and_child_items() throws {
-        // Given
-        let parent = Product.fake()
-        let children = [ProductRowViewModel(product: .fake()),
-                        ProductRowViewModel(productVariation: .fake(), name: "Variation", displayMode: .stock)]
-            .map {
-                ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
-                                                                            name: "",
-                                                                            quantityUpdatedCallback: { _ in }),
-                                                    rowViewModel: $0,
-                                                    canChangeQuantity: true)
-            }
-
-        // When
-        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
-                                                                                    name: "",
-                                                                                    quantityUpdatedCallback: { _ in }),
-                                                            rowViewModel: .init(product: parent, childProductRows: children),
-                                                            canChangeQuantity: false)
-
-        // Then
-        XCTAssertFalse(viewModel.rowViewModel.isReadOnly, "Parent product should not be read only")
-        XCTAssertFalse(try XCTUnwrap(viewModel.rowViewModel.childProductRows[0]).rowViewModel.isReadOnly, "Child product should not be read only")
-        XCTAssertFalse(try XCTUnwrap(viewModel.rowViewModel.childProductRows[1]).rowViewModel.isReadOnly, "Child product variation should not be read only")
-    }
-
-    func test_isReadOnly_is_false_for_bundle_parent_and_true_for_bundle_child_items() throws {
-        // Given
-        let parent = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue)
-        let children = [ProductRowViewModel(product: .fake()),
-                        ProductRowViewModel(productVariation: .fake(), name: "Variation", displayMode: .stock)]
-            .map {
-                ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
-                                                                            name: "",
-                                                                            quantityUpdatedCallback: { _ in }),
-                                                    rowViewModel: $0,
-                                                    canChangeQuantity: false)
-            }
-
-        // When
-        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
-                                                                                    name: "",
-                                                                                    quantityUpdatedCallback: { _ in }),
-                                                            rowViewModel: .init(product: parent, childProductRows: children),
-                                                            canChangeQuantity: true)
-
-        // Then
-        XCTAssertFalse(viewModel.rowViewModel.isReadOnly, "Parent product should not be read only")
-        XCTAssertTrue(try XCTUnwrap(viewModel.rowViewModel.childProductRows[0]).rowViewModel.isReadOnly,
-                      "Child product should be read only")
-        XCTAssertTrue(try XCTUnwrap(viewModel.rowViewModel.childProductRows[1]).rowViewModel.isReadOnly,
-                      "Child product variation should be read only")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -22,14 +22,13 @@ final class ProductRowViewModelTests: XCTestCase {
                                           images: [ProductImage.fake().copy(src: imageURLString)])
 
         // When
-        let viewModel = ProductRowViewModel(id: rowID, product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(id: rowID, product: product)
 
         // Then
         XCTAssertEqual(viewModel.id, rowID)
         XCTAssertEqual(viewModel.productOrVariationID, product.productID)
         XCTAssertEqual(viewModel.name, product.name)
         XCTAssertEqual(viewModel.imageURL, URL(string: imageURLString))
-        XCTAssertFalse(viewModel.canChangeQuantity)
         XCTAssertEqual(viewModel.quantity, 1)
         XCTAssertEqual(viewModel.numberOfVariations, 0)
     }
@@ -39,7 +38,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: "variable", variations: [0, 1, 2])
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         XCTAssertEqual(viewModel.numberOfVariations, 3)
@@ -55,30 +54,41 @@ final class ProductRowViewModelTests: XCTestCase {
                                                             image: ProductImage.fake().copy(src: imageURLString))
 
         // When
-        let viewModel = ProductRowViewModel(id: rowID, productVariation: productVariation, name: name, canChangeQuantity: false, displayMode: .stock)
+        let viewModel = ProductRowViewModel(id: rowID, productVariation: productVariation, name: name, displayMode: .stock)
 
         // Then
         XCTAssertEqual(viewModel.id, rowID)
         XCTAssertEqual(viewModel.productOrVariationID, productVariation.productVariationID)
         XCTAssertEqual(viewModel.name, name)
         XCTAssertEqual(viewModel.imageURL, URL(string: imageURLString))
-        XCTAssertFalse(viewModel.canChangeQuantity)
         XCTAssertEqual(viewModel.quantity, 1)
     }
 
     func test_viewModel_is_created_with_correct_initial_values_from_product_with_child_product_rows() {
         // Given
         let product = Product.fake()
-        let childProductRows = [ProductRowViewModel(product: .fake(), canChangeQuantity: false),
-                                ProductRowViewModel(product: .fake(), canChangeQuantity: false)]
+        let childProductRows = [ProductRowViewModel(product: .fake()),
+                                ProductRowViewModel(product: .fake())]
+            .map {
+                ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                            name: "",
+                                                                            quantityUpdatedCallback: { _ in }),
+                                                    rowViewModel: $0,
+                                                    canChangeQuantity: false)
+            }
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true, childProductRows: childProductRows)
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: product,
+                                                                                childProductRows: childProductRows),
+                                                            canChangeQuantity: true)
 
         // Then
         XCTAssertTrue(viewModel.canChangeQuantity)
-        XCTAssertEqual(viewModel.childProductRows.count, 2)
-        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).canChangeQuantity)
+        XCTAssertEqual(viewModel.rowViewModel.childProductRows.count, 2)
+        XCTAssertFalse(try XCTUnwrap(viewModel.rowViewModel.childProductRows[0]).canChangeQuantity)
     }
 
     func test_view_model_creates_expected_label_for_product_with_managed_stock() {
@@ -87,7 +97,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(manageStock: true, stockQuantity: stockQuantity, stockStatusKey: "instock")
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
@@ -102,7 +112,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(stockStatusKey: "instock")
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let expectedStockLabel = NSLocalizedString("In stock", comment: "Display label for the product's inventory stock status")
@@ -115,7 +125,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(stockStatusKey: "outofstock")
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let expectedStockLabel = NSLocalizedString("Out of stock", comment: "Display label for the product's inventory stock status")
@@ -130,7 +140,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+        let viewModel = ProductRowViewModel(product: product, currencyFormatter: currencyFormatter)
 
         // Then
         let expectedPriceLabel = "2.50"
@@ -146,7 +156,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = ProductRowViewModel(product: product, discount: discount, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+        let viewModel = ProductRowViewModel(product: product, discount: discount, currencyFormatter: currencyFormatter)
 
         // Then
         let expectedPriceLabel = "2.50" + " - " + (currencyFormatter.formatAmount(discount) ?? "")
@@ -161,7 +171,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+        let viewModel = ProductRowViewModel(product: product, currencyFormatter: currencyFormatter)
 
         // Then
         let expectedPriceLabel = "$0.00"
@@ -175,13 +185,17 @@ final class ProductRowViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: product, currencyFormatter: currencyFormatter),
+                                                            canChangeQuantity: false)
         viewModel.stepperViewModel.incrementQuantity()
 
         // Then
         let expectedPriceLabel = "$5.00"
-        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedPriceLabel),
-                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
+        XCTAssertTrue(viewModel.rowViewModel.productDetailsLabel.contains(expectedPriceLabel),
+                      "Expected label to contain \"\(expectedPriceLabel)\" but actual label was \"\(viewModel.rowViewModel.productDetailsLabel)\"")
     }
 
     func test_view_model_creates_expected_product_details_label_for_variable_product() {
@@ -189,7 +203,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: "variable", stockStatusKey: "instock", variations: [0, 1])
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let expectedProductDetailsLabel = "In stock • 2 variations"
@@ -202,7 +216,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let attributes = [VariationAttributeViewModel(name: "Color", value: "Blue"), VariationAttributeViewModel(name: "Size")]
 
         // When
-        let viewModel = ProductRowViewModel(productVariation: variation, name: "", canChangeQuantity: false, displayMode: .attributes(attributes))
+        let viewModel = ProductRowViewModel(productVariation: variation, name: "", displayMode: .attributes(attributes))
 
         // Then
         let expectedAttributesText = "Blue, Any Size"
@@ -217,7 +231,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let variation = ProductVariation.fake().copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")], stockStatus: .inStock)
 
         // When
-        let viewModel = ProductRowViewModel(productVariation: variation, name: "", canChangeQuantity: false, displayMode: .stock)
+        let viewModel = ProductRowViewModel(productVariation: variation, name: "", displayMode: .stock)
 
         // Then
         let expectedStockText = "In stock"
@@ -233,7 +247,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(sku: sku)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let format = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
@@ -247,7 +261,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(sku: sku)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let expectedSKULabel = ""
@@ -260,7 +274,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(sku: sku)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let format = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
@@ -274,7 +288,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(sku: sku)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let expectedSKULabel = ""
@@ -288,7 +302,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(productBundlesInOrderForm: true)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, featureFlagService: featureFlagService, configure: {})
+        let viewModel = ProductRowViewModel(product: product, featureFlagService: featureFlagService, configure: {})
 
         // Then
         let format = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
@@ -304,7 +318,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(productBundlesInOrderForm: true)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, featureFlagService: featureFlagService, configure: {})
+        let viewModel = ProductRowViewModel(product: product, featureFlagService: featureFlagService, configure: {})
 
         // Then
         XCTAssertEqual(viewModel.secondaryProductDetailsLabel, ProductType.bundle.description)
@@ -316,7 +330,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(stockStatusKey: stockStatus.rawValue)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         assertEqual(stockStatus.description, viewModel.orderProductDetailsLabel)
@@ -331,7 +345,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let attributes = [VariationAttributeViewModel(name: "Color", value: "Blue"), VariationAttributeViewModel(name: "Size")]
 
         // When
-        let viewModel = ProductRowViewModel(productVariation: variation, name: "", canChangeQuantity: true, displayMode: .attributes(attributes))
+        let viewModel = ProductRowViewModel(productVariation: variation, name: "", displayMode: .attributes(attributes))
 
         // Then
         XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(variationAttribute), "Label should contain variation attribute")
@@ -345,7 +359,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(productBundlesInOrderForm: true)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, featureFlagService: featureFlagService, configure: {})
+        let viewModel = ProductRowViewModel(product: product, featureFlagService: featureFlagService, configure: {})
 
         // Then
         XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(ProductType.bundle.description), "Label should contain product type (Bundle)")
@@ -356,7 +370,6 @@ final class ProductRowViewModelTests: XCTestCase {
         // Given
         let product = Product.fake()
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: true,
                                             analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
@@ -370,7 +383,6 @@ final class ProductRowViewModelTests: XCTestCase {
         // Given
         let product = Product.fake()
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: true,
                                             analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
@@ -386,7 +398,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, currencyFormatter: currencyFormatter)
+        let viewModel = ProductRowViewModel(product: product, currencyFormatter: currencyFormatter)
 
         // Then
         let expectedLabel = "Test Product. In stock. $10.00. 2 variations. SKU: 123456"
@@ -399,7 +411,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService(productBundles: false))
 
         // Then
@@ -414,7 +425,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService())
 
         // Then
@@ -429,7 +439,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService())
 
         // Then
@@ -444,7 +453,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService(productBundles: false))
 
         // Then
@@ -461,7 +469,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService())
 
         // Then
@@ -476,7 +483,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let price = "2.50"
         let product = Product.fake().copy(price: price)
 
-        let viewModel = ProductRowViewModel(product: product, discount: nil, quantity: 1, canChangeQuantity: true)
+        let viewModel = ProductRowViewModel(product: product, discount: nil, quantity: 1)
 
         XCTAssertFalse(viewModel.hasDiscount)
     }
@@ -486,7 +493,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let discount: Decimal = 0.50
         let product = Product.fake().copy(price: price)
 
-        let viewModel = ProductRowViewModel(product: product, discount: discount, quantity: 1, canChangeQuantity: true)
+        let viewModel = ProductRowViewModel(product: product, discount: discount, quantity: 1)
 
         XCTAssertTrue(viewModel.hasDiscount)
     }
@@ -498,7 +505,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: true)
+        let viewModel = ProductRowViewModel(product: product, quantity: quantity)
 
         // Then
         assertEqual("8 × $10.71", viewModel.priceQuantityLine)
@@ -511,7 +518,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: false, pricedIndividually: false)
+        let viewModel = ProductRowViewModel(product: product, quantity: quantity, pricedIndividually: false)
 
         // Then
         assertEqual("8 × $0.00", viewModel.priceQuantityLine)
@@ -523,7 +530,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, pricedIndividually: true)
+        let viewModel = ProductRowViewModel(product: product, pricedIndividually: true)
 
         // Then
         assertEqual(price, viewModel.price)
@@ -535,7 +542,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: false, pricedIndividually: false)
+        let viewModel = ProductRowViewModel(product: product, pricedIndividually: false)
 
         // Then
         assertEqual("0", viewModel.price)
@@ -546,7 +553,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let discount: Decimal = 0.50
         let product = Product.fake().copy(price: price)
 
-        let viewModel = ProductRowViewModel(product: product, discount: discount, quantity: 1, canChangeQuantity: true)
+        let viewModel = ProductRowViewModel(product: product, discount: discount, quantity: 1)
 
         assertEqual("$2.00", viewModel.totalPriceAfterDiscountLabel)
     }
@@ -559,8 +566,7 @@ final class ProductRowViewModelTests: XCTestCase {
 
         let viewModel = ProductRowViewModel(product: product,
                                             discount: discount,
-                                            quantity: quantity,
-                                            canChangeQuantity: true)
+                                            quantity: quantity)
 
         assertEqual("$24.50", viewModel.totalPriceAfterDiscountLabel)
     }
@@ -571,7 +577,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake().copy()
 
         // When
-        let viewModel = ProductRowViewModel(product: product, quantity: quantity, canChangeQuantity: true)
+        let viewModel = ProductRowViewModel(product: product, quantity: quantity)
 
         // Then
         assertEqual("8 × -", viewModel.priceQuantityLine)
@@ -585,7 +591,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService(productBundlesInOrderForm: false))
 
         // Then
@@ -598,7 +603,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true))
 
         // Then
@@ -611,7 +615,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true),
                                             configure: {})
 
@@ -625,7 +628,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // When
         let viewModel = ProductRowViewModel(product: product,
-                                            canChangeQuantity: false,
                                             featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true),
                                             configure: nil)
 
@@ -642,7 +644,6 @@ final class ProductRowViewModelTests: XCTestCase {
 
             // When
             let viewModel = ProductRowViewModel(product: product,
-                                                canChangeQuantity: false,
                                                 featureFlagService: createFeatureFlagService(productBundlesInOrderForm: true),
                                                 configure: {})
 
@@ -658,7 +659,7 @@ final class ProductRowViewModelTests: XCTestCase {
         let product = Product.fake()
 
         // When
-        let viewModel = ProductRowViewModel(product: product, canChangeQuantity: true)
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         XCTAssertFalse(viewModel.isReadOnly, "Product should not be read only")
@@ -667,31 +668,55 @@ final class ProductRowViewModelTests: XCTestCase {
     func test_isReadOnly_is_false_for_non_bundle_parent_and_child_items() throws {
         // Given
         let parent = Product.fake()
-        let children: [ProductRowViewModel] = [.init(product: .fake(), canChangeQuantity: true),
-                                               .init(productVariation: .fake(), name: "Variation", canChangeQuantity: true, displayMode: .stock)]
+        let children = [ProductRowViewModel(product: .fake()),
+                        ProductRowViewModel(productVariation: .fake(), name: "Variation", displayMode: .stock)]
+            .map {
+                ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                            name: "",
+                                                                            quantityUpdatedCallback: { _ in }),
+                                                    rowViewModel: $0,
+                                                    canChangeQuantity: true)
+            }
 
         // When
-        let viewModel = ProductRowViewModel(product: parent, canChangeQuantity: true, childProductRows: children)
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: parent, childProductRows: children),
+                                                            canChangeQuantity: false)
 
         // Then
-        XCTAssertFalse(viewModel.isReadOnly, "Parent product should not be read only")
-        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).isReadOnly, "Child product should not be read only")
-        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[1]).isReadOnly, "Child product variation should not be read only")
+        XCTAssertFalse(viewModel.rowViewModel.isReadOnly, "Parent product should not be read only")
+        XCTAssertFalse(try XCTUnwrap(viewModel.rowViewModel.childProductRows[0]).rowViewModel.isReadOnly, "Child product should not be read only")
+        XCTAssertFalse(try XCTUnwrap(viewModel.rowViewModel.childProductRows[1]).rowViewModel.isReadOnly, "Child product variation should not be read only")
     }
 
     func test_isReadOnly_is_false_for_bundle_parent_and_true_for_bundle_child_items() throws {
         // Given
         let parent = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue)
-        let children: [ProductRowViewModel] = [.init(product: .fake(), canChangeQuantity: false),
-                                               .init(productVariation: .fake(), name: "Variation", canChangeQuantity: false, displayMode: .stock)]
+        let children = [ProductRowViewModel(product: .fake()),
+                        ProductRowViewModel(productVariation: .fake(), name: "Variation", displayMode: .stock)]
+            .map {
+                ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                            name: "",
+                                                                            quantityUpdatedCallback: { _ in }),
+                                                    rowViewModel: $0,
+                                                    canChangeQuantity: false)
+            }
 
         // When
-        let viewModel = ProductRowViewModel(product: parent, canChangeQuantity: true, childProductRows: children)
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: parent, childProductRows: children),
+                                                            canChangeQuantity: true)
 
         // Then
-        XCTAssertFalse(viewModel.isReadOnly, "Parent product should not be read only")
-        XCTAssertTrue(try XCTUnwrap(viewModel.childProductRows[0]).isReadOnly, "Child product should be read only")
-        XCTAssertTrue(try XCTUnwrap(viewModel.childProductRows[1]).isReadOnly, "Child product variation should be read only")
+        XCTAssertFalse(viewModel.rowViewModel.isReadOnly, "Parent product should not be read only")
+        XCTAssertTrue(try XCTUnwrap(viewModel.rowViewModel.childProductRows[0]).rowViewModel.isReadOnly,
+                      "Child product should be read only")
+        XCTAssertTrue(try XCTUnwrap(viewModel.rowViewModel.childProductRows[1]).rowViewModel.isReadOnly,
+                      "Child product variation should be read only")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -44,7 +44,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.totalSelectedItemsCount, 0)
     }
 
-    func test_view_model_adds_product_rows_with_unchangeable_quantity() {
+    func test_view_model_adds_product_rows() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, purchasable: true)
         insert(product)
@@ -54,9 +54,6 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.productRows.count, 1)
-
-        let productRow = viewModel.productRows[0]
-        XCTAssertFalse(productRow.canChangeQuantity, "Product row canChangeQuantity property should be false but is true instead")
     }
 
     func test_scrolling_indicator_appears_only_during_sync() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -39,8 +39,6 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productVariationRows.count, 1)
 
         let productVariationRow = viewModel.productVariationRows[0]
-        XCTAssertFalse(productVariationRow.canChangeQuantity,
-                       "Product variation row canChangeQuantity property should be false but is true instead")
         XCTAssertEqual(productVariationRow.name, "Blue - Any Size")
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductWithQuantityStepperViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductWithQuantityStepperViewModelTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class ProductWithQuantityStepperViewModelTests: XCTestCase {
+
+    // MARK: - `isReadOnly`
+
+    func test_isReadOnly_is_false_for_products_by_default() {
+        // Given
+        let product = Product.fake()
+
+        // When
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: product),
+                                                            canChangeQuantity: true)
+
+        // Then
+        XCTAssertFalse(viewModel.isReadOnly, "Product should not be read only")
+    }
+
+    func test_isReadOnly_is_false_for_non_bundle_parent_and_child_items() throws {
+        // Given
+        let parent = Product.fake()
+        let children = [ProductRowViewModel(product: .fake()),
+                        ProductRowViewModel(productVariation: .fake(), name: "Variation", displayMode: .stock)]
+            .map {
+                ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                            name: "",
+                                                                            quantityUpdatedCallback: { _ in }),
+                                                    rowViewModel: $0,
+                                                    canChangeQuantity: true)
+            }
+
+        // When
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 1,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: parent),
+                                                            canChangeQuantity: false,
+                                                            childProductRows: children)
+
+        // Then
+        XCTAssertFalse(viewModel.isReadOnly, "Parent product should not be read only")
+        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).isReadOnly, "Child product should not be read only")
+        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[1]).isReadOnly, "Child product variation should not be read only")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/ProductInOrderViewModelTests.swift
@@ -11,7 +11,7 @@ final class ProductInOrderViewModelTests: XCTestCase {
 
         analytics = MockAnalyticsProvider()
         let product = Product.fake()
-        let productRowViewModel = ProductRowViewModel(product: product, quantity: 0, canChangeQuantity: true)
+        let productRowViewModel = ProductRowViewModel(product: product, quantity: 0)
         viewModel = ProductInOrderViewModel(productRowViewModel: productRowViewModel,
                                             productDiscountConfiguration: nil,
                                             showCouponsAndDiscountsAlert: false,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11368 
Part of #11357 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Now that the `ProductStepper` has its own view model after the previous PR https://github.com/woocommerce/woocommerce-ios/pull/11362, the `ProductStepper` view can now be extracted from  the parent view `ProductRow` so that the UI/UX of each SwiftUI view is clearly separated without a lot of conditional logic. Sorry for the 500+ diffs, a lot of them are simple renaming, and I tried documenting the major changes in the section below.

## How

The major changes were to move the following properties from `ProductRowViewModel` to a new view model `ProductWithQuantityStepperViewModel` for a new view `ProductWithQuantityStepperView` that contains a `ProductRow` and `ProductStepper` like how `ProductRow` used to be when `canChangeQuantity` is `true`.

- `canChangeQuantity: Bool`
- `isReadOnly: Bool`: the bundle product logic was moved to `EditableOrderViewModel`
- `childProductRows: [ProductRowViewModel]`

`ProductWithQuantityStepperView` is used in two cases, `ConfigurableBundleItemView` and `CollapsibleProductCard`. These two views have a few more properties specific to these views like `isConfigurable` that are still in `ProductRowViewModel` or `ProductWithQuantityStepperView`, these will be extracted to their own view models in future subtasks of #11357.

After the changes, `ProductRow` is just a simple view that contains a thumbnail and a V stack of product-related info that is shown in product/variation selector and a few other screens.

Unit tests were updated to fix the interface changes plus the move of properties. I didn't add new tests for `ProductWithQuantityStepperView` since the PR diffs are already large.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

No changes on the order form UX are expected. The following steps might not cover all the possible cases, please feel free to diverge a bit and share any issues!

- Go to the Orders tab
- Tap on `+` to create an order
- Tap `Add Products` --> the product rows in the product selector should behave the same as before
- Search/select at least one product and tap the bottom CTA to confirm the selection --> the selected product(s) should show quantity as 1
- Expand any product card
- Tap to increment the product quantity --> the quantity label in the price in the product card should also be updated
- After the payments section is synced, tap `Create` to create the order --> the created order should have the recently set quantity for each product
- Tap `Edit` to edit the order --> the quantity for each product should match what was set previously
- Tap to increment the product quantity --> after syncing, the quantity label in the price in the product card should be updated
- Tap to decrease the product quantity to 0 --> the product should be removed
- Tap `Done` --> the updated order should have the recently set quantity for each product 

---

- [ ] @jaclync tests the product bundle configuration flow for order creation
- [ ] @jaclync tests the product bundle configuration flow for order editing

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
