### PR TITLE
[HACK week] Update plugins list to display versions, and allow plugin update from the app

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
@@ -35,24 +35,15 @@ struct PluginListDetailView: View {
 
     var body: some View {
         ScrollView {
-            Spacer()
             ForEach(viewModel.pluginList(), id: \.self) { plugin in
-                VStack {
-                    NavigationRow(content: {
-                        Text(plugin.name)
-                        Text(plugin.description)
-                        Text(plugin.upToDate)
-                            .foregroundColor(.green)
-                    }, action: {
-                        showWebView = true
-                    })
-                    .sheet(isPresented: $showWebView, content: {
-                        if let updateUrl = updateUrl {
-                            SafariView(url: updateUrl)
-                        }
-                    })
-                }
-                Divider()
+                let pluginDetailsViewModel = PluginDetailsViewModel(siteID: 215063064,
+                                                                    pluginName: plugin.name)
+                NavigationRow(content: {
+                    PluginDetailsRowContent(viewModel: pluginDetailsViewModel)
+                }, action: {
+                    print("\(plugin.name) tapped")
+                    
+                })
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
@@ -1,6 +1,63 @@
 import SwiftUI
 import Yosemite
 
+struct PluginListView: View {
+    @ObservedObject var viewModel: PluginListViewModel
+
+    @State private var showModal = false
+
+    var body: some View {
+        NavigationRow(selectable: true, content: {
+            Text("Plugins")
+        }, action: {
+            showModal = true
+        })
+        .sheet(isPresented: $showModal, content: {
+            PluginListDetailView(viewModel: viewModel)
+        })
+    }
+}
+
+struct PluginListDetailView: View {
+
+    private let viewModel: PluginListViewModel
+
+    init(viewModel: PluginListViewModel) {
+        self.viewModel = viewModel
+    }
+
+    @State private var showWebView = false
+
+    var updateUrl: URL? {
+        // TODO: Inject from storesManager.sessionManager.defaultSite?.pluginsURL,
+        return URL(string: "https://woo.com")!
+    }
+
+    var body: some View {
+        ScrollView {
+            Spacer()
+            ForEach(viewModel.pluginList(), id: \.self) { plugin in
+                VStack {
+                    NavigationRow(content: {
+                        Text(plugin.name)
+                        Text(plugin.description)
+                        Text(plugin.upToDate)
+                            .foregroundColor(.green)
+                    }, action: {
+                        showWebView = true
+                    })
+                    .sheet(isPresented: $showWebView, content: {
+                        if let updateUrl = updateUrl {
+                            SafariView(url: updateUrl)
+                        }
+                    })
+                }
+                Divider()
+            }
+        }
+    }
+}
+
 struct PluginDetailsRowView: View {
     @ObservedObject var viewModel: PluginDetailsViewModel
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -9,7 +9,7 @@ final class PluginListViewController: UIViewController, GhostableViewController 
 
     @IBOutlet private var tableView: UITableView!
 
-    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: HeadlineLabelTableViewCell.self,
+    lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: TitleAndSubtitleAndStatusTableViewCell.self,
                                                                                                 rowsPerSection: [10],
                                                                                                 isScrollEnabled: false))
 
@@ -53,7 +53,7 @@ private extension PluginListViewController {
     }
 
     func configureTableView() {
-        tableView.registerNib(for: HeadlineLabelTableViewCell.self)
+        tableView.registerNib(for: TitleAndSubtitleAndStatusTableViewCell.self)
         tableView.estimatedRowHeight = CGFloat(44)
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
@@ -105,9 +105,14 @@ extension PluginListViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(HeadlineLabelTableViewCell.self, for: indexPath)
+        let cell = tableView.dequeueReusableCell(TitleAndSubtitleAndStatusTableViewCell.self, for: indexPath)
         let cellModel = viewModel.cellModelForRow(at: indexPath)
-        cell.update(style: .bodyWithLineLimit(count: 2), headline: cellModel.name, body: cellModel.description)
+        // TODO: Change statusBackgroundColor or font based on plugin status being out of date (or not)
+        cell.configureCell(viewModel: TitleAndSubtitleAndStatusTableViewCell.ViewModel(title: cellModel.name,
+                                                                                       subtitle: cellModel.description,
+                                                                                       accessibilityLabel: "",
+                                                                                       status: cellModel.upToDate,
+                                                                                       statusBackgroundColor: .gray(.shade5)))
         return cell
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -18,19 +18,14 @@ final class PluginListViewModel {
 
     /// Results controller for the plugin list
     ///
-    private lazy var resultsController: ResultsController<StorageSitePlugin> = {
+    private lazy var resultsController: ResultsController<StorageSystemPlugin> = {
         let predicate = NSPredicate(format: "siteID = %ld", self.siteID)
-        let nameDescriptor = NSSortDescriptor(keyPath: \StorageSitePlugin.name, ascending: true)
-        // Results need to be grouped in sections so sorting by section is required.
-        // Make sure this sort descriptor is first in the list to make grouping works.
-        let statusDescriptor = NSSortDescriptor(keyPath: \StorageSitePlugin.status, ascending: true)
-        let resultsController = ResultsController<StorageSitePlugin>(
+        let nameDescriptor = NSSortDescriptor(keyPath: \StorageSystemPlugin.name, ascending: true)
+        let resultsController = ResultsController<StorageSystemPlugin>(
             storageManager: storageManager,
-            sectionNameKeyPath: "status",
             matching: predicate,
-            sortedBy: [statusDescriptor, nameDescriptor]
+            sortedBy: [nameDescriptor]
         )
-
         do {
             try resultsController.performFetch()
         } catch {
@@ -126,11 +121,13 @@ extension PluginListViewModel {
     ///
     func cellModelForRow(at indexPath: IndexPath) -> PluginListCellViewModel {
         let plugin = resultsController.object(at: indexPath)
+        let isUpToDate: Bool = (plugin.version == plugin.versionLatest)
         // Plugin name and description can sometimes contain HTML tags and entities
         // so it's best to be extra safe by removing them
         return PluginListCellViewModel(
             name: plugin.name.strippedHTML,
-            description: plugin.descriptionRaw.strippedHTML
+            description: "Version: \(plugin.version) - Latest Version: \(plugin.versionLatest) ",
+            upToDate: isUpToDate ? "Up to date" : "Update available"
         )
     }
 }
@@ -155,6 +152,7 @@ private extension PluginListViewModel {
 // MARK: - Model for plugin list cells
 //
 struct PluginListCellViewModel {
-     let name: String
-     let description: String
+    let name: String
+    let description: String
+    let upToDate: String
  }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 
-final class PluginListViewModel {
+final class PluginListViewModel: ObservableObject {
 
     /// ID of the site to load plugins for
     ///
@@ -130,6 +130,17 @@ extension PluginListViewModel {
             upToDate: isUpToDate ? "Up to date" : "Update available"
         )
     }
+
+    func pluginList() -> [PluginListCellViewModel] {
+        let plugins = resultsController.fetchedObjects.map {
+            PluginListCellViewModel(
+                name: $0.name,
+                description: "Version: \($0.version) - Latest Version: \($0.versionLatest) ",
+                upToDate: "Up to date"
+            )
+        }
+        return plugins
+    }
 }
 
 // MARK: - Localization
@@ -151,7 +162,8 @@ private extension PluginListViewModel {
 
 // MARK: - Model for plugin list cells
 //
-struct PluginListCellViewModel {
+struct PluginListCellViewModel: Hashable {
+    let id: UUID = UUID()
     let name: String
     let description: String
     let upToDate: String

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -140,6 +140,8 @@ private extension SettingsViewController {
             configureSwitchStore(cell: cell)
         case let cell as BasicTableViewCell where row == .plugins:
             configurePlugins(cell: cell)
+        case let cell as HostingTableViewCell<PluginListView> where row == .newPlugins:
+            configurePluginList(cell: cell)
         case let cell as HostingTableViewCell<PluginDetailsRowView> where row == .woocommerceDetails:
             configureWooCommmerceDetails(cell: cell)
         case let cell as BasicTableViewCell where row == .domain:
@@ -191,6 +193,13 @@ private extension SettingsViewController {
         cell.selectionStyle = .default
         cell.accessoryType = .disclosureIndicator
         cell.textLabel?.text = Localization.plugins
+    }
+
+    func configurePluginList(cell: HostingTableViewCell<PluginListView>) {
+        let pluginListViewModel = PluginListViewModel(siteID: stores.sessionManager.defaultStoreID ?? 0)
+        let view = PluginListView.init(viewModel: pluginListViewModel)
+        cell.host(view, parent: self)
+        cell.selectionStyle = .none
     }
 
     func configureWooCommmerceDetails(cell: HostingTableViewCell<PluginDetailsRowView>) {
@@ -689,6 +698,7 @@ extension SettingsViewController {
 
         // Plugins
         case plugins
+        case newPlugins
         case woocommerceDetails
 
         // Store settings
@@ -722,7 +732,7 @@ extension SettingsViewController {
 
         fileprivate var registerWithNib: Bool {
             switch self {
-            case .woocommerceDetails:
+            case .woocommerceDetails, .newPlugins:
                 return false
             default:
                 return true
@@ -737,6 +747,8 @@ extension SettingsViewController {
                 return BasicTableViewCell.self
             case .plugins:
                 return BasicTableViewCell.self
+            case .newPlugins:
+                return HostingTableViewCell<PluginListView>.self
             case .woocommerceDetails:
                 return HostingTableViewCell<PluginDetailsRowView>.self
             case .support:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -271,8 +271,9 @@ private extension SettingsViewModel {
                 return nil
             }
 
+            // TODO: Temporary. newPlugins, and plugins rows exist at the same time
             return Section(title: Localization.pluginsTitle,
-                           rows: [.plugins, .woocommerceDetails],
+                           rows: [.newPlugins, .plugins, .woocommerceDetails],
                            footerHeight: UITableView.automaticDimension)
         }()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

From feedback:
> It's fairly common while working on Woo Mobile tickets to come across merchants that are using older versions of WordPress, the Jetpack plugin, the WooCommerce plugin, and the WooCommerce database.
> Often times it's a simple case of suggesting the user update those components, which in some cases resolves the issue for the merchant.
> It would be useful if the WooCommerce app was more proactive about helping users keep those up to date before they run into any issues managing their store.

## Description
This PR updates the existing Plugin List view by migrating it to SwiftUI, and displaying the title, the plugin version, a message stating if it's up-to-date or outdated, and makes the plugin rows clickable to these can be updated via a web view.

## Changes
- Update plugin list with fetching from `StorageSystemPlugin`, rather than `StorageSitePlugin`. This gives us access to properties like the plugin's version and the most up-to-date available version.

## Testing instructions
1. On a store with both up-to-date, and out-of-date plugins (you can use XYZ site) 
2. Go to Menu > Settings > Plugins
3. Observe that the UI has been updated and shows the name of the plugin, the version, and a "Up to date" or "Update available" message.
4. Tapping on an "Up to date" plugin opens a webview that redirects to the site's plugins page.

## Screenshots

| Before | After |
|--------|--------|
| ![simulator_screenshot_8F3D4868-B12B-416C-BF5F-77A8F0E104F5](https://github.com/woocommerce/woocommerce-ios/assets/3812076/d3297c22-24e1-42cb-9369-d89dcb96c89b) | ![Simulator Screenshot - iPhone 15 - 2023-12-08 at 11 03 46](https://github.com/woocommerce/woocommerce-ios/assets/3812076/a767649d-21c0-42e2-a0be-814bb021cf69) | 
