### PR TITLE
[Crash] Attempt to fix crash with magic link login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Payments menu: restored the ability to search for Payments in device Spotlight. [https://github.com/woocommerce/woocommerce-ios/pull/11343]
 - [*] Payments menu: show the selected payment gateway when there's more than one to choose from [https://github.com/woocommerce/woocommerce-ios/pull/11345]
 - [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience. [https://github.com/woocommerce/woocommerce-ios/pull/11350]
+- [**] Attempted to fix a crash that has been occurring for some users during magic link login. [https://github.com/woocommerce/woocommerce-ios/pull/11373]
 
 16.5
 -----

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -85,6 +85,7 @@ final class AppCoordinator {
                     // This is not an expected auth state. When the user is logged out, we expect the default store will not be set.
                     // Starting the auth flow from this state seems to cause a crash: peaMlT-hY-p2
                     // To get into the expected logged-out state, we can fully deauthenticate before starting the auth flow.
+                    DDLogWarn("⚠️ Unexpected authentication state: Unauthenticated user has a default store set.")
                     stores.deauthenticate()
                     self.displayAuthenticatorWithOnboardingIfNeeded()
                 case (true, true):

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -79,7 +79,13 @@ final class AppCoordinator {
 
                 // More details about the UI states: https://github.com/woocommerce/woocommerce-ios/pull/3498
                 switch (isLoggedIn, needsDefaultStore) {
-                case (false, true), (false, false):
+                case (false, true):
+                    self.displayAuthenticatorWithOnboardingIfNeeded()
+                case (false, false):
+                    // This is not an expected auth state. When the user is logged out, we expect the default store will not be set.
+                    // Starting the auth flow from this state seems to cause a crash: peaMlT-hY-p2
+                    // To get into the expected logged-out state, we can fully deauthenticate before starting the auth flow.
+                    stores.deauthenticate()
                     self.displayAuthenticatorWithOnboardingIfNeeded()
                 case (true, true):
                     self.displayLoggedInStateWithoutDefaultStore()

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -128,6 +128,7 @@ class DefaultStoresManager: StoresManager {
 
         isLoggedIn = isAuthenticated
 
+        fullyDeauthenticateIfNeeded()
         restoreSessionAccountIfPossible()
         restoreSessionSiteIfPossible()
     }
@@ -214,6 +215,19 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()
+    }
+
+    /// Fully deauthenticates the user, if needed.
+    ///
+    /// This handles the scenario where `DefaultStoresManager` can't be initialized
+    /// in an authenticated state, but the default store is unexpectedly still set.
+    ///
+    func fullyDeauthenticateIfNeeded() {
+        guard !isLoggedIn && !needsDefaultStore else {
+            return
+        }
+
+        deauthenticate()
     }
 
     /// Switches the state to a Deauthenticated one.

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -571,14 +571,12 @@ final class AppCoordinatorTests: XCTestCase {
 
     func test_appCoordinator_start_resets_default_store_and_proceeds_to_login_when_isAuthenticated_and_needsDefaultStore_are_false() {
         // Given
-        sessionManager = .makeForTesting(authenticated: false, defaultSite: Site.fake().copy(siteID: 123))
-        stores = MockStoresManager(sessionManager: sessionManager)
-        let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
-                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
-        coordinator = appCoordinator
-
+        stores.updateDefaultStore(storeID: 123)
         XCTAssertFalse(stores.isAuthenticated)
         XCTAssertFalse(stores.needsDefaultStore)
+
+        let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
 
         // When
         appCoordinator.start()

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -568,6 +568,27 @@ final class AppCoordinatorTests: XCTestCase {
         }
         XCTAssertNil(loginNavigationController.presentedViewController)
     }
+
+    func test_appCoordinator_start_resets_default_store_and_proceeds_to_login_when_isAuthenticated_and_needsDefaultStore_are_false() {
+        // Given
+        sessionManager = .makeForTesting(authenticated: false, defaultSite: Site.fake().copy(siteID: 123))
+        stores = MockStoresManager(sessionManager: sessionManager)
+        let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
+        coordinator = appCoordinator
+
+        XCTAssertFalse(stores.isAuthenticated)
+        XCTAssertFalse(stores.needsDefaultStore)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        waitUntil {
+            self.window.rootViewController is LoginNavigationController
+        }
+        XCTAssertTrue(stores.needsDefaultStore)
+    }
 }
 
 private extension AppCoordinatorTests {

--- a/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
@@ -52,7 +52,7 @@ final class MainTabViewModelTests: XCTestCase {
 
     func test_loadHubMenuTabBadge_when_should_show_reviews_badge_only_calls_onMenuBadgeShouldBeDisplayed_with_type_secondary() {
         // Given
-        let sessionManager = SessionManager.makeForTesting()
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
         sessionManager.setStoreId(sampleStoreID)
         let storesManager = MockStoresManager(sessionManager: sessionManager)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialSurvey/FreeTrialSurveyViewModelTests.swift
@@ -195,7 +195,7 @@ final class FreeTrialSurveyViewModelTests: XCTestCase {
     func test_threeDaysAfterStillExploring_local_notification_is_scheduled_if_submitted_answer_is_stillExploring() throws {
         // Given
         let sampleSiteID: Int64 = 123
-        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: Site.fake().copy(siteID: sampleSiteID)))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: Site.fake().copy(siteID: sampleSiteID)))
 
         let pushNotesManager = MockPushNotificationsManager()
         let viewModel = FreeTrialSurveyViewModel(source: .freeTrialSurvey24hAfterFreeTrialSubscribed,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenterTests.swift
@@ -51,7 +51,7 @@ final class StorePlanBannerPresenterTests: XCTestCase {
     func test_banner_is_displayed_when_site_plan_is_free_and_site_was_ecommerce_trial() {
         // Given
         let defaultSite = Site.fake().copy(siteID: siteID, isWordPressComStore: false, wasEcommerceTrial: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: defaultSite))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: defaultSite))
         presenter = StorePlanBannerPresenter(viewController: UIViewController(),
                                              containerView: containerView,
                                              siteID: siteID,
@@ -73,7 +73,7 @@ final class StorePlanBannerPresenterTests: XCTestCase {
     func test_banner_is_dismissed_when_connection_is_lost() {
         // Given
         let defaultSite = Site.fake().copy(siteID: siteID, isWordPressComStore: false, wasEcommerceTrial: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: defaultSite))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: defaultSite))
         let connectivityObserver = MockConnectivityObserver()
         presenter = StorePlanBannerPresenter(viewController: UIViewController(),
                                              containerView: containerView,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
@@ -92,7 +92,7 @@ final class StoreNameSetupViewModelTests: XCTestCase {
     func test_default_store_name_is_updated_upon_saving_store_name_completes() async {
         // Given
         let originalSite = Site.fake().copy(siteID: 123, name: "Test")
-        stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: originalSite))
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: originalSite))
         let viewModel = StoreNameSetupViewModel(siteID: originalSite.siteID, name: originalSite.name, stores: stores, onNameSaved: {})
         mockStoreNameUpdate(result: .success(Site.fake().copy(siteID: 123, name: "Miffy")))
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -15,7 +15,7 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
     private let sampleConfiguration: CardPresentPaymentsConfiguration = CardPresentPaymentsConfiguration(country: .US)
 
     override func setUp() {
-        let sessionManager = SessionManager.makeForTesting()
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
         sessionManager.setStoreId(sampleSiteID)
         stores = MockStoresManager(sessionManager: sessionManager)
         connectionControllerFactory = MockBuiltInCardReaderConnectionControllerFactory()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -22,7 +22,7 @@ final class UpgradesViewModelTests: XCTestCase {
 
         let site = Site.fake().copy(isSiteOwner: isSiteOwner)
 
-        stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
             case .isRemoteFeatureFlagEnabled(.hardcodedPlanUpgradeDetailsMilestone1AreAccurate, defaultValue: _, let completion):

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -468,6 +468,18 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertFalse(manager.isAuthenticated)
         XCTAssertEqual(isLoggedInValues, [false, true, false])
     }
+
+    /// Verifies that default store is reset when initialized in an unexpected state: deauthenticated state with default store set.
+    ///
+    func test_it_resets_default_store_when_initialized_with_deauthenticated_state_and_default_store_set() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(defaultSite: Site.fake().copy(siteID: 123))
+        let manager = DefaultStoresManager(sessionManager: sessionManager)
+
+        // Assert
+        XCTAssertFalse(manager.isAuthenticated)
+        XCTAssertTrue(manager.needsDefaultStore)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -476,7 +476,7 @@ final class StoresManagerTests: XCTestCase {
         let sessionManager = SessionManager.makeForTesting(defaultSite: Site.fake().copy(siteID: 123))
         let manager = DefaultStoresManager(sessionManager: sessionManager)
 
-        // Assert
+        // Then
         XCTAssertFalse(manager.isAuthenticated)
         XCTAssertTrue(manager.needsDefaultStore)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3865
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
As discussed in peaMlT-hY-p2, there is a long-running crash during login that seems to be limited to certain magic link logins. We haven't been able to reproduce the exact scenario seen in crash reports but I have a theory about the root cause and this PR attempts to fix it.

### Cause

There are a few common factors in the crash reports:

* It only happens when logging in with a magic link.
* It seems to happen when users are switching to a new device. This can be seen in their Tracks history, which shows the events leading up to the crash coming from a different device than previous events. 
* The user seems to be in an unexpected authentication state: They are not logged in but they do have a default store set (`ServiceLocator.stores.isAuthenticated` is `false` and `ServiceLocator.stores.needsDefaultStore` is `false`). This can be seen in the app logs, which show an unexpected mix of login flow actions and background updates that should only happen while logged in (e.g. attempting to dispatch logged-in actions, or syncing dashboard data).

I believe the point where the user gets into this auth state is when `DefaultStoresManager` is initialized, if the credentials can't be retrieved:

https://github.com/woocommerce/woocommerce-ios/blob/e5b29b6a8243f477c6c0a5cd6a8ec5e2437192e1/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L125

This sets `isAuthenticated` to `false` but doesn't reset the `sessionManager` (including the default store) so `needsDefaultStore` remains `false`. Normally `needsDefaultStore` would be set to `true` when a user is deauthenticated.

### How it happens

Unfortunately I haven't been able to consistently reproduce this crash, but here's what I think is happening:

1. They are probably migrating their data to the new device, but their keychain isn't migrated so they aren't fully authenticated. This gets them into the unexpected auth state.
2. They are taken to the login flow. They choose magic link login, so as soon as they open the magic link they are fully authenticated (logged in with a default store).
3. The magic link login flow handles the link in `WordPressAuthenticator` and presents a `LoginNavigationController`, which eventually tries to show the login epilogue (store picker - where we expect the default store to be set). Note: Presenting the login epilogue requires a navigation controller.
4. At the same time, as soon as they are fully authenticated, `AppCoordinator.start()` treats them as logged in. It checks their user role and then replaces `LoginNavigationController` with `MainTabBarController` as the root view controller.
5. Because the login epilogue requires a navigation controller, it then crashes when it tries to present the epilogue in `LoginViewController.showLoginEpilogue(for:)`.

I believe this wasn't a problem when `AppCoordinator.start()` immediately displayed the logged in UI to fully authenticated users, interrupting the login flow. However, in release 7.2 we delayed that (by checking the user role first) which allows the magic link login flow to proceed long enough to create this race condition.

However, I can't be 100% sure because even in testing I can't figure out the exact conditions/steps to reproduce this (even when testing setting up a new device as I suspect is happening here).

## Fix

This changes how we handle this auth state in two places:

1. `DefaultStoresManager` now fully deauthenticates the user if it's initialized in the unexpected auth state (logged out but with a default store set).
2. `AppCoordinator.start()` now handles this auth state differently from the expected fully logged-out state. It fully deauthenticates the user before starting the login flow, to ensure login can proceed as expected. (Hopefully users won't be able to get into this state anymore, since we're also fixing the root cause in `DefaultStoresManager`.)

This should ensure that users are fully deauthenticated when starting the login flow, so that when they get to the step where they open the magic link it proceeds as expected to the store picker.

Let me know if you have any doubts or concerns about the cause or fix here.

## Testing instructions

Because I don't have steps to reproduce this crash, please build and run the app and confirm that you see the expected state and the app behaves as expected while authenticated or deauthenticated.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.