### PR TITLE
[Order form] Remove `removeProductIntent` from `ProductRowViewModel`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -213,7 +213,7 @@ private struct CollapsibleProductRowCard: View {
                     .padding()
 
                 Button(Localization.removeProductLabel) {
-                    if let removeProductIntent = viewModel.rowViewModel.removeProductIntent {
+                    if let removeProductIntent = viewModel.stepperViewModel.removeProductIntent {
                         removeProductIntent()
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -596,9 +596,7 @@ final class EditableOrderViewModel: ObservableObject {
                                                    quantity: item.quantity,
                                                    displayMode: .attributes(attributes),
                                                    hasParentProduct: item.parent != nil,
-                                                   pricedIndividually: pricedIndividually,
-                                                   removeProductIntent: { [weak self] in
-                self?.removeItemFromOrder(item)})
+                                                   pricedIndividually: pricedIndividually)
             let stepperViewModel = ProductStepperViewModel(quantity: item.quantity,
                                                            name: item.name,
                                                            quantityUpdatedCallback: { [weak self] _ in
@@ -630,8 +628,6 @@ final class EditableOrderViewModel: ObservableObject {
                                                    quantity: item.quantity,
                                                    hasParentProduct: item.parent != nil,
                                                    pricedIndividually: pricedIndividually,
-                                                   removeProductIntent: { [weak self] in
-                self?.removeItemFromOrder(item)},
                                                    configure: { [weak self] in
                 guard let self else { return }
                 switch product.productType {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -246,10 +246,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     @Published var quantity: Decimal
 
-    /// Closure to run when the quantity is decremented below the minimum quantity.
-    ///
-    let removeProductIntent: (() -> Void)?
-
     /// Closure to configure a product if it is configurable.
     let configure: (() -> Void)?
 
@@ -285,7 +281,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
          isConfigurable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
-         removeProductIntent: (() -> Void)? = nil,
          configure: (() -> Void)? = nil) {
         self.id = id ?? Int64(UUID().uuidString.hashValue)
         self.selectedState = selectedState
@@ -307,7 +302,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         self.analytics = analytics
         self.numberOfVariations = numberOfVariations
         self.variationDisplayMode = variationDisplayMode
-        self.removeProductIntent = removeProductIntent
         self.configure = configure
     }
 
@@ -322,7 +316,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      pricedIndividually: Bool = true,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                      analytics: Analytics = ServiceLocator.analytics,
-                     removeProductIntent: @escaping (() -> Void) = {},
                      featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
                      configure: (() -> Void)? = nil) {
         // Don't show any price for variable products; price will be shown for each product variation.
@@ -393,7 +386,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   isConfigurable: isConfigurable,
                   currencyFormatter: currencyFormatter,
                   analytics: analytics,
-                  removeProductIntent: removeProductIntent,
                   configure: configure)
     }
 
@@ -409,8 +401,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                      hasParentProduct: Bool = false,
                      pricedIndividually: Bool = true,
                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-                     analytics: Analytics = ServiceLocator.analytics,
-                     removeProductIntent: @escaping (() -> Void) = {}) {
+                     analytics: Analytics = ServiceLocator.analytics) {
         let imageURL: URL?
         if let encodedImageURLString = productVariation.image?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
             imageURL = URL(string: encodedImageURLString)
@@ -435,8 +426,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
                   pricedIndividually: pricedIndividually,
                   isConfigurable: false,
                   currencyFormatter: currencyFormatter,
-                  analytics: analytics,
-                  removeProductIntent: removeProductIntent)
+                  analytics: analytics)
     }
 
     /// Determines which product variation details to display.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductWithQuantityStepperViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductWithQuantityStepperViewModelTests.swift
@@ -47,4 +47,35 @@ final class ProductWithQuantityStepperViewModelTests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).isReadOnly, "Child product should not be read only")
         XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[1]).isReadOnly, "Child product variation should not be read only")
     }
+
+    // MARK: - Quantity
+
+    func test_ProductStepperViewModel_and_ProductRowViewModel_quantity_have_the_same_initial_value() {
+        // When
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 2,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: .fake()),
+                                                            canChangeQuantity: true)
+
+        // Then
+        XCTAssertEqual(viewModel.stepperViewModel.quantity, 2)
+        XCTAssertEqual(viewModel.rowViewModel.quantity, 2)
+    }
+
+    func test_ProductStepperViewModel_quantity_change_updates_ProductRowViewModel_quantity() {
+        // Given
+        let viewModel = ProductWithQuantityStepperViewModel(stepperViewModel: .init(quantity: 2,
+                                                                                    name: "",
+                                                                                    quantityUpdatedCallback: { _ in }),
+                                                            rowViewModel: .init(product: .fake()),
+                                                            canChangeQuantity: true)
+
+        // When
+        viewModel.stepperViewModel.incrementQuantity()
+
+        // Then
+        XCTAssertEqual(viewModel.stepperViewModel.quantity, 3)
+        XCTAssertEqual(viewModel.rowViewModel.quantity, 3)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11368 
Based on https://github.com/woocommerce/woocommerce-ios/pull/11370
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is a small addition to https://github.com/woocommerce/woocommerce-ios/pull/11370 to remove the `removeProductIntent` closure property from `ProductRowViewModel`, as this property is now in `ProductStepperViewModel` where the product can be removed by updating the quantity to 0. I noticed this unused property late, and thought a separate PR would be better since the main PR is already big. Two test cases were also added for `ProductWithQuantityStepperViewModel`, they weren't related to `removeProductIntent` but I meant to add them before.

## How

`removeProductIntent` was removed from `ProductRowViewModel`, and the only use case in `CollapsibleProductRowCard` now uses the stepper view model `ProductStepperViewModel`'s `removeProductIntent` to remove a product from an order.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

For this PR, we can focus on the UX for removing a product by either decrementing the quantity to 0 or tapping on the CTA in the order product card.

🗒️ Removing a bundle product still leaves the original bundled products in the order. This is the same behavior as in core, and a known issue/enhancement in https://github.com/woocommerce/woocommerce-ios/issues/10428. 

- Go to the Orders tab
- Tap on `+` to create an order
- Tap `Add Products`
- Search/select at least one product and tap the bottom CTA to confirm the selection
- After the payments section is synced, tap `Create` to create the order
- Tap `Edit` to edit the order
- Expand any product card
- Tap to decrease the product quantity to 0 --> the product should be removed
- Tap `Add Products`
- Search/select at least one product and tap the bottom CTA to confirm the selection
- Expand any product card
- Tap to increment the product quantity
- Tap `Remove product from order` --> the product should be removed

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
