### PR TITLE
[HACK week] Networking: Process network response in background thread

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -977,6 +977,7 @@
 		EEA658462966C67C00112DF0 /* products-ids-only-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EEA658452966C67C00112DF0 /* products-ids-only-without-data.json */; };
 		EEA658482966CBAD00112DF0 /* EntityIDMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA658472966CBAD00112DF0 /* EntityIDMapperTests.swift */; };
 		EEA6584C2966CC4800112DF0 /* product-id-only-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EEA6584B2966CC4800112DF0 /* product-id-only-without-data.json */; };
+		EEA693572B21703D00BAECA6 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA693562B21703D00BAECA6 /* Publisher+Concurrency.swift */; };
 		EEAB476A2A851AFD00E55B25 /* site-upload-profiler-answers-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EEAB47692A851AFD00E55B25 /* site-upload-profiler-answers-success.json */; };
 		EEC312C32AFDF79E004369F7 /* ProductSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC312C22AFDF79E004369F7 /* ProductSubscriptionTests.swift */; };
 		EEC312C52AFE01BC004369F7 /* ProductEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC312C42AFE01BC004369F7 /* ProductEncoderTests.swift */; };
@@ -2001,6 +2002,7 @@
 		EEA658452966C67C00112DF0 /* products-ids-only-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-ids-only-without-data.json"; sourceTree = "<group>"; };
 		EEA658472966CBAD00112DF0 /* EntityIDMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityIDMapperTests.swift; sourceTree = "<group>"; };
 		EEA6584B2966CC4800112DF0 /* product-id-only-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-id-only-without-data.json"; sourceTree = "<group>"; };
+		EEA693562B21703D00BAECA6 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
 		EEAB47692A851AFD00E55B25 /* site-upload-profiler-answers-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-upload-profiler-answers-success.json"; sourceTree = "<group>"; };
 		EEC312C22AFDF79E004369F7 /* ProductSubscriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscriptionTests.swift; sourceTree = "<group>"; };
 		EEC312C42AFE01BC004369F7 /* ProductEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEncoderTests.swift; sourceTree = "<group>"; };
@@ -3143,6 +3145,7 @@
 		B5BB1D0A20A204F400112D92 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				EEA693562B21703D00BAECA6 /* Publisher+Concurrency.swift */,
 				CE6D666B2379E19D007835A1 /* Array+Woo.swift */,
 				B58E5BE920FFB3D0003C986E /* CodingUserInfoKey+Woo.swift */,
 				B5BB1D0B20A2050300112D92 /* DateFormatter+Woo.swift */,
@@ -4093,6 +4096,7 @@
 				31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */,
 				D89A01D426D3F8D9008195BE /* ReaderLocation.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
+				EEA693572B21703D00BAECA6 /* Publisher+Concurrency.swift in Sources */,
 				02C254AC2563781800A04423 /* ShippingLabelStatus.swift in Sources */,
 				0359EA1B27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift in Sources */,
 				74ABA1D3213F25AE00FFAD30 /* TopEarnerStatsMapper.swift in Sources */,

--- a/Networking/Networking/Extensions/Publisher+Concurrency.swift
+++ b/Networking/Networking/Extensions/Publisher+Concurrency.swift
@@ -1,6 +1,6 @@
 import Combine
 
-extension Publisher {
+public extension Publisher {
     /// Transforms the publisher with an async operator that does not throw an error.
     ///
     /// Original implementation:

--- a/Networking/Networking/Mapper/AIProductMapper.swift
+++ b/Networking/Networking/Mapper/AIProductMapper.swift
@@ -5,7 +5,7 @@ import Foundation
 struct AIProductMapper: Mapper {
     let siteID: Int64
 
-    func map(response: Data) throws -> AIProduct {
+    func map(response: Data) async throws -> AIProduct {
         let decoder = JSONDecoder()
         let textCompletion = try decoder.decode(TextCompletionResponse.self, from: response).completion
         return try decoder.decode(AIProduct.self, from: Data(textCompletion.utf8))

--- a/Networking/Networking/Mapper/AccountMapper.swift
+++ b/Networking/Networking/Mapper/AccountMapper.swift
@@ -7,7 +7,7 @@ class AccountMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an Account entity.
     ///
-    func map(response: Data) throws -> Account {
+    func map(response: Data) async throws -> Account {
         let decoder = JSONDecoder()
         return try decoder.decode(Account.self, from: response)
     }

--- a/Networking/Networking/Mapper/AccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/AccountSettingsMapper.swift
@@ -13,7 +13,7 @@ struct AccountSettingsMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an AccountSettings entity.
     ///
-    func map(response: Data) throws -> AccountSettings {
+    func map(response: Data) async throws -> AccountSettings {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .userID: userID

--- a/Networking/Networking/Mapper/AddOnGroupMapper.swift
+++ b/Networking/Networking/Mapper/AddOnGroupMapper.swift
@@ -8,7 +8,7 @@ struct AddOnGroupMapper: Mapper {
     ///
     let siteID: Int64
 
-    func map(response: Data) throws -> [AddOnGroup] {
+    func map(response: Data) async throws -> [AddOnGroup] {
         let decoder = JSONDecoder()
         decoder.userInfo = [.siteID: siteID]
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/AnnouncementListMapper.swift
+++ b/Networking/Networking/Mapper/AnnouncementListMapper.swift
@@ -5,7 +5,7 @@ struct AnnouncementListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a list of `Announcement`.
     ///
-    func map(response: Data) throws -> [Announcement] {
+    func map(response: Data) async throws -> [Announcement] {
         let decoder = JSONDecoder()
         return try decoder.decode(AnnouncementsContainer.self, from: response).announcements
     }

--- a/Networking/Networking/Mapper/ApplicationPassword/ApplicationPasswordMapper.swift
+++ b/Networking/Networking/Mapper/ApplicationPassword/ApplicationPasswordMapper.swift
@@ -7,7 +7,7 @@ struct ApplicationPasswordMapper: Mapper {
     ///
     let wpOrgUsername: String
 
-    func map(response: Data) throws -> ApplicationPassword {
+    func map(response: Data) async throws -> ApplicationPassword {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .wpOrgUsername: wpOrgUsername

--- a/Networking/Networking/Mapper/ApplicationPassword/ApplicationPasswordNameAndUUIDMapper.swift
+++ b/Networking/Networking/Mapper/ApplicationPassword/ApplicationPasswordNameAndUUIDMapper.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct ApplicationPasswordNameAndUUIDMapper: Mapper {
-    func map(response: Data) throws -> [ApplicationPasswordNameAndUUID] {
+    func map(response: Data) async throws -> [ApplicationPasswordNameAndUUID] {
         let decoder = JSONDecoder()
         return try decoder.decode([ApplicationPasswordNameAndUUID].self, from: response)
     }

--- a/Networking/Networking/Mapper/BlazeCampaignListMapper.swift
+++ b/Networking/Networking/Mapper/BlazeCampaignListMapper.swift
@@ -9,7 +9,7 @@ struct BlazeCampaignListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[BlazeCampaign]`.
     ///
-    func map(response: Data) throws -> [BlazeCampaign] {
+    func map(response: Data) async throws -> [BlazeCampaign] {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/CommentResultMapper.swift
+++ b/Networking/Networking/Mapper/CommentResultMapper.swift
@@ -7,7 +7,7 @@ struct CommentResultMapper: Mapper {
 
     /// (Attempts) to extract the updated `status` field from a given JSON Encoded response.
     ///
-    func map(response: Data) throws -> CommentStatus {
+    func map(response: Data) async throws -> CommentStatus {
 
         let dictionary = try JSONDecoder().decode([String: AnyDecodable].self, from: response)
         let status = (dictionary[Constants.statusKey]?.value as? String) ?? ""

--- a/Networking/Networking/Mapper/CountryListMapper.swift
+++ b/Networking/Networking/Mapper/CountryListMapper.swift
@@ -7,7 +7,7 @@ struct CountryListMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into an array of Country Entities.
     ///
-    func map(response: Data) throws -> [Country] {
+    func map(response: Data) async throws -> [Country] {
         if hasDataEnvelope(in: response) {
             return try JSONDecoder().decode(CountryListEnvelope.self, from: response).data
         } else {

--- a/Networking/Networking/Mapper/CouponListMapper.swift
+++ b/Networking/Networking/Mapper/CouponListMapper.swift
@@ -10,7 +10,7 @@ struct CouponListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[Coupon]`.
     ///
-    func map(response: Data) throws -> [Coupon] {
+    func map(response: Data) async throws -> [Coupon] {
         let decoder = Coupon.decoder
         if hasDataEnvelope(in: response) {
             let coupons = try decoder.decode(CouponListEnvelope.self, from: response).coupons

--- a/Networking/Networking/Mapper/CouponMapper.swift
+++ b/Networking/Networking/Mapper/CouponMapper.swift
@@ -10,7 +10,7 @@ struct CouponMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `Coupon`.
     ///
-    func map(response: Data) throws -> Coupon {
+    func map(response: Data) async throws -> Coupon {
         let decoder = Coupon.decoder
         if hasDataEnvelope(in: response) {
             let coupon = try decoder.decode(CouponEnvelope.self, from: response).coupon

--- a/Networking/Networking/Mapper/CouponReportListMapper.swift
+++ b/Networking/Networking/Mapper/CouponReportListMapper.swift
@@ -6,7 +6,7 @@ struct CouponReportListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[CouponReport]`.
     ///
-    func map(response: Data) throws -> [CouponReport] {
+    func map(response: Data) async throws -> [CouponReport] {
         let decoder = JSONDecoder()
         if hasDataEnvelope(in: response) {
             return try decoder.decode(CouponReportsEnvelope.self, from: response).reports

--- a/Networking/Networking/Mapper/CustomerMapper.swift
+++ b/Networking/Networking/Mapper/CustomerMapper.swift
@@ -9,7 +9,7 @@ struct CustomerMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a `Customer` entity
     ///
-    func map(response: Data) throws -> Customer {
+    func map(response: Data) async throws -> Customer {
         let decoder = JSONDecoder()
         decoder.userInfo = [.siteID: siteID]
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/DataBoolMapper.swift
+++ b/Networking/Networking/Mapper/DataBoolMapper.swift
@@ -6,7 +6,7 @@ struct DataBoolMapper: Mapper {
 
     /// (Attempts) to extract the boolean flag from a given JSON Encoded response.
     ///
-    func map(response: Data) throws -> Bool {
+    func map(response: Data) async throws -> Bool {
         if hasDataEnvelope(in: response) {
             return try JSONDecoder().decode(DataBool.self, from: response).data
         } else {

--- a/Networking/Networking/Mapper/DotcomDeviceMapper.swift
+++ b/Networking/Networking/Mapper/DotcomDeviceMapper.swift
@@ -7,7 +7,7 @@ struct DotcomDeviceMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into an array of Note Entities.
     ///
-    func map(response: Data) throws -> DotcomDevice {
+    func map(response: Data) async throws -> DotcomDevice {
         return try JSONDecoder().decode(DotcomDevice.self, from: response)
     }
 }

--- a/Networking/Networking/Mapper/EntityDateModifiedMapper.swift
+++ b/Networking/Networking/Mapper/EntityDateModifiedMapper.swift
@@ -6,7 +6,7 @@ struct EntityDateModifiedMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into a date
     ///
-    func map(response: Data) throws -> Date {
+    func map(response: Data) async throws -> Date {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
 

--- a/Networking/Networking/Mapper/EntityIDMapper.swift
+++ b/Networking/Networking/Mapper/EntityIDMapper.swift
@@ -6,7 +6,7 @@ struct EntityIDMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into an into an ID
     ///
-    func map(response: Data) throws -> Int64 {
+    func map(response: Data) async throws -> Int64 {
         let decoder = JSONDecoder()
 
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/IgnoringResponseMapper.swift
+++ b/Networking/Networking/Mapper/IgnoringResponseMapper.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 struct IgnoringResponseMapper: Mapper {
 
-    func map(response: Data) throws -> Void {
+    func map(response: Data) async throws -> Void {
         // Do nothing, accept any type of response, including null
     }
 }

--- a/Networking/Networking/Mapper/InAppPurchaseOrderResultMapper.swift
+++ b/Networking/Networking/Mapper/InAppPurchaseOrderResultMapper.swift
@@ -7,7 +7,7 @@ struct InAppPurchaseOrderResultMapper: Mapper {
 
     /// (Attempts) to extract the order ID from a given JSON Encoded response.
     ///
-    func map(response: Data) throws -> Int {
+    func map(response: Data) async throws -> Int {
 
         let dictionary = try JSONDecoder().decode([String: AnyDecodable].self, from: response)
         guard let orderId = (dictionary[Constants.orderIdKey]?.value as? Int) else {

--- a/Networking/Networking/Mapper/InAppPurchasesProductMapper.swift
+++ b/Networking/Networking/Mapper/InAppPurchasesProductMapper.swift
@@ -5,7 +5,7 @@ import Foundation
 struct InAppPurchasesProductMapper: Mapper {
     /// (Attempts) to convert a dictionary into a list of product identifiers.
     ///
-    func map(response: Data) throws -> [String] {
+    func map(response: Data) async throws -> [String] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         return try decoder.decode([String].self, from: response)

--- a/Networking/Networking/Mapper/InAppPurchasesTransactionMapper.swift
+++ b/Networking/Networking/Mapper/InAppPurchasesTransactionMapper.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Mapper: IAP-WPCOM transaction verification result
 ///
 struct InAppPurchasesTransactionMapper: Mapper {
-    func map(response: Data) throws -> InAppPurchasesTransactionResponse {
+    func map(response: Data) async throws -> InAppPurchasesTransactionResponse {
         let decoder = JSONDecoder()
         return try decoder.decode(InAppPurchasesTransactionResponse.self, from: response)
     }

--- a/Networking/Networking/Mapper/InboxNoteListMapper.swift
+++ b/Networking/Networking/Mapper/InboxNoteListMapper.swift
@@ -11,7 +11,7 @@ struct InboxNoteListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an Inbox Note Array.
     ///
-    func map(response: Data) throws -> [InboxNote] {
+    func map(response: Data) async throws -> [InboxNote] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/InboxNoteMapper.swift
+++ b/Networking/Networking/Mapper/InboxNoteMapper.swift
@@ -11,7 +11,7 @@ struct InboxNoteMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an Inbox Note.
     ///
-    func map(response: Data) throws -> InboxNote {
+    func map(response: Data) async throws -> InboxNote {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/JWTokenMapper.swift
+++ b/Networking/Networking/Mapper/JWTokenMapper.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Mapper to parse the JWToken
 ///
 struct JWTokenMapper: Mapper {
-    func map(response: Data) throws -> JWToken {
+    func map(response: Data) async throws -> JWToken {
         let decoder = JSONDecoder()
         let jwt = try decoder.decode(JWTokenResponse.self, from: response).token
 

--- a/Networking/Networking/Mapper/JetpackConnectionURLMapper.swift
+++ b/Networking/Networking/Mapper/JetpackConnectionURLMapper.swift
@@ -6,7 +6,7 @@ struct JetpackConnectionURLMapper: Mapper {
 
     /// (Attempts) to convert the response into a URL.
     ///
-    func map(response: Data) throws -> URL {
+    func map(response: Data) async throws -> URL {
         guard let escapedString = String(data: response, encoding: .utf8) else {
             throw JetpackConnectionRemote.ConnectionError.malformedURL
         }

--- a/Networking/Networking/Mapper/JetpackUserMapper.swift
+++ b/Networking/Networking/Mapper/JetpackUserMapper.swift
@@ -6,7 +6,7 @@ struct JetpackUserMapper: Mapper {
 
     /// (Attempts) to extract the updated `currentUser` field from a given JSON Encoded response.
     ///
-    func map(response: Data) throws -> JetpackUser {
+    func map(response: Data) async throws -> JetpackUser {
         let decoder = JSONDecoder()
         return try decoder.decode(JetpackConnectionData.self, from: response).currentUser
     }

--- a/Networking/Networking/Mapper/JustInTimeMessageListMapper.swift
+++ b/Networking/Networking/Mapper/JustInTimeMessageListMapper.swift
@@ -11,7 +11,7 @@ struct JustInTimeMessageListMapper: Mapper {
 
     /// (Attempts) to convert an array into a Just In Time Message.
     ///
-    func map(response: Data) throws -> [JustInTimeMessage] {
+    func map(response: Data) async throws -> [JustInTimeMessage] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/Mapper.swift
+++ b/Networking/Networking/Mapper/Mapper.swift
@@ -11,5 +11,5 @@ protocol Mapper {
 
     /// Maps a Backend Response into a generic entity of Type `Output`. This method *can throw* errors.
     ///
-    func map(response: Data) throws -> Output
+    func map(response: Data) async throws -> Output
 }

--- a/Networking/Networking/Mapper/MediaListMapper.swift
+++ b/Networking/Networking/Mapper/MediaListMapper.swift
@@ -3,7 +3,7 @@
 struct MediaMapper: Mapper {
     /// (Attempts) to convert data into a Media.
     ///
-    func map(response: Data) throws -> Media {
+    func map(response: Data) async throws -> Media {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.iso8601)
         return try decoder.decode(Media.self, from: response)
@@ -15,7 +15,7 @@ struct MediaMapper: Mapper {
 struct MediaListMapper: Mapper {
     /// (Attempts) to convert data into a Media list.
     ///
-    func map(response: Data) throws -> [Media] {
+    func map(response: Data) async throws -> [Media] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.iso8601)
         return try decoder.decode(MediaListEnvelope.self, from: response).mediaList

--- a/Networking/Networking/Mapper/NewShipmentTrackingMapper.swift
+++ b/Networking/Networking/Mapper/NewShipmentTrackingMapper.swift
@@ -15,7 +15,7 @@ struct NewShipmentTrackingMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an ShipmentTracking entity.
     ///
-    func map(response: Data) throws -> ShipmentTracking {
+    func map(response: Data) async throws -> ShipmentTracking {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.yearMonthDayDateFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/NoteHashListMapper.swift
+++ b/Networking/Networking/Mapper/NoteHashListMapper.swift
@@ -7,7 +7,7 @@ struct NoteHashListMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into an array of NoteHash Entities.
     ///
-    func map(response: Data) throws -> [NoteHash] {
+    func map(response: Data) async throws -> [NoteHash] {
         return try JSONDecoder().decode(NoteHashesEnvelope.self, from: response).hashes
     }
 }

--- a/Networking/Networking/Mapper/NoteListMapper.swift
+++ b/Networking/Networking/Mapper/NoteListMapper.swift
@@ -7,7 +7,7 @@ struct NoteListMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into an array of Note Entities.
     ///
-    func map(response: Data) throws -> [Note] {
+    func map(response: Data) async throws -> [Note] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
 

--- a/Networking/Networking/Mapper/OrderListMapper.swift
+++ b/Networking/Networking/Mapper/OrderListMapper.swift
@@ -14,7 +14,7 @@ struct OrderListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [Order].
     ///
-    func map(response: Data) throws -> [Order] {
+    func map(response: Data) async throws -> [Order] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/OrderMapper.swift
+++ b/Networking/Networking/Mapper/OrderMapper.swift
@@ -14,7 +14,7 @@ struct OrderMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [Order].
     ///
-    func map(response: Data) throws -> Order {
+    func map(response: Data) async throws -> Order {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/OrderNoteMapper.swift
+++ b/Networking/Networking/Mapper/OrderNoteMapper.swift
@@ -7,7 +7,7 @@ class OrderNoteMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a single OrderNote
     ///
-    func map(response: Data) throws -> OrderNote {
+    func map(response: Data) async throws -> OrderNote {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
 

--- a/Networking/Networking/Mapper/OrderNotesMapper.swift
+++ b/Networking/Networking/Mapper/OrderNotesMapper.swift
@@ -7,7 +7,7 @@ class OrderNotesMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [OrderNote].
     ///
-    func map(response: Data) throws -> [OrderNote] {
+    func map(response: Data) async throws -> [OrderNote] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
 

--- a/Networking/Networking/Mapper/OrderShippingLabelListMapper.swift
+++ b/Networking/Networking/Mapper/OrderShippingLabelListMapper.swift
@@ -24,7 +24,7 @@ struct OrderShippingLabelListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into OrderShippingLabelListResponse.
     ///
-    func map(response: Data) throws -> OrderShippingLabelListResponse {
+    func map(response: Data) async throws -> OrderShippingLabelListResponse {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/OrderStatsV4Mapper.swift
+++ b/Networking/Networking/Mapper/OrderStatsV4Mapper.swift
@@ -18,7 +18,7 @@ struct OrderStatsV4Mapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an OrderStats entity.
     ///
-    func map(response: Data) throws -> OrderStatsV4 {
+    func map(response: Data) async throws -> OrderStatsV4 {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID,

--- a/Networking/Networking/Mapper/PaymentGatewayListMapper.swift
+++ b/Networking/Networking/Mapper/PaymentGatewayListMapper.swift
@@ -12,7 +12,7 @@ struct PaymentGatewayListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[PaymentGateway]`
     ///
-    func map(response: Data) throws -> [PaymentGateway] {
+    func map(response: Data) async throws -> [PaymentGateway] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID,

--- a/Networking/Networking/Mapper/PaymentGatewayMapper.swift
+++ b/Networking/Networking/Mapper/PaymentGatewayMapper.swift
@@ -12,7 +12,7 @@ struct PaymentGatewayMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `PaymentGateway`
     ///
-    func map(response: Data) throws -> PaymentGateway {
+    func map(response: Data) async throws -> PaymentGateway {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID,

--- a/Networking/Networking/Mapper/PostMapper.swift
+++ b/Networking/Networking/Mapper/PostMapper.swift
@@ -7,7 +7,7 @@ class PostMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a Post entity.
     ///
-    func map(response: Data) throws -> Post {
+    func map(response: Data) async throws -> Post {
         let decoder = JSONDecoder()
         return try decoder.decode(Post.self, from: response)
     }

--- a/Networking/Networking/Mapper/ProductAttributeListMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeListMapper.swift
@@ -11,7 +11,7 @@ struct ProductAttributeListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [ProductAttribute].
     ///
-    func map(response: Data) throws -> [ProductAttribute] {
+    func map(response: Data) async throws -> [ProductAttribute] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductAttributeMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeMapper.swift
@@ -14,7 +14,7 @@ struct ProductAttributeMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductAttribute.
     ///
-    func map(response: Data) throws -> ProductAttribute {
+    func map(response: Data) async throws -> ProductAttribute {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductAttributeTermListMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeTermListMapper.swift
@@ -11,7 +11,7 @@ struct ProductAttributeTermListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[ProductAttributeTerm]`.
     ///
-    func map(response: Data) throws -> [ProductAttributeTerm] {
+    func map(response: Data) async throws -> [ProductAttributeTerm] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductAttributeTermMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeTermMapper.swift
@@ -12,7 +12,7 @@ struct ProductAttributeTermMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `ProductAttributeTerm`.
     ///
-    func map(response: Data) throws -> ProductAttributeTerm {
+    func map(response: Data) async throws -> ProductAttributeTerm {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductCategoryListMapper.swift
+++ b/Networking/Networking/Mapper/ProductCategoryListMapper.swift
@@ -13,7 +13,7 @@ struct ProductCategoryListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [ProductCategory].
     ///
-    func map(response: Data) throws -> [ProductCategory] {
+    func map(response: Data) async throws -> [ProductCategory] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductCategoryMapper.swift
+++ b/Networking/Networking/Mapper/ProductCategoryMapper.swift
@@ -14,7 +14,7 @@ struct ProductCategoryMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductCategory.
     ///
-    func map(response: Data) throws -> ProductCategory {
+    func map(response: Data) async throws -> ProductCategory {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductIDMapper.swift
+++ b/Networking/Networking/Mapper/ProductIDMapper.swift
@@ -6,7 +6,7 @@ struct ProductIDMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into an array of Product IDs
     ///
-    func map(response: Data) throws -> [Int64] {
+    func map(response: Data) async throws -> [Int64] {
         let decoder = JSONDecoder()
 
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/ProductListMapper.swift
+++ b/Networking/Networking/Mapper/ProductListMapper.swift
@@ -12,7 +12,7 @@ struct ProductListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [Product].
     ///
-    func map(response: Data) throws -> [Product] {
+    func map(response: Data) async throws -> [Product] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductMapper.swift
+++ b/Networking/Networking/Mapper/ProductMapper.swift
@@ -14,7 +14,7 @@ struct ProductMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into Product.
     ///
-    func map(response: Data) throws -> Product {
+    func map(response: Data) async throws -> Product {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductReviewListMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewListMapper.swift
@@ -11,7 +11,7 @@ struct ProductReviewListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [Product].
     ///
-    func map(response: Data) throws -> [ProductReview] {
+    func map(response: Data) async throws -> [ProductReview] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductReviewMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewMapper.swift
@@ -14,7 +14,7 @@ struct ProductReviewMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductReview.
     ///
-    func map(response: Data) throws -> ProductReview {
+    func map(response: Data) async throws -> ProductReview {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductShippingClassListMapper.swift
+++ b/Networking/Networking/Mapper/ProductShippingClassListMapper.swift
@@ -11,7 +11,7 @@ struct ProductShippingClassListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [ProductShippingClass].
     ///
-    func map(response: Data) throws -> [ProductShippingClass] {
+    func map(response: Data) async throws -> [ProductShippingClass] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductShippingClassMapper.swift
+++ b/Networking/Networking/Mapper/ProductShippingClassMapper.swift
@@ -11,7 +11,7 @@ struct ProductShippingClassMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductShippingClass.
     ///
-    func map(response: Data) throws -> ProductShippingClass {
+    func map(response: Data) async throws -> ProductShippingClass {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductSkuMapper.swift
+++ b/Networking/Networking/Mapper/ProductSkuMapper.swift
@@ -7,7 +7,7 @@ struct ProductSkuMapper: Mapper {
 
     /// (Attempts) to convert an instance of Data into a Product Sku string
     ///
-    func map(response: Data) throws -> String {
+    func map(response: Data) async throws -> String {
         let decoder = JSONDecoder()
 
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/ProductTagListMapper.swift
+++ b/Networking/Networking/Mapper/ProductTagListMapper.swift
@@ -13,7 +13,7 @@ struct ProductTagListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [ProductTag].
     ///
-    func map(response: Data) throws -> [ProductTag] {
+    func map(response: Data) async throws -> [ProductTag] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ProductVariationListMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationListMapper.swift
@@ -18,7 +18,7 @@ struct ProductVariationListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductVariation.
     ///
-    func map(response: Data) throws -> [ProductVariation] {
+    func map(response: Data) async throws -> [ProductVariation] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductVariationMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationMapper.swift
@@ -17,7 +17,7 @@ struct ProductVariationMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductVariation.
     ///
-    func map(response: Data) throws -> ProductVariation {
+    func map(response: Data) async throws -> ProductVariation {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductVariationsBulkCreateMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationsBulkCreateMapper.swift
@@ -17,7 +17,7 @@ struct ProductVariationsBulkCreateMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductVariations.
     ///
-    func map(response: Data) throws -> [ProductVariation] {
+    func map(response: Data) async throws -> [ProductVariation] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductVariationsBulkUpdateMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationsBulkUpdateMapper.swift
@@ -17,7 +17,7 @@ struct ProductVariationsBulkUpdateMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ProductVariations.
     ///
-    func map(response: Data) throws -> [ProductVariation] {
+    func map(response: Data) async throws -> [ProductVariation] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductsBulkUpdateMapper.swift
+++ b/Networking/Networking/Mapper/ProductsBulkUpdateMapper.swift
@@ -11,7 +11,7 @@ struct ProductsBulkUpdateMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into Products.
     ///
-    func map(response: Data) throws -> [Product] {
+    func map(response: Data) async throws -> [Product] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ProductsReportMapper.swift
+++ b/Networking/Networking/Mapper/ProductsReportMapper.swift
@@ -6,7 +6,7 @@ struct ProductsReportMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[ProductsReportItem]`.
     ///
-    func map(response: Data) throws -> [ProductsReportItem] {
+    func map(response: Data) async throws -> [ProductsReportItem] {
         let decoder = JSONDecoder()
         if hasDataEnvelope(in: response) {
             return try decoder.decode(ProductsReportEnvelope.self, from: response).items

--- a/Networking/Networking/Mapper/ProductsTotalMapper.swift
+++ b/Networking/Networking/Mapper/ProductsTotalMapper.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Mapper: ProductsTotal
 ///
 struct ProductsTotalMapper: Mapper {
-    func map(response: Data) throws -> Int64 {
+    func map(response: Data) async throws -> Int64 {
         let decoder = JSONDecoder()
         let totals: [ProductTypeTotal]
 

--- a/Networking/Networking/Mapper/ReaderConnectionTokenMapper.swift
+++ b/Networking/Networking/Mapper/ReaderConnectionTokenMapper.swift
@@ -4,7 +4,7 @@ struct ReaderConnectionTokenMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a connection token.
     ///
-    func map(response: Data) throws -> ReaderConnectionToken {
+    func map(response: Data) async throws -> ReaderConnectionToken {
         let decoder = JSONDecoder()
 
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/RefundListMapper.swift
+++ b/Networking/Networking/Mapper/RefundListMapper.swift
@@ -19,7 +19,7 @@ struct RefundListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [Refund].
     ///
-    func map(response: Data) throws -> [Refund] {
+    func map(response: Data) async throws -> [Refund] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/RefundMapper.swift
+++ b/Networking/Networking/Mapper/RefundMapper.swift
@@ -19,7 +19,7 @@ struct RefundMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a single Refund.
     ///
-    func map(response: Data) throws -> Refund {
+    func map(response: Data) async throws -> Refund {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/RemotePaymentIntentMapper.swift
+++ b/Networking/Networking/Mapper/RemotePaymentIntentMapper.swift
@@ -6,7 +6,7 @@ struct RemotePaymentIntentMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an payment intent.
     ///
-    func map(response: Data) throws -> RemotePaymentIntent {
+    func map(response: Data) async throws -> RemotePaymentIntent {
         let decoder = JSONDecoder()
 
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/RemoteReaderLocationMapper.swift
+++ b/Networking/Networking/Mapper/RemoteReaderLocationMapper.swift
@@ -6,7 +6,7 @@ struct RemoteReaderLocationMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a location.
     ///
-    func map(response: Data) throws -> RemoteReaderLocation {
+    func map(response: Data) async throws -> RemoteReaderLocation {
         let decoder = JSONDecoder()
 
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/ReportOrderTotalsMapper.swift
+++ b/Networking/Networking/Mapper/ReportOrderTotalsMapper.swift
@@ -14,7 +14,7 @@ struct ReportOrderTotalsMapper: Mapper {
 
     /// (Attempts) to extract order totals report from a given JSON Encoded response.
     ///
-    func map(response: Data) throws -> [OrderStatus] {
+    func map(response: Data) async throws -> [OrderStatus] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/ShipmentTrackingListMapper.swift
+++ b/Networking/Networking/Mapper/ShipmentTrackingListMapper.swift
@@ -19,7 +19,7 @@ struct ShipmentTrackingListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [ShipmentTracking]
     ///
-    func map(response: Data) throws -> [ShipmentTracking] {
+    func map(response: Data) async throws -> [ShipmentTracking] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.yearMonthDayDateFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ShipmentTrackingProviderListMapper.swift
+++ b/Networking/Networking/Mapper/ShipmentTrackingProviderListMapper.swift
@@ -9,7 +9,7 @@ struct ShipmentTrackingProviderListMapper: Mapper {
         self.siteID = siteID
     }
 
-    func map(response: Data) throws -> [ShipmentTrackingProviderGroup] {
+    func map(response: Data) async throws -> [ShipmentTrackingProviderGroup] {
         let decoder = JSONDecoder()
         let rawDictionary: ShipmentTrackingProviderListEnvelope.RawData
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
@@ -10,7 +10,7 @@ struct ShippingLabelAccountSettingsMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into ShippingLabelAccountSettings.
     ///
-    func map(response: Data) throws -> ShippingLabelAccountSettings {
+    func map(response: Data) async throws -> ShippingLabelAccountSettings {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.yearMonthDayDateFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ShippingLabelAddressValidationSuccessMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelAddressValidationSuccessMapper.swift
@@ -6,7 +6,7 @@ import Foundation
 struct ShippingLabelAddressValidationSuccessMapper: Mapper {
     /// (Attempts) to convert a dictionary into ShippingLabelAddressValidationResponse.
     ///
-    func map(response: Data) throws -> ShippingLabelAddressValidationSuccess {
+    func map(response: Data) async throws -> ShippingLabelAddressValidationSuccess {
         let decoder = JSONDecoder()
         let data: ShippingLabelAddressValidationResponse = try {
             if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/ShippingLabelCarriersAndRatesMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelCarriersAndRatesMapper.swift
@@ -6,7 +6,7 @@ import Foundation
 struct ShippingLabelCarriersAndRatesMapper: Mapper {
     /// (Attempts) to convert a dictionary into ShippingLabelCarriersAndRates array.
     ///
-    func map(response: Data) throws -> [ShippingLabelCarriersAndRates] {
+    func map(response: Data) async throws -> [ShippingLabelCarriersAndRates] {
         let decoder = JSONDecoder()
         if hasDataEnvelope(in: response) {
             return try decoder.decode(ShippingLabelDataEnvelope.self, from: response).data.rates.boxes

--- a/Networking/Networking/Mapper/ShippingLabelCreationEligibilityMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelCreationEligibilityMapper.swift
@@ -5,7 +5,7 @@ import Foundation
 struct ShippingLabelCreationEligibilityMapper: Mapper {
     /// (Attempts) to convert a dictionary into ShippingLabelAccountSettings.
     ///
-    func map(response: Data) throws -> ShippingLabelCreationEligibilityResponse {
+    func map(response: Data) async throws -> ShippingLabelCreationEligibilityResponse {
         let decoder = JSONDecoder()
         if hasDataEnvelope(in: response) {
             return try decoder.decode(ShippingLabelCreationEligibilityMapperEnvelope.self, from: response).eligibility

--- a/Networking/Networking/Mapper/ShippingLabelPackagesMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelPackagesMapper.swift
@@ -6,7 +6,7 @@ import Foundation
 struct ShippingLabelPackagesMapper: Mapper {
     /// (Attempts) to convert a dictionary into ShippingLabelPackagesResponse.
     ///
-    func map(response: Data) throws -> ShippingLabelPackagesResponse {
+    func map(response: Data) async throws -> ShippingLabelPackagesResponse {
         let decoder = JSONDecoder()
         if hasDataEnvelope(in: response) {
             return try decoder.decode(ShippingLabelPackagesMapperEnvelope.self, from: response).data

--- a/Networking/Networking/Mapper/ShippingLabelPrintDataMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelPrintDataMapper.swift
@@ -6,7 +6,7 @@ import Foundation
 struct ShippingLabelPrintDataMapper: Mapper {
     /// (Attempts) to convert a dictionary into ShippingLabelPrintData.
     ///
-    func map(response: Data) throws -> ShippingLabelPrintData {
+    func map(response: Data) async throws -> ShippingLabelPrintData {
         let decoder = JSONDecoder()
         if hasDataEnvelope(in: response) {
             return try decoder.decode(ShippingLabelPrintDataEnvelope.self, from: response).printData

--- a/Networking/Networking/Mapper/ShippingLabelPurchaseMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelPurchaseMapper.swift
@@ -17,7 +17,7 @@ struct ShippingLabelPurchaseMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [ShippingLabelPurchase].
     ///
-    func map(response: Data) throws -> [ShippingLabelPurchase] {
+    func map(response: Data) async throws -> [ShippingLabelPurchase] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/ShippingLabelRefundMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelRefundMapper.swift
@@ -6,7 +6,7 @@ import Foundation
 struct ShippingLabelRefundMapper: Mapper {
     /// (Attempts) to convert a dictionary into ShippingLabelRefund.
     ///
-    func map(response: Data) throws -> ShippingLabelRefund {
+    func map(response: Data) async throws -> ShippingLabelRefund {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/ShippingLabelStatusMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelStatusMapper.swift
@@ -17,7 +17,7 @@ struct ShippingLabelStatusMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `ShippingLabelStatusPollingResponse`.
     ///
-    func map(response: Data) throws -> [ShippingLabelStatusPollingResponse] {
+    func map(response: Data) async throws -> [ShippingLabelStatusPollingResponse] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/SiteAPIMapper.swift
+++ b/Networking/Networking/Mapper/SiteAPIMapper.swift
@@ -12,7 +12,7 @@ struct SiteAPIMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [SiteSetting].
     ///
-    func map(response: Data) throws -> SiteAPI {
+    func map(response: Data) async throws -> SiteAPI {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/SiteListMapper.swift
+++ b/Networking/Networking/Mapper/SiteListMapper.swift
@@ -7,7 +7,7 @@ final class SiteListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [Site].
     ///
-    func map(response: Data) throws -> [Site] {
+    func map(response: Data) async throws -> [Site] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
 

--- a/Networking/Networking/Mapper/SitePlanMapper.swift
+++ b/Networking/Networking/Mapper/SitePlanMapper.swift
@@ -7,7 +7,7 @@ class SitePlanMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a site plan attribute for the site entity.
     ///
-    func map(response: Data) throws -> SitePlan {
+    func map(response: Data) async throws -> SitePlan {
         let decoder = JSONDecoder()
         return try decoder.decode(SitePlan.self, from: response)
     }

--- a/Networking/Networking/Mapper/SitePluginMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginMapper.swift
@@ -19,7 +19,7 @@ struct SitePluginMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into SitePlugin.
     ///
-    func map(response: Data) throws -> SitePlugin {
+    func map(response: Data) async throws -> SitePlugin {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/SitePluginsMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginsMapper.swift
@@ -11,7 +11,7 @@ struct SitePluginsMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [SitePlugin].
     ///
-    func map(response: Data) throws -> [SitePlugin] {
+    func map(response: Data) async throws -> [SitePlugin] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/SiteSettingMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingMapper.swift
@@ -17,7 +17,7 @@ struct SiteSettingMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into SiteSetting.
     ///
-    func map(response: Data) throws -> SiteSetting {
+    func map(response: Data) async throws -> SiteSetting {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/SiteSettingsMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingsMapper.swift
@@ -18,7 +18,7 @@ struct SiteSettingsMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [SiteSetting].
     ///
-    func map(response: Data) throws -> [SiteSetting] {
+    func map(response: Data) async throws -> [SiteSetting] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/SiteSummaryStatsMapper.swift
+++ b/Networking/Networking/Mapper/SiteSummaryStatsMapper.swift
@@ -11,7 +11,7 @@ struct SiteSummaryStatsMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an SiteSummaryStats entity.
     ///
-    func map(response: Data) throws -> SiteSummaryStats {
+    func map(response: Data) async throws -> SiteSummaryStats {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID,

--- a/Networking/Networking/Mapper/SiteVisitStatsMapper.swift
+++ b/Networking/Networking/Mapper/SiteVisitStatsMapper.swift
@@ -12,7 +12,7 @@ struct SiteVisitStatsMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an SiteVisitStats entity.
     ///
-    func map(response: Data) throws -> SiteVisitStats {
+    func map(response: Data) async throws -> SiteVisitStats {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID,

--- a/Networking/Networking/Mapper/StoreOnboardingTaskListMapper.swift
+++ b/Networking/Networking/Mapper/StoreOnboardingTaskListMapper.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Mapper: StoreOnboardingTask
 ///
 struct StoreOnboardingTaskListMapper: Mapper {
-    func map(response: Data) throws -> [StoreOnboardingTask] {
+    func map(response: Data) async throws -> [StoreOnboardingTask] {
         let decoder = JSONDecoder()
         let taskGroup: [StoreOnboardingTaskGroup]
 

--- a/Networking/Networking/Mapper/StripeAccountMapper.swift
+++ b/Networking/Networking/Mapper/StripeAccountMapper.swift
@@ -6,7 +6,7 @@ struct StripeAccountMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an account.
     ///
-    func map(response: Data) throws -> StripeAccount {
+    func map(response: Data) async throws -> StripeAccount {
         let decoder = JSONDecoder()
 
         /// Needed for currentDeadline, which is given as a UNIX timestamp.

--- a/Networking/Networking/Mapper/SubscriptionListMapper.swift
+++ b/Networking/Networking/Mapper/SubscriptionListMapper.swift
@@ -10,7 +10,7 @@ struct SubscriptionListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[Subscription]`.
     ///
-    func map(response: Data) throws -> [Subscription] {
+    func map(response: Data) async throws -> [Subscription] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/SubscriptionMapper.swift
+++ b/Networking/Networking/Mapper/SubscriptionMapper.swift
@@ -10,7 +10,7 @@ struct SubscriptionMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `Subscription`.
     ///
-    func map(response: Data) throws -> Subscription {
+    func map(response: Data) async throws -> Subscription {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/SuccessDataResultMapper.swift
+++ b/Networking/Networking/Mapper/SuccessDataResultMapper.swift
@@ -7,7 +7,7 @@ struct SuccessDataResultMapper: Mapper {
 
     /// (Attempts) to extract the `success` flag from a given JSON Encoded response.
     ///
-    func map(response: Data) throws -> Bool {
+    func map(response: Data) async throws -> Bool {
         let decoder = JSONDecoder()
         let rawData: [String: Bool] = try {
             if hasDataEnvelope(in: response) {

--- a/Networking/Networking/Mapper/SuccessResultMapper.swift
+++ b/Networking/Networking/Mapper/SuccessResultMapper.swift
@@ -7,7 +7,7 @@ struct SuccessResultMapper: Mapper {
 
     /// (Attempts) to extract the `success` flag from a given JSON Encoded response.
     ///
-    func map(response: Data) throws -> Bool {
+    func map(response: Data) async throws -> Bool {
         return try JSONDecoder().decode(SuccessResult.self, from: response).success
     }
 }

--- a/Networking/Networking/Mapper/SystemPluginMapper.swift
+++ b/Networking/Networking/Mapper/SystemPluginMapper.swift
@@ -11,7 +11,7 @@ struct SystemPluginMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [SystemPlugin].
     ///
-    func map(response: Data) throws -> [SystemPlugin] {
+    func map(response: Data) async throws -> [SystemPlugin] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/SystemStatusMapper.swift
+++ b/Networking/Networking/Mapper/SystemStatusMapper.swift
@@ -11,7 +11,7 @@ struct SystemStatusMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into SystemStatus
     ///
-    func map(response: Data) throws -> SystemStatus {
+    func map(response: Data) async throws -> SystemStatus {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/TaxClassListMapper.swift
+++ b/Networking/Networking/Mapper/TaxClassListMapper.swift
@@ -12,7 +12,7 @@ struct TaxClassListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [TaxClass].
     ///
-    func map(response: Data) throws -> [TaxClass] {
+    func map(response: Data) async throws -> [TaxClass] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/TaxRateListMapper.swift
+++ b/Networking/Networking/Mapper/TaxRateListMapper.swift
@@ -11,7 +11,7 @@ struct TaxRateListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into [TaxRate].
     ///
-    func map(response: Data) throws -> [TaxRate] {
+    func map(response: Data) async throws -> [TaxRate] {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/TaxRateMapper.swift
+++ b/Networking/Networking/Mapper/TaxRateMapper.swift
@@ -13,7 +13,7 @@ struct TaxRateMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into TaxRate.
     ///
-    func map(response: Data) throws -> TaxRate {
+    func map(response: Data) async throws -> TaxRate {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Networking/Networking/Mapper/TopEarnerStatsMapper.swift
+++ b/Networking/Networking/Mapper/TopEarnerStatsMapper.swift
@@ -12,7 +12,7 @@ struct TopEarnerStatsMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an TopEarnerStats entity.
     ///
-    func map(response: Data) throws -> TopEarnerStats {
+    func map(response: Data) async throws -> TopEarnerStats {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID,

--- a/Networking/Networking/Mapper/UserMapper.swift
+++ b/Networking/Networking/Mapper/UserMapper.swift
@@ -10,7 +10,7 @@ struct UserMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into User.
     ///
-    func map(response: Data) throws -> User {
+    func map(response: Data) async throws -> User {
         let decoder = JSONDecoder()
         decoder.userInfo = [
             .siteID: siteID

--- a/Networking/Networking/Mapper/WCAnalyticsCustomerMapper.swift
+++ b/Networking/Networking/Mapper/WCAnalyticsCustomerMapper.swift
@@ -9,7 +9,7 @@ struct WCAnalyticsCustomerMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a `[WCAnalyticsCustomer]` entity
     ///
-    func map(response: Data) throws -> [WCAnalyticsCustomer] {
+    func map(response: Data) async throws -> [WCAnalyticsCustomer] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [.siteID: siteID]

--- a/Networking/Networking/Mapper/WCPayAccountMapper.swift
+++ b/Networking/Networking/Mapper/WCPayAccountMapper.swift
@@ -6,7 +6,7 @@ struct WCPayAccountMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an account.
     ///
-    func map(response: Data) throws -> WCPayAccount {
+    func map(response: Data) async throws -> WCPayAccount {
         let decoder = JSONDecoder()
 
         /// Needed for currentDeadline, which is given as a UNIX timestamp.

--- a/Networking/Networking/Mapper/WCPayChargeMapper.swift
+++ b/Networking/Networking/Mapper/WCPayChargeMapper.swift
@@ -7,7 +7,7 @@ struct WCPayChargeMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into an account.
     ///
-    func map(response: Data) throws -> WCPayCharge {
+    func map(response: Data) async throws -> WCPayCharge {
         let decoder = JSONDecoder()
         decoder.userInfo = [.siteID: siteID]
 

--- a/Networking/Networking/Mapper/WooCommerceAvailabilityMapper.swift
+++ b/Networking/Networking/Mapper/WooCommerceAvailabilityMapper.swift
@@ -6,7 +6,7 @@ struct WooCommerceAvailabilityMapper: Mapper {
 
     /// Any store with valid WooCommerce site settings response data is considered to have an active WooCommerce plugin.
     ///
-    func map(response: Data) throws -> Bool {
+    func map(response: Data) async throws -> Bool {
         true
     }
 }

--- a/Networking/Networking/Mapper/WooPaymentsDepositsOverviewMapper.swift
+++ b/Networking/Networking/Mapper/WooPaymentsDepositsOverviewMapper.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct WooPaymentsDepositsOverviewMapper: Mapper {
-    func map(response: Data) throws -> WooPaymentsDepositsOverview {
+    func map(response: Data) async throws -> WooPaymentsDepositsOverview {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
 

--- a/Networking/Networking/Mapper/WordPressMediaMapper.swift
+++ b/Networking/Networking/Mapper/WordPressMediaMapper.swift
@@ -2,7 +2,7 @@
 ///
 struct WordPressMediaMapper: Mapper {
     /// (Attempts) to convert data into a WordPressMedia.
-    func map(response: Data) throws -> WordPressMedia {
+    func map(response: Data) async throws -> WordPressMedia {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Constants.dateFormatterForDecoding)
         return try decoder.decode(WordPressMedia.self, from: response)
@@ -13,7 +13,7 @@ struct WordPressMediaMapper: Mapper {
 ///
 struct WordPressMediaListMapper: Mapper {
     /// (Attempts) to convert data into a WordPressMedia list.
-    func map(response: Data) throws -> [WordPressMedia] {
+    func map(response: Data) async throws -> [WordPressMedia] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Constants.dateFormatterForDecoding)
         return try decoder.decode([WordPressMedia].self, from: response)

--- a/Networking/Networking/Mapper/WordPressSiteMapper.swift
+++ b/Networking/Networking/Mapper/WordPressSiteMapper.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 struct WordPressSiteMapper: Mapper {
 
-    func map(response: Data) throws -> WordPressSite {
+    func map(response: Data) async throws -> WordPressSite {
         let decoder = JSONDecoder()
         return try decoder.decode(WordPressSite.self, from: response)
     }

--- a/Networking/Networking/Mapper/WordPressSiteSettingsMapper.swift
+++ b/Networking/Networking/Mapper/WordPressSiteSettingsMapper.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 struct WordPressSiteSettingsMapper: Mapper {
     /// (Attempts) to convert a dictionary into `WordPressSiteSettings`.
-    func map(response: Data) throws -> WordPressSiteSettings {
+    func map(response: Data) async throws -> WordPressSiteSettings {
         let decoder = JSONDecoder()
         return try decoder.decode(WordPressSiteSettings.self, from: response)
     }

--- a/Networking/Networking/Mapper/WordPressThemeListMapper.swift
+++ b/Networking/Networking/Mapper/WordPressThemeListMapper.swift
@@ -6,7 +6,7 @@ struct WordPressThemeListMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `[WordPressTheme]`.
     ///
-    func map(response: Data) throws -> [WordPressTheme] {
+    func map(response: Data) async throws -> [WordPressTheme] {
         let decoder = JSONDecoder()
         return try decoder.decode(WordPressThemeListEnvelope.self, from: response).themes
     }

--- a/Networking/Networking/Mapper/WordPressThemeMapper.swift
+++ b/Networking/Networking/Mapper/WordPressThemeMapper.swift
@@ -6,7 +6,7 @@ struct WordPressThemeMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into `WordPressTheme`.
     ///
-    func map(response: Data) throws -> WordPressTheme {
+    func map(response: Data) async throws -> WordPressTheme {
         let decoder = JSONDecoder()
         return try decoder.decode(WordPressTheme.self, from: response)
     }

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -312,7 +312,7 @@ private extension GenerativeContentRemote {
 // MARK: - Mapper to parse the `text-completion` endpoint response
 //
 private struct TextCompletionResponseMapper: Mapper {
-    func map(response: Data) throws -> String {
+    func map(response: Data) async throws -> String {
         let decoder = JSONDecoder()
         return try decoder.decode(TextCompletionResponse.self, from: response).completion
     }

--- a/Networking/Networking/Remote/IPLocationRemote.swift
+++ b/Networking/Networking/Remote/IPLocationRemote.swift
@@ -40,7 +40,7 @@ private struct IPCountryCodeMapper: Mapper {
         let countryCode: String
     }
 
-    func map(response: Data) throws -> String {
+    func map(response: Data) async throws -> String {
         try JSONDecoder().decode(Response.self, from: response).countryCode
     }
 }

--- a/Networking/Networking/Remote/PaymentRemote.swift
+++ b/Networking/Networking/Remote/PaymentRemote.swift
@@ -231,7 +231,7 @@ private struct SiteCurrentPlanResponseMapper: Mapper {
 
     /// (Attempts) to convert a dictionary into a WPCom site plan entity.
     ///
-    func map(response: Data) throws -> [String: SiteCurrentPlanResponse] {
+    func map(response: Data) async throws -> [String: SiteCurrentPlanResponse] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return try decoder.decode([String: SiteCurrentPlanResponse].self, from: response)

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -242,16 +242,18 @@ public class Remote: NSObject {
 
                 switch result {
                 case .success(let data):
-                    do {
-                        let validator = request.responseDataValidator()
-                        try validator.validate(data: data)
-                        let parsed = try mapper.map(response: data)
-                        continuation.resume(returning: parsed)
-                    } catch {
-                        DDLogError("<> Mapping Error: \(error)")
-                        self.handleResponseError(error: error, for: request)
-                        self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
-                        continuation.resume(throwing: error)
+                    Task {
+                        do {
+                            let validator = request.responseDataValidator()
+                            try validator.validate(data: data)
+                            let parsed = try await mapper.map(response: data)
+                            continuation.resume(returning: parsed)
+                        } catch {
+                            DDLogError("<> Mapping Error: \(error)")
+                            self.handleResponseError(error: error, for: request)
+                            self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                            continuation.resume(throwing: error)
+                        }
                     }
                 case .failure(let error):
                     continuation.resume(throwing: self.mapNetworkError(error: error, for: request))

--- a/Networking/NetworkingTests/Mapper/AIProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AIProductMapperTests.swift
@@ -4,13 +4,13 @@ import XCTest
 final class AIProductMapperTests: XCTestCase {
     private let siteID: Int64 = 123
 
-    func test_it_maps_AIProduct_correctly_from_AI_json_response() throws {
+    func test_it_maps_AIProduct_correctly_from_AI_json_response() async throws {
         // Given
         let data = try retrieveGenerateProductResponse()
         let mapper = AIProductMapper(siteID: siteID)
 
         // When
-        let product = try mapper.map(response: data)
+        let product = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(product.name, "Cookie")
@@ -26,13 +26,13 @@ final class AIProductMapperTests: XCTestCase {
         XCTAssertEqual(product.price, "250")
     }
 
-    func test_it_maps_AIProduct_correctly_when_no_shipping_info_available() throws {
+    func test_it_maps_AIProduct_correctly_when_no_shipping_info_available() async throws {
         // Given
         let data = try retrieveGenerateProductNoShippingInfoResponse()
         let mapper = AIProductMapper(siteID: siteID)
 
         // When
-        let product = try mapper.map(response: data)
+        let product = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(product.name, "Cookie")
@@ -48,13 +48,13 @@ final class AIProductMapperTests: XCTestCase {
         XCTAssertEqual(product.price, "250")
     }
 
-    func test_it_maps_AIProduct_correctly_when_no_weight_info_available() throws {
+    func test_it_maps_AIProduct_correctly_when_no_weight_info_available() async throws {
         // Given
         let data = try retrieveGenerateProductNoWeightInfoResponse()
         let mapper = AIProductMapper(siteID: siteID)
 
         // When
-        let product = try mapper.map(response: data)
+        let product = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(product.name, "Cookie")
@@ -70,13 +70,13 @@ final class AIProductMapperTests: XCTestCase {
         XCTAssertEqual(product.price, "250")
     }
 
-    func test_it_maps_AIProduct_correctly_when_no_dimensions_info_available() throws {
+    func test_it_maps_AIProduct_correctly_when_no_dimensions_info_available() async throws {
         // Given
         let data = try retrieveGenerateProductNoDimensionsInfoResponse()
         let mapper = AIProductMapper(siteID: siteID)
 
         // When
-        let product = try mapper.map(response: data)
+        let product = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(product.name, "Cookie")

--- a/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AccountMapperTests.swift
@@ -8,8 +8,8 @@ final class AccountMapperTests: XCTestCase {
 
     /// Verifies that all of the Account fields are properly parsed.
     ///
-    func test_Account_fields_are_properly_parsed() {
-        guard let account = mapLoadAccountResponse() else {
+    func test_Account_fields_are_properly_parsed() async {
+        guard let account = await mapLoadAccountResponse() else {
             XCTFail()
             return
         }
@@ -23,8 +23,8 @@ final class AccountMapperTests: XCTestCase {
 
     /// Verifies that all of the Site fields are properly parsed.
     ///
-    func test_Site_fields_are_properly_parsed() {
-        let sites = mapLoadSitesResponse()
+    func test_Site_fields_are_properly_parsed() async {
+        let sites = await mapLoadSitesResponse()
         XCTAssert(sites?.count == 2)
 
         // The first site is a Jetpack site.
@@ -78,8 +78,8 @@ final class AccountMapperTests: XCTestCase {
 
     /// Verifies that the Plan field for Site is properly parsed.
     ///
-    func test_SitePlan_field_is_properly_parsed() {
-        let site = mapLoadSitePlanResponse()
+    func test_SitePlan_field_is_properly_parsed() async {
+        let site = await mapLoadSitePlanResponse()
 
         XCTAssertEqual(site!.siteID, 1112233334444555)
         XCTAssertEqual(site!.shortName, "Business")
@@ -94,31 +94,31 @@ private extension AccountMapperTests {
 
     /// Returns the AccountMapper output upon receiving `me` mock response (Data Encoded).
     ///
-    func mapLoadAccountResponse() -> Account? {
+    func mapLoadAccountResponse() async -> Account? {
         guard let response = Loader.contentsOf("me") else {
             return nil
         }
 
-        return try? AccountMapper().map(response: response)
+        return try? await AccountMapper().map(response: response)
     }
 
     /// Returns the SiteListMapper output upon receiving `me/sites` mock response (Data Encoded).
     ///
-    func mapLoadSitesResponse() -> [Site]? {
+    func mapLoadSitesResponse() async -> [Site]? {
         guard let response = Loader.contentsOf("sites") else {
             return nil
         }
 
-        return try? SiteListMapper().map(response: response)
+        return try? await SiteListMapper().map(response: response)
     }
 
     /// Returns the SitePlanMapper output upon receiving `sites/$site` mock response (Data Encoded).
     ///
-    func mapLoadSitePlanResponse() -> SitePlan? {
+    func mapLoadSitePlanResponse() async -> SitePlan? {
         guard let response = Loader.contentsOf("site-plan") else {
             return nil
         }
 
-        return try? SitePlanMapper().map(response: response)
+        return try? await SitePlanMapper().map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/AccountSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AccountSettingsMapperTests.swift
@@ -8,8 +8,8 @@ class AccountSettingsMapperTests: XCTestCase {
 
     /// Verifies that all of the AccountSettings fields are properly parsed.
     ///
-    func test_Account_fields_are_properly_parsed() {
-        guard let account = mapLoadAccountSettingsResponse() else {
+    func test_Account_fields_are_properly_parsed() async {
+        guard let account = await mapLoadAccountSettingsResponse() else {
             XCTFail()
             return
         }
@@ -29,11 +29,11 @@ private extension AccountSettingsMapperTests {
 
     /// Returns the AccountSettingsMapper output upon receiving `me-settings` mock response (Data Encoded).
     ///
-    func mapLoadAccountSettingsResponse() -> AccountSettings? {
+    func mapLoadAccountSettingsResponse() async -> AccountSettings? {
         guard let response = Loader.contentsOf("me-settings") else {
             return nil
         }
 
-        return try? AccountSettingsMapper(userID: 10).map(response: response)
+        return try? await AccountSettingsMapper(userID: 10).map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/AddOnGroupMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AddOnGroupMapperTests.swift
@@ -5,9 +5,9 @@ class AddOnGroupMapperTests: XCTestCase {
 
     private let dummySiteID: Int64 = 123
 
-    func test_addOnGroups_field_are_properly_parsed() throws {
+    func test_addOnGroups_field_are_properly_parsed() async throws {
         // Given & When
-        let addOnGroups = try XCTUnwrap(mapLoadGroupAddOnsResponse())
+        let addOnGroups = try await mapLoadGroupAddOnsResponse()
 
         // Then
         XCTAssertEqual(addOnGroups.count, 2)
@@ -25,9 +25,9 @@ class AddOnGroupMapperTests: XCTestCase {
         XCTAssertEqual(secondGroup.addOns.count, 1)
     }
 
-    func test_addOnGroups_field_are_properly_parsed_when_response_has_no_data_envelope() throws {
+    func test_addOnGroups_field_are_properly_parsed_when_response_has_no_data_envelope() async throws {
         // Given & When
-        let addOnGroups = try XCTUnwrap(mapLoadGroupAddOnsResponseWithoutDataEnvelope())
+        let addOnGroups = try await mapLoadGroupAddOnsResponseWithoutDataEnvelope()
 
         // Then
         XCTAssertEqual(addOnGroups.count, 2)
@@ -48,17 +48,19 @@ class AddOnGroupMapperTests: XCTestCase {
 
 // MARK: JSON Loading
 private extension AddOnGroupMapperTests {
-    func mapLoadGroupAddOnsResponse() -> [AddOnGroup]? {
+    func mapLoadGroupAddOnsResponse() async throws -> [AddOnGroup] {
         guard let response = Loader.contentsOf("add-on-groups") else {
-            return nil
+            throw FileNotFoundError()
         }
-        return try? AddOnGroupMapper(siteID: dummySiteID).map(response: response)
+        return try await AddOnGroupMapper(siteID: dummySiteID).map(response: response)
     }
 
-    func mapLoadGroupAddOnsResponseWithoutDataEnvelope() -> [AddOnGroup]? {
+    func mapLoadGroupAddOnsResponseWithoutDataEnvelope() async throws -> [AddOnGroup] {
         guard let response = Loader.contentsOf("add-on-groups-without-data") else {
-            return nil
+            throw FileNotFoundError()
         }
-        return try? AddOnGroupMapper(siteID: dummySiteID).map(response: response)
+        return try await AddOnGroupMapper(siteID: dummySiteID).map(response: response)
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/AnnouncementListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AnnouncementListMapperTests.swift
@@ -4,8 +4,8 @@ import XCTest
 final class AnnouncementListMapperTests: XCTestCase {
     /// Verifies that all of the Announcement fields are properly parsed.
     ///
-    func test_announcements_are_properly_parsed() {
-        let announcements = mapLoadAnnouncementListResponse()
+    func test_announcements_are_properly_parsed() async {
+        let announcements = await mapLoadAnnouncementListResponse()
 
         assertEqual(1, announcements.count)
         let firstItem = announcements[0]
@@ -28,11 +28,11 @@ final class AnnouncementListMapperTests: XCTestCase {
 }
 
 private extension AnnouncementListMapperTests {
-    func mapLoadAnnouncementListResponse() -> [Announcement] {
+    func mapLoadAnnouncementListResponse() async -> [Announcement] {
         guard let response = Loader.contentsOf("announcements") else {
             return []
         }
 
-        return (try? AnnouncementListMapper().map(response: response)) ?? []
+        return (try? await AnnouncementListMapper().map(response: response)) ?? []
     }
 }

--- a/Networking/NetworkingTests/Mapper/ApplicationPasswordMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ApplicationPasswordMapperTests.swift
@@ -10,8 +10,8 @@ final class ApplicationPasswordMapperTests: XCTestCase {
 
     /// Verifies that generate password using WPCOM token response is parsed properly
     ///
-    func test_response_is_properly_parsed_while_generating_password_using_WPCOM_token() {
-        guard let password = mapGenerateUsingWPOrgResponse() else {
+    func test_response_is_properly_parsed_while_generating_password_using_WPCOM_token() async {
+        guard let password = await mapGenerateUsingWPOrgResponse() else {
             XCTFail()
             return
         }
@@ -28,11 +28,11 @@ private extension ApplicationPasswordMapperTests {
 
     /// Returns the ApplicationPasswordMapper output upon receiving success response
     ///
-    func mapGenerateUsingWPOrgResponse() -> ApplicationPassword? {
+    func mapGenerateUsingWPOrgResponse() async -> ApplicationPassword? {
         guard let response = Loader.contentsOf("generate-application-password-using-wporg-creds-success") else {
             return nil
         }
 
-        return try? ApplicationPasswordMapper(wpOrgUsername: wpOrgUsername).map(response: response)
+        return try? await ApplicationPasswordMapper(wpOrgUsername: wpOrgUsername).map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/ApplicationPasswordNameAndUUIDMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ApplicationPasswordNameAndUUIDMapperTests.swift
@@ -6,8 +6,8 @@ import XCTest
 final class ApplicationPasswordNameAndUUIDMapperTests: XCTestCase {
     /// Verifies that GET application password response is parsed properly
     ///
-    func test_response_is_properly_parsed_when_loading_all_application_passwords() throws {
-        guard let passwords = mapGetApplicationPasswordsResponse() else {
+    func test_response_is_properly_parsed_when_loading_all_application_passwords() async throws {
+        guard let passwords = await mapGetApplicationPasswordsResponse() else {
             XCTFail()
             return
         }
@@ -24,11 +24,11 @@ private extension ApplicationPasswordNameAndUUIDMapperTests {
 
     /// Returns the ApplicationPasswordNameAndUUIDMapper output upon receiving success response
     ///
-    func mapGetApplicationPasswordsResponse() -> [ApplicationPasswordNameAndUUID]? {
+    func mapGetApplicationPasswordsResponse() async -> [ApplicationPasswordNameAndUUID]? {
         guard let response = Loader.contentsOf("get-application-passwords-success") else {
             return nil
         }
 
-        return try? ApplicationPasswordNameAndUUIDMapper().map(response: response)
+        return try? await ApplicationPasswordNameAndUUIDMapper().map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
@@ -9,8 +9,8 @@ final class BlazeCampaignListMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed.
     ///
-    func test_BlazeCampaignListMapper_parses_all_contents_in_response() throws {
-        let campaigns = try mapLoadBlazeCampaignListResponse()
+    func test_BlazeCampaignListMapper_parses_all_contents_in_response() async throws {
+        let campaigns = try await mapLoadBlazeCampaignListResponse()
         XCTAssertEqual(campaigns.count, 1)
 
         let item = try XCTUnwrap(campaigns.first)
@@ -33,17 +33,17 @@ private extension BlazeCampaignListMapperTests {
 
     /// Returns the BlazeCampaignListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapBlazeCampaignList(from filename: String) throws -> [BlazeCampaign] {
+    func mapBlazeCampaignList(from filename: String) async throws -> [BlazeCampaign] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try BlazeCampaignListMapper(siteID: dummySiteID).map(response: response)
+        return try await BlazeCampaignListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the BlazeCampaignListMapper output from `blaze-campaigns-success.json`
     ///
-    func mapLoadBlazeCampaignListResponse() throws -> [BlazeCampaign] {
-        return try mapBlazeCampaignList(from: "blaze-campaigns-success")
+    func mapLoadBlazeCampaignListResponse() async throws -> [BlazeCampaign] {
+        try await mapBlazeCampaignList(from: "blaze-campaigns-success")
     }
 }

--- a/Networking/NetworkingTests/Mapper/CommentResultMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CommentResultMapperTests.swift
@@ -8,8 +8,8 @@ class CommentResultMapperTests: XCTestCase {
 
     /// Verifies that the broken response causes the mapper to return an unknown status
     ///
-    func test_broken_response_returns_unknown_status() {
-        let commentStatus = try? mapLoadBrokenResponse()
+    func test_broken_response_returns_unknown_status() async {
+        let commentStatus = try? await mapLoadBrokenResponse()
 
         XCTAssertNotNil(commentStatus)
         XCTAssertEqual(commentStatus, .unknown)
@@ -17,8 +17,8 @@ class CommentResultMapperTests: XCTestCase {
 
     /// Verifies that an approved status response is properly parsed (YAY!).
     ///
-    func test_sample_approved_response_loaded() {
-        let commentStatus = try? mapApprovedResponse()
+    func test_sample_approved_response_loaded() async {
+        let commentStatus = try? await mapApprovedResponse()
 
         XCTAssertNotNil(commentStatus)
         XCTAssertEqual(commentStatus, .approved)
@@ -26,8 +26,8 @@ class CommentResultMapperTests: XCTestCase {
 
     /// Verifies that an unapproved status response is properly parsed (YAY!).
     ///
-    func test_sample_unapproved_response_loaded() {
-        let commentStatus = try? mapUnapprovedResponse()
+    func test_sample_unapproved_response_loaded() async {
+        let commentStatus = try? await mapUnapprovedResponse()
 
         XCTAssertNotNil(commentStatus)
         XCTAssertEqual(commentStatus, .unapproved)
@@ -35,8 +35,8 @@ class CommentResultMapperTests: XCTestCase {
 
     /// Verifies that a spam status response is properly parsed (YAY!).
     ///
-    func test_sample_spam_response_loaded() {
-        let commentStatus = try? mapSpamResponse()
+    func test_sample_spam_response_loaded() async {
+        let commentStatus = try? await mapSpamResponse()
 
         XCTAssertNotNil(commentStatus)
         XCTAssertEqual(commentStatus, .spam)
@@ -44,8 +44,8 @@ class CommentResultMapperTests: XCTestCase {
 
     /// Verifies that a trash status response is properly parsed (YAY!).
     ///
-    func test_sample_trash_response_loaded() {
-        let commentStatus = try? mapTrashResponse()
+    func test_sample_trash_response_loaded() async {
+        let commentStatus = try? await mapTrashResponse()
 
         XCTAssertNotNil(commentStatus)
         XCTAssertEqual(commentStatus, .trash)
@@ -59,40 +59,40 @@ private extension CommentResultMapperTests {
 
     /// Returns the CommentResultMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapCommentResult(from filename: String) throws -> CommentStatus {
+    func mapCommentResult(from filename: String) async throws -> CommentStatus {
         let response = Loader.contentsOf(filename)!
         let mapper = CommentResultMapper()
 
-        return try mapper.map(response: response)
+        return try await mapper.map(response: response)
     }
 
     /// Returns the CommentResultMapper output upon receiving an 'approved' status from the endpoint
     ///
-    func mapApprovedResponse() throws -> CommentStatus {
-        return try mapCommentResult(from: "comment-moderate-approved")
+    func mapApprovedResponse() async throws -> CommentStatus {
+        return try await mapCommentResult(from: "comment-moderate-approved")
     }
 
     /// Returns the CommentResultMapper output upon receiving an 'unapproved' status from the endpoint
     ///
-    func mapUnapprovedResponse() throws -> CommentStatus {
-        return try mapCommentResult(from: "comment-moderate-unapproved")
+    func mapUnapprovedResponse() async throws -> CommentStatus {
+        return try await mapCommentResult(from: "comment-moderate-unapproved")
     }
 
     /// Returns the CommentResultMapper output upon receiving an 'spam' status from the endpoint
     ///
-    func mapSpamResponse() throws -> CommentStatus {
-        return try mapCommentResult(from: "comment-moderate-spam")
+    func mapSpamResponse() async throws -> CommentStatus {
+        return try await mapCommentResult(from: "comment-moderate-spam")
     }
 
     /// Returns the CommentResultMapper output upon receiving an 'trash' status from the endpoint
     ///
-    func mapTrashResponse() throws -> CommentStatus {
-        return try mapCommentResult(from: "comment-moderate-trash")
+    func mapTrashResponse() async throws -> CommentStatus {
+        return try await mapCommentResult(from: "comment-moderate-trash")
     }
 
     /// Returns the CommentResultMapper output upon receiving a broken response.
     ///
-    func mapLoadBrokenResponse() throws -> CommentStatus {
-        return try mapCommentResult(from: "generic_error")
+    func mapLoadBrokenResponse() async throws -> CommentStatus {
+        return try await mapCommentResult(from: "generic_error")
     }
 }

--- a/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
@@ -8,8 +8,8 @@ class CountryListMapperTests: XCTestCase {
 
     /// Verifies that the Country List is parsed correctly.
     ///
-    func test_countries_are_properly_parsed() {
-        guard let countries = mapCountriesResponse() else {
+    func test_countries_are_properly_parsed() async {
+        guard let countries = await mapCountriesResponse() else {
             XCTFail()
             return
         }
@@ -22,8 +22,8 @@ class CountryListMapperTests: XCTestCase {
         XCTAssertEqual(countries[1].states.first, StateOfACountry(code: "PY-ASU", name: "Asunción"))
     }
 
-    func test_countries_are_properly_parsed_if_the_response_has_no_data_envelope() {
-        guard let countries = mapCountriesResponseWithoutDataEnvelope() else {
+    func test_countries_are_properly_parsed_if_the_response_has_no_data_envelope() async {
+        guard let countries = await mapCountriesResponseWithoutDataEnvelope() else {
             XCTFail()
             return
         }
@@ -43,23 +43,23 @@ private extension CountryListMapperTests {
 
     /// Returns the CountryListMapperTests output upon receiving `filename` (Data Encoded)
     ///
-    func mapCountries(from filename: String) -> [Country]? {
+    func mapCountries(from filename: String) async -> [Country]? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! CountryListMapper().map(response: response)
+        return try! await CountryListMapper().map(response: response)
     }
 
     /// Returns the [Country] output upon receiving `countries`
     ///
-    func mapCountriesResponse() -> [Country]? {
-        return mapCountries(from: "countries")
+    func mapCountriesResponse() async -> [Country]? {
+        return await mapCountries(from: "countries")
     }
 
     /// Returns the [Country] output upon receiving `countries-without-data`
     ///
-    func mapCountriesResponseWithoutDataEnvelope() -> [Country]? {
-        return mapCountries(from: "countries-without-data")
+    func mapCountriesResponseWithoutDataEnvelope() async -> [Country]? {
+        return await mapCountries(from: "countries-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
@@ -9,22 +9,22 @@ class CouponListMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed, minus the items with non-default discount type.
     ///
-    func test_CouponsList_map_parses_all_coupons_in_response() throws {
-        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
+    func test_CouponsList_map_parses_all_coupons_in_response() async throws {
+        let coupons = try await mapLoadAllCouponsResponseWithDataEnvelope()
         XCTAssertEqual(coupons.count, 4)
     }
 
     /// Verifies that the whole list is parsed, minus the items with non-default discount type.
     ///
-    func test_CouponsList_map_parses_all_coupons_in_response_without_data_envelope() throws {
-        let coupons = try mapLoadAllCouponsResponseWithoutDataEnvelope()
+    func test_CouponsList_map_parses_all_coupons_in_response_without_data_envelope() async throws {
+        let coupons = try await mapLoadAllCouponsResponseWithoutDataEnvelope()
         XCTAssertEqual(coupons.count, 4)
     }
 
     /// Verifies that the `siteID` is added in the mapper, to all results, because it's not provided by the API endpoint
     ///
-    func test_CouponsList_map_includes_siteID_in_parsed_results() throws {
-        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
+    func test_CouponsList_map_includes_siteID_in_parsed_results() async throws {
+        let coupons = try await mapLoadAllCouponsResponseWithDataEnvelope()
         XCTAssertTrue(coupons.count > 0)
 
         for coupon in coupons {
@@ -34,8 +34,8 @@ class CouponListMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly
     ///
-    func test_CouponsList_map_parses_all_fields_in_result() throws {
-        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
+    func test_CouponsList_map_parses_all_fields_in_result() async throws {
+        let coupons = try await mapLoadAllCouponsResponseWithDataEnvelope()
         let coupon = coupons[0]
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
@@ -69,8 +69,8 @@ class CouponListMapperTests: XCTestCase {
 
     /// Verifies that nulls in optional fields are parsed correctly
     ///
-    func test_CouponsList_map_accepts_nulls_in_expected_optional_fields() throws {
-        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
+    func test_CouponsList_map_accepts_nulls_in_expected_optional_fields() async throws {
+        let coupons = try await mapLoadAllCouponsResponseWithDataEnvelope()
         let coupon = coupons[2]
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
@@ -110,23 +110,23 @@ private extension CouponListMapperTests {
 
     /// Returns the CouponListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapCoupons(from filename: String) throws -> [Coupon] {
+    func mapCoupons(from filename: String) async throws -> [Coupon] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try CouponListMapper(siteID: dummySiteID).map(response: response)
+        return try await CouponListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the CouponsMapper output from `coupons-all.json`
     ///
-    func mapLoadAllCouponsResponseWithDataEnvelope() throws -> [Coupon] {
-        return try mapCoupons(from: "coupons-all")
+    func mapLoadAllCouponsResponseWithDataEnvelope() async throws -> [Coupon] {
+        return try await mapCoupons(from: "coupons-all")
     }
 
     /// Returns the CouponsMapper output from `coupons-all-without-data.json`
     ///
-    func mapLoadAllCouponsResponseWithoutDataEnvelope() throws -> [Coupon] {
-        return try mapCoupons(from: "coupons-all-without-data")
+    func mapLoadAllCouponsResponseWithoutDataEnvelope() async throws -> [Coupon] {
+        return try await mapCoupons(from: "coupons-all-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/CouponMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponMapperTests.swift
@@ -9,29 +9,29 @@ final class CouponMapperTests: XCTestCase {
 
     /// Verifies that the coupon is parsed.
     ///
-    func test_Coupon_map_parses_coupon_in_response() throws {
-        let coupon = try mapRetrieveCouponResponse()
+    func test_Coupon_map_parses_coupon_in_response() async throws {
+        let coupon = try await mapRetrieveCouponResponse()
         XCTAssertNotNil(coupon)
     }
 
     /// Verifies that the coupon is parsed.
     ///
-    func test_Coupon_map_parses_coupon_in_response_without_data_envelope() throws {
-        let coupon = try mapRetrieveCouponResponseWithoutDataEnvelope()
+    func test_Coupon_map_parses_coupon_in_response_without_data_envelope() async throws {
+        let coupon = try await mapRetrieveCouponResponseWithoutDataEnvelope()
         XCTAssertNotNil(coupon)
     }
 
     /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint
     ///
-    func test_coupon_map_includes_siteID_in_parsed_results() throws {
-        let coupon = try mapRetrieveCouponResponse()
+    func test_coupon_map_includes_siteID_in_parsed_results() async throws {
+        let coupon = try await mapRetrieveCouponResponse()
         XCTAssertEqual(coupon.siteID, dummySiteID)
     }
 
     /// Verifies that the fields are all parsed correctly
     ///
-    func test_coupon_map_parses_all_fields_in_result() throws {
-        let coupon = try mapRetrieveCouponResponse()
+    func test_coupon_map_parses_all_fields_in_result() async throws {
+        let coupon = try await mapRetrieveCouponResponse()
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
 
@@ -71,24 +71,24 @@ private extension CouponMapperTests {
 
     /// Returns the CouponMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapCoupon(from filename: String) throws -> Coupon {
+    func mapCoupon(from filename: String) async throws -> Coupon {
         guard let response = Loader.contentsOf(filename) else {
             throw FileNotFoundError()
         }
 
-        return try CouponMapper(siteID: dummySiteID).map(response: response)
+        return try await CouponMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the CouponMapper output from `coupon.json`
     ///
-    func mapRetrieveCouponResponse() throws -> Coupon {
-        return try mapCoupon(from: "coupon")
+    func mapRetrieveCouponResponse() async throws -> Coupon {
+        return try await mapCoupon(from: "coupon")
     }
 
     /// Returns the CouponMapper output from `coupon-without-data.json`
     ///
-    func mapRetrieveCouponResponseWithoutDataEnvelope() throws -> Coupon {
-        return try mapCoupon(from: "coupon-without-data")
+    func mapRetrieveCouponResponseWithoutDataEnvelope() async throws -> Coupon {
+        return try await mapCoupon(from: "coupon-without-data")
     }
 
     struct FileNotFoundError: Error {}

--- a/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponReportListMapperTests.swift
@@ -5,9 +5,9 @@ final class CouponReportListMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed.
     ///
-    func test_mapper_parses_all_reports_in_response() throws {
+    func test_mapper_parses_all_reports_in_response() async throws {
         // Given
-        let reports = try mapLoadAllCouponReportsResponseWithDataEnvelope()
+        let reports = try await mapLoadAllCouponReportsResponseWithDataEnvelope()
 
         // Then
         XCTAssertEqual(reports.count, 1)
@@ -15,9 +15,9 @@ final class CouponReportListMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed.
     ///
-    func test_mapper_parses_all_reports_in_response_without_data_envelop() throws {
+    func test_mapper_parses_all_reports_in_response_without_data_envelop() async throws {
         // Given
-        let reports = try mapLoadAllCouponReportsResponseWithoutDataEnvelope()
+        let reports = try await mapLoadAllCouponReportsResponseWithoutDataEnvelope()
 
         // Then
         XCTAssertEqual(reports.count, 1)
@@ -25,9 +25,9 @@ final class CouponReportListMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly
     ///
-    func test_mapper_parses_all_fields_in_result() throws {
+    func test_mapper_parses_all_fields_in_result() async throws {
         // Given
-        let reports = try mapLoadAllCouponReportsResponseWithDataEnvelope()
+        let reports = try await mapLoadAllCouponReportsResponseWithDataEnvelope()
         let report = reports[0]
         let expectedReport = CouponReport(couponID: 571, amount: 12, ordersCount: 1)
 
@@ -42,23 +42,23 @@ private extension CouponReportListMapperTests {
 
     /// Returns the CouponReportListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapReports(from filename: String) throws -> [CouponReport] {
+    func mapReports(from filename: String) async throws -> [CouponReport] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try CouponReportListMapper().map(response: response)
+        return try await CouponReportListMapper().map(response: response)
     }
 
     /// Returns the CouponsReport list from `coupon-reports.json`
     ///
-    func mapLoadAllCouponReportsResponseWithDataEnvelope() throws -> [CouponReport] {
-        return try mapReports(from: "coupon-reports")
+    func mapLoadAllCouponReportsResponseWithDataEnvelope() async throws -> [CouponReport] {
+        return try await mapReports(from: "coupon-reports")
     }
 
     /// Returns the CouponsReport list from `coupon-reports-without-data.json`
     ///
-    func mapLoadAllCouponReportsResponseWithoutDataEnvelope() throws -> [CouponReport] {
-        return try mapReports(from: "coupon-reports-without-data")
+    func mapLoadAllCouponReportsResponseWithoutDataEnvelope() async throws -> [CouponReport] {
+        return try await mapReports(from: "coupon-reports-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
@@ -16,7 +16,7 @@ class CustomerMapperTests: XCTestCase {
 
     /// Verifies that the Customer object can be mapped fron the Encoded data
     ///
-    func test_Customer_is_mapped_from_encoded_data() {
+    func test_Customer_is_mapped_from_encoded_data() async throws {
         // Given
         let mapper = CustomerMapper(siteID: dummySiteID)
         guard let data = Loader.contentsOf(filename) else {
@@ -25,7 +25,7 @@ class CustomerMapperTests: XCTestCase {
         }
 
         // When
-        let customer = try? mapper.map(response: data)
+        let customer = try await mapper.map(response: data)
 
         // Then
         XCTAssertNotNil(mapper)
@@ -34,9 +34,9 @@ class CustomerMapperTests: XCTestCase {
 
     /// Verifies that all of the Customer response values are parsed correctly
     ///
-    func test_Customer_response_values_are_correctly_parsed() throws {
+    func test_Customer_response_values_are_correctly_parsed() async throws {
         // Given
-        guard let customer = try mapCustomer(from: filename) else {
+        guard let customer = try await mapCustomer(from: filename) else {
             XCTFail()
             return
         }
@@ -66,9 +66,9 @@ class CustomerMapperTests: XCTestCase {
 
     /// Verifies that all of the Customer response values are parsed correctly
     ///
-    func test_Customer_response_values_are_correctly_parsed_when_response_has_no_data_envelope() throws {
+    func test_Customer_response_values_are_correctly_parsed_when_response_has_no_data_envelope() async throws {
         // Given
-        guard let customer = try mapCustomer(from: fileNameWithoutDataEnvelope) else {
+        guard let customer = try await mapCustomer(from: fileNameWithoutDataEnvelope) else {
             XCTFail()
             return
         }
@@ -100,10 +100,10 @@ class CustomerMapperTests: XCTestCase {
 private extension CustomerMapperTests {
     /// Returns the CustomerMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapCustomer(from filename: String) throws -> Customer? {
+    func mapCustomer(from filename: String) async throws -> Customer? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
-        return try! CustomerMapper(siteID: dummySiteID).map(response: response)
+        return try await CustomerMapper(siteID: dummySiteID).map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/DotcomDeviceMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/DotcomDeviceMapperTests.swift
@@ -13,8 +13,8 @@ class DotcomDeviceMapperTests: XCTestCase {
 
     /// Verifies that DotcomDeviceMapper correctly parses the DeviceSettings Entity
     ///
-    func test_device_settings_mapper_correctly_parses_device_identifier() {
-        let settings = try? mapDotcomDevice(from: sampleDeviceSettings)
+    func test_device_settings_mapper_correctly_parses_device_identifier() async {
+        let settings = try? await mapDotcomDevice(from: sampleDeviceSettings)
 
         XCTAssertNotNil(settings)
         XCTAssertEqual(settings!.deviceID, "12345678")
@@ -27,10 +27,10 @@ private extension DotcomDeviceMapperTests {
 
     /// Returns the DotcomDeviceMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapDotcomDevice(from filename: String) throws -> DotcomDevice {
+    func mapDotcomDevice(from filename: String) async throws -> DotcomDevice {
         let response = Loader.contentsOf(filename)!
         let mapper = DotcomDeviceMapper()
 
-        return try mapper.map(response: response)
+        return try await mapper.map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/EntityDateModifiedMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/EntityDateModifiedMapperTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 final class EntityDateModifiedMapperTests: XCTestCase {
 
-    func test_date_modified_is_properly_parsed() throws {
+    func test_date_modified_is_properly_parsed() async throws {
         // Given
-        let dates = [mapLoadDatesResponse(), mapLoadDatesResponseWithoutData()]
+        let dates = [await mapLoadDatesResponse(), await mapLoadDatesResponseWithoutData()]
         let expectedDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2023-03-29T03:23:02")
 
         for date in dates {
@@ -22,23 +22,23 @@ private extension EntityDateModifiedMapperTests {
 
     /// Returns the EntityIDMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapDate(from filename: String) -> Date? {
+    func mapDate(from filename: String) async -> Date? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! EntityDateModifiedMapper().map(response: response)
+        return try! await EntityDateModifiedMapper().map(response: response)
     }
 
     /// Returns the EntityIDMapper output upon receiving `date-modified-gmt`
     ///
-    func mapLoadDatesResponse() -> Date? {
-        mapDate(from: "date-modified-gmt")
+    func mapLoadDatesResponse() async -> Date? {
+        await mapDate(from: "date-modified-gmt")
     }
 
     /// Returns the EntityIDMapper output upon receiving `date-modified-gmt-without-data`
     ///
-    func mapLoadDatesResponseWithoutData() -> Date? {
-        mapDate(from: "date-modified-gmt-without-data")
+    func mapLoadDatesResponseWithoutData() async -> Date? {
+        await mapDate(from: "date-modified-gmt-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/EntityIDMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/EntityIDMapperTests.swift
@@ -11,9 +11,9 @@ final class EntityIDMapperTests: XCTestCase {
 
     /// Verifies that IDs are parsed correctly.
     ///
-    func test_id_is_properly_parsed() throws {
+    func test_id_is_properly_parsed() async throws {
         // Given
-        let ids = try [mapLoadIDsResponse(), mapLoadIDsResponseWithoutData()]
+        let ids = try [await mapLoadIDsResponse(), await mapLoadIDsResponseWithoutData()]
         let expected: Int64 = 3946
 
         for id in ids {
@@ -29,23 +29,23 @@ private extension EntityIDMapperTests {
 
     /// Returns the EntityIDMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapIDs(from filename: String) throws -> Int64 {
+    func mapIDs(from filename: String) async throws -> Int64 {
         guard let response = Loader.contentsOf(filename) else {
             throw EntityIDMapperTestsError.unableToLoadFile
         }
 
-        return try! EntityIDMapper().map(response: response)
+        return try await EntityIDMapper().map(response: response)
     }
 
     /// Returns the EntityIDMapper output upon receiving `product-id-only`
     ///
-    func mapLoadIDsResponse() throws -> Int64 {
-        try mapIDs(from: "product-id-only")
+    func mapLoadIDsResponse() async throws -> Int64 {
+        try await mapIDs(from: "product-id-only")
     }
 
     /// Returns the EntityIDMapper output upon receiving `product-id-only-without-data`
     ///
-    func mapLoadIDsResponseWithoutData() throws -> Int64 {
-        try mapIDs(from: "product-id-only-without-data")
+    func mapLoadIDsResponseWithoutData() async throws -> Int64 {
+        try await mapIDs(from: "product-id-only-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/IgnoringResponseMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/IgnoringResponseMapperTests.swift
@@ -6,16 +6,16 @@ import XCTest
 ///
 class IgnoringResponseMapperTests: XCTestCase {
 
-    func test_null_data_does_not_error() throws {
-        try mapData(from: "null-data")
+    func test_null_data_does_not_error() async throws {
+        try await mapData(from: "null-data")
     }
 
-    func test_non_null_data_does_not_error() throws {
-        try mapData(from: "generic_success_data")
+    func test_non_null_data_does_not_error() async throws {
+        try await mapData(from: "generic_success_data")
     }
 
-    func test_missing_data_envelope_does_not_error() throws {
-        try mapData(from: "generic_success")
+    func test_missing_data_envelope_does_not_error() async throws {
+        try await mapData(from: "generic_success")
     }
 }
 
@@ -23,12 +23,12 @@ private extension IgnoringResponseMapperTests {
 
     /// Runs EmptyResponseMapper on encoded data in `filename`
     ///
-    func mapData(from filename: String) throws {
+    func mapData(from filename: String) async throws {
         guard let response = Loader.contentsOf(filename) else {
             throw IgnoringResponseMapperTestsError.noFileFound
         }
 
-        try IgnoringResponseMapper().map(response: response)
+        try await IgnoringResponseMapper().map(response: response)
     }
 
     enum IgnoringResponseMapperTestsError: Error {

--- a/Networking/NetworkingTests/Mapper/InAppPurchaseOrderResultMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InAppPurchaseOrderResultMapperTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import Networking
 
 final class InAppPurchasesOrderResultMapperTests: XCTestCase {
-    func test_iap_order_creation_is_decoded_from_json_response() throws {
+    func test_iap_order_creation_is_decoded_from_json_response() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-order-create"))
         let expectedOrderId = 12345
 
         // When
-        let orderId = try InAppPurchaseOrderResultMapper().map(response: jsonData)
+        let orderId = try await InAppPurchaseOrderResultMapper().map(response: jsonData)
 
         // Then
         assertEqual(expectedOrderId, orderId)

--- a/Networking/NetworkingTests/Mapper/InAppPurchasesProductsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InAppPurchasesProductsMapperTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Networking
 
 final class InAppPurchasesProductsMapperTests: XCTestCase {
-    func test_iap_products_list_is_decoded_from_json_response() throws {
+    func test_iap_products_list_is_decoded_from_json_response() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-products"))
         let expectedProductIdentifiers = [
@@ -10,7 +10,7 @@ final class InAppPurchasesProductsMapperTests: XCTestCase {
         ]
 
         // When
-        let products = try InAppPurchasesProductMapper().map(response: jsonData)
+        let products = try await InAppPurchasesProductMapper().map(response: jsonData)
 
         // Then
         assertEqual(expectedProductIdentifiers, products)

--- a/Networking/NetworkingTests/Mapper/InAppPurchasesTransactionMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InAppPurchasesTransactionMapperTests.swift
@@ -2,26 +2,26 @@ import XCTest
 @testable import Networking
 
 final class InAppPurchasesTransactionMapperTests: XCTestCase {
-    func test_iap_handled_transaction_is_decoded_from_json_response() throws {
+    func test_iap_handled_transaction_is_decoded_from_json_response() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-transaction-handled"))
         let expectedSiteID = Int64(1234)
 
         // When
-        let decodedResponse = try InAppPurchasesTransactionMapper().map(response: jsonData)
+        let decodedResponse = try await InAppPurchasesTransactionMapper().map(response: jsonData)
 
         // Then
         assertEqual(expectedSiteID, decodedResponse.siteID)
     }
 
-    func test_iap_unhandled_transaction_is_decoded_from_json_response() throws {
+    func test_iap_unhandled_transaction_is_decoded_from_json_response() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-transaction-not-handled"))
         let expectedErrorMessage = "Transaction not found."
         let expectedErrorCode = 404
 
         // When
-        let decodedResponse = try InAppPurchasesTransactionMapper().map(response: jsonData)
+        let decodedResponse = try await InAppPurchasesTransactionMapper().map(response: jsonData)
 
         // Then
         assertEqual(expectedErrorMessage, decodedResponse.message)

--- a/Networking/NetworkingTests/Mapper/InboxNoteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InboxNoteListMapperTests.swift
@@ -9,22 +9,22 @@ final class InboxNoteListMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed.
     ///
-    func test_InboxNoteListMapper_parses_all_InboxNotes_in_response() throws {
-        let inboxNotes = try mapLoadInboxNoteListResponse()
+    func test_InboxNoteListMapper_parses_all_InboxNotes_in_response() async throws {
+        let inboxNotes = try await mapLoadInboxNoteListResponse()
         XCTAssertEqual(inboxNotes.count, 24)
     }
 
     /// Verifies that the whole list is parsed when response has no data envelope.
     ///
-    func test_InboxNoteListMapper_parses_all_InboxNotes_in_response_without_data_envelope() throws {
-        let inboxNotes = try mapLoadInboxNoteListResponseWithoutDataEnvelope()
+    func test_InboxNoteListMapper_parses_all_InboxNotes_in_response_without_data_envelope() async throws {
+        let inboxNotes = try await mapLoadInboxNoteListResponseWithoutDataEnvelope()
         XCTAssertEqual(inboxNotes.count, 2)
     }
 
     /// Verifies that the `siteID` is added in the mapper, to all results, because it's not provided by the API endpoint.
     ///
-    func test_InboxNoteListMapper_includes_siteID_in_parsed_results() throws {
-        let inboxNotes = try mapLoadInboxNoteListResponse()
+    func test_InboxNoteListMapper_includes_siteID_in_parsed_results() async throws {
+        let inboxNotes = try await mapLoadInboxNoteListResponse()
         XCTAssertTrue(inboxNotes.count > 0)
 
         for inboxNote in inboxNotes {
@@ -34,9 +34,9 @@ final class InboxNoteListMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly.
     ///
-    func test_InboxNoteListMapper_parses_all_fields_in_result() throws {
+    func test_InboxNoteListMapper_parses_all_fields_in_result() async throws {
         // Given
-        let inboxNotes = try mapLoadInboxNoteListResponse()
+        let inboxNotes = try await mapLoadInboxNoteListResponse()
         let inboxNote = inboxNotes[0]
 
         // When
@@ -71,23 +71,23 @@ private extension InboxNoteListMapperTests {
 
     /// Returns the InboxNoteListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapInboxNoteList(from filename: String) throws -> [InboxNote] {
+    func mapInboxNoteList(from filename: String) async throws -> [InboxNote] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try InboxNoteListMapper(siteID: dummySiteID).map(response: response)
+        return try await InboxNoteListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the InboxNoteListMapper output from `inbox-note-list.json`
     ///
-    func mapLoadInboxNoteListResponse() throws -> [InboxNote] {
-        return try mapInboxNoteList(from: "inbox-note-list")
+    func mapLoadInboxNoteListResponse() async throws -> [InboxNote] {
+        return try await mapInboxNoteList(from: "inbox-note-list")
     }
 
     /// Returns the InboxNoteListMapper output from `inbox-note-list-without-data.json`
     ///
-    func mapLoadInboxNoteListResponseWithoutDataEnvelope() throws -> [InboxNote] {
-        return try mapInboxNoteList(from: "inbox-note-list-without-data")
+    func mapLoadInboxNoteListResponseWithoutDataEnvelope() async throws -> [InboxNote] {
+        return try await mapInboxNoteList(from: "inbox-note-list-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InboxNoteMapperTests.swift
@@ -9,30 +9,30 @@ final class InboxNoteMapperTests: XCTestCase {
 
     /// Verifies that the inbox note is parsed.
     ///
-    func test_InboxNoteMapper_parses_the_InboxNote_in_response() throws {
-        let inboxNote = try mapLoadInboxNoteResponse()
+    func test_InboxNoteMapper_parses_the_InboxNote_in_response() async throws {
+        let inboxNote = try await mapLoadInboxNoteResponse()
         XCTAssertNotNil(inboxNote)
     }
 
     /// Verifies that the inbox note is parsed when response has no data envelope.
     ///
-    func test_InboxNoteMapper_parses_the_InboxNote_in_response_without_data_envelope() throws {
-        let inboxNote = try mapLoadInboxNoteResponseWithoutDataEnvelope()
+    func test_InboxNoteMapper_parses_the_InboxNote_in_response_without_data_envelope() async throws {
+        let inboxNote = try await mapLoadInboxNoteResponseWithoutDataEnvelope()
         XCTAssertNotNil(inboxNote)
     }
 
     /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint.
     ///
-    func test_InboxNoteMapper_includes_siteID_in_parsed_result() throws {
-        let inboxNote = try mapLoadInboxNoteResponse()
-        XCTAssertEqual(inboxNote?.siteID, dummySiteID)
+    func test_InboxNoteMapper_includes_siteID_in_parsed_result() async throws {
+        let inboxNote = try await mapLoadInboxNoteResponse()
+        XCTAssertEqual(inboxNote.siteID, dummySiteID)
     }
 
     /// Verifies that the fields are all parsed correctly.
     ///
-    func test_InboxNoteMapper_parses_all_fields_in_result() throws {
+    func test_InboxNoteMapper_parses_all_fields_in_result() async throws {
         // Given
-        let inboxNote = try mapLoadInboxNoteResponse()
+        let inboxNote = try await mapLoadInboxNoteResponse()
 
         // When
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
@@ -60,9 +60,9 @@ final class InboxNoteMapperTests: XCTestCase {
 
     /// Verifies that `isRead` field is set to `false` when the corresponding API field (`is_read`) is not available.
     ///
-    func test_InboxNoteMapper_sets_isRead_to_false_when_API_field_is_unavailable() throws {
+    func test_InboxNoteMapper_sets_isRead_to_false_when_API_field_is_unavailable() async throws {
         // When
-        let inboxNote = try XCTUnwrap(mapLoadInboxNoteWithoutIsReadResponse())
+        let inboxNote = try await mapLoadInboxNoteWithoutIsReadResponse()
 
         // Then
         XCTAssertFalse(inboxNote.isRead)
@@ -76,29 +76,31 @@ private extension InboxNoteMapperTests {
 
     /// Returns the InboxNoteMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapInboxNote(from filename: String) throws -> InboxNote? {
+    func mapInboxNote(from filename: String) async throws -> InboxNote {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try InboxNoteMapper(siteID: dummySiteID).map(response: response)
+        return try await InboxNoteMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the InboxNoteMapper output from `inbox-note.json`
     ///
-    func mapLoadInboxNoteResponse() throws -> InboxNote? {
-        return try mapInboxNote(from: "inbox-note")
+    func mapLoadInboxNoteResponse() async throws -> InboxNote {
+        try await mapInboxNote(from: "inbox-note")
     }
 
     /// Returns the InboxNoteMapper output from `inbox-note-without-data.json`
     ///
-    func mapLoadInboxNoteResponseWithoutDataEnvelope() throws -> InboxNote? {
-        return try mapInboxNote(from: "inbox-note-without-data")
+    func mapLoadInboxNoteResponseWithoutDataEnvelope() async throws -> InboxNote {
+        try await mapInboxNote(from: "inbox-note-without-data")
     }
 
     /// Returns the InboxNoteMapper output from `inbox-note-without-isRead.json`
     ///
-    func mapLoadInboxNoteWithoutIsReadResponse() throws -> InboxNote? {
-        try mapInboxNote(from: "inbox-note-without-isRead")
+    func mapLoadInboxNoteWithoutIsReadResponse() async throws -> InboxNote {
+        try await mapInboxNote(from: "inbox-note-without-isRead")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/JWTokenMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/JWTokenMapperTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import Networking
 
 final class JWTokenMapperTests: XCTestCase {
-    func test_it_maps_JWToken_correctly_from_token_response() throws {
+    func test_it_maps_JWToken_correctly_from_token_response() async throws {
         // Given
         let data = try retrieveJWTResponse()
         let mapper = JWTokenMapper()
 
         // When
-        let jwtoken = try mapper.map(response: data)
+        let jwtoken = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(jwtoken.expiryDate.timeIntervalSince1970, 7282344061)

--- a/Networking/NetworkingTests/Mapper/JetpackConnectionURLMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/JetpackConnectionURLMapperTests.swift
@@ -5,8 +5,8 @@ import XCTest
 ///
 final class JetpackConnectionURLMapperTests: XCTestCase {
 
-    func test_url_is_properly_parsed() {
-        guard let url = mapURLFromMockResponse() else {
+    func test_url_is_properly_parsed() async {
+        guard let url = await mapURLFromMockResponse() else {
             XCTFail()
             return
         }
@@ -16,11 +16,11 @@ final class JetpackConnectionURLMapperTests: XCTestCase {
 }
 
 private extension JetpackConnectionURLMapperTests {
-    func mapURLFromMockResponse() -> URL? {
+    func mapURLFromMockResponse() async -> URL? {
         guard let response = Loader.contentsOf("jetpack-connection-url") else {
             return nil
         }
 
-        return try? JetpackConnectionURLMapper().map(response: response)
+        return try? await JetpackConnectionURLMapper().map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/JetpackUserMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/JetpackUserMapperTests.swift
@@ -5,9 +5,9 @@ import XCTest
 ///
 final class JetpackUserMapperTests: XCTestCase {
 
-    func test_all_fields_are_parsed_properly_when_user_is_connected() throws {
+    func test_all_fields_are_parsed_properly_when_user_is_connected() async throws {
         // Given
-        let user = try mapUserFromMockResponse()
+        let user = try await mapUserFromMockResponse()
         let wpcomUser = try XCTUnwrap(user.wpcomUser)
 
         // Then
@@ -23,9 +23,9 @@ final class JetpackUserMapperTests: XCTestCase {
         XCTAssertEqual(wpcomUser.avatar, "http://2.gravatar.com/avatar/5e1a8fhjd")
     }
 
-    func test_all_fields_are_parsed_properly_when_user_is_not_connected() throws {
+    func test_all_fields_are_parsed_properly_when_user_is_not_connected() async throws {
         // Given
-        let user = try mapNotConnectedUserFromMockResponse()
+        let user = try await mapNotConnectedUserFromMockResponse()
 
         // Then
         XCTAssertFalse(user.isPrimary)
@@ -37,20 +37,20 @@ final class JetpackUserMapperTests: XCTestCase {
 }
 
 private extension JetpackUserMapperTests {
-    func mapUserFromMockResponse() throws -> JetpackUser {
+    func mapUserFromMockResponse() async throws -> JetpackUser {
         guard let response = Loader.contentsOf("jetpack-connected-user") else {
             throw FileNotFoundError()
         }
 
-        return try JetpackUserMapper().map(response: response)
+        return try await JetpackUserMapper().map(response: response)
     }
 
-    func mapNotConnectedUserFromMockResponse() throws -> JetpackUser {
+    func mapNotConnectedUserFromMockResponse() async throws -> JetpackUser {
         guard let response = Loader.contentsOf("jetpack-user-not-connected") else {
             throw FileNotFoundError()
         }
 
-        return try JetpackUserMapper().map(response: response)
+        return try await JetpackUserMapper().map(response: response)
     }
 
     struct FileNotFoundError: Error {}

--- a/Networking/NetworkingTests/Mapper/JustInTimeMessageListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/JustInTimeMessageListMapperTests.swift
@@ -9,25 +9,25 @@ final class JustInTimeMessageListMapperTests: XCTestCase {
 
     /// Verifies that the message is parsed.
     ///
-    func test_JustInTimeMessageListMapper_parses_the_JustInTimeMessage_in_response() throws {
-        let justInTimeMessages = try mapLoadJustInTimeMessageListResponse()
+    func test_JustInTimeMessageListMapper_parses_the_JustInTimeMessage_in_response() async throws {
+        let justInTimeMessages = try await mapLoadJustInTimeMessageListResponse()
         XCTAssertNotNil(justInTimeMessages)
-        assertEqual(1, justInTimeMessages?.count)
+        assertEqual(1, justInTimeMessages.count)
     }
 
     /// Verifies that the message is parsed.
     ///
-    func test_JustInTimeMessageListMapper_parses_the_JustInTimeMessage_in_response_without_data_envelope() throws {
-        let justInTimeMessages = try mapLoadJustInTimeMessageListResponseWithoutDataEnvelope()
+    func test_JustInTimeMessageListMapper_parses_the_JustInTimeMessage_in_response_without_data_envelope() async throws {
+        let justInTimeMessages = try await mapLoadJustInTimeMessageListResponseWithoutDataEnvelope()
         XCTAssertNotNil(justInTimeMessages)
-        assertEqual(1, justInTimeMessages?.count)
+        assertEqual(1, justInTimeMessages.count)
     }
 
     /// Verifies that the fields are all parsed correctly.
     ///
-    func test_JustInTimeMessageListMapper_parses_all_fields_in_result() throws {
+    func test_JustInTimeMessageListMapper_parses_all_fields_in_result() async throws {
         // Given, When
-        let justInTimeMessage = try XCTUnwrap(mapLoadJustInTimeMessageListResponse()).first
+        let justInTimeMessage = try await mapLoadJustInTimeMessageListResponse().first
 
         // Then
         let expectedJustInTimeMessage = JustInTimeMessage(
@@ -47,9 +47,9 @@ final class JustInTimeMessageListMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly.
     ///
-    func test_JustInTimeMessageListMapper_parses_correctly_when_nonessential_keys_are_missing() throws {
+    func test_JustInTimeMessageListMapper_parses_correctly_when_nonessential_keys_are_missing() async throws {
         // Given, When
-        let justInTimeMessage = try XCTUnwrap(mapLoadJustInTimeMessageListWithoutNonessentialKeysResponse()).first
+        let justInTimeMessage = try await mapLoadJustInTimeMessageListWithoutNonessentialKeysResponse().first
 
         // Then
         let expectedJustInTimeMessage = JustInTimeMessage(siteID: dummySiteID,
@@ -73,27 +73,29 @@ final class JustInTimeMessageListMapperTests: XCTestCase {
 private extension JustInTimeMessageListMapperTests {
     /// Returns the JustInTimeMessageMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapJustInTimeMessageList(from filename: String) throws -> [JustInTimeMessage]? {
+    func mapJustInTimeMessageList(from filename: String) async throws -> [JustInTimeMessage] {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try JustInTimeMessageListMapper(siteID: dummySiteID).map(response: response)
+        return try await JustInTimeMessageListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the JustInTimeMessageListMapper output from `just-in-time-message-list.json`
     ///
-    func mapLoadJustInTimeMessageListResponse() throws -> [JustInTimeMessage]? {
-        return try mapJustInTimeMessageList(from: "just-in-time-message-list")
+    func mapLoadJustInTimeMessageListResponse() async throws -> [JustInTimeMessage] {
+        return try await mapJustInTimeMessageList(from: "just-in-time-message-list")
     }
 
-    func mapLoadJustInTimeMessageListWithoutNonessentialKeysResponse() throws -> [JustInTimeMessage]? {
-        return try mapJustInTimeMessageList(from: "just-in-time-message-list-without-nonessential-keys")
+    func mapLoadJustInTimeMessageListWithoutNonessentialKeysResponse() async throws -> [JustInTimeMessage] {
+        return try await mapJustInTimeMessageList(from: "just-in-time-message-list-without-nonessential-keys")
     }
 
     /// Returns the JustInTimeMessageListMapper output from `just-in-time-message-list-without-data.json`
     ///
-    func mapLoadJustInTimeMessageListResponseWithoutDataEnvelope() throws -> [JustInTimeMessage]? {
-        return try mapJustInTimeMessageList(from: "just-in-time-message-list-without-data")
+    func mapLoadJustInTimeMessageListResponseWithoutDataEnvelope() async throws -> [JustInTimeMessage] {
+        return try await mapJustInTimeMessageList(from: "just-in-time-message-list-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/NewShipmentTrackingMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/NewShipmentTrackingMapperTests.swift
@@ -13,8 +13,8 @@ final class NewShipmentTrackingMapperTests: XCTestCase {
     ///
     private let dummyOrderID: Int64 = 99999999
 
-    func test_tracking_fields_are_properly_parsed() throws {
-        let shipmentTracking = try mapLoadShipmentTrackingResponse()
+    func test_tracking_fields_are_properly_parsed() async throws {
+        let shipmentTracking = try await mapLoadShipmentTrackingResponse()
         let shipmentTrackingShipDate = DateFormatter.Defaults.yearMonthDayDateFormatter.date(from: "2019-03-12")
         XCTAssertEqual(shipmentTracking.siteID, dummySiteID)
         XCTAssertEqual(shipmentTracking.orderID, dummyOrderID)
@@ -25,8 +25,8 @@ final class NewShipmentTrackingMapperTests: XCTestCase {
         XCTAssertEqual(shipmentTracking.dateShipped, shipmentTrackingShipDate)
     }
 
-    func test_tracking_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let shipmentTracking = try mapLoadShipmentTrackingResponseWithoutDataEnvelope()
+    func test_tracking_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let shipmentTracking = try await mapLoadShipmentTrackingResponseWithoutDataEnvelope()
         let shipmentTrackingShipDate = DateFormatter.Defaults.yearMonthDayDateFormatter.date(from: "2019-03-12")
         XCTAssertEqual(shipmentTracking.siteID, dummySiteID)
         XCTAssertEqual(shipmentTracking.orderID, dummyOrderID)
@@ -45,24 +45,24 @@ private extension NewShipmentTrackingMapperTests {
 
     /// Returns the NewShipmentTrackingMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShipmentTracking(from filename: String) throws -> ShipmentTracking {
+    func mapShipmentTracking(from filename: String) async throws -> ShipmentTracking {
         guard let response = Loader.contentsOf(filename) else {
             throw ParsingError.unableToLoadFile
         }
 
-        return try! NewShipmentTrackingMapper(siteID: dummySiteID, orderID: dummyOrderID).map(response: response)
+        return try await NewShipmentTrackingMapper(siteID: dummySiteID, orderID: dummyOrderID).map(response: response)
     }
 
     /// Returns the NewShipmentTrackingMapper output upon receiving `shipment_tracking_new`
     ///
-    func mapLoadShipmentTrackingResponse() throws -> ShipmentTracking {
-        try mapShipmentTracking(from: "shipment_tracking_new")
+    func mapLoadShipmentTrackingResponse() async throws -> ShipmentTracking {
+        try await mapShipmentTracking(from: "shipment_tracking_new")
     }
 
     /// Returns the NewShipmentTrackingMapper output upon receiving `shipment_tracking_new-without-data`
     ///
-    func mapLoadShipmentTrackingResponseWithoutDataEnvelope() throws -> ShipmentTracking {
-        try mapShipmentTracking(from: "shipment_tracking_new-without-data")
+    func mapLoadShipmentTrackingResponseWithoutDataEnvelope() async throws -> ShipmentTracking {
+        try await mapShipmentTracking(from: "shipment_tracking_new-without-data")
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/NoteHashListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/NoteHashListMapperTests.swift
@@ -8,14 +8,19 @@ class NoteHashListMapperTests: XCTestCase {
 
     /// Verifies that the Broken Response causes the mapper to throw an error.
     ///
-    func test_broken_response_forces_mapper_to_throw_an_error() {
-        XCTAssertThrowsError(try mapLoadBrokenResponse())
+    func test_broken_response_forces_mapper_to_throw_an_error() async throws {
+        do {
+            _ = try await mapLoadBrokenResponse()
+            XCTFail("Mapper should throw an error.")
+        } catch {
+            XCTAssertTrue(error is DecodingError)
+        }
     }
 
     /// Verifies that a proper response is properly parsed (YAY!).
     ///
-    func test_sample_hashes_are_properly_loaded() {
-        let hashes = try? mapLoadAllHashesResponse()
+    func test_sample_hashes_are_properly_loaded() async {
+        let hashes = try? await mapLoadAllHashesResponse()
 
         XCTAssertNotNil(hashes)
         XCTAssertEqual(hashes?.count, 40)
@@ -23,8 +28,8 @@ class NoteHashListMapperTests: XCTestCase {
 
     /// Verifies that a sample NoteHash entity is properly deserialized.
     ///
-    func test_NoteHash_entity_is_properly_parsed() {
-        let hashes = try? mapLoadAllHashesResponse()
+    func test_NoteHash_entity_is_properly_parsed() async {
+        let hashes = try? await mapLoadAllHashesResponse()
         let hashZero = hashes![0]
 
         XCTAssertEqual(hashZero.noteID, 3606596126)
@@ -39,22 +44,22 @@ private extension NoteHashListMapperTests {
 
     /// Returns the NoteHashListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapNoteHashes(from filename: String) throws -> [NoteHash] {
+    func mapNoteHashes(from filename: String) async throws -> [NoteHash] {
         let response = Loader.contentsOf(filename)!
         let mapper = NoteHashListMapper()
 
-        return try mapper.map(response: response)
+        return try await mapper.map(response: response)
     }
 
     /// Returns the NoteHashListMapper output upon receiving `notifications` endpoint's response.
     ///
-    func mapLoadAllHashesResponse() throws -> [NoteHash] {
-        return try mapNoteHashes(from: "notifications-load-hashes")
+    func mapLoadAllHashesResponse() async throws -> [NoteHash] {
+        try await mapNoteHashes(from: "notifications-load-hashes")
     }
 
     /// Returns the NoteHashListMapper output upon receiving a broken response.
     ///
-    func mapLoadBrokenResponse() throws -> [NoteHash] {
-        return try mapNoteHashes(from: "generic_error")
+    func mapLoadBrokenResponse() async throws -> [NoteHash] {
+        try await mapNoteHashes(from: "generic_error")
     }
 }

--- a/Networking/NetworkingTests/Mapper/NoteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/NoteListMapperTests.swift
@@ -8,18 +8,18 @@ class NoteListMapperTests: XCTestCase {
 
     /// Sample Notes: 99 Entries!
     ///
-    private lazy var sampleNotes: [Note] = {
-        return try! mapLoadAllNotificationsResponse()
-    }()
+    private var sampleNotes: [Note]!
 
 
     /// Broken Notes: 2 (Hopefully gracefully handled) Scenarios.
     ///
-    private lazy var brokenNotes: [Note] = {
-        return try! mapLoadBrokenNotificationsResponse()
-    }()
+    private var brokenNotes: [Note]!
 
-
+    override func setUp() async throws {
+        try await super.setUp()
+        sampleNotes = try! await mapLoadAllNotificationsResponse()
+        brokenNotes = try! await mapLoadBrokenNotificationsResponse()
+    }
 
     /// Verifies that all of the Sample Notifications are properly parsed.
     ///
@@ -268,20 +268,20 @@ private extension NoteListMapperTests {
 
     /// Returns the NoteListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapNotes(from filename: String) throws -> [Note] {
+    func mapNotes(from filename: String) async throws -> [Note] {
         let response = Loader.contentsOf(filename)!
-        return try NoteListMapper().map(response: response)
+        return try await NoteListMapper().map(response: response)
     }
 
     /// Returns the NoteListMapper output upon receiving `notifications` endpoint's response.
     ///
-    func mapLoadAllNotificationsResponse() throws -> [Note] {
-        return try mapNotes(from: "notifications-load-all")
+    func mapLoadAllNotificationsResponse() async throws -> [Note] {
+        try await mapNotes(from: "notifications-load-all")
     }
 
     /// Returns the NoteListMapper output upon receiving `notifications` endpoint's response.
     ///
-    func mapLoadBrokenNotificationsResponse() throws -> [Note] {
-        return try mapNotes(from: "broken-notifications")
+    func mapLoadBrokenNotificationsResponse() async throws -> [Note] {
+        try await mapNotes(from: "broken-notifications")
     }
 }

--- a/Networking/NetworkingTests/Mapper/OrderListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderListMapperTests.swift
@@ -13,8 +13,8 @@ class OrderListMapperTests: XCTestCase {
 
     /// Verifies that all of the Order Fields are parsed correctly.
     ///
-    func test_order_fields_are_properly_parsed() {
-        let orders = mapLoadAllOrdersResponse()
+    func test_order_fields_are_properly_parsed() async {
+        let orders = await mapLoadAllOrdersResponse()
         XCTAssert(orders.count == 4)
 
         let firstOrder = orders[0]
@@ -42,8 +42,8 @@ class OrderListMapperTests: XCTestCase {
 
     /// Verifies that all of the Order Fields are parsed correctly when the response has no data envelope.
     ///
-    func test_order_fields_are_properly_parsed_when_the_response_has_no_data_envelope() {
-        let orders = mapLoadAllOrdersResponseWithoutDataEnvelope()
+    func test_order_fields_are_properly_parsed_when_the_response_has_no_data_envelope() async {
+        let orders = await mapLoadAllOrdersResponseWithoutDataEnvelope()
         XCTAssert(orders.count == 1)
 
         let firstOrder = orders[0]
@@ -71,16 +71,16 @@ class OrderListMapperTests: XCTestCase {
 
     /// Verifies that the siteID field is properly set.
     ///
-    func test_site_identifier_is_properly_injected_into_every_order() {
-        for order in mapLoadAllOrdersResponse() {
+    func test_site_identifier_is_properly_injected_into_every_order() async {
+        for order in await mapLoadAllOrdersResponse() {
             XCTAssertEqual(order.siteID, dummySiteID)
         }
     }
 
     /// Verifies that all of the Order Address fields are parsed correctly.
     ///
-    func test_order_addresses_are_correctly_parsed() {
-        let orders = mapLoadAllOrdersResponse()
+    func test_order_addresses_are_correctly_parsed() async {
+        let orders = await mapLoadAllOrdersResponse()
         XCTAssert(orders.count == 4)
 
         let firstOrder = orders[0]
@@ -108,8 +108,8 @@ class OrderListMapperTests: XCTestCase {
 
     /// Verifies that all of the Order Items are parsed correctly.
     ///
-    func test_order_items_are_correctly_parsed() {
-        let order = mapLoadAllOrdersResponse()[0]
+    func test_order_items_are_correctly_parsed() async {
+        let order = await mapLoadAllOrdersResponse()[0]
         XCTAssertEqual(order.items.count, 2)
 
         let firstItem = order.items[0]
@@ -129,8 +129,8 @@ class OrderListMapperTests: XCTestCase {
 
     /// Verifies that an Order in a broken state does [gets default values] | [gets skipped while parsing]
     ///
-    func test_order_has_default_date_created_when_null_date_received() {
-        let orders = mapLoadBrokenOrderResponse()
+    func test_order_has_default_date_created_when_null_date_received() async {
+        let orders = await mapLoadBrokenOrderResponse()
         XCTAssert(orders.count == 1)
 
         let brokenOrder = orders[0]
@@ -150,8 +150,8 @@ class OrderListMapperTests: XCTestCase {
     ///
     /// Ref. Issue: https://github.com/woocommerce/woocommerce-ios/issues/221
     ///
-    func test_order_list_with_breaking_format_is_properly_parsed() {
-        let orders = mapLoadBrokenOrdersResponseMarkII()
+    func test_order_list_with_breaking_format_is_properly_parsed() async {
+        let orders = await mapLoadBrokenOrdersResponseMarkII()
         XCTAssertEqual(orders.count, 6)
 
         for order in orders {
@@ -171,35 +171,35 @@ private extension OrderListMapperTests {
 
     /// Returns the [Order] output upon receiving `filename` (Data Encoded)
     ///
-    func mapOrders(from filename: String) -> [Order] {
+    func mapOrders(from filename: String) async -> [Order] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! OrderListMapper(siteID: dummySiteID).map(response: response)
+        return try! await OrderListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the [Order] output upon receiving `orders-load-all`
     ///
-    func mapLoadAllOrdersResponse() -> [Order] {
-        return mapOrders(from: "orders-load-all")
+    func mapLoadAllOrdersResponse() async -> [Order] {
+        await mapOrders(from: "orders-load-all")
     }
 
     /// Returns the [Order] output upon receiving `orders-load-all-without-data`
     ///
-    func mapLoadAllOrdersResponseWithoutDataEnvelope() -> [Order] {
-        return mapOrders(from: "orders-load-all-without-data")
+    func mapLoadAllOrdersResponseWithoutDataEnvelope() async -> [Order] {
+        await mapOrders(from: "orders-load-all-without-data")
     }
 
     /// Returns the [Order] output upon receiving `broken-order`
     ///
-    func mapLoadBrokenOrderResponse() -> [Order] {
-        return mapOrders(from: "broken-orders")
+    func mapLoadBrokenOrderResponse() async -> [Order] {
+        await mapOrders(from: "broken-orders")
     }
 
     /// Returns the [Order] output upon receiving `broken-orders-mark-2`
     ///
-    func mapLoadBrokenOrdersResponseMarkII() -> [Order] {
-        return mapOrders(from: "broken-orders-mark-2")
+    func mapLoadBrokenOrdersResponseMarkII() async -> [Order] {
+        await mapOrders(from: "broken-orders-mark-2")
     }
 }

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -13,11 +13,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that all of the Order Fields are parsed correctly.
     ///
-    func test_Order_fields_are_properly_parsed() {
-        guard let order = mapLoadOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_fields_are_properly_parsed() async throws {
+        let order = try await mapLoadOrderResponse()
 
         let dateCreated = DateFormatter.Defaults.dateTimeFormatter.date(from: "2018-04-03T23:05:12")
         let dateModified = DateFormatter.Defaults.dateTimeFormatter.date(from: "2018-04-03T23:05:14")
@@ -46,11 +43,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that all of the Order Fields are parsed correctly when response has no data envelope.
     ///
-    func test_Order_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        guard let order = mapLoadOrderResponseWithoutDataEnvelope() else {
-            XCTFail()
-            return
-        }
+    func test_Order_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let order = try await mapLoadOrderResponseWithoutDataEnvelope()
 
         let dateCreated = DateFormatter.Defaults.dateTimeFormatter.date(from: "2018-04-03T23:05:12")
         let dateModified = DateFormatter.Defaults.dateTimeFormatter.date(from: "2018-04-03T23:05:14")
@@ -78,11 +72,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that all of the Order Address fields are parsed correctly.
     ///
-    func test_Order_addresses_are_correctly_parsed() {
-        guard let order = mapLoadOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_addresses_are_correctly_parsed() async throws {
+        let order = try await mapLoadOrderResponse()
 
         let dummyAddresses = [order.shippingAddress, order.billingAddress].compactMap({ $0 })
         XCTAssertEqual(dummyAddresses.count, 2)
@@ -103,8 +94,9 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that Order shipping phone is parsed correctly from metadata.
     ///
-    func test_Order_shipping_phone_is_correctly_parsed_from_metadata() {
-        guard let order = mapLoadFullyRefundedOrderResponse(), let shippingAddress = order.shippingAddress else {
+    func test_Order_shipping_phone_is_correctly_parsed_from_metadata() async throws {
+        let order = try await mapLoadFullyRefundedOrderResponse()
+        guard let shippingAddress = order.shippingAddress else {
             XCTFail("Expected a mapped order response with a non-nil shipping address.")
             return
         }
@@ -114,11 +106,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that all of the Order Items are parsed correctly.
     ///
-    func test_Order_items_are_correctly_parsed() {
-        guard let order = mapLoadOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_items_are_correctly_parsed() async throws {
+        let order = try await mapLoadOrderResponse()
 
         let firstItem = order.items[0]
         XCTAssertEqual(firstItem.itemID, 890)
@@ -137,11 +126,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that Order Items with a decimal quantity are parsed properly
     ///
-    func test_Order_items_with_decimal_quantity_are_correctly_parsed() {
-        guard let order = mapLoadOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_items_with_decimal_quantity_are_correctly_parsed() async throws {
+        let order = try await mapLoadOrderResponse()
 
         let secondItem = order.items[1]
         XCTAssertEqual(secondItem.itemID, 891)
@@ -150,11 +136,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that an Order in a broken state does [gets default values] | [gets skipped while parsing]
     ///
-    func test_Order_has_default_dateCreated_when_null_date_received() {
-        guard let brokenOrder = mapLoadBrokenOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_has_default_dateCreated_when_null_date_received() async throws {
+        let brokenOrder = try await mapLoadBrokenOrderResponse()
 
         let format = DateFormatter()
         format.dateStyle = .short
@@ -169,11 +152,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that the coupon fields for an Order are correctly parsed.
     ///
-    func test_Order_coupon_fields_are_correctly_parsed() {
-        guard let order = mapLoadOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_coupon_fields_are_correctly_parsed() async throws {
+        let order = try await mapLoadOrderResponse()
 
         XCTAssertNotNil(order.coupons)
         XCTAssertEqual(order.coupons.count, 1)
@@ -191,22 +171,15 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that an Order with no refunds is correctly parsed to an empty array.
     ///
-    func test_Order_refund_condensed_fields_do_not_exist_are_parsed_correctly() {
-        guard let order = mapLoadOrderResponse() else {
-            XCTFail()
-            return
-        }
-
+    func test_Order_refund_condensed_fields_do_not_exist_are_parsed_correctly() async throws {
+        let order = try await mapLoadOrderResponse()
         XCTAssertEqual(order.refunds, [])
     }
 
     /// Verifies that an Order with refund fields are correctly parsed.
     ///
-    func test_Order_full_refund_fields_are_parsed_correctly() {
-        guard let order = mapLoadFullyRefundedOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_full_refund_fields_are_parsed_correctly() async throws {
+        let order = try await mapLoadFullyRefundedOrderResponse()
 
         let refunds = order.refunds
         XCTAssertEqual(refunds.count, 1)
@@ -223,11 +196,8 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that an Order with multiple, partial refunds have the refunds fields correctly parsed.
     ///
-    func test_Order_partial_refund_fields_are_parsed_correctly() {
-        guard let order = mapLoadPartiallRefundedOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_partial_refund_fields_are_parsed_correctly() async throws {
+        let order = try await mapLoadPartialRefundedOrderResponse()
 
         let refunds = order.refunds
         XCTAssertEqual(refunds.count, 2)
@@ -245,9 +215,9 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that an Order ignores deleted refunds.
     ///
-    func test_Order_deleted_refund_fields_are_ignored() throws {
+    func test_Order_deleted_refund_fields_are_ignored() async throws {
         // When
-        let order = try XCTUnwrap(mapLoadOrderWithDeletedRefundsResponse())
+        let order = try await mapLoadOrderWithDeletedRefundsResponse()
 
         // Then
         XCTAssertEqual(order.refunds.count, 1)
@@ -258,9 +228,9 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(refund.total, "-16.00")
     }
 
-    func test_taxes_are_parsed_correctly() throws {
+    func test_taxes_are_parsed_correctly() async throws {
         // When
-        let order = try XCTUnwrap(mapLoadOrderResponse())
+        let order = try await mapLoadOrderResponse()
         let shippingLine = try XCTUnwrap(order.shippingLines.first)
 
         // Then
@@ -268,8 +238,8 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(shippingLine.taxes, [expectedTax])
     }
 
-    func test_OrderLineItem_attributes_are_parsed_correctly() throws {
-        let order = try XCTUnwrap(mapLoadOrderWithLineItemAttributesResponse())
+    func test_OrderLineItem_attributes_are_parsed_correctly() async throws {
+        let order = try await mapLoadOrderWithLineItemAttributesResponse()
 
         let lineItems = order.items
         XCTAssertEqual(lineItems.count, 2)
@@ -291,8 +261,8 @@ final class OrderMapperTests: XCTestCase {
     }
 
     /// The attributes API support are added in WC version 4.7, and WC version 4.6.1 returns a different structure of order line item attributes.
-    func test_OrderLineItem_attributes_are_empty_before_API_support() throws {
-        let order = try XCTUnwrap(mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse())
+    func test_OrderLineItem_attributes_are_empty_before_API_support() async throws {
+        let order = try await mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse()
 
         let lineItems = order.items
         XCTAssertEqual(lineItems.count, 1)
@@ -302,11 +272,8 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(variationLineItem.name, "Hoodie - Green, No")
     }
 
-    func test_Order_fees_are_correctly_parsed() {
-        guard let order = mapLoadOrderResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_fees_are_correctly_parsed() async throws {
+        let order = try await mapLoadOrderResponse()
 
         XCTAssertNotNil(order.fees)
         XCTAssertEqual(order.fees.count, 1)
@@ -326,11 +293,8 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(fee.attributes, [])
     }
 
-    func test_Order_fees_are_correctly_parsed_when_special_characters() {
-        guard let order = mapLoadOrderWithSpecialCharactersResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_fees_are_correctly_parsed_when_special_characters() async throws {
+        let order = try await mapLoadOrderWithSpecialCharactersResponse()
 
         XCTAssertNotNil(order.fees)
         XCTAssertEqual(order.fees.count, 1)
@@ -350,9 +314,9 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(fee.attributes, [])
     }
 
-    func test_order_line_item_attributes_handle_unexpected_formatted_attributes() throws {
+    func test_order_line_item_attributes_handle_unexpected_formatted_attributes() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadOrderWithFaultyAttributesResponse())
+        let order = try await mapLoadOrderWithFaultyAttributesResponse()
 
         // When
         let attributes = try XCTUnwrap(order.items.first?.attributes)
@@ -362,8 +326,8 @@ final class OrderMapperTests: XCTestCase {
         assertEqual(attributes, expectedAttributes)
     }
 
-    func test_order_tax_lines_are_parsed_successfully() throws {
-        let order = try XCTUnwrap(mapLoadOrderResponse())
+    func test_order_tax_lines_are_parsed_successfully() async throws {
+        let order = try await mapLoadOrderResponse()
 
         XCTAssertNotNil(order.taxes)
         XCTAssertEqual(order.taxes.count, 1)
@@ -380,23 +344,23 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(tax.attributes, [])
     }
 
-    func test_order_charge_id_is_parsed_successfully() throws {
-        let order = try XCTUnwrap(mapLoadOrderWithChargeResponse())
+    func test_order_charge_id_is_parsed_successfully() async throws {
+        let order = try await mapLoadOrderWithChargeResponse()
 
         XCTAssertEqual(order.chargeID, "ch_3KMuym2EdyGr1FMV0uQZeFqm")
     }
 
-    func test_order_custom_fields_correctly_remove_internal_metadata() throws {
+    func test_order_custom_fields_correctly_remove_internal_metadata() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadFullyRefundedOrderResponse())
+        let order = try await mapLoadFullyRefundedOrderResponse()
 
         // Then
         XCTAssertEqual(order.customFields.count, 4)
     }
 
-    func test_order_custom_fields_are_parsed_correctly() throws {
+    func test_order_custom_fields_are_parsed_correctly() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadFullyRefundedOrderResponse())
+        let order = try await mapLoadFullyRefundedOrderResponse()
 
         // When
         let customField = try XCTUnwrap(order.customFields.first)
@@ -406,15 +370,15 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(customField, expectedCustomField)
     }
 
-    func test_order_renewal_subscription_id_is_parsed_successfully() throws {
-        let order = try XCTUnwrap(mapLoadOrderWithSubscriptionRenewal())
+    func test_order_renewal_subscription_id_is_parsed_successfully() async throws {
+        let order = try await mapLoadOrderWithSubscriptionRenewal()
 
         XCTAssertEqual(order.renewalSubscriptionID, "282")
     }
 
-    func test_order_applied_gift_cards_are_parsed_successfully() throws {
+    func test_order_applied_gift_cards_are_parsed_successfully() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadOrderWithGiftCards())
+        let order = try await mapLoadOrderWithGiftCards()
 
         // When
         let giftCard = try XCTUnwrap(order.appliedGiftCards.first)
@@ -425,9 +389,9 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(giftCard.amount, 20)
     }
 
-    func test_order_line_items_parse_bundled_item_parent_correctly() throws {
+    func test_order_line_items_parse_bundled_item_parent_correctly() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadOrderWithBundledLineItems())
+        let order = try await mapLoadOrderWithBundledLineItems()
 
         // When
         let lineItems = order.items
@@ -440,9 +404,9 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(bundledItem.parent, 752)
     }
 
-    func test_order_line_items_parse_composite_product_component_parent_correctly() throws {
+    func test_order_line_items_parse_composite_product_component_parent_correctly() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadOrderWithCompositeProduct())
+        let order = try await mapLoadOrderWithCompositeProduct()
 
         // When
         let lineItems = order.items
@@ -455,18 +419,18 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(component.parent, 830)
     }
 
-    func test_that_order_alternative_types_are_properly_parsed() throws {
+    func test_that_order_alternative_types_are_properly_parsed() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadOrderResponseWithAlternativeTypes())
+        let order = try await mapLoadOrderResponseWithAlternativeTypes()
 
         // Then
         XCTAssertEqual(order.shippingLines.first?.taxes.first?.taxID, 1)
         XCTAssertEqual(order.items.first?.sku, "123")
     }
 
-    func test_order_line_item_addons_without_ID_are_parsed_correctly() throws {
+    func test_order_line_item_addons_without_ID_are_parsed_correctly() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadOrderWithAddOnButNoAddIDResponse())
+        let order = try await mapLoadOrderWithAddOnButNoAddIDResponse()
 
         // When
         let addOns = try XCTUnwrap(order.items.first?.addOns)
@@ -475,9 +439,9 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(addOns, [.init(addOnID: nil, key: "As a Gift", value: "No")])
     }
 
-    func test_order_line_item_addons_with_all_types_are_decoded_correctly() throws {
+    func test_order_line_item_addons_with_all_types_are_decoded_correctly() async throws {
         // Given
-        let order = try XCTUnwrap(mapLoadOrderWithAllAddOnTypesResponse())
+        let order = try await mapLoadOrderWithAllAddOnTypesResponse()
 
         // When
         let addOns = try XCTUnwrap(order.items.first?.addOns)
@@ -504,117 +468,118 @@ private extension OrderMapperTests {
 
     /// Returns the Order output upon receiving `filename` (Data Encoded)
     ///
-    func mapOrder(from filename: String) -> Order? {
+    func mapOrder(from filename: String) async throws -> Order {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try! OrderMapper(siteID: dummySiteID).map(response: response)
+        return try await OrderMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the Order output upon receiving `order`
     ///
-    func mapLoadOrderResponse() -> Order? {
-        return mapOrder(from: "order")
+    func mapLoadOrderResponse() async throws -> Order {
+        try await mapOrder(from: "order")
     }
 
-    func mapLoadOrderWithSpecialCharactersResponse() -> Order? {
-        return mapOrder(from: "order-with-special-character-currency")
+    func mapLoadOrderWithSpecialCharactersResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-special-character-currency")
     }
 
     /// Returns the Order output upon receiving `order-without-data`
     ///
-    func mapLoadOrderResponseWithoutDataEnvelope() -> Order? {
-        return mapOrder(from: "order-without-data")
+    func mapLoadOrderResponseWithoutDataEnvelope() async throws -> Order {
+        try await mapOrder(from: "order-without-data")
     }
 
     /// Returns the Order output upon receiving `broken-order`
     ///
-    func mapLoadBrokenOrderResponse() -> Order? {
-        return mapOrder(from: "broken-order")
+    func mapLoadBrokenOrderResponse() async throws -> Order {
+        try await mapOrder(from: "broken-order")
     }
 
     /// Returns the Order output upon receiving `order-fully-refunded`
     ///
-    func mapLoadFullyRefundedOrderResponse() -> Order? {
-        return mapOrder(from: "order-fully-refunded")
+    func mapLoadFullyRefundedOrderResponse() async throws -> Order {
+        try await mapOrder(from: "order-fully-refunded")
     }
 
     /// Returns the Order output upon receiving `order-details-partially-refunded`
     ///
-    func mapLoadPartiallRefundedOrderResponse() -> Order? {
-        return mapOrder(from: "order-details-partially-refunded")
+    func mapLoadPartialRefundedOrderResponse() async throws -> Order {
+        try await mapOrder(from: "order-details-partially-refunded")
     }
 
     /// Returns the Order output upon receiving `order-with-line-item-attributes`
     ///
-    func mapLoadOrderWithLineItemAttributesResponse() -> Order? {
-        return mapOrder(from: "order-with-line-item-attributes")
+    func mapLoadOrderWithLineItemAttributesResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-line-item-attributes")
     }
 
     /// Returns the Order output upon receiving `order-with-faulty-attributes`
     /// Where the `value` to `_measurement_data` is not a `string` but a `JSON object`
     ///
-    func mapLoadOrderWithFaultyAttributesResponse() -> Order? {
-        return mapOrder(from: "order-with-faulty-attributes")
+    func mapLoadOrderWithFaultyAttributesResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-faulty-attributes")
     }
 
     /// Returns the Order output with a line item with a product add-on but no ID.
-    func mapLoadOrderWithAddOnButNoAddIDResponse() -> Order? {
-        mapOrder(from: "order-with-subscription-renewal")
+    func mapLoadOrderWithAddOnButNoAddIDResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-subscription-renewal")
     }
 
     /// Returns the Order output with a line item with all types of product add-ons.
-    func mapLoadOrderWithAllAddOnTypesResponse() -> Order? {
-        return mapOrder(from: "order-with-all-addon-types")
+    func mapLoadOrderWithAllAddOnTypesResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-all-addon-types")
     }
 
     /// Returns the Order output upon receiving `order-with-line-item-attributes-before-API-support`
     ///
-    func mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse() -> Order? {
-        return mapOrder(from: "order-with-line-item-attributes-before-API-support")
+    func mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-line-item-attributes-before-API-support")
     }
 
     /// Returns the Order output upon receiving `order-with-deleted-refunds`
     ///
-    func mapLoadOrderWithDeletedRefundsResponse() -> Order? {
-        return mapOrder(from: "order-with-deleted-refunds")
+    func mapLoadOrderWithDeletedRefundsResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-deleted-refunds")
     }
 
     /// Returns the Order output upon receiving `order-with-charge`
     ///
-    func mapLoadOrderWithChargeResponse() -> Order? {
-        return mapOrder(from: "order-with-charge")
+    func mapLoadOrderWithChargeResponse() async throws -> Order {
+        try await mapOrder(from: "order-with-charge")
     }
 
     /// Returns the Order output upon receiving `order-with-subscription-renewal`
     ///
-    func mapLoadOrderWithSubscriptionRenewal() -> Order? {
-        return mapOrder(from: "order-with-subscription-renewal")
+    func mapLoadOrderWithSubscriptionRenewal() async throws -> Order {
+        try await mapOrder(from: "order-with-subscription-renewal")
     }
 
     /// Returns the Order output upon receiving `order-with-gift-cards`
     ///
-    func mapLoadOrderWithGiftCards() -> Order? {
-        return mapOrder(from: "order-with-gift-cards")
+    func mapLoadOrderWithGiftCards() async throws -> Order {
+        try await mapOrder(from: "order-with-gift-cards")
     }
 
     /// Returns the Order output upon receiving `order-with-bundled-line-items`
     ///
-    func mapLoadOrderWithBundledLineItems() -> Order? {
-        return mapOrder(from: "order-with-bundled-line-items")
+    func mapLoadOrderWithBundledLineItems() async throws -> Order {
+        try await mapOrder(from: "order-with-bundled-line-items")
     }
 
     /// Returns the Order output upon receiving `order-with-composite-product`
     ///
-    func mapLoadOrderWithCompositeProduct() -> Order? {
-        return mapOrder(from: "order-with-composite-product")
+    func mapLoadOrderWithCompositeProduct() async throws -> Order {
+        try await mapOrder(from: "order-with-composite-product")
     }
 
     /// Returns the Order output upon receiving `order-alternative-types`
     ///
-    func mapLoadOrderResponseWithAlternativeTypes() -> Order? {
-        return mapOrder(from: "order-alternative-types")
+    func mapLoadOrderResponseWithAlternativeTypes() async throws -> Order {
+        try await mapOrder(from: "order-alternative-types")
     }
 
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/OrderNotesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderNotesMapperTests.swift
@@ -8,8 +8,8 @@ class OrderNotesMapperTests: XCTestCase {
 
     /// Verifies that all of the OrderNote Fields are parsed correctly.
     ///
-    func test_Note_fields_are_properly_parsed() {
-        let notes = mapLoadAllOrderNotesResponse()
+    func test_Note_fields_are_properly_parsed() async {
+        let notes = await mapLoadAllOrderNotesResponse()
         XCTAssertEqual(notes.count, 19)
 
         let firstNote = notes[0]
@@ -33,8 +33,8 @@ class OrderNotesMapperTests: XCTestCase {
 
     /// Verifies that all of the OrderNote Fields are parsed correctly.
     ///
-    func test_Note_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let notes = mapLoadAllOrderNotesResponseWithoutDataEnvelope()
+    func test_Note_fields_are_properly_parsed_when_response_has_no_data_envelope() async {
+        let notes = await mapLoadAllOrderNotesResponseWithoutDataEnvelope()
         XCTAssertEqual(notes.count, 2)
 
         let firstNote = notes[0]
@@ -58,8 +58,8 @@ class OrderNotesMapperTests: XCTestCase {
 
     /// Verifies that an Note in a broken state does [gets default values] | [gets skipped while parsing]
     ///
-    func test_Note_has_default_dateCreated_when_null_date_received() {
-        let notes = mapLoadBrokenOrderNotesResponse()
+    func test_Note_has_default_dateCreated_when_null_date_received() async {
+        let notes = await mapLoadBrokenOrderNotesResponse()
         XCTAssert(notes.count == 1)
 
         let brokenNote = notes[0]
@@ -79,29 +79,29 @@ private extension OrderNotesMapperTests {
 
     /// Returns the [OrderNote] output upon receiving `filename` (Data Encoded)
     ///
-    func mapNotes(from filename: String) -> [OrderNote] {
+    func mapNotes(from filename: String) async -> [OrderNote] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! OrderNotesMapper().map(response: response)
+        return try! await OrderNotesMapper().map(response: response)
     }
 
     /// Returns the [OrderNote] output upon receiving `order-notes`
     ///
-    func mapLoadAllOrderNotesResponse() -> [OrderNote] {
-        return mapNotes(from: "order-notes")
+    func mapLoadAllOrderNotesResponse() async -> [OrderNote] {
+        await mapNotes(from: "order-notes")
     }
 
     /// Returns the [OrderNote] output upon receiving `order-notes-without-data`
     ///
-    func mapLoadAllOrderNotesResponseWithoutDataEnvelope() -> [OrderNote] {
-        return mapNotes(from: "order-notes-without-data")
+    func mapLoadAllOrderNotesResponseWithoutDataEnvelope() async -> [OrderNote] {
+        await mapNotes(from: "order-notes-without-data")
     }
 
     /// Returns the [OrderNote] output upon receiving `broken-order`
     ///
-    func mapLoadBrokenOrderNotesResponse() -> [OrderNote] {
-        return mapNotes(from: "broken-notes")
+    func mapLoadBrokenOrderNotesResponse() async -> [OrderNote] {
+        await mapNotes(from: "broken-notes")
     }
 }

--- a/Networking/NetworkingTests/Mapper/OrderShippingLabelListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderShippingLabelListMapperTests.swift
@@ -10,12 +10,12 @@ final class OrderShippingLabelListMapperTests: XCTestCase {
     /// Order ID for testing.
     private let sampleOrderID: Int64 = 630
 
-    func test_order_shipping_labels_and_settings_are_properly_parsed() throws {
+    func test_order_shipping_labels_and_settings_are_properly_parsed() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("order-shipping-labels"))
 
         // When
-        let response = try OrderShippingLabelListMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: jsonData)
+        let response = try await OrderShippingLabelListMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: jsonData)
 
         // Then
         XCTAssertEqual(response.settings, .init(siteID: sampleSiteID, orderID: sampleOrderID, paperSize: .label))
@@ -77,12 +77,12 @@ final class OrderShippingLabelListMapperTests: XCTestCase {
         XCTAssertEqual(response.shippingLabels, [shippingLabelWithoutRefund, shippingLabelWithRefund])
     }
 
-    func test_order_shipping_labels_and_settings_are_properly_parsed_when_response_has_no_data_envelope() throws {
+    func test_order_shipping_labels_and_settings_are_properly_parsed_when_response_has_no_data_envelope() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("order-shipping-labels-without-data"))
 
         // When
-        let response = try OrderShippingLabelListMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: jsonData)
+        let response = try await OrderShippingLabelListMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: jsonData)
 
         // Then
         XCTAssertEqual(response.settings, .init(siteID: sampleSiteID, orderID: sampleOrderID, paperSize: .label))

--- a/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
@@ -11,11 +11,8 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
     /// Verifies that all of the hourly unit OrderStatsV4 fields are parsed correctly.
     ///
-    func test_hourly_unit_stat_fields_are_properly_parsed() {
-        guard let hourlyStats = mapOrderStatsWithHourlyUnitResponse() else {
-            XCTFail()
-            return
-        }
+    func test_hourly_unit_stat_fields_are_properly_parsed() async throws {
+        let hourlyStats = try await mapOrderStatsWithHourlyUnitResponse()
 
         XCTAssertEqual(hourlyStats.siteID, Constants.siteID)
         XCTAssertEqual(hourlyStats.granularity, .hourly)
@@ -41,11 +38,8 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
     /// Verifies that all of the daily unit OrderStatsV4 fields are parsed correctly.
     ///
-    func test_daily_unit_stat_fields_are_properly_parsed() {
-        guard let dailyStats = mapOrderStatsWithDailyUnitResponse() else {
-            XCTFail()
-            return
-        }
+    func test_daily_unit_stat_fields_are_properly_parsed() async throws {
+        let dailyStats = try await mapOrderStatsWithDailyUnitResponse()
 
         XCTAssertEqual(dailyStats.siteID, Constants.siteID)
         XCTAssertEqual(dailyStats.granularity, .daily)
@@ -71,11 +65,8 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
     /// Verifies that all of the weekly unit OrderStatsV4 fields are parsed correctly.
     ///
-    func test_weekly_unit_stat_fields_are_properly_parsed() {
-        guard let weeklyStats = mapOrderStatsWithWeeklyUnitResponse() else {
-            XCTFail()
-            return
-        }
+    func test_weekly_unit_stat_fields_are_properly_parsed() async throws {
+        let weeklyStats = try await mapOrderStatsWithWeeklyUnitResponse()
 
         XCTAssertEqual(weeklyStats.siteID, Constants.siteID)
         XCTAssertEqual(weeklyStats.granularity, .weekly)
@@ -101,11 +92,8 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
     /// Verifies that all of the monthly unit OrderStatsV4 fields are parsed correctly.
     ///
-    func test_monthly_unit_stat_fields_are_properly_parsed() {
-        guard let monthlyStats = mapOrderStatsWithMonthlyUnitResponse() else {
-            XCTFail()
-            return
-        }
+    func test_monthly_unit_stat_fields_are_properly_parsed() async throws {
+        let monthlyStats = try await mapOrderStatsWithMonthlyUnitResponse()
 
         XCTAssertEqual(monthlyStats.siteID, Constants.siteID)
         XCTAssertEqual(monthlyStats.granularity, .monthly)
@@ -131,11 +119,8 @@ final class OrderStatsV4MapperTests: XCTestCase {
 
     /// Verifies that all of the yearly unit OrderStatsV4 fields are parsed correctly.
     ///
-    func test_yearly_unit_stat_fields_are_properly_parsed() {
-        guard let yearlyStats = mapOrderStatsWithYearlyUnitResponse() else {
-            XCTFail()
-            return
-        }
+    func test_yearly_unit_stat_fields_are_properly_parsed() async throws {
+        let yearlyStats = try await mapOrderStatsWithYearlyUnitResponse()
 
         XCTAssertEqual(yearlyStats.siteID, Constants.siteID)
         XCTAssertEqual(yearlyStats.granularity, .yearly)
@@ -162,11 +147,8 @@ final class OrderStatsV4MapperTests: XCTestCase {
     /// Verifies that all of the yearly unit OrderStatsV4 fields are parsed correctly
     /// if the response contains no data envelope.
     ///
-    func test_yearly_unit_stat_fields_are_properly_parsed_without_data_envelope() {
-        guard let yearlyStats = mapOrderStatsWithYearlyUnitResponseWithoutDataEnvelope() else {
-            XCTFail()
-            return
-        }
+    func test_yearly_unit_stat_fields_are_properly_parsed_without_data_envelope() async throws {
+        let yearlyStats = try await mapOrderStatsWithYearlyUnitResponseWithoutDataEnvelope()
 
         XCTAssertEqual(yearlyStats.siteID, Constants.siteID)
         XCTAssertEqual(yearlyStats.granularity, .yearly)
@@ -194,48 +176,50 @@ final class OrderStatsV4MapperTests: XCTestCase {
 private extension OrderStatsV4MapperTests {
     /// Returns the OrderStatsV4Mapper output upon receiving `order-stats-v4-hour`
     ///
-    func mapOrderStatsWithHourlyUnitResponse() -> OrderStatsV4? {
-        return mapStatItems(from: "order-stats-v4-hour", granularity: .hourly)
+    func mapOrderStatsWithHourlyUnitResponse() async throws -> OrderStatsV4 {
+        try await mapStatItems(from: "order-stats-v4-hour", granularity: .hourly)
     }
 
     /// Returns the OrderStatsV4Mapper output upon receiving `order-stats-v4-default`
     ///
-    func mapOrderStatsWithDailyUnitResponse() -> OrderStatsV4? {
-        return mapStatItems(from: "order-stats-v4-daily", granularity: .daily)
+    func mapOrderStatsWithDailyUnitResponse() async throws -> OrderStatsV4 {
+        try await mapStatItems(from: "order-stats-v4-daily", granularity: .daily)
     }
 
     /// Returns the OrderStatsV4Mapper output upon receiving `order-stats-v4-default`
     ///
-    func mapOrderStatsWithWeeklyUnitResponse() -> OrderStatsV4? {
-        return mapStatItems(from: "order-stats-v4-defaults", granularity: .weekly)
+    func mapOrderStatsWithWeeklyUnitResponse() async throws -> OrderStatsV4 {
+        try await mapStatItems(from: "order-stats-v4-defaults", granularity: .weekly)
     }
 
     /// Returns the OrderStatsV4Mapper output upon receiving `order-stats-v4-month`
     ///
-    func mapOrderStatsWithMonthlyUnitResponse() -> OrderStatsV4? {
-        return mapStatItems(from: "order-stats-v4-month", granularity: .monthly)
+    func mapOrderStatsWithMonthlyUnitResponse() async throws -> OrderStatsV4 {
+        try await mapStatItems(from: "order-stats-v4-month", granularity: .monthly)
     }
 
     /// Returns the OrderStatsV4Mapper output upon receiving `order-stats-v4-year`
     ///
-    func mapOrderStatsWithYearlyUnitResponse() -> OrderStatsV4? {
-        return mapStatItems(from: "order-stats-v4-year", granularity: .yearly)
+    func mapOrderStatsWithYearlyUnitResponse() async throws -> OrderStatsV4 {
+        try await mapStatItems(from: "order-stats-v4-year", granularity: .yearly)
     }
 
     /// Returns the OrderStatsV4Mapper output upon receiving `order-stats-v4-year-without-data`
     ///
-    func mapOrderStatsWithYearlyUnitResponseWithoutDataEnvelope() -> OrderStatsV4? {
-        return mapStatItems(from: "order-stats-v4-year-without-data", granularity: .yearly)
+    func mapOrderStatsWithYearlyUnitResponseWithoutDataEnvelope() async throws -> OrderStatsV4 {
+        try await mapStatItems(from: "order-stats-v4-year-without-data", granularity: .yearly)
     }
 
     /// Returns the OrderStatsV4Mapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapStatItems(from filename: String, granularity: StatsGranularityV4) -> OrderStatsV4? {
+    func mapStatItems(from filename: String, granularity: StatsGranularityV4) async throws -> OrderStatsV4 {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try! OrderStatsV4Mapper(siteID: Constants.siteID,
+        return try await OrderStatsV4Mapper(siteID: Constants.siteID,
                                        granularity: granularity).map(response: response)
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/PaymentGatewayListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/PaymentGatewayListMapperTests.swift
@@ -8,25 +8,25 @@ final class PaymentGatewayListMapperTests: XCTestCase {
     ///
     static let sampleSiteID: Int64 = 123
 
-    func test_payment_gateway_list_is_decoded_from_json_response() throws {
+    func test_payment_gateway_list_is_decoded_from_json_response() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("payment-gateway-list"))
         let expectedGateways = [Self.bankTransferGateway, Self.checkGateway, Self.cashGateway, Self.paypalGateway]
 
         // When
-        let gateways = try PaymentGatewayListMapper(siteID: Self.sampleSiteID).map(response: jsonData)
+        let gateways = try await PaymentGatewayListMapper(siteID: Self.sampleSiteID).map(response: jsonData)
 
         // Then
         assertEqual(expectedGateways, gateways)
     }
 
-    func test_payment_gateway_list_is_decoded_from_json_response_without_data_envelope() throws {
+    func test_payment_gateway_list_is_decoded_from_json_response_without_data_envelope() async throws {
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("payment-gateway-list-without-data"))
         let expectedGateways = [Self.bankTransferGateway, Self.checkGateway, Self.cashGateway, Self.paypalGateway]
 
         // When
-        let gateways = try PaymentGatewayListMapper(siteID: Self.sampleSiteID).map(response: jsonData)
+        let gateways = try await PaymentGatewayListMapper(siteID: Self.sampleSiteID).map(response: jsonData)
 
         // Then
         assertEqual(expectedGateways, gateways)

--- a/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
@@ -9,22 +9,22 @@ final class PaymentGatewayMapperTests: XCTestCase {
 
     /// Verifies that the PaymentGateway is parsed.
     ///
-    func test_PaymentGateway_map_parses_all_paymentGateways_in_response() throws {
-        let paymentGateway = try mapRetrievePaymentGatewayResponse()
+    func test_PaymentGateway_map_parses_all_paymentGateways_in_response() async throws {
+        let paymentGateway = try await mapRetrievePaymentGatewayResponse()
         XCTAssertNotNil(paymentGateway)
     }
 
     /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint
     ///
-    func test_PaymentGatewaysList_map_includes_siteID_in_parsed_results() throws {
-        let paymentGateway = try mapRetrievePaymentGatewayResponse()
+    func test_PaymentGatewaysList_map_includes_siteID_in_parsed_results() async throws {
+        let paymentGateway = try await mapRetrievePaymentGatewayResponse()
         XCTAssertEqual(paymentGateway.siteID, dummySiteID)
     }
 
     /// Verifies that the fields are all parsed correctly
     ///
-    func test_PaymentGatewaysList_map_parses_all_fields_in_result() throws {
-        let paymentGateway = try mapRetrievePaymentGatewayResponse()
+    func test_PaymentGatewaysList_map_parses_all_fields_in_result() async throws {
+        let paymentGateway = try await mapRetrievePaymentGatewayResponse()
 
         let expectedPaymentGateway = PaymentGateway(siteID: dummySiteID,
                                                     gatewayID: "cod",
@@ -39,8 +39,8 @@ final class PaymentGatewayMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly
     ///
-    func test_PaymentGatewaysList_map_parses_all_fields_in_result_when_response_has_no_data_envelope() throws {
-        let paymentGateway = try mapRetrievePaymentGatewayResponseWithoutDataEnvelope()
+    func test_PaymentGatewaysList_map_parses_all_fields_in_result_when_response_has_no_data_envelope() async throws {
+        let paymentGateway = try await mapRetrievePaymentGatewayResponseWithoutDataEnvelope()
 
         let expectedPaymentGateway = PaymentGateway(siteID: dummySiteID,
                                                     gatewayID: "cod",
@@ -61,24 +61,24 @@ private extension PaymentGatewayMapperTests {
 
     /// Returns the PaymentGatewayMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapPaymentGateway(from filename: String) throws -> PaymentGateway {
+    func mapPaymentGateway(from filename: String) async throws -> PaymentGateway {
         guard let response = Loader.contentsOf(filename) else {
             throw FileNotFoundError()
         }
 
-        return try PaymentGatewayMapper(siteID: dummySiteID).map(response: response)
+        return try await PaymentGatewayMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the PaymentGateway output from `payment-gateway-cod.json`
     ///
-    func mapRetrievePaymentGatewayResponse() throws -> PaymentGateway {
-        return try mapPaymentGateway(from: "payment-gateway-cod")
+    func mapRetrievePaymentGatewayResponse() async throws -> PaymentGateway {
+        try await mapPaymentGateway(from: "payment-gateway-cod")
     }
 
     /// Returns the PaymentGateway output from `payment-gateway-cod-without-data.json`
     ///
-    func mapRetrievePaymentGatewayResponseWithoutDataEnvelope() throws -> PaymentGateway {
-        return try mapPaymentGateway(from: "payment-gateway-cod-without-data")
+    func mapRetrievePaymentGatewayResponseWithoutDataEnvelope() async throws -> PaymentGateway {
+        try await mapPaymentGateway(from: "payment-gateway-cod-without-data")
     }
 
     struct FileNotFoundError: Error {}

--- a/Networking/NetworkingTests/Mapper/PostMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/PostMapperTests.swift
@@ -8,8 +8,8 @@ final class PostMapperTests: XCTestCase {
 
     /// Verifies that all of the Post fields are parsed correctly.
     ///
-    func test_fields_are_properly_parsed() {
-        guard let sitePost = mapSitePost() else {
+    func test_fields_are_properly_parsed() async {
+        guard let sitePost = await mapSitePost() else {
             XCTFail()
             return
         }
@@ -26,11 +26,11 @@ private extension PostMapperTests {
 
     /// Returns the PostMapper output upon receiving `site-post` json (Data Encoded)
     ///
-    func mapSitePost() -> Post? {
+    func mapSitePost() async -> Post? {
         guard let response = Loader.contentsOf("site-post") else {
             return nil
         }
 
-        return try! PostMapper().map(response: response)
+        return try! await PostMapper().map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductAttributeListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeListMapperTests.swift
@@ -12,8 +12,8 @@ final class ProductAttributeListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductAttribute Fields are parsed correctly.
     ///
-    func test_ProductAttribute_fields_are_properly_parsed() throws {
-        let productAttributes = try mapProductAttributesResponse()
+    func test_ProductAttribute_fields_are_properly_parsed() async throws {
+        let productAttributes = try await mapProductAttributesResponse()
         XCTAssertEqual(productAttributes.count, 2)
 
         let secondProductAttribute = productAttributes[1]
@@ -28,8 +28,8 @@ final class ProductAttributeListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductAttribute Fields are parsed correctly when response has no data envelope
     ///
-    func test_ProductAttribute_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productAttributes = try mapProductAttributeResponseWithoutDataEnvelope()
+    func test_ProductAttribute_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productAttributes = try await mapProductAttributeResponseWithoutDataEnvelope()
         XCTAssertEqual(productAttributes.count, 2)
 
         let secondProductAttribute = productAttributes[1]
@@ -50,22 +50,22 @@ private extension ProductAttributeListMapperTests {
 
     /// Returns the ProductAttributeMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductAttribute(from filename: String) throws -> [ProductAttribute] {
+    func mapProductAttribute(from filename: String) async throws -> [ProductAttribute] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try ProductAttributeListMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductAttributeListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductAttributeListMapper output upon receiving `product-attribute-all`
     ///
-    func mapProductAttributesResponse() throws -> [ProductAttribute] {
-        return try mapProductAttribute(from: "product-attributes-all")
+    func mapProductAttributesResponse() async throws -> [ProductAttribute] {
+        try await mapProductAttribute(from: "product-attributes-all")
     }
 
     /// Returns the ProductAttributeListMapper output upon receiving `product-attributes-all-without-data`
     ///
-    func mapProductAttributeResponseWithoutDataEnvelope() throws -> [ProductAttribute] {
-        try mapProductAttribute(from: "product-attributes-all-without-data")
+    func mapProductAttributeResponseWithoutDataEnvelope() async throws -> [ProductAttribute] {
+        try await mapProductAttribute(from: "product-attributes-all-without-data")
     }}

--- a/Networking/NetworkingTests/Mapper/ProductAttributeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeMapperTests.swift
@@ -12,8 +12,8 @@ final class ProductAttributeMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductAttribute Fields are parsed correctly.
     ///
-    func test_ProductAttribute_fields_are_properly_parsed() throws {
-        let productAttribute = try XCTUnwrap(mapProductAttributeResponse())
+    func test_ProductAttribute_fields_are_properly_parsed() async throws {
+        let productAttribute = try await mapProductAttributeResponse()
 
         XCTAssertEqual(productAttribute.attributeID, 1)
         XCTAssertEqual(productAttribute.name, "Color")
@@ -25,8 +25,8 @@ final class ProductAttributeMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductAttribute Fields are parsed correctly when response has no data envelope
     ///
-    func test_ProductAttribute_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productAttribute = try XCTUnwrap(mapProductAttributeResponseWithoutDataEnvelope())
+    func test_ProductAttribute_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productAttribute = try await mapProductAttributeResponseWithoutDataEnvelope()
 
         XCTAssertEqual(productAttribute.attributeID, 1)
         XCTAssertEqual(productAttribute.name, "Color")
@@ -44,23 +44,25 @@ private extension ProductAttributeMapperTests {
 
     /// Returns the ProductAttributeMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductAttribute(from filename: String) throws -> ProductAttribute? {
+    func mapProductAttribute(from filename: String) async throws -> ProductAttribute {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try ProductAttributeMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductAttributeMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductAttributeMapper output upon receiving `product-attribute-create`
     ///
-    func mapProductAttributeResponse() throws -> ProductAttribute? {
-        return try mapProductAttribute(from: "product-attribute-create")
+    func mapProductAttributeResponse() async throws -> ProductAttribute {
+        try await mapProductAttribute(from: "product-attribute-create")
     }
 
     /// Returns the ProductAttributeMapper output upon receiving `product-attribute-create-without-data`
     ///
-    func mapProductAttributeResponseWithoutDataEnvelope() throws -> ProductAttribute? {
-        try mapProductAttribute(from: "product-attribute-create-without-data")
+    func mapProductAttributeResponseWithoutDataEnvelope() async throws -> ProductAttribute {
+        try await mapProductAttribute(from: "product-attribute-create-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/ProductAttributeTermListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeTermListMapperTests.swift
@@ -6,8 +6,8 @@ final class ProductAttributeTermListMapperTests: XCTestCase {
     ///
     private let dummySiteID: Int64 = 33334444
 
-    func test_productAttributeTerm_fields_are_correctly_mapped() throws {
-        let terms = try mapLoadAllProductAttributeTermsResponse()
+    func test_productAttributeTerm_fields_are_correctly_mapped() async throws {
+        let terms = try await mapLoadAllProductAttributeTermsResponse()
         XCTAssertEqual(terms.count, 3)
 
         let secondTerm = terms[1]
@@ -16,8 +16,8 @@ final class ProductAttributeTermListMapperTests: XCTestCase {
         XCTAssertEqual(secondTerm, expectedTerm)
     }
 
-    func test_productAttributeTerm_fields_are_correctly_mapped_when_response_has_no_data_envelope() throws {
-        let terms = try mapLoadAllProductAttributeTermsResponseWithoutDataEnvelope()
+    func test_productAttributeTerm_fields_are_correctly_mapped_when_response_has_no_data_envelope() async throws {
+        let terms = try await mapLoadAllProductAttributeTermsResponseWithoutDataEnvelope()
         XCTAssertEqual(terms.count, 3)
 
         let secondTerm = terms[1]
@@ -29,19 +29,19 @@ final class ProductAttributeTermListMapperTests: XCTestCase {
 
 // MARK: Helpers
 private extension ProductAttributeTermListMapperTests {
-    func mapProductAttributeTerms(from filename: String) throws -> [ProductAttributeTerm] {
+    func mapProductAttributeTerms(from filename: String) async throws -> [ProductAttributeTerm] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try ProductAttributeTermListMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductAttributeTermListMapper(siteID: dummySiteID).map(response: response)
     }
 
-    func mapLoadAllProductAttributeTermsResponse() throws -> [ProductAttributeTerm] {
-        return try mapProductAttributeTerms(from: "product-attribute-terms")
+    func mapLoadAllProductAttributeTermsResponse() async throws -> [ProductAttributeTerm] {
+        return try await mapProductAttributeTerms(from: "product-attribute-terms")
     }
 
-    func mapLoadAllProductAttributeTermsResponseWithoutDataEnvelope() throws -> [ProductAttributeTerm] {
-        return try mapProductAttributeTerms(from: "product-attribute-terms-without-data")
+    func mapLoadAllProductAttributeTermsResponseWithoutDataEnvelope() async throws -> [ProductAttributeTerm] {
+        return try await mapProductAttributeTerms(from: "product-attribute-terms-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductAttributeTermMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeTermMapperTests.swift
@@ -6,16 +6,16 @@ final class ProductAttributeTermMapperTests: XCTestCase {
     ///
     private let dummySiteID: Int64 = 33334444
 
-    func test_productAttributeTerm_fields_are_correctly_mapped() throws {
-        let term = try mapLoadProductAttributeTermsResponse()
+    func test_productAttributeTerm_fields_are_correctly_mapped() async throws {
+        let term = try await mapLoadProductAttributeTermsResponse()
 
         let expectedTerm = ProductAttributeTerm(siteID: dummySiteID, termID: 23, name: "XXS", slug: "xxs", count: 1)
 
         XCTAssertEqual(term, expectedTerm)
     }
 
-    func test_productAttributeTerm_fields_are_correctly_mapped_when_response_has_no_data_envelope() throws {
-        let term = try mapLoadProductAttributeTermResponseWithoutDataEnvelope()
+    func test_productAttributeTerm_fields_are_correctly_mapped_when_response_has_no_data_envelope() async throws {
+        let term = try await mapLoadProductAttributeTermResponseWithoutDataEnvelope()
 
         let expectedTerm = ProductAttributeTerm(siteID: dummySiteID, termID: 23, name: "XXS", slug: "xxs", count: 1)
 
@@ -25,20 +25,20 @@ final class ProductAttributeTermMapperTests: XCTestCase {
 
 // MARK: Helpers
 private extension ProductAttributeTermMapperTests {
-    func mapProductAttributeTerm(from filename: String) throws -> ProductAttributeTerm {
+    func mapProductAttributeTerm(from filename: String) async throws -> ProductAttributeTerm {
         guard let response = Loader.contentsOf(filename) else {
             throw ParsingError.unableToLoadFile
         }
 
-        return try ProductAttributeTermMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductAttributeTermMapper(siteID: dummySiteID).map(response: response)
     }
 
-    func mapLoadProductAttributeTermsResponse() throws -> ProductAttributeTerm {
-        return try mapProductAttributeTerm(from: "attribute-term")
+    func mapLoadProductAttributeTermsResponse() async throws -> ProductAttributeTerm {
+        try await mapProductAttributeTerm(from: "attribute-term")
     }
 
-    func mapLoadProductAttributeTermResponseWithoutDataEnvelope() throws -> ProductAttributeTerm {
-        return try mapProductAttributeTerm(from: "attribute-term-without-data")
+    func mapLoadProductAttributeTermResponseWithoutDataEnvelope() async throws -> ProductAttributeTerm {
+        try await mapProductAttributeTerm(from: "attribute-term-without-data")
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
@@ -12,8 +12,8 @@ final class ProductCategoryMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductCategory Fields are parsed correctly.
     ///
-    func test_ProductCategory_fields_are_properly_parsed() throws {
-        let productCategory = try XCTUnwrap(mapProductCategoryResponse())
+    func test_ProductCategory_fields_are_properly_parsed() async throws {
+        let productCategory = try await mapProductCategoryResponse()
 
         XCTAssertEqual(productCategory.categoryID, 104)
         XCTAssertEqual(productCategory.parentID, 0)
@@ -24,8 +24,8 @@ final class ProductCategoryMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductCategory Fields are parsed correctly.
     ///
-    func test_ProductCategory_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productCategory = try XCTUnwrap(mapProductCategoryResponseWithoutDataEnvelope())
+    func test_ProductCategory_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productCategory = try await mapProductCategoryResponseWithoutDataEnvelope()
 
         XCTAssertEqual(productCategory.categoryID, 104)
         XCTAssertEqual(productCategory.parentID, 0)
@@ -42,23 +42,25 @@ private extension ProductCategoryMapperTests {
 
     /// Returns the ProducCategoryMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductCategory(from filename: String) throws -> ProductCategory? {
+    func mapProductCategory(from filename: String) async throws -> ProductCategory {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try ProductCategoryMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductCategoryMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductCategoryMapper output upon receiving `category`
     ///
-    func mapProductCategoryResponse() throws -> ProductCategory? {
-        return try mapProductCategory(from: "category")
+    func mapProductCategoryResponse() async throws -> ProductCategory {
+        return try await mapProductCategory(from: "category")
     }
 
     /// Returns the ProductCategoryMapper output upon receiving `category-without-data`
     ///
-    func mapProductCategoryResponseWithoutDataEnvelope() throws -> ProductCategory? {
-        return try mapProductCategory(from: "category-without-data")
+    func mapProductCategoryResponseWithoutDataEnvelope() async throws -> ProductCategory {
+        return try await mapProductCategory(from: "category-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/ProductCategoyListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoyListMapperTests.swift
@@ -8,8 +8,8 @@ final class ProductCategoryListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductCategory Fields are parsed correctly.
     ///
-    func test_ProductCategory_fields_are_properly_parsed() throws {
-        let productCategories = try mapLoadAllProductCategoriesResponse()
+    func test_ProductCategory_fields_are_properly_parsed() async throws {
+        let productCategories = try await mapLoadAllProductCategoriesResponse()
         XCTAssertEqual(productCategories.count, 2)
 
         let secondProductCategory = productCategories[1]
@@ -22,8 +22,8 @@ final class ProductCategoryListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductCategory Fields are parsed correctly.
     ///
-    func test_ProductCategory_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productCategories = try mapLoadAllProductCategoriesResponseWithoutDataEnvelope()
+    func test_ProductCategory_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productCategories = try await mapLoadAllProductCategoriesResponseWithoutDataEnvelope()
         XCTAssertEqual(productCategories.count, 2)
 
         let secondProductCategory = productCategories[1]
@@ -36,8 +36,8 @@ final class ProductCategoryListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductCategory Fields under `create` field are parsed correctly.
     ///
-    func test_ProductCategory_fields_when_created_are_properly_parsed() throws {
-        let categories = try mapLoadProductCategoriesCreatedResponse()
+    func test_ProductCategory_fields_when_created_are_properly_parsed() async throws {
+        let categories = try await mapLoadProductCategoriesCreatedResponse()
         XCTAssertEqual(categories.count, 1)
 
         let first = categories[0]
@@ -50,8 +50,8 @@ final class ProductCategoryListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductCategory Fields under `create` field are parsed correctly without data enveloper.
     ///
-    func test_ProductCategory_fields_when_created_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let categories = try mapLoadProductCategoriesCreatedResponseWithoutDataEnvelope()
+    func test_ProductCategory_fields_when_created_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let categories = try await mapLoadProductCategoriesCreatedResponseWithoutDataEnvelope()
         XCTAssertEqual(categories.count, 1)
 
         let first = categories[0]
@@ -70,35 +70,35 @@ private extension ProductCategoryListMapperTests {
 
     /// Returns the ProducCategoryListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductCategories(from filename: String, responseType: ProductCategoryListMapper.ResponseType) throws -> [ProductCategory] {
+    func mapProductCategories(from filename: String, responseType: ProductCategoryListMapper.ResponseType) async throws -> [ProductCategory] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try ProductCategoryListMapper(siteID: dummySiteID, responseType: responseType).map(response: response)
+        return try await ProductCategoryListMapper(siteID: dummySiteID, responseType: responseType).map(response: response)
     }
 
     /// Returns the ProductCategoryListMapper output upon receiving `categories-all`
     ///
-    func mapLoadAllProductCategoriesResponse() throws -> [ProductCategory] {
-        return try mapProductCategories(from: "categories-all", responseType: .load)
+    func mapLoadAllProductCategoriesResponse() async throws -> [ProductCategory] {
+        try await mapProductCategories(from: "categories-all", responseType: .load)
     }
 
     /// Returns the ProductCategoryListMapper output upon receiving `categories-all-without-data`
     ///
-    func mapLoadAllProductCategoriesResponseWithoutDataEnvelope() throws -> [ProductCategory] {
-        return try mapProductCategories(from: "categories-all-without-data", responseType: .load)
+    func mapLoadAllProductCategoriesResponseWithoutDataEnvelope() async throws -> [ProductCategory] {
+        try await mapProductCategories(from: "categories-all-without-data", responseType: .load)
     }
 
     /// Returns the ProductCategoryListMapper output upon receiving `product-categories-created`
     ///
-    func mapLoadProductCategoriesCreatedResponse() throws -> [ProductCategory] {
-        return try mapProductCategories(from: "product-categories-created", responseType: .create)
+    func mapLoadProductCategoriesCreatedResponse() async throws -> [ProductCategory] {
+        try await mapProductCategories(from: "product-categories-created", responseType: .create)
     }
 
     /// Returns the ProductCategoryListMapper output upon receiving `product-categories-created-without-data`
     ///
-    func mapLoadProductCategoriesCreatedResponseWithoutDataEnvelope() throws -> [ProductCategory] {
-        return try mapProductCategories(from: "product-categories-created-without-data", responseType: .create)
+    func mapLoadProductCategoriesCreatedResponseWithoutDataEnvelope() async throws -> [ProductCategory] {
+        try await mapProductCategories(from: "product-categories-created-without-data", responseType: .create)
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductIDMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductIDMapperTests.swift
@@ -11,9 +11,9 @@ final class ProductIDMapperTests: XCTestCase {
 
     /// Verifies that IDs are parsed correctly.
     ///
-    func test_id_is_properly_parsed() throws {
+    func test_id_is_properly_parsed() async throws {
         // Given
-        let ids = try [mapLoadIDsResponse(), mapLoadIDsResponseWithoutData()]
+        let ids = try [await mapLoadIDsResponse(), await mapLoadIDsResponseWithoutData()]
         let expected: [Int64] = [3946]
 
         for id in ids {
@@ -30,23 +30,23 @@ private extension ProductIDMapperTests {
 
     /// Returns the ProductIDMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapIDs(from filename: String) throws -> [Int64] {
+    func mapIDs(from filename: String) async throws -> [Int64] {
         guard let response = Loader.contentsOf(filename) else {
             throw ProductIDMapperTestsError.unableToLoadFile
         }
 
-        return try! ProductIDMapper().map(response: response)
+        return try await ProductIDMapper().map(response: response)
     }
 
     /// Returns the ProductIDMapper output upon receiving `products-ids-only`
     ///
-    func mapLoadIDsResponse() throws -> [Int64] {
-        try mapIDs(from: "products-ids-only")
+    func mapLoadIDsResponse() async throws -> [Int64] {
+        try await mapIDs(from: "products-ids-only")
     }
 
     /// Returns the ProductIDMapper output upon receiving `products-ids-only-without-data`
     ///
-    func mapLoadIDsResponseWithoutData() throws -> [Int64] {
-        try mapIDs(from: "products-ids-only-without-data")
+    func mapLoadIDsResponseWithoutData() async throws -> [Int64] {
+        try await mapIDs(from: "products-ids-only-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductListMapperTests.swift
@@ -15,8 +15,8 @@ final class ProductListMapperTests: XCTestCase {
 
     /// Verifies that all of the Product Fields are parsed correctly.
     ///
-    func test_Product_fields_are_properly_parsed() throws {
-        for products in try mapLoadAllProductsResponse() {
+    func test_Product_fields_are_properly_parsed() async throws {
+        for products in try await mapLoadAllProductsResponse() {
             XCTAssertEqual(products.count, 10)
 
             let firstProduct = products[0]
@@ -97,8 +97,8 @@ final class ProductListMapperTests: XCTestCase {
 
     /// Test that ProductTypeKey converts to
     /// a ProductType enum properly.
-    func test_that_productTypeKey_converts_to_enum_properly() throws {
-        for products in try mapLoadAllProductsResponse() {
+    func test_that_productTypeKey_converts_to_enum_properly() async throws {
+        for products in try await mapLoadAllProductsResponse() {
 
             let firstProduct = products[0]
             let customType = ProductType(rawValue: "booking")
@@ -129,8 +129,8 @@ final class ProductListMapperTests: XCTestCase {
 
     /// Test that categories are properly mapped.
     ///
-    func test_that_product_categories_are_properly_mapped() throws {
-        for products in try mapLoadAllProductsResponse() {
+    func test_that_product_categories_are_properly_mapped() async throws {
+        for products in try await mapLoadAllProductsResponse() {
             let firstProduct = products[0]
             let categories = firstProduct.categories
             XCTAssertEqual(categories.count, 1)
@@ -145,8 +145,8 @@ final class ProductListMapperTests: XCTestCase {
 
     /// Test that tags are properly mapped.
     ///
-    func test_that_product_tags_are_properly_mapped() throws {
-        for products in try mapLoadAllProductsResponse() {
+    func test_that_product_tags_are_properly_mapped() async throws {
+        for products in try await mapLoadAllProductsResponse() {
             let firstProduct = products[0]
             let tags = firstProduct.tags
             XCTAssert(tags.count == 9)
@@ -160,8 +160,8 @@ final class ProductListMapperTests: XCTestCase {
 
     /// Test that product images are properly mapped.
     ///
-    func test_that_product_images_are_properly_mapped() throws {
-        for products in try mapLoadAllProductsResponse() {
+    func test_that_product_images_are_properly_mapped() async throws {
+        for products in try await mapLoadAllProductsResponse() {
             let product = products[1]
             let images = product.images
             XCTAssertEqual(images.count, 1)
@@ -181,8 +181,8 @@ final class ProductListMapperTests: XCTestCase {
 
     /// Test that product attributes are properly mapped
     ///
-    func test_that_product_attributes_are_properly_mapped() throws {
-        for products in try mapLoadAllProductsResponse() {
+    func test_that_product_attributes_are_properly_mapped() async throws {
+        for products in try await mapLoadAllProductsResponse() {
             let product = products[4]
             let attributes = product.attributes
             XCTAssertEqual(attributes.count, 2)
@@ -205,8 +205,8 @@ final class ProductListMapperTests: XCTestCase {
 
     /// Test that the default product attributes map properly
     ///
-    func test_that_default_product_attributes_map_properly() throws {
-        for products in try mapLoadAllProductsResponse() {
+    func test_that_default_product_attributes_map_properly() async throws {
+        for products in try await mapLoadAllProductsResponse() {
             let product = products[4]
             let defaultAttributes = product.defaultAttributes
             XCTAssertEqual(defaultAttributes.count, 2)
@@ -231,19 +231,19 @@ private extension ProductListMapperTests {
 
     /// Returns the ProductListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProducts(from filename: String) throws -> [Product] {
+    func mapProducts(from filename: String) async throws -> [Product] {
         guard let response = Loader.contentsOf(filename) else {
             throw ProductListMapperTestsError.unableToLoadFile
         }
 
-        return try ProductListMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductListMapper output upon receiving `products-load-all` and `products-load-all-without-data`
     ///
-    func mapLoadAllProductsResponse() throws -> [[Product]] {
-        let products = try mapProducts(from: "products-load-all")
-        let productsWithoutDataEnvelope = try mapProducts(from: "products-load-all-without-data")
+    func mapLoadAllProductsResponse() async throws -> [[Product]] {
+        let products = try await mapProducts(from: "products-load-all")
+        let productsWithoutDataEnvelope = try await mapProducts(from: "products-load-all-without-data")
 
         return [products, productsWithoutDataEnvelope]
     }

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -20,8 +20,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Verifies that all of the Product Fields are parsed correctly.
     ///
-    func test_Product_fields_are_properly_parsed() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_Product_fields_are_properly_parsed() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             XCTAssertEqual(product.siteID, dummySiteID)
             XCTAssertEqual(product.productID, dummyProductID)
@@ -108,8 +108,8 @@ final class ProductMapperTests: XCTestCase {
     /// Verifies that the fields of the Product with alternative types are parsed correctly when they have different types than in the struct.
     /// Currently, `price`, `regularPrice`, `salePrice`, `manageStock`, `soldIndividually`, `purchasable`, and `permalink`  allow alternative types.
     ///
-    func test_that_product_alternative_types_are_properly_parsed() throws {
-        let product = try XCTUnwrap(mapLoadProductResponseWithAlternativeTypes())
+    func test_that_product_alternative_types_are_properly_parsed() async throws {
+        let product = try await mapLoadProductResponseWithAlternativeTypes()
 
         XCTAssertEqual(product.price, "17")
         XCTAssertEqual(product.regularPrice, "12.89")
@@ -132,11 +132,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string
     ///
-    func test_that_product_sale_price_is_properly_parsed() {
-        guard let product = mapLoadProductOnSaleWithEmptySalePriceResponse() else {
-            XCTFail("Failed to parse product")
-            return
-        }
+    func test_that_product_sale_price_is_properly_parsed() async throws {
+        let product = try await mapLoadProductOnSaleWithEmptySalePriceResponse()
 
         XCTAssertEqual(product.salePrice, "0")
         XCTAssertTrue(product.onSale)
@@ -144,8 +141,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that ProductTypeKey converts to a ProductType enum properly.
     ///
-    func test_that_product_type_key_converts_to_enum_properly() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_that_product_type_key_converts_to_enum_properly() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             let customType = ProductType(rawValue: "booking")
             XCTAssertEqual(product.productTypeKey, "booking")
@@ -155,8 +152,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that categories are properly mapped.
     ///
-    func test_that_product_categories_are_properly_mapped() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_that_product_categories_are_properly_mapped() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             let categories = product.categories
             XCTAssertEqual(categories.count, 1)
@@ -172,8 +169,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that tags are properly mapped.
     ///
-    func test_that_product_tags_are_properly_mapped() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_that_product_tags_are_properly_mapped() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             let tags = product.tags
             XCTAssertNotNil(tags)
@@ -188,8 +185,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that product images are properly mapped.
     ///
-    func test_that_product_images_are_properly_mapped() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_that_product_images_are_properly_mapped() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             let images = product.images
             XCTAssertEqual(images.count, 1)
@@ -209,9 +206,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that product downloadable files are properly mapped.
     ///
-    func test_that_product_downloadable_files_are_properly_mapped() throws {
+    func test_that_product_downloadable_files_are_properly_mapped() async throws {
         // Given
-        let productsToTest = try mapLoadProductResponse()
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             // When
             let files = product.downloads
@@ -229,8 +226,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that product attributes are properly mapped
     ///
-    func test_that_product_attributes_are_properly_mapped() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_that_product_attributes_are_properly_mapped() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             let attributes = product.attributes
             XCTAssertEqual(attributes.count, 2)
@@ -254,8 +251,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that the default product attributes map properly
     ///
-    func test_that_default_product_attributes_map_properly() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_that_default_product_attributes_map_properly() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             let defaultAttributes = product.defaultAttributes
             XCTAssertEqual(defaultAttributes.count, 2)
@@ -275,8 +272,8 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that product add-ons are properly parsed.
     ///
-    func test_product_add_ons_are_properly_parsed() throws {
-        let productsToTest = try mapLoadProductResponse()
+    func test_product_add_ons_are_properly_parsed() async throws {
+        let productsToTest = try await mapLoadProductResponse()
         for product in productsToTest {
             let addOns = product.addOns
             XCTAssertEqual(addOns.count, 3)
@@ -291,18 +288,18 @@ final class ProductMapperTests: XCTestCase {
         }
     }
 
-    func test_product_image_alt_is_nil_when_malformed() throws {
+    func test_product_image_alt_is_nil_when_malformed() async throws {
         // Given
-        let product = try XCTUnwrap(mapLoadProductWithMalformedImageAltAndVariations())
+        let product = try await mapLoadProductWithMalformedImageAltAndVariations()
 
         // Then
         XCTAssertFalse(product.images.isEmpty)
         XCTAssertNil(product.images.first?.alt)
     }
 
-    func test_product_variation_list_is_empty_when_malformed() throws {
+    func test_product_variation_list_is_empty_when_malformed() async throws {
         // Given
-        let product = try XCTUnwrap(mapLoadProductWithMalformedImageAltAndVariations())
+        let product = try await mapLoadProductWithMalformedImageAltAndVariations()
 
         // Then
         XCTAssertTrue(product.variations.isEmpty)
@@ -310,9 +307,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that products with the `bundle` product type are properly parsed.
     ///
-    func test_product_bundles_are_properly_parsed() throws {
+    func test_product_bundles_are_properly_parsed() async throws {
         // Given
-        let product = try XCTUnwrap(mapLoadProductBundleResponse())
+        let product = try await mapLoadProductBundleResponse()
         let bundledItem = try XCTUnwrap(product.bundledItems.first)
 
         // Then
@@ -346,9 +343,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that products with the `composite` product type are properly parsed.
     ///
-    func test_composite_products_are_properly_parsed() throws {
+    func test_composite_products_are_properly_parsed() async throws {
         // Given
-        let product = try XCTUnwrap(mapLoadCompositeProductResponse())
+        let product = try await mapLoadCompositeProductResponse()
         let compositeComponent = try XCTUnwrap(product.compositeComponents.first)
 
         // Then
@@ -369,9 +366,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that products with the `subscription` product type are properly parsed.
     ///
-    func test_subscription_products_are_properly_parsed() throws {
+    func test_subscription_products_are_properly_parsed() async throws {
         // Given
-        let product = try XCTUnwrap(mapLoadSubscriptionProductResponse())
+        let product = try await mapLoadSubscriptionProductResponse()
         let subscriptionSettings = try XCTUnwrap(product.subscription)
 
         // Then
@@ -389,9 +386,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that products with the `subscription` product type are properly parsed when sync renewal value is in dict format.
     ///
-    func test_subscription_products_with_sync_renewals_in_dict_format_are_properly_parsed() throws {
+    func test_subscription_products_with_sync_renewals_in_dict_format_are_properly_parsed() async throws {
         // Given
-        let product = try XCTUnwrap(mapProduct(from: "product-subscription-sync-renewals-day-month-format"))
+        let product = try await mapProduct(from: "product-subscription-sync-renewals-day-month-format")
         let subscriptionSettings = try XCTUnwrap(product.subscription)
 
         // Then
@@ -410,9 +407,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that products with the `subscription` product type are properly parsed when sync renewal value is in dict format with int values.
     ///
-    func test_subscription_products_with_sync_renewals_in_dict_format_with_int_values_are_properly_parsed() throws {
+    func test_subscription_products_with_sync_renewals_in_dict_format_with_int_values_are_properly_parsed() async throws {
         // Given
-        let product = try XCTUnwrap(mapProduct(from: "product-subscription-sync-renewals-day-month-format-int-values"))
+        let product = try await mapProduct(from: "product-subscription-sync-renewals-day-month-format-int-values")
         let subscriptionSettings = try XCTUnwrap(product.subscription)
 
         // Then
@@ -431,9 +428,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that `subscription` is nil when parsing non-subscription product response
     ///
-    func test_subscription_is_nil_when_parsing_non_subscription_product_response() throws {
+    func test_subscription_is_nil_when_parsing_non_subscription_product_response() async throws {
         // Given
-        let productsToTest = try XCTUnwrap(mapLoadProductResponse())
+        let productsToTest = try await mapLoadProductResponse()
 
         // Then
         for product in productsToTest {
@@ -443,9 +440,9 @@ final class ProductMapperTests: XCTestCase {
 
     /// Test that products with properties from the Min/Max Quantities extension are properly parsed.
     ///
-    func test_min_max_quantities_are_properly_parsed() throws {
+    func test_min_max_quantities_are_properly_parsed() async throws {
         // Given
-        let product = try XCTUnwrap(mapLoadMinMaxQuantitiesProductResponse())
+        let product = try await mapLoadMinMaxQuantitiesProductResponse()
 
         // Then
         XCTAssertEqual(product.minAllowedQuantity, "4")
@@ -462,67 +459,61 @@ private extension ProductMapperTests {
 
     /// Returns the ProductMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProduct(from filename: String) -> Product? {
+    func mapProduct(from filename: String) async throws -> Product {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw ProductMapperTestsError.unableToLoadFile
         }
 
-        return try! ProductMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductMapper output upon receiving `product`
     ///
-    func mapLoadProductResponse() throws -> [Product] {
-        guard let product = mapProduct(from: "product") else {
-            throw ProductMapperTestsError.unableToLoadFile
-        }
-
-        guard let productWithoutDataEnvelope = mapProduct(from: "product-without-data") else {
-            throw ProductMapperTestsError.unableToLoadFile
-        }
-
+    func mapLoadProductResponse() async throws -> [Product] {
+        let product = try await mapProduct(from: "product")
+        let productWithoutDataEnvelope = try await mapProduct(from: "product-without-data")
         return [product, productWithoutDataEnvelope]
     }
 
     /// Returns the ProductMapper output upon receiving `product-alternative-types`
     ///
-    func mapLoadProductResponseWithAlternativeTypes() -> Product? {
-        return mapProduct(from: "product-alternative-types")
+    func mapLoadProductResponseWithAlternativeTypes() async throws -> Product {
+        try await mapProduct(from: "product-alternative-types")
     }
 
     /// Returns the ProductMapper output upon receiving `product` on sale, with empty sale price
     ///
-    func mapLoadProductOnSaleWithEmptySalePriceResponse() -> Product? {
-        return mapProduct(from: "product-on-sale-with-empty-sale-price")
+    func mapLoadProductOnSaleWithEmptySalePriceResponse() async throws -> Product {
+        try await mapProduct(from: "product-on-sale-with-empty-sale-price")
     }
 
     /// Returns the ProductMapper output upon receiving `product` with malformed image `alt` and `variations`
     ///
-    func mapLoadProductWithMalformedImageAltAndVariations() -> Product? {
-        return mapProduct(from: "product-malformed-variations-and-image-alt")
+    func mapLoadProductWithMalformedImageAltAndVariations() async throws -> Product {
+        try await mapProduct(from: "product-malformed-variations-and-image-alt")
     }
 
     /// Returns the ProductMapper output upon receiving `product-bundle`
     ///
-    func mapLoadProductBundleResponse() -> Product? {
-        return mapProduct(from: "product-bundle")
+    func mapLoadProductBundleResponse() async throws -> Product {
+        try await mapProduct(from: "product-bundle")
     }
 
     /// Returns the ProductMapper output upon receiving `product-composite`
     ///
-    func mapLoadCompositeProductResponse() -> Product? {
-        return mapProduct(from: "product-composite")
+    func mapLoadCompositeProductResponse() async throws -> Product {
+        try await mapProduct(from: "product-composite")
     }
 
     /// Returns the ProductMapper output upon receiving `product-subscription`
     ///
-    func mapLoadSubscriptionProductResponse() -> Product? {
-        return mapProduct(from: "product-subscription")
+    func mapLoadSubscriptionProductResponse() async throws -> Product {
+        try await mapProduct(from: "product-subscription")
     }
 
     /// Returns the ProductMapper output upon receiving `product-min-max-quantities`
     ///
-    func mapLoadMinMaxQuantitiesProductResponse() -> Product? {
-        return mapProduct(from: "product-min-max-quantities")
+    func mapLoadMinMaxQuantitiesProductResponse() async throws -> Product {
+        try await mapProduct(from: "product-min-max-quantities")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
@@ -9,8 +9,8 @@ final class ProductReviewListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductReview Fields are parsed correctly.
     ///
-    func test_ProductReview_fields_are_properly_parsed() {
-        let productReviews = mapLoadAllProductReviewsResponse()
+    func test_ProductReview_fields_are_properly_parsed() async {
+        let productReviews = await mapLoadAllProductReviewsResponse()
         XCTAssertEqual(productReviews.count, 2)
 
         let firstProductReview = productReviews[0]
@@ -34,8 +34,8 @@ final class ProductReviewListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductReview Fields are parsed correctly.
     ///
-    func test_ProductReview_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let productReviews = mapLoadAllProductReviewsResponseWithoutDataEnvelope()
+    func test_ProductReview_fields_are_properly_parsed_when_response_has_no_data_envelope() async {
+        let productReviews = await mapLoadAllProductReviewsResponseWithoutDataEnvelope()
         XCTAssertEqual(productReviews.count, 2)
 
         let firstProductReview = productReviews[0]
@@ -65,23 +65,23 @@ private extension ProductReviewListMapperTests {
 
     /// Returns the ProducReviewtListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductReviews(from filename: String) -> [ProductReview] {
+    func mapProductReviews(from filename: String) async -> [ProductReview] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! ProductReviewListMapper(siteID: dummySiteID).map(response: response)
+        return try! await ProductReviewListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductListMapper output upon receiving `reviews-all`
     ///
-    func mapLoadAllProductReviewsResponse() -> [ProductReview] {
-        return mapProductReviews(from: "reviews-all")
+    func mapLoadAllProductReviewsResponse() async -> [ProductReview] {
+        await mapProductReviews(from: "reviews-all")
     }
 
     /// Returns the ProductListMapper output upon receiving `reviews-all-without-data`
     ///
-    func mapLoadAllProductReviewsResponseWithoutDataEnvelope() -> [ProductReview] {
-        return mapProductReviews(from: "reviews-all-without-data")
+    func mapLoadAllProductReviewsResponseWithoutDataEnvelope() async -> [ProductReview] {
+        await mapProductReviews(from: "reviews-all-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductShippingClassListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductShippingClassListMapperTests.swift
@@ -10,8 +10,8 @@ final class ProductShippingClassListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductShippingClass Fields are parsed correctly.
     ///
-    func test_ProductShippingClass_fields_are_properly_parsed() throws {
-        let productVariation = try XCTUnwrap(mapLoadAllProductShippingClassResponse()?.first)
+    func test_ProductShippingClass_fields_are_properly_parsed() async throws {
+        let productVariation = try await mapLoadAllProductShippingClassResponse().first
 
         let expected = ProductShippingClass(count: 3,
                                             descriptionHTML: "Limited offer!",
@@ -25,8 +25,8 @@ final class ProductShippingClassListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductShippingClass Fields are parsed correctly when response has no data envelope.
     ///
-    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productVariation = try XCTUnwrap(mapLoadAllProductShippingClassResponseWithoutDataEnvelope()?.first)
+    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productVariation = try await mapLoadAllProductShippingClassResponseWithoutDataEnvelope().first
 
         let expected = ProductShippingClass(count: 3,
                                             descriptionHTML: "Limited offer!",
@@ -44,23 +44,25 @@ final class ProductShippingClassListMapperTests: XCTestCase {
 private extension ProductShippingClassListMapperTests {
     /// Returns the ProductShippingClassListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductShippingClass(from filename: String) -> [ProductShippingClass]? {
+    func mapProductShippingClass(from filename: String) async throws -> [ProductShippingClass] {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? ProductShippingClassListMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductShippingClassListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductShippingClassListMapper output upon receiving `product-shipping-classes-load-all`
     ///
-    func mapLoadAllProductShippingClassResponse() -> [ProductShippingClass]? {
-        return mapProductShippingClass(from: "product-shipping-classes-load-all")
+    func mapLoadAllProductShippingClassResponse() async throws -> [ProductShippingClass] {
+        try await mapProductShippingClass(from: "product-shipping-classes-load-all")
     }
 
     /// Returns the ProductShippingClassListMapper output upon receiving `product-shipping-classes-load-all-without-data`
     ///
-    func mapLoadAllProductShippingClassResponseWithoutDataEnvelope() -> [ProductShippingClass]? {
-        return mapProductShippingClass(from: "product-shipping-classes-load-all-without-data")
+    func mapLoadAllProductShippingClassResponseWithoutDataEnvelope() async throws -> [ProductShippingClass] {
+        try await mapProductShippingClass(from: "product-shipping-classes-load-all-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/ProductShippingClassMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductShippingClassMapperTests.swift
@@ -10,8 +10,8 @@ final class ProductShippingClassMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductShippingClass Fields are parsed correctly.
     ///
-    func test_ProductShippingClass_fields_are_properly_parsed() throws {
-        let productVariation = try XCTUnwrap(mapLoadProductShippingClassResponse())
+    func test_ProductShippingClass_fields_are_properly_parsed() async throws {
+        let productVariation = try await mapLoadProductShippingClassResponse()
 
         let expected = ProductShippingClass(count: 3,
                                             descriptionHTML: "Limited offer!",
@@ -25,8 +25,8 @@ final class ProductShippingClassMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductShippingClass Fields are parsed correctly when response has no data envelope.
     ///
-    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productVariation = try XCTUnwrap(mapLoadProductShippingClassResponseWithoutDataEnvelope())
+    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productVariation = try await mapLoadProductShippingClassResponseWithoutDataEnvelope()
 
         let expected = ProductShippingClass(count: 3,
                                             descriptionHTML: "Limited offer!",
@@ -44,23 +44,25 @@ final class ProductShippingClassMapperTests: XCTestCase {
 private extension ProductShippingClassMapperTests {
     /// Returns the ProductShippingClassMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductShippingClass(from filename: String) -> ProductShippingClass? {
+    func mapProductShippingClass(from filename: String) async throws -> ProductShippingClass {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? ProductShippingClassMapper(siteID: dummySiteID).map(response: response)
+        return try await ProductShippingClassMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ProductShippingClassMapper output upon receiving `product-shipping-classes-load-one`
     ///
-    func mapLoadProductShippingClassResponse() -> ProductShippingClass? {
-        return mapProductShippingClass(from: "product-shipping-classes-load-one")
+    func mapLoadProductShippingClassResponse() async throws -> ProductShippingClass {
+        try await mapProductShippingClass(from: "product-shipping-classes-load-one")
     }
 
     /// Returns the ProductShippingClassMapper output upon receiving `product-shipping-classes-load-one-without-data`
     ///
-    func mapLoadProductShippingClassResponseWithoutDataEnvelope() -> ProductShippingClass? {
-        return mapProductShippingClass(from: "product-shipping-classes-load-one-without-data")
+    func mapLoadProductShippingClassResponseWithoutDataEnvelope() async throws -> ProductShippingClass {
+        try await mapProductShippingClass(from: "product-shipping-classes-load-one-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/ProductSkuMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductSkuMapperTests.swift
@@ -8,8 +8,8 @@ final class ProductSkuMapperTests: XCTestCase {
 
     /// Verifies that SKU are parsed correctly.
     ///
-    func test_sku_is_properly_parsed() {
-        let skus = [mapLoadSkuResponse(), mapLoadSkuResponseWithoutData()]
+    func test_sku_is_properly_parsed() async throws {
+        let skus = [try await mapLoadSkuResponse(), try await mapLoadSkuResponseWithoutData()]
 
         for sku in skus {
             XCTAssertEqual(sku, "T-SHIRT-HAPPY-NINJA")
@@ -24,23 +24,23 @@ private extension ProductSkuMapperTests {
 
     /// Returns the ProductSkuMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSku(from filename: String) -> String {
+    func mapSku(from filename: String) async throws -> String {
         guard let response = Loader.contentsOf(filename) else {
             return ""
         }
 
-        return try! ProductSkuMapper().map(response: response)
+        return try await ProductSkuMapper().map(response: response)
     }
 
     /// Returns the ProductSkuMapper output upon receiving `product-search-sku`
     ///
-    func mapLoadSkuResponse() -> String {
-        return mapSku(from: "product-search-sku")
+    func mapLoadSkuResponse() async throws -> String {
+        try await mapSku(from: "product-search-sku")
     }
 
     /// Returns the ProductSkuMapper output upon receiving `product-search-sku-without-data`
     ///
-    func mapLoadSkuResponseWithoutData() -> String {
-        return mapSku(from: "product-search-sku-without-data")
+    func mapLoadSkuResponseWithoutData() async throws -> String {
+        try await mapSku(from: "product-search-sku-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductTagListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductTagListMapperTests.swift
@@ -8,8 +8,8 @@ final class ProductTagListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductTag Fields are parsed correctly.
     ///
-    func test_ProductTag_fields_are_properly_parsed() throws {
-        let tags = try mapLoadAllProductTagsResponse()
+    func test_ProductTag_fields_are_properly_parsed() async throws {
+        let tags = try await mapLoadAllProductTagsResponse()
         XCTAssertEqual(tags.count, 4)
 
         let secondTag = tags[1]
@@ -20,8 +20,8 @@ final class ProductTagListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductTag Fields are parsed correctly.
     ///
-    func test_ProductTag_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let tags = try mapLoadAllProductTagsResponseWithoutDataEnvelope()
+    func test_ProductTag_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let tags = try await mapLoadAllProductTagsResponseWithoutDataEnvelope()
         XCTAssertEqual(tags.count, 4)
 
         let secondTag = tags[1]
@@ -32,8 +32,8 @@ final class ProductTagListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductTag Fields under `create` field are parsed correctly.
     ///
-    func test_ProductTag_fields_when_created_are_properly_parsed() throws {
-        let tags = try mapLoadProductTagsCreatedResponse()
+    func test_ProductTag_fields_when_created_are_properly_parsed() async throws {
+        let tags = try await mapLoadProductTagsCreatedResponse()
         XCTAssertEqual(tags.count, 2)
 
         let firstTag = tags[0]
@@ -44,8 +44,8 @@ final class ProductTagListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductTag Fields under `create` field are parsed correctly.
     ///
-    func test_ProductTag_fields_when_created_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let tags = try mapLoadProductTagsCreatedResponseWithoutDataEnvelope()
+    func test_ProductTag_fields_when_created_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let tags = try await mapLoadProductTagsCreatedResponseWithoutDataEnvelope()
         XCTAssertEqual(tags.count, 2)
 
         let firstTag = tags[0]
@@ -56,8 +56,8 @@ final class ProductTagListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductTag Fields under `delete` field are parsed correctly.
     ///
-    func test_ProductTag_fields_when_deleted_are_properly_parsed() throws {
-        let tags = try mapLoadProductTagsDeletedResponse()
+    func test_ProductTag_fields_when_deleted_are_properly_parsed() async throws {
+        let tags = try await mapLoadProductTagsDeletedResponse()
         XCTAssertEqual(tags.count, 1)
 
         let firstTag = tags[0]
@@ -68,8 +68,8 @@ final class ProductTagListMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductTag Fields under `delete` field are parsed correctly.
     ///
-    func test_ProductTag_fields_when_deleted_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let tags = try mapLoadProductTagsDeletedResponseWithoutDataEnvelope()
+    func test_ProductTag_fields_when_deleted_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let tags = try await mapLoadProductTagsDeletedResponseWithoutDataEnvelope()
         XCTAssertEqual(tags.count, 1)
 
         let firstTag = tags[0]
@@ -86,47 +86,47 @@ private extension ProductTagListMapperTests {
 
     /// Returns the ProductTagListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductTags(from filename: String, responseType: ProductTagListMapper.ResponseType) throws -> [ProductTag] {
+    func mapProductTags(from filename: String, responseType: ProductTagListMapper.ResponseType) async throws -> [ProductTag] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try ProductTagListMapper(siteID: dummySiteID, responseType: responseType).map(response: response)
+        return try await ProductTagListMapper(siteID: dummySiteID, responseType: responseType).map(response: response)
     }
 
     /// Returns the ProductTagListMapper output upon receiving `product-tags-all`
     ///
-    func mapLoadAllProductTagsResponse() throws -> [ProductTag] {
-        return try mapProductTags(from: "product-tags-all", responseType: .load)
+    func mapLoadAllProductTagsResponse() async throws -> [ProductTag] {
+        try await mapProductTags(from: "product-tags-all", responseType: .load)
     }
 
     /// Returns the ProductTagListMapper output upon receiving `product-tags-all-without-data`
     ///
-    func mapLoadAllProductTagsResponseWithoutDataEnvelope() throws -> [ProductTag] {
-        return try mapProductTags(from: "product-tags-all-without-data", responseType: .load)
+    func mapLoadAllProductTagsResponseWithoutDataEnvelope() async throws -> [ProductTag] {
+        try await mapProductTags(from: "product-tags-all-without-data", responseType: .load)
     }
 
     /// Returns the ProductTagListMapper output upon receiving `product-tags-created`
     ///
-    func mapLoadProductTagsCreatedResponse() throws -> [ProductTag] {
-        return try mapProductTags(from: "product-tags-created", responseType: .create)
+    func mapLoadProductTagsCreatedResponse() async throws -> [ProductTag] {
+        try await mapProductTags(from: "product-tags-created", responseType: .create)
     }
 
     /// Returns the ProductTagListMapper output upon receiving `product-tags-created-without-data`
     ///
-    func mapLoadProductTagsCreatedResponseWithoutDataEnvelope() throws -> [ProductTag] {
-        return try mapProductTags(from: "product-tags-created-without-data", responseType: .create)
+    func mapLoadProductTagsCreatedResponseWithoutDataEnvelope() async throws -> [ProductTag] {
+        try await mapProductTags(from: "product-tags-created-without-data", responseType: .create)
     }
 
     /// Returns the ProductTagListMapper output upon receiving `product-tags-deleted`
     ///
-    func mapLoadProductTagsDeletedResponse() throws -> [ProductTag] {
-        return try mapProductTags(from: "product-tags-deleted", responseType: .delete)
+    func mapLoadProductTagsDeletedResponse() async throws -> [ProductTag] {
+        try await mapProductTags(from: "product-tags-deleted", responseType: .delete)
     }
 
     /// Returns the ProductTagListMapper output upon receiving `product-tags-deleted-without-data`
     ///
-    func mapLoadProductTagsDeletedResponseWithoutDataEnvelope() throws -> [ProductTag] {
-        return try mapProductTags(from: "product-tags-deleted-without-data", responseType: .delete)
+    func mapLoadProductTagsDeletedResponseWithoutDataEnvelope() async throws -> [ProductTag] {
+        try await mapProductTags(from: "product-tags-deleted-without-data", responseType: .delete)
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -14,16 +14,16 @@ final class ProductVariationMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductVariation Fields are parsed correctly.
     ///
-    func test_ProductVariation_fields_are_properly_parsed() throws {
-        let productVariation = try XCTUnwrap(mapLoadProductVariationResponse())
+    func test_ProductVariation_fields_are_properly_parsed() async throws {
+        let productVariation = try await mapLoadProductVariationResponse()
 
         XCTAssertEqual(productVariation, sampleProductVariation(siteID: dummySiteID, productID: dummyProductID, id: 2783))
     }
 
     /// Verifies that all of the ProductVariation Fields are parsed correctly when response has no data envelope.
     ///
-    func test_ProductVariation_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productVariation = try XCTUnwrap(mapLoadProductVariationResponseWithoutDataEnvelope())
+    func test_ProductVariation_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productVariation = try await mapLoadProductVariationResponseWithoutDataEnvelope()
 
         XCTAssertEqual(productVariation, sampleProductVariation(siteID: dummySiteID, productID: dummyProductID, id: 2783))
     }
@@ -31,8 +31,8 @@ final class ProductVariationMapperTests: XCTestCase {
     /// Verifies that the fields of the Product Variations with alternative types are parsed correctly when they have different types than in the struct.
     /// Currently, `price`, `regularPrice`, `salePrice`, `manageStock`, `purchasable`, and `permalink`  allow alternative types.
     ///
-    func test_that_product_variations_alternative_types_are_properly_parsed() throws {
-        let productVariation = try XCTUnwrap(mapLoadProductVariationResponseWithAlternativeTypes())
+    func test_that_product_variations_alternative_types_are_properly_parsed() async throws {
+        let productVariation = try await mapLoadProductVariationResponseWithAlternativeTypes()
 
         XCTAssertEqual(productVariation.price, "13.99")
         XCTAssertEqual(productVariation.regularPrice, "16")
@@ -49,9 +49,9 @@ final class ProductVariationMapperTests: XCTestCase {
 
     /// Test that the fields for variations of a subscription product are properly parsed.
     ///
-    func test_subscription_variations_are_properly_parsed() throws {
+    func test_subscription_variations_are_properly_parsed() async throws {
         // Given
-        let productVariation = try XCTUnwrap(mapLoadSubscriptionVariationResponse())
+        let productVariation = try await mapLoadSubscriptionVariationResponse()
         let subscriptionSettings = try XCTUnwrap(productVariation.subscription)
 
         // Then
@@ -68,9 +68,9 @@ final class ProductVariationMapperTests: XCTestCase {
 
     /// Test that the fields for variations of a subscription product are properly parsed when missing fields.
     ///
-    func test_subscription_variations_are_properly_parsed_when_response_has_missing_fields() throws {
+    func test_subscription_variations_are_properly_parsed_when_response_has_missing_fields() async throws {
         // Given
-        let productVariation = try XCTUnwrap(mapLoadSubscriptionVariationIncompleteResponse())
+        let productVariation = try await mapLoadSubscriptionVariationIncompleteResponse()
         let subscriptionSettings = try XCTUnwrap(productVariation.subscription)
 
         // Then
@@ -87,9 +87,9 @@ final class ProductVariationMapperTests: XCTestCase {
 
     /// Test that subscription is nil when parsing non-subscription product response
     ///
-    func test_subscription_is_nil_when_parsing_non_subscription_product_response() throws {
+    func test_subscription_is_nil_when_parsing_non_subscription_product_response() async throws {
         // Given
-        let productVariation = try XCTUnwrap(mapLoadProductVariationResponse())
+        let productVariation = try await mapLoadProductVariationResponse()
 
         // Then
         XCTAssertNil(productVariation.subscription)
@@ -97,9 +97,9 @@ final class ProductVariationMapperTests: XCTestCase {
 
     /// Test that product variations with properties from the Min/Max Quantities extension are properly parsed.
     ///
-    func test_min_max_quantities_are_properly_parsed() throws {
+    func test_min_max_quantities_are_properly_parsed() async throws {
         // Given
-        let productVariation = try XCTUnwrap(mapLoadMinMaxQuantityVariationResponse())
+        let productVariation = try await mapLoadMinMaxQuantityVariationResponse()
 
         // Then
         XCTAssertEqual(productVariation.minAllowedQuantity, "6")
@@ -114,49 +114,51 @@ final class ProductVariationMapperTests: XCTestCase {
 private extension ProductVariationMapperTests {
     /// Returns the ProductVariationMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductVariation(from filename: String) -> ProductVariation? {
+    func mapProductVariation(from filename: String) async throws -> ProductVariation {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? ProductVariationMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
+        return try await ProductVariationMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
     }
 
     /// Returns the ProductVariationMapper output upon receiving `ProductVariation`
     ///
-    func mapLoadProductVariationResponse() -> ProductVariation? {
-        return mapProductVariation(from: "product-variation-update")
+    func mapLoadProductVariationResponse() async throws -> ProductVariation {
+        try await mapProductVariation(from: "product-variation-update")
     }
 
     /// Returns the ProductVariationMapper output upon receiving `ProductVariation`
     ///
-    func mapLoadProductVariationResponseWithoutDataEnvelope() -> ProductVariation? {
-        return mapProductVariation(from: "product-variation-update-without-data")
+    func mapLoadProductVariationResponseWithoutDataEnvelope() async throws -> ProductVariation {
+        try await mapProductVariation(from: "product-variation-update-without-data")
     }
 
     /// Returns the ProductVariationMapper output upon receiving `ProductVariation`
     ///
-    func mapLoadProductVariationResponseWithAlternativeTypes() -> ProductVariation? {
-        return mapProductVariation(from: "product-variation-alternative-types")
+    func mapLoadProductVariationResponseWithAlternativeTypes() async throws -> ProductVariation {
+        try await mapProductVariation(from: "product-variation-alternative-types")
     }
 
     /// Returns the ProductVariationMapper output upon receiving `product-variation-subscription`
     ///
-    func mapLoadSubscriptionVariationResponse() -> ProductVariation? {
-        return mapProductVariation(from: "product-variation-subscription")
+    func mapLoadSubscriptionVariationResponse() async throws -> ProductVariation {
+        try await mapProductVariation(from: "product-variation-subscription")
     }
 
     /// Returns the ProductVariationMapper output upon receiving `product-variation-subscription-incomplete`
     ///
-    func mapLoadSubscriptionVariationIncompleteResponse() -> ProductVariation? {
-        return mapProductVariation(from: "product-variation-subscription-incomplete")
+    func mapLoadSubscriptionVariationIncompleteResponse() async throws -> ProductVariation {
+        try await mapProductVariation(from: "product-variation-subscription-incomplete")
     }
 
     /// Returns the ProductVariationMapper output upon receiving `product-variation-min-max-quantities`
     ///
-    func mapLoadMinMaxQuantityVariationResponse() -> ProductVariation? {
-        return mapProductVariation(from: "product-variation-min-max-quantities")
+    func mapLoadMinMaxQuantityVariationResponse() async throws -> ProductVariation {
+        try await mapProductVariation(from: "product-variation-min-max-quantities")
     }
+
+    struct FileNotFoundError: Error {}
 }
 
 private extension ProductVariationMapperTests {

--- a/Networking/NetworkingTests/Mapper/ProductVariationsBulkCreateMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationsBulkCreateMapperTests.swift
@@ -15,8 +15,8 @@ final class ProductVariationsBulkCreateMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductVariation Fields are parsed correctly.
     ///
-    func test_ProductVariation_fields_are_properly_parsed() throws {
-        let productVariations = try XCTUnwrap(mapLoadProductVariationBulkCreateResponse())
+    func test_ProductVariation_fields_are_properly_parsed() async throws {
+        let productVariations = try await mapLoadProductVariationBulkCreateResponse()
         XCTAssertTrue(productVariations.count == 1)
 
         let variation = try XCTUnwrap(productVariations.first)
@@ -25,8 +25,8 @@ final class ProductVariationsBulkCreateMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductVariation Fields are parsed correctly.
     ///
-    func test_ProductVariation_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productVariations = try XCTUnwrap(mapLoadProductVariationBulkCreateResponseWithoutDataEnvelope())
+    func test_ProductVariation_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productVariations = try await mapLoadProductVariationBulkCreateResponseWithoutDataEnvelope()
         XCTAssertTrue(productVariations.count == 1)
 
         let variation = try XCTUnwrap(productVariations.first)
@@ -40,23 +40,25 @@ private extension ProductVariationsBulkCreateMapperTests {
 
     /// Returns the ProductVariationsBulkCreateMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductVariations(from filename: String) -> [ProductVariation]? {
+    func mapProductVariations(from filename: String) async throws -> [ProductVariation] {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? ProductVariationsBulkCreateMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
+        return try await ProductVariationsBulkCreateMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
     }
 
     /// Returns the ProductVariationsBulkCreateMapper output upon receiving `product`
     ///
-    func mapLoadProductVariationBulkCreateResponse() -> [ProductVariation]? {
-        return mapProductVariations(from: "product-variations-bulk-create")
+    func mapLoadProductVariationBulkCreateResponse() async throws -> [ProductVariation] {
+        try await mapProductVariations(from: "product-variations-bulk-create")
     }
 
     /// Returns the ProductVariationsBulkCreateMapper output upon receiving `product`
     ///
-    func mapLoadProductVariationBulkCreateResponseWithoutDataEnvelope() -> [ProductVariation]? {
-        return mapProductVariations(from: "product-variations-bulk-create-without-data")
+    func mapLoadProductVariationBulkCreateResponseWithoutDataEnvelope() async throws -> [ProductVariation] {
+        try await mapProductVariations(from: "product-variations-bulk-create-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/ProductVariationsBulkUpdateMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationsBulkUpdateMapperTests.swift
@@ -15,8 +15,8 @@ final class ProductVariationsBulkUpdateMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductVariation Fields are parsed correctly.
     ///
-    func test_ProductVariation_fields_are_properly_parsed() throws {
-        let productVariations = try XCTUnwrap(mapLoadProductVariationBulkUpdateResponse())
+    func test_ProductVariation_fields_are_properly_parsed() async throws {
+        let productVariations = try await mapLoadProductVariationBulkUpdateResponse()
         XCTAssertTrue(productVariations.count == 1)
 
         let variation = try XCTUnwrap(productVariations.first)
@@ -25,8 +25,8 @@ final class ProductVariationsBulkUpdateMapperTests: XCTestCase {
 
     /// Verifies that all of the ProductVariation Fields are parsed correctly.
     ///
-    func test_ProductVariation_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let productVariations = try XCTUnwrap(mapLoadProductVariationBulkUpdateResponseWithoutDataEnvelope())
+    func test_ProductVariation_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let productVariations = try await mapLoadProductVariationBulkUpdateResponseWithoutDataEnvelope()
         XCTAssertTrue(productVariations.count == 1)
 
         let variation = try XCTUnwrap(productVariations.first)
@@ -40,23 +40,25 @@ private extension ProductVariationsBulkUpdateMapperTests {
 
     /// Returns the ProductVariationsBulkUpdateMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductVariations(from filename: String) -> [ProductVariation]? {
+    func mapProductVariations(from filename: String) async throws -> [ProductVariation] {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? ProductVariationsBulkUpdateMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
+        return try await ProductVariationsBulkUpdateMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
     }
 
     /// Returns the ProductVariationsBulkUpdateMapper output upon receiving `product`
     ///
-    func mapLoadProductVariationBulkUpdateResponse() -> [ProductVariation]? {
-        return mapProductVariations(from: "product-variations-bulk-update")
+    func mapLoadProductVariationBulkUpdateResponse() async throws -> [ProductVariation] {
+        try await mapProductVariations(from: "product-variations-bulk-update")
     }
 
     /// Returns the ProductVariationsBulkUpdateMapper output upon receiving `product`
     ///
-    func mapLoadProductVariationBulkUpdateResponseWithoutDataEnvelope() -> [ProductVariation]? {
-        return mapProductVariations(from: "product-variations-bulk-update-without-data")
+    func mapLoadProductVariationBulkUpdateResponseWithoutDataEnvelope() async throws -> [ProductVariation] {
+        try await mapProductVariations(from: "product-variations-bulk-update-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/ProductsReportMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductsReportMapperTests.swift
@@ -5,9 +5,9 @@ final class ProductsReportMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed.
     ///
-    func test_mapper_parses_all_products_in_response() throws {
+    func test_mapper_parses_all_products_in_response() async throws {
         // Given
-        let products = try mapLoadProductsReportResponseWithDataEnvelope()
+        let products = try await mapLoadProductsReportResponseWithDataEnvelope()
 
         // Then
         XCTAssertEqual(products.count, 2)
@@ -15,9 +15,9 @@ final class ProductsReportMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed.
     ///
-    func test_mapper_parses_all_products_in_response_without_data_envelope() throws {
+    func test_mapper_parses_all_products_in_response_without_data_envelope() async throws {
         // Given
-        let products = try mapLoadProductsReportResponseWithoutDataEnvelope()
+        let products = try await mapLoadProductsReportResponseWithoutDataEnvelope()
 
         // Then
         XCTAssertEqual(products.count, 2)
@@ -25,9 +25,9 @@ final class ProductsReportMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly
     ///
-    func test_mapper_parses_all_fields_in_result() throws {
+    func test_mapper_parses_all_fields_in_result() async throws {
         // Given
-        let products = try mapLoadProductsReportResponseWithDataEnvelope()
+        let products = try await mapLoadProductsReportResponseWithDataEnvelope()
         let product = products[0]
         let expectedProduct = ProductsReportItem(productID: 233,
                                                  productName: "Colorful Sunglasses Subscription",
@@ -47,23 +47,23 @@ private extension ProductsReportMapperTests {
 
     /// Returns the ProductsReportMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapReport(from filename: String) throws -> [ProductsReportItem] {
+    func mapReport(from filename: String) async throws -> [ProductsReportItem] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try ProductsReportMapper().map(response: response)
+        return try await ProductsReportMapper().map(response: response)
     }
 
     /// Returns the ProductsReportItem list from `coupon-reports.json`
     ///
-    func mapLoadProductsReportResponseWithDataEnvelope() throws -> [ProductsReportItem] {
-        return try mapReport(from: "reports-products")
+    func mapLoadProductsReportResponseWithDataEnvelope() async throws -> [ProductsReportItem] {
+        try await mapReport(from: "reports-products")
     }
 
     /// Returns the ProductsReportItem list from `coupon-reports-without-data.json`
     ///
-    func mapLoadProductsReportResponseWithoutDataEnvelope() throws -> [ProductsReportItem] {
-        return try mapReport(from: "reports-products-without-data")
+    func mapLoadProductsReportResponseWithoutDataEnvelope() async throws -> [ProductsReportItem] {
+        try await mapReport(from: "reports-products-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/RefundListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundListMapperTests.swift
@@ -16,8 +16,8 @@ final class RefundListMapperTests: XCTestCase {
 
     /// Verifies that all the Refund fields are parsed correctly.
     ///
-    func test_Refund_fields_are_properly_parsed() {
-        let result = [mapLoadAllRefundsResponse(), mapLoadAllRefundsResponseWithoutDataEnvelope()]
+    func test_Refund_fields_are_properly_parsed() async throws {
+        let result = [try await mapLoadAllRefundsResponse(), try await mapLoadAllRefundsResponseWithoutDataEnvelope()]
         for refunds in result {
             XCTAssertEqual(refunds.count, 2)
 
@@ -56,8 +56,8 @@ final class RefundListMapperTests: XCTestCase {
 
     /// Verifies that all of the Refunded Order Items are parsed correctly.
     ///
-    func test_Refund_items_are_correctly_parsed() {
-        let refunds = mapLoadAllRefundsResponse()
+    func test_Refund_items_are_correctly_parsed() async throws {
+        let refunds = try await mapLoadAllRefundsResponse()
         XCTAssertEqual(refunds.count, 2)
 
         let refund = refunds[0]
@@ -117,23 +117,23 @@ private extension RefundListMapperTests {
 
     /// Returns the RefundListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapRefunds(from filename: String) -> [Refund] {
+    func mapRefunds(from filename: String) async throws -> [Refund] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! RefundListMapper(siteID: dummySiteID, orderID: orderID).map(response: response)
+        return try await RefundListMapper(siteID: dummySiteID, orderID: orderID).map(response: response)
     }
 
     /// Returns the RefundListMapper output upon receiving `refunds-all`
     ///
-    func mapLoadAllRefundsResponse() -> [Refund] {
-        return mapRefunds(from: "refunds-all")
+    func mapLoadAllRefundsResponse() async throws -> [Refund] {
+        try await mapRefunds(from: "refunds-all")
     }
 
     /// Returns the RefundListMapper output upon receiving `refunds-all-without-data`
     ///
-    func mapLoadAllRefundsResponseWithoutDataEnvelope() -> [Refund] {
-        return mapRefunds(from: "refunds-all-without-data")
+    func mapLoadAllRefundsResponseWithoutDataEnvelope() async throws -> [Refund] {
+        try await mapRefunds(from: "refunds-all-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ReportOrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ReportOrderMapperTests.swift
@@ -12,15 +12,15 @@ class ReportOrderMapperTests: XCTestCase {
 
     /// Verifies that the broken response causes the mapper to return an unknown status
     ///
-    func test_broken_response_returns_unknown_status() {
-        let reportTotals = try? mapLoadBrokenResponse()
+    func test_broken_response_returns_unknown_status() async {
+        let reportTotals = try? await mapLoadBrokenResponse()
         XCTAssertNil(reportTotals)
     }
 
     /// Verifies that a valid report totals response is properly parsed (YAY!).
     ///
-    func test_sample_response_loaded() {
-        guard let results = try? mapSuccessfulResponse() else {
+    func test_sample_response_loaded() async {
+        guard let results = try? await mapSuccessfulResponse() else {
             XCTFail("Sample order report totals didn't load.")
             return
         }
@@ -95,21 +95,21 @@ private extension ReportOrderMapperTests {
 
     /// Returns the ReportOrderMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapOrderStatusResult(from filename: String) throws -> [OrderStatus] {
+    func mapOrderStatusResult(from filename: String) async throws -> [OrderStatus] {
         let response = Loader.contentsOf(filename)!
         let mapper = ReportOrderTotalsMapper(siteID: 1234)
-        return try mapper.map(response: response)
+        return try await mapper.map(response: response)
     }
 
     /// Returns the ReportOrderMapper output upon receiving data from the endpoint
     ///
-    func mapSuccessfulResponse() throws -> [OrderStatus] {
-        return try mapOrderStatusResult(from: "report-orders")
+    func mapSuccessfulResponse() async throws -> [OrderStatus] {
+        return try await mapOrderStatusResult(from: "report-orders")
     }
 
     /// Returns the ReportOrderMapper output upon receiving a broken response.
     ///
-    func mapLoadBrokenResponse() throws -> [OrderStatus] {
-        return try mapOrderStatusResult(from: "generic_error")
+    func mapLoadBrokenResponse() async throws -> [OrderStatus] {
+        return try await mapOrderStatusResult(from: "generic_error")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ReportOrderTotalsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ReportOrderTotalsMapperTests.swift
@@ -10,7 +10,7 @@ final class ReportOrderTotalsMapperTests: XCTestCase {
     private let fileNameWithDataEnvelope = "report-orders-total"
     private let fileNameWithoutDataEnvelope = "report-orders-total-without-data"
 
-    func test_order_statuses_is_mapped_from_response_with_data_envelope() throws {
+    func test_order_statuses_is_mapped_from_response_with_data_envelope() async throws {
         // Given
         let mapper = ReportOrderTotalsMapper(siteID: dummySiteID)
         guard let data = Loader.contentsOf(fileNameWithDataEnvelope) else {
@@ -19,13 +19,13 @@ final class ReportOrderTotalsMapperTests: XCTestCase {
         }
 
         // When
-        let statuses = try mapper.map(response: data)
+        let statuses = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(statuses.count, 8)
     }
 
-    func test_order_statuses_is_mapped_from_response_without_data_envelope() throws {
+    func test_order_statuses_is_mapped_from_response_without_data_envelope() async throws {
         // Given
         let mapper = ReportOrderTotalsMapper(siteID: dummySiteID)
         guard let data = Loader.contentsOf(fileNameWithoutDataEnvelope) else {
@@ -34,7 +34,7 @@ final class ReportOrderTotalsMapperTests: XCTestCase {
         }
 
         // When
-        let statuses = try mapper.map(response: data)
+        let statuses = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(statuses.count, 8)

--- a/Networking/NetworkingTests/Mapper/ShipmentTrackingListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShipmentTrackingListMapperTests.swift
@@ -16,8 +16,8 @@ final class ShipmentTrackingListMapperTests: XCTestCase {
 
     /// Verifies that all of the ShipmentTracking Fields are parsed correctly for multiple tracking JSON objects.
     ///
-    func test_tracking_fields_are_properly_parsed_for_multiple() {
-        let shipmentTrackings = mapLoadMultipleTrackingsResponse()
+    func test_tracking_fields_are_properly_parsed_for_multiple() async {
+        let shipmentTrackings = await mapLoadMultipleTrackingsResponse()
         XCTAssertEqual(shipmentTrackings.count, 4)
 
         let firstTracking = shipmentTrackings.first
@@ -42,8 +42,8 @@ final class ShipmentTrackingListMapperTests: XCTestCase {
 
     /// Verifies that all of the ShipmentTracking Fields are parsed correctly for a single tracking JSON object.
     ///
-    func test_tracking_fields_are_properly_parsed_for_single() {
-        let shipmentTrackings = mapLoadSingleTrackingsResponse()
+    func test_tracking_fields_are_properly_parsed_for_single() async {
+        let shipmentTrackings = await mapLoadSingleTrackingsResponse()
         XCTAssertEqual(shipmentTrackings.count, 1)
 
         let firstTracking = shipmentTrackings.first
@@ -59,15 +59,15 @@ final class ShipmentTrackingListMapperTests: XCTestCase {
 
     /// Verifies that all of the ShipmentTracking Fields are parsed correctly an empty JSON array.
     ///
-    func test_tracking_fields_are_properly_parsed_for_empty() {
-        let shipmentTrackings = mapLoadEmptyTrackingsResponse()
+    func test_tracking_fields_are_properly_parsed_for_empty() async {
+        let shipmentTrackings = await mapLoadEmptyTrackingsResponse()
         XCTAssertEqual(shipmentTrackings.count, 0)
     }
 
     /// Verifies that all of the ShipmentTracking Fields are parsed correctly for a single tracking JSON object.
     ///
-    func test_tracking_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let shipmentTrackings = mapLoadSingleTrackingsResponseWithoutDataEnvelope()
+    func test_tracking_fields_are_properly_parsed_when_response_has_no_data_envelope() async {
+        let shipmentTrackings = await mapLoadSingleTrackingsResponseWithoutDataEnvelope()
         XCTAssertEqual(shipmentTrackings.count, 1)
 
         let firstTracking = shipmentTrackings.first
@@ -89,35 +89,35 @@ private extension ShipmentTrackingListMapperTests {
 
     /// Returns the ShipmentTrackingsMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShipmentTrackings(from filename: String) -> [ShipmentTracking] {
+    func mapShipmentTrackings(from filename: String) async -> [ShipmentTracking] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! ShipmentTrackingListMapper(siteID: dummySiteID, orderID: dummyOrderID).map(response: response)
+        return try! await ShipmentTrackingListMapper(siteID: dummySiteID, orderID: dummyOrderID).map(response: response)
     }
 
     /// Returns the ShipmentTrackingsMapper output upon receiving `shipment_tracking_single`
     ///
-    func mapLoadSingleTrackingsResponse() -> [ShipmentTracking] {
-        return mapShipmentTrackings(from: "shipment_tracking_single")
+    func mapLoadSingleTrackingsResponse() async -> [ShipmentTracking] {
+        await mapShipmentTrackings(from: "shipment_tracking_single")
     }
 
     /// Returns the ShipmentTrackingsMapper output upon receiving `shipment_tracking_multiple`
     ///
-    func mapLoadMultipleTrackingsResponse() -> [ShipmentTracking] {
-        return mapShipmentTrackings(from: "shipment_tracking_multiple")
+    func mapLoadMultipleTrackingsResponse() async -> [ShipmentTracking] {
+        await mapShipmentTrackings(from: "shipment_tracking_multiple")
     }
 
     /// Returns the ShipmentTrackingsMapper output upon receiving `shipment_tracking_empty`
     ///
-    func mapLoadEmptyTrackingsResponse() -> [ShipmentTracking] {
-        return mapShipmentTrackings(from: "shipment_tracking_empty")
+    func mapLoadEmptyTrackingsResponse() async -> [ShipmentTracking] {
+        await mapShipmentTrackings(from: "shipment_tracking_empty")
     }
 
     /// Returns the ShipmentTrackingsMapper output upon receiving `shipment_tracking_single_without_data`
     ///
-    func mapLoadSingleTrackingsResponseWithoutDataEnvelope() -> [ShipmentTracking] {
-        return mapShipmentTrackings(from: "shipment_tracking_single_without_data")
+    func mapLoadSingleTrackingsResponseWithoutDataEnvelope() async -> [ShipmentTracking] {
+        await mapShipmentTrackings(from: "shipment_tracking_single_without_data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ShipmentTrackingProviderListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShipmentTrackingProviderListMapperTests.swift
@@ -9,8 +9,8 @@ final class ShipmentTrackingProviderListMapperTests: XCTestCase {
     ///
     private let dummySiteID: Int64 = 424242
 
-    func test_provider_fields_are_properly_parsed() throws {
-        let shipmentTrackingProviders = try mapLoadShipmentTrackingProviderResponse()
+    func test_provider_fields_are_properly_parsed() async throws {
+        let shipmentTrackingProviders = try await mapLoadShipmentTrackingProviderResponse()
         XCTAssertEqual(shipmentTrackingProviders.count, 19)
 
         let shipmentProviderGroup = try XCTUnwrap(shipmentTrackingProviders.first(where:) { $0.name ==  "Australia" })
@@ -20,8 +20,8 @@ final class ShipmentTrackingProviderListMapperTests: XCTestCase {
         XCTAssertTrue(shipmentProviderGroup.providers.contains(where: { $0.name == "Fastway Couriers" }))
     }
 
-    func test_provider_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let shipmentTrackingProviders = try mapLoadShipmentTrackingProviderResponseWithoutDataEnvelope()
+    func test_provider_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let shipmentTrackingProviders = try await mapLoadShipmentTrackingProviderResponseWithoutDataEnvelope()
         XCTAssertEqual(shipmentTrackingProviders.count, 19)
 
         let shipmentProviderGroup = try XCTUnwrap(shipmentTrackingProviders.first(where:) { $0.name ==  "Australia" })
@@ -38,24 +38,24 @@ private extension ShipmentTrackingProviderListMapperTests {
 
     /// Returns the ShipmentTrackingProviderListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShipmentTrackingProvider(from filename: String) throws -> [ShipmentTrackingProviderGroup] {
+    func mapShipmentTrackingProvider(from filename: String) async throws -> [ShipmentTrackingProviderGroup] {
         guard let response = Loader.contentsOf(filename) else {
             throw ParsingError.unableToLoadFile
         }
 
-        return try! ShipmentTrackingProviderListMapper(siteID: dummySiteID).map(response: response)
+        return try! await ShipmentTrackingProviderListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the ShipmentTrackingProviderListMapper output upon receiving `shipment_tracking_providers`
     ///
-    func mapLoadShipmentTrackingProviderResponse() throws -> [ShipmentTrackingProviderGroup] {
-        try mapShipmentTrackingProvider(from: "shipment_tracking_providers")
+    func mapLoadShipmentTrackingProviderResponse() async throws -> [ShipmentTrackingProviderGroup] {
+        try await mapShipmentTrackingProvider(from: "shipment_tracking_providers")
     }
 
     /// Returns the ShipmentTrackingProviderListMapper output upon receiving `shipment_tracking_providers_without_data`
     ///
-    func mapLoadShipmentTrackingProviderResponseWithoutDataEnvelope() throws -> [ShipmentTrackingProviderGroup] {
-        try mapShipmentTrackingProvider(from: "shipment_tracking_providers_without_data")
+    func mapLoadShipmentTrackingProviderResponseWithoutDataEnvelope() async throws -> [ShipmentTrackingProviderGroup] {
+        try await mapShipmentTrackingProvider(from: "shipment_tracking_providers_without_data")
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
@@ -11,8 +11,8 @@ class ShippingLabelAccountSettingsMapperTests: XCTestCase {
 
     /// Verifies that the Shipping Label Account Settings are parsed correctly.
     ///
-    func test_Account_Settings_are_properly_parsed() {
-        guard let settings = mapLoadShippingLabelAccountSettings() else {
+    func test_Account_Settings_are_properly_parsed() async {
+        guard let settings = await mapLoadShippingLabelAccountSettings() else {
             XCTFail()
             return
         }
@@ -33,8 +33,8 @@ class ShippingLabelAccountSettingsMapperTests: XCTestCase {
 
     /// Verifies that the Shipping Label Account Settings are parsed correctly.
     ///
-    func test_Account_Settings_are_properly_parsed_when_response_has_no_data_envelope() {
-        guard let settings = mapLoadShippingLabelAccountSettingsWithoutDataEnvelope() else {
+    func test_Account_Settings_are_properly_parsed_when_response_has_no_data_envelope() async {
+        guard let settings = await mapLoadShippingLabelAccountSettingsWithoutDataEnvelope() else {
             XCTFail()
             return
         }
@@ -55,8 +55,8 @@ class ShippingLabelAccountSettingsMapperTests: XCTestCase {
 
     /// Verifies that the Shipping Label Account Settings without any payment methods are parsed correctly.
     ///
-    func test_Account_Settings_without_payment_methods_are_properly_parsed() {
-        guard let settings = mapLoadIncompleteShippingLabelAccountSettings() else {
+    func test_Account_Settings_without_payment_methods_are_properly_parsed() async {
+        guard let settings = await mapLoadIncompleteShippingLabelAccountSettings() else {
             XCTFail()
             return
         }
@@ -83,30 +83,30 @@ private extension ShippingLabelAccountSettingsMapperTests {
 
     /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapAccountSettings(from filename: String) -> ShippingLabelAccountSettings? {
+    func mapAccountSettings(from filename: String) async -> ShippingLabelAccountSettings? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! ShippingLabelAccountSettingsMapper(siteID: sampleSiteID).map(response: response)
+        return try! await ShippingLabelAccountSettingsMapper(siteID: sampleSiteID).map(response: response)
     }
 
     /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `shipping-label-account-settings`
     ///
-    func mapLoadShippingLabelAccountSettings() -> ShippingLabelAccountSettings? {
-        return mapAccountSettings(from: "shipping-label-account-settings")
+    func mapLoadShippingLabelAccountSettings() async -> ShippingLabelAccountSettings? {
+        await mapAccountSettings(from: "shipping-label-account-settings")
     }
 
     /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `shipping-label-account-settings-without-data`
     ///
-    func mapLoadShippingLabelAccountSettingsWithoutDataEnvelope() -> ShippingLabelAccountSettings? {
-        return mapAccountSettings(from: "shipping-label-account-settings-without-data")
+    func mapLoadShippingLabelAccountSettingsWithoutDataEnvelope() async -> ShippingLabelAccountSettings? {
+        await mapAccountSettings(from: "shipping-label-account-settings-without-data")
     }
 
     /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `shipping-label-account-settings-no-payment-methods`
     ///
-    func mapLoadIncompleteShippingLabelAccountSettings() -> ShippingLabelAccountSettings? {
-        return mapAccountSettings(from: "shipping-label-account-settings-no-payment-methods")
+    func mapLoadIncompleteShippingLabelAccountSettings() async -> ShippingLabelAccountSettings? {
+        await mapAccountSettings(from: "shipping-label-account-settings-no-payment-methods")
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ShippingLabelCreationEligibilityMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelCreationEligibilityMapperTests.swift
@@ -10,36 +10,36 @@ class ShippingLabelCreationEligibilityMapperTests: XCTestCase {
     /// Sample Order ID
     private let sampleOrderID: Int64 = 123
 
-    func test_shipping_label_creation_eligibility_success_is_properly_parsed() throws {
+    func test_shipping_label_creation_eligibility_success_is_properly_parsed() async throws {
         // Given
-        let response = try XCTUnwrap(mapEligibilityResponse(from: "shipping-label-eligibility-success"))
+        let response = try await mapEligibilityResponse(from: "shipping-label-eligibility-success")
 
         // Then
         XCTAssertEqual(response.isEligible, true)
         XCTAssertEqual(response.reason, nil)
     }
 
-    func test_shipping_label_creation_eligibility_success_is_properly_parsed_when_response_has_no_data_envelope() throws {
+    func test_shipping_label_creation_eligibility_success_is_properly_parsed_when_response_has_no_data_envelope() async throws {
         // Given
-        let response = try XCTUnwrap(mapEligibilityResponse(from: "shipping-label-eligibility-success-without-data"))
+        let response = try await mapEligibilityResponse(from: "shipping-label-eligibility-success-without-data")
 
         // Then
         XCTAssertEqual(response.isEligible, true)
         XCTAssertEqual(response.reason, nil)
     }
 
-    func test_shipping_label_creation_eligibility_failure_is_properly_parsed() throws {
+    func test_shipping_label_creation_eligibility_failure_is_properly_parsed() async throws {
         // Given
-        let response = try XCTUnwrap(mapEligibilityResponse(from: "shipping-label-eligibility-failure"))
+        let response = try await mapEligibilityResponse(from: "shipping-label-eligibility-failure")
 
         // Then
         XCTAssertEqual(response.isEligible, false)
         XCTAssertEqual(response.reason, "no_selected_payment_method_and_user_cannot_manage_payment_methods")
     }
 
-    func test_shipping_label_creation_eligibility_failure_is_properly_parsed_when_response_has_no_data_envelope() throws {
+    func test_shipping_label_creation_eligibility_failure_is_properly_parsed_when_response_has_no_data_envelope() async throws {
         // Given
-        let response = try XCTUnwrap(mapEligibilityResponse(from: "shipping-label-eligibility-failure-without-data"))
+        let response = try await mapEligibilityResponse(from: "shipping-label-eligibility-failure-without-data")
 
         // Then
         XCTAssertEqual(response.isEligible, false)
@@ -53,11 +53,13 @@ private extension ShippingLabelCreationEligibilityMapperTests {
 
     /// Returns the `ShippingLabelCreationEligibilityMapper` output upon receiving `filename` (Data Encoded)
     ///
-    func mapEligibilityResponse(from filename: String) -> ShippingLabelCreationEligibilityResponse? {
+    func mapEligibilityResponse(from filename: String) async throws -> ShippingLabelCreationEligibilityResponse {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? ShippingLabelCreationEligibilityMapper().map(response: response)
+        return try await ShippingLabelCreationEligibilityMapper().map(response: response)
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
@@ -8,8 +8,8 @@ final class ShippingLabelPackagesMapperTests: XCTestCase {
 
     /// Verifies that all of the ShippingLabelPackagesResponse Fields are parsed correctly.
     ///
-    func test_ShippingLabelPackages_fields_are_properly_parsed() throws {
-        let shippingLabelPackages = try XCTUnwrap(mapLoadShippingLabelPackagesResponse())
+    func test_ShippingLabelPackages_fields_are_properly_parsed() async throws {
+        let shippingLabelPackages = try await mapLoadShippingLabelPackagesResponse()
 
         XCTAssertEqual(shippingLabelPackages.storeOptions, sampleShippingLabelStoreOptions())
         XCTAssertEqual(shippingLabelPackages.customPackages, sampleShippingLabelCustomPackages())
@@ -21,8 +21,8 @@ final class ShippingLabelPackagesMapperTests: XCTestCase {
 
     /// Verifies that all of the ShippingLabelPackagesResponse Fields are parsed correctly.
     ///
-    func test_ShippingLabelPackages_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let shippingLabelPackages = try XCTUnwrap(mapLoadShippingLabelPackagesResponseWithoutDataEnvelope())
+    func test_ShippingLabelPackages_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let shippingLabelPackages = try await mapLoadShippingLabelPackagesResponseWithoutDataEnvelope()
 
         XCTAssertEqual(shippingLabelPackages.storeOptions, sampleShippingLabelStoreOptions())
         XCTAssertEqual(shippingLabelPackages.customPackages.first?.title, "Small box")
@@ -34,26 +34,28 @@ final class ShippingLabelPackagesMapperTests: XCTestCase {
 private extension ShippingLabelPackagesMapperTests {
     /// Returns the ProductVariationMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShippingLabelPackages(from filename: String) -> ShippingLabelPackagesResponse? {
+    func mapShippingLabelPackages(from filename: String) async throws -> ShippingLabelPackagesResponse {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+           throw FileNotFoundError()
         }
 
-        return try? ShippingLabelPackagesMapper().map(response: response)
+        return try await ShippingLabelPackagesMapper().map(response: response)
     }
 
     /// Returns the ShippingLabelPackagesMapper output upon receiving `shipping-label-packages-success`
     ///
-    func mapLoadShippingLabelPackagesResponse() -> ShippingLabelPackagesResponse? {
-        return mapShippingLabelPackages(from: "shipping-label-packages-success")
+    func mapLoadShippingLabelPackagesResponse() async throws -> ShippingLabelPackagesResponse {
+        try await mapShippingLabelPackages(from: "shipping-label-packages-success")
     }
 
     /// Returns the ShippingLabelPackagesMapper output upon receiving
     /// `shipping-label-packages-success-without-data`
     ///
-    func mapLoadShippingLabelPackagesResponseWithoutDataEnvelope() -> ShippingLabelPackagesResponse? {
-        return mapShippingLabelPackages(from: "shipping-label-packages-success-without-data")
+    func mapLoadShippingLabelPackagesResponseWithoutDataEnvelope() async throws -> ShippingLabelPackagesResponse {
+        try await mapShippingLabelPackages(from: "shipping-label-packages-success-without-data")
     }
+
+    struct FileNotFoundError: Error {}
 }
 
 private extension ShippingLabelPackagesMapperTests {

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPurchaseMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPurchaseMapperTests.swift
@@ -13,8 +13,8 @@ class ShippingLabelPurchaseMapperTests: XCTestCase {
 
     /// Verifies that the Shipping Label Purchase is parsed correctly.
     ///
-    func test_ShippingLabelPurchase_is_properly_parsed() {
-        guard let shippingLabelList = mapLoadShippingLabelPurchase(),
+    func test_ShippingLabelPurchase_is_properly_parsed() async {
+        guard let shippingLabelList = await mapLoadShippingLabelPurchase(),
               let shippingLabel = shippingLabelList.first else {
             XCTFail()
             return
@@ -36,8 +36,8 @@ class ShippingLabelPurchaseMapperTests: XCTestCase {
 
     /// Verifies that the Shipping Label Purchase is parsed correctly.
     ///
-    func test_ShippingLabelPurchase_is_properly_parsed_when_response_has_no_data_envelope() {
-        guard let shippingLabelList = mapLoadShippingLabelPurchaseWithoutDataEnvelope(),
+    func test_ShippingLabelPurchase_is_properly_parsed_when_response_has_no_data_envelope() async {
+        guard let shippingLabelList = await mapLoadShippingLabelPurchaseWithoutDataEnvelope(),
               let shippingLabel = shippingLabelList.first else {
             XCTFail()
             return
@@ -64,23 +64,23 @@ private extension ShippingLabelPurchaseMapperTests {
 
     /// Returns the ShippingLabelPurchaseMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShippingLabelPurchase(from filename: String) -> [ShippingLabelPurchase]? {
+    func mapShippingLabelPurchase(from filename: String) async -> [ShippingLabelPurchase]? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! ShippingLabelPurchaseMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: response)
+        return try! await ShippingLabelPurchaseMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: response)
     }
 
     /// Returns the ShippingLabelPurchaseMapper output upon receiving `shipping-label-purchase-success`
     ///
-    func mapLoadShippingLabelPurchase() -> [ShippingLabelPurchase]? {
-        return mapShippingLabelPurchase(from: "shipping-label-purchase-success")
+    func mapLoadShippingLabelPurchase() async -> [ShippingLabelPurchase]? {
+        await mapShippingLabelPurchase(from: "shipping-label-purchase-success")
     }
 
     /// Returns the ShippingLabelPurchaseMapper output upon receiving `shipping-label-purchase-success-without-data`
     ///
-    func mapLoadShippingLabelPurchaseWithoutDataEnvelope() -> [ShippingLabelPurchase]? {
-        return mapShippingLabelPurchase(from: "shipping-label-purchase-success-without-data")
+    func mapLoadShippingLabelPurchaseWithoutDataEnvelope() async -> [ShippingLabelPurchase]? {
+        await mapShippingLabelPurchase(from: "shipping-label-purchase-success-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ShippingLabelStatusMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelStatusMapperTests.swift
@@ -13,9 +13,9 @@ class ShippingLabelStatusMapperTests: XCTestCase {
 
     /// Verifies that the Shipping Label Status Polling Response is parsed correctly when it receives a purchased shipping label.
     ///
-    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_purchased_label() {
+    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_purchased_label() async {
         // Given
-        guard let shippingLabelList = mapLoadShippingLabelStatus(),
+        guard let shippingLabelList = await mapLoadShippingLabelStatus(),
               let shippingLabelResponse = shippingLabelList.first else {
             XCTFail()
             return
@@ -47,9 +47,9 @@ class ShippingLabelStatusMapperTests: XCTestCase {
         XCTAssertEqual(shippingLabel?.productNames, ["WordPress Pennant"])
     }
 
-    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_purchased_label_when_response_has_no_data_envelope() {
+    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_purchased_label_when_response_has_no_data_envelope() async {
         // Given
-        guard let shippingLabelList = mapLoadShippingLabelStatusWithoutDataEnvelope(),
+        guard let shippingLabelList = await mapLoadShippingLabelStatusWithoutDataEnvelope(),
               let shippingLabelResponse = shippingLabelList.first else {
             XCTFail()
             return
@@ -83,8 +83,8 @@ class ShippingLabelStatusMapperTests: XCTestCase {
 
     /// Verifies that the Shipping Label Status Polling Response is parsed correctly when it receives a pending shipping label purchase.
     ///
-    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_pending_label_purchase() {
-        guard let shippingLabelList = mapLoadShippingLabelPurchaseStatus(),
+    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_pending_label_purchase() async {
+        guard let shippingLabelList = await mapLoadShippingLabelPurchaseStatus(),
               let shippingLabelResponse = shippingLabelList.first else {
             XCTFail()
             return
@@ -101,29 +101,29 @@ private extension ShippingLabelStatusMapperTests {
 
     /// Returns the ShippingLabelStatusMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShippingLabelStatus(from filename: String) -> [ShippingLabelStatusPollingResponse]? {
+    func mapShippingLabelStatus(from filename: String) async -> [ShippingLabelStatusPollingResponse]? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! ShippingLabelStatusMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: response)
+        return try! await ShippingLabelStatusMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: response)
     }
 
     /// Returns the ShippingLabelStatusMapper output upon receiving `shipping-label-status-success`
     ///
-    func mapLoadShippingLabelStatus() -> [ShippingLabelStatusPollingResponse]? {
-        return mapShippingLabelStatus(from: "shipping-label-status-success")
+    func mapLoadShippingLabelStatus() async -> [ShippingLabelStatusPollingResponse]? {
+        await mapShippingLabelStatus(from: "shipping-label-status-success")
     }
 
     /// Returns the ShippingLabelStatusMapper output upon receiving `shipping-label-status-success-without-data`
     ///
-    func mapLoadShippingLabelStatusWithoutDataEnvelope() -> [ShippingLabelStatusPollingResponse]? {
-        return mapShippingLabelStatus(from: "shipping-label-status-success-without-data")
+    func mapLoadShippingLabelStatusWithoutDataEnvelope() async -> [ShippingLabelStatusPollingResponse]? {
+        await mapShippingLabelStatus(from: "shipping-label-status-success-without-data")
     }
 
     /// Returns the ShippingLabelStatusMapper output upon receiving `shipping-label-purchase-success`
     ///
-    func mapLoadShippingLabelPurchaseStatus() -> [ShippingLabelStatusPollingResponse]? {
-        return mapShippingLabelStatus(from: "shipping-label-purchase-success")
+    func mapLoadShippingLabelPurchaseStatus() async -> [ShippingLabelStatusPollingResponse]? {
+        await mapShippingLabelStatus(from: "shipping-label-purchase-success")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SiteAPIMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteAPIMapperTests.swift
@@ -20,8 +20,8 @@ class SiteAPIMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly.
     ///
-    func test_SiteSetting_fields_are_properly_parsed() {
-        let apiSettings = mapLoadSiteAPIResponse()
+    func test_SiteSetting_fields_are_properly_parsed() async {
+        let apiSettings = await mapLoadSiteAPIResponse()
 
         XCTAssertNotNil(apiSettings)
         XCTAssertEqual(apiSettings?.siteID, dummySiteID)
@@ -32,8 +32,8 @@ class SiteAPIMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly.
     ///
-    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let apiSettings = mapLoadSiteAPIResponseWithoutDataEnvelope()
+    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() async {
+        let apiSettings = await mapLoadSiteAPIResponseWithoutDataEnvelope()
 
         XCTAssertNotNil(apiSettings)
         XCTAssertEqual(apiSettings?.siteID, dummySiteID)
@@ -44,8 +44,8 @@ class SiteAPIMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly.
     ///
-    func test_broken_SiteSetting_fields_are_properly_parsed() {
-        let apiSettings = mapLoadBrokenSiteAPIResponse()
+    func test_broken_SiteSetting_fields_are_properly_parsed() async {
+        let apiSettings = await mapLoadBrokenSiteAPIResponse()
 
         XCTAssertNotNil(apiSettings)
         XCTAssertEqual(apiSettings?.siteID, dummySiteID)
@@ -62,29 +62,29 @@ private extension SiteAPIMapperTests {
 
     /// Returns the SiteAPIMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSiteAPIData(from filename: String) -> SiteAPI? {
+    func mapSiteAPIData(from filename: String) async -> SiteAPI? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! SiteAPIMapper(siteID: dummySiteID).map(response: response)
+        return try! await SiteAPIMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the SiteAPIMapper output upon receiving `site-api`
     ///
-    func mapLoadSiteAPIResponse() -> SiteAPI? {
-        return mapSiteAPIData(from: "site-api")
+    func mapLoadSiteAPIResponse() async -> SiteAPI? {
+        await mapSiteAPIData(from: "site-api")
     }
 
     /// Returns the SiteAPIMapper output upon receiving `site-api-without-data`
     ///
-    func mapLoadSiteAPIResponseWithoutDataEnvelope() -> SiteAPI? {
-        return mapSiteAPIData(from: "site-api-without-data")
+    func mapLoadSiteAPIResponseWithoutDataEnvelope() async -> SiteAPI? {
+        await mapSiteAPIData(from: "site-api-without-data")
     }
 
     /// Returns the SiteAPIMapper output upon receiving `site-api`
     ///
-    func mapLoadBrokenSiteAPIResponse() -> SiteAPI? {
-        return mapSiteAPIData(from: "site-api-no-woo")
+    func mapLoadBrokenSiteAPIResponse() async -> SiteAPI? {
+        await mapSiteAPIData(from: "site-api-no-woo")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SiteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteListMapperTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 final class SiteListMapperTests: XCTestCase {
 
-    func test_site_without_can_blaze_key_is_parsed_successfully() throws {
+    func test_site_without_can_blaze_key_is_parsed_successfully() async throws {
         // Given
-        let sites = mapLoadSiteListResponse()
+        let sites = try await mapLoadSiteListResponse()
 
         // Then
         let second = try XCTUnwrap(sites[safe: 1])
@@ -14,9 +14,9 @@ final class SiteListMapperTests: XCTestCase {
 
     /// `sites-malformed.json` contains a correct site and a site without options(malformed)
     ///
-    func test_malformed_sites_are_evicted_from_site_list() throws {
+    func test_malformed_sites_are_evicted_from_site_list() async throws {
         // Given
-        let sites = mapLoadMalformedSiteListResponse()
+        let sites = try await mapLoadMalformedSiteListResponse()
 
         // Then
         XCTAssertEqual(sites.count, 1)
@@ -27,19 +27,21 @@ final class SiteListMapperTests: XCTestCase {
 }
 
 private extension SiteListMapperTests {
-    func mapSiteListData(from filename: String) -> [Site] {
+    func mapSiteListData(from filename: String) async throws -> [Site] {
         guard let response = Loader.contentsOf(filename) else {
-            return []
+            throw FileNotFoundError()
         }
 
-        return (try? SiteListMapper().map(response: response)) ?? []
+        return try await SiteListMapper().map(response: response)
     }
 
-    func mapLoadSiteListResponse() -> [Site] {
-        mapSiteListData(from: "sites")
+    func mapLoadSiteListResponse() async throws -> [Site] {
+        try await mapSiteListData(from: "sites")
     }
 
-    func mapLoadMalformedSiteListResponse() -> [Site] {
-        return mapSiteListData(from: "sites-malformed")
+    func mapLoadMalformedSiteListResponse() async throws -> [Site] {
+        try await mapSiteListData(from: "sites-malformed")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
@@ -11,8 +11,8 @@ final class SitePluginMapperTests: XCTestCase {
 
     /// Verifies the SitePlugin fields are parsed correctly.
     ///
-    func test_SitePlugin_fields_are_properly_parsed() throws {
-        let plugin = try XCTUnwrap(mapPlugin(from: "plugin"))
+    func test_SitePlugin_fields_are_properly_parsed() async throws {
+        let plugin = try await mapPlugin(from: "plugin")
         XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
         XCTAssertEqual(plugin.siteID, dummySiteID)
         XCTAssertEqual(plugin.status, .active)
@@ -28,8 +28,8 @@ final class SitePluginMapperTests: XCTestCase {
 
     /// Verifies the SitePlugin fields are parsed correctly when there's no data envelope wrapping the response.
     ///
-    func test_SitePlugin_fields_are_properly_parsed_for_response_without_data_envelope() throws {
-        let plugin = try XCTUnwrap(mapPluginWithoutEnvelope(from: "site-plugin-without-envelope"))
+    func test_SitePlugin_fields_are_properly_parsed_for_response_without_data_envelope() async throws {
+        let plugin = try await mapPluginWithoutEnvelope(from: "site-plugin-without-envelope")
         XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
         XCTAssertEqual(plugin.siteID, -1)
         XCTAssertEqual(plugin.status, .active)
@@ -53,22 +53,24 @@ private extension SitePluginMapperTests {
 
     /// Returns the SitePluginMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapPlugin(from filename: String) -> SitePlugin? {
+    func mapPlugin(from filename: String) async throws -> SitePlugin {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? SitePluginMapper(siteID: dummySiteID).map(response: response)
+        return try await SitePluginMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the SitePluginMapper output upon receiving `filename` (Data Encoded)
     /// The decoder should not include data envelope.
     ///
-    func mapPluginWithoutEnvelope(from filename: String) -> SitePlugin? {
+    func mapPluginWithoutEnvelope(from filename: String) async throws -> SitePlugin {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? SitePluginMapper().map(response: response)
+        return try await SitePluginMapper().map(response: response)
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
@@ -11,8 +11,8 @@ class SitePluginsMapperTests: XCTestCase {
 
     /// Verifies the SitePlugin fields are parsed correctly.
     ///
-    func test_SitePlugin_fields_are_properly_parsed() {
-        let plugins = mapLoadSitePluginsResponse()
+    func test_SitePlugin_fields_are_properly_parsed() async {
+        let plugins = await mapLoadSitePluginsResponse()
         XCTAssertEqual(plugins.count, 5)
 
         let helloDollyPlugin = plugins[0]
@@ -42,8 +42,8 @@ class SitePluginsMapperTests: XCTestCase {
 
     /// Verifies the SitePlugin fields are parsed correctly.
     ///
-    func test_SitePlugin_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let plugins = mapLoadSitePluginsResponseWithoutDataEnvelope()
+    func test_SitePlugin_fields_are_properly_parsed_when_response_has_no_data_envelope() async {
+        let plugins = await mapLoadSitePluginsResponseWithoutDataEnvelope()
         XCTAssertEqual(plugins.count, 3)
 
         let helloDollyPlugin = plugins[0]
@@ -67,23 +67,23 @@ private extension SitePluginsMapperTests {
 
     /// Returns the SitePluginsMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapPlugins(from filename: String) -> [SitePlugin] {
+    func mapPlugins(from filename: String) async -> [SitePlugin] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! SitePluginsMapper(siteID: dummySiteID).map(response: response)
+        return try! await SitePluginsMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the SitePluginsMapper output upon receiving `plugins`
     ///
-    func mapLoadSitePluginsResponse() -> [SitePlugin] {
-        return mapPlugins(from: "plugins")
+    func mapLoadSitePluginsResponse() async -> [SitePlugin] {
+        return await mapPlugins(from: "plugins")
     }
 
     /// Returns the SitePluginsMapper output upon receiving `plugins-without-data`
     ///
-    func mapLoadSitePluginsResponseWithoutDataEnvelope() -> [SitePlugin] {
-        return mapPlugins(from: "plugins-without-data")
+    func mapLoadSitePluginsResponseWithoutDataEnvelope() async -> [SitePlugin] {
+        return await mapPlugins(from: "plugins-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
@@ -9,8 +9,8 @@ final class SiteSettingMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly.
     ///
-    func test_SiteSetting_fields_are_properly_parsed() throws {
-        let setting = try XCTUnwrap(mapLoadCouponSettingResponse())
+    func test_SiteSetting_fields_are_properly_parsed() async throws {
+        let setting = try await mapLoadCouponSettingResponse()
         XCTAssertEqual(setting.siteID, dummySiteID)
         XCTAssertEqual(setting.settingID, "woocommerce_enable_coupons")
         XCTAssertEqual(setting.settingDescription, "Enable the use of coupon codes")
@@ -20,8 +20,8 @@ final class SiteSettingMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly when response has no data envelope.
     ///
-    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        let setting = try XCTUnwrap(mapLoadCouponSettingResponseWithoutDataEnvelope())
+    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
+        let setting = try await mapLoadCouponSettingResponseWithoutDataEnvelope()
         XCTAssertEqual(setting.siteID, dummySiteID)
         XCTAssertEqual(setting.settingID, "woocommerce_enable_coupons")
         XCTAssertEqual(setting.settingDescription, "Enable the use of coupon codes")
@@ -29,8 +29,8 @@ final class SiteSettingMapperTests: XCTestCase {
         XCTAssertEqual(setting.value, "yes")
     }
 
-    func test_SiteSetting_value_field_is_properly_parsed_when_value_field_is_not_string() throws {
-        let setting = try XCTUnwrap(loadMultiselectValueSettingResponse())
+    func test_SiteSetting_value_field_is_properly_parsed_when_value_field_is_not_string() async throws {
+        let setting = try await loadMultiselectValueSettingResponse()
         XCTAssertEqual(setting.settingID, "woocommerce_all_except_countries")
         XCTAssertTrue(setting.value.isEmpty)
     }
@@ -40,29 +40,31 @@ private extension SiteSettingMapperTests {
 
     /// Returns the SiteSettingMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSetting(from filename: String) -> SiteSetting? {
+    func mapSetting(from filename: String) async throws -> SiteSetting {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? SiteSettingMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general).map(response: response)
+        return try await SiteSettingMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general).map(response: response)
     }
 
     /// Returns the SiteSettingMapper output upon receiving `setting-coupon`
     ///
-    func mapLoadCouponSettingResponse() -> SiteSetting? {
-        return mapSetting(from: "setting-coupon")
+    func mapLoadCouponSettingResponse() async throws -> SiteSetting {
+        try await mapSetting(from: "setting-coupon")
     }
 
     /// Returns the SiteSettingMapper output upon receiving `setting-coupon-without-data`
     ///
-    func mapLoadCouponSettingResponseWithoutDataEnvelope() -> SiteSetting? {
-        return mapSetting(from: "setting-coupon-without-data")
+    func mapLoadCouponSettingResponseWithoutDataEnvelope() async throws -> SiteSetting {
+        try await mapSetting(from: "setting-coupon-without-data")
     }
 
     /// Returns the SiteSettingMapper output upon receiving `setting-all-except-countries`
     ///
-    func loadMultiselectValueSettingResponse() -> SiteSetting? {
-        return mapSetting(from: "setting-all-except-countries")
+    func loadMultiselectValueSettingResponse() async throws -> SiteSetting {
+        try await mapSetting(from: "setting-all-except-countries")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
@@ -12,8 +12,8 @@ class SiteSettingsMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly.
     ///
-    func test_SiteSetting_fields_are_properly_parsed() {
-        let settings = mapLoadGeneralSiteSettingsResponse()
+    func test_SiteSetting_fields_are_properly_parsed() async {
+        let settings = await mapLoadGeneralSiteSettingsResponse()
         XCTAssertEqual(settings.count, 20)
 
         let firstSetting = settings[0]
@@ -44,8 +44,8 @@ class SiteSettingsMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly when response has no data envelope.
     ///
-    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let settings = mapLoadGeneralSiteSettingsResponseWithoutDataEnvelope()
+    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() async {
+        let settings = await mapLoadGeneralSiteSettingsResponseWithoutDataEnvelope()
         XCTAssertEqual(settings.count, 20)
 
         let firstSetting = settings[0]
@@ -76,8 +76,8 @@ class SiteSettingsMapperTests: XCTestCase {
 
     /// Verifies that a SiteSetting in a broken state gets default values
     ///
-    func test_SiteSettings_are_properly_parsed_when_nulls_received() {
-        let settings = mapLoadBrokenGeneralSiteSettingsResponse()
+    func test_SiteSettings_are_properly_parsed_when_nulls_received() async {
+        let settings = await mapLoadBrokenGeneralSiteSettingsResponse()
         XCTAssertEqual(settings.count, 1)
 
         let firstSetting = settings[0]
@@ -97,29 +97,29 @@ private extension SiteSettingsMapperTests {
 
     /// Returns the [SiteSetting] output upon receiving `filename` (Data Encoded)
     ///
-    func mapGeneralSettings(from filename: String) -> [SiteSetting] {
+    func mapGeneralSettings(from filename: String) async -> [SiteSetting] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! SiteSettingsMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general).map(response: response)
+        return try! await SiteSettingsMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general).map(response: response)
     }
 
     /// Returns the [SiteSetting] output upon receiving `settings-general`
     ///
-    func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
-        return mapGeneralSettings(from: "settings-general")
+    func mapLoadGeneralSiteSettingsResponse() async -> [SiteSetting] {
+        return await mapGeneralSettings(from: "settings-general")
     }
 
     /// Returns the [SiteSetting] output upon receiving `settings-general-without-data`
     ///
-    func mapLoadGeneralSiteSettingsResponseWithoutDataEnvelope() -> [SiteSetting] {
-        return mapGeneralSettings(from: "settings-general-without-data")
+    func mapLoadGeneralSiteSettingsResponseWithoutDataEnvelope() async -> [SiteSetting] {
+        return await mapGeneralSettings(from: "settings-general-without-data")
     }
 
     /// Returns the [SiteSetting] output upon receiving `broken-settings-general`
     ///
-    func mapLoadBrokenGeneralSiteSettingsResponse() -> [SiteSetting] {
-        return mapGeneralSettings(from: "broken-settings-general")
+    func mapLoadBrokenGeneralSiteSettingsResponse() async -> [SiteSetting] {
+        return await mapGeneralSettings(from: "broken-settings-general")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SiteSummaryStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSummaryStatsMapperTests.swift
@@ -9,9 +9,9 @@ final class SiteSummaryStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the summary stats fields are parsed correctly
     ///
-    func test_summary_stat_fields_are_properly_parsed() {
+    func test_summary_stat_fields_are_properly_parsed() async throws {
         // Given
-        guard let summaryStats = mapSiteSummaryStats(from: "site-summary-stats") else {
+        guard let summaryStats = await mapSiteSummaryStats(from: "site-summary-stats") else {
             XCTFail()
             return
         }
@@ -31,11 +31,11 @@ private extension SiteSummaryStatsMapperTests {
 
     /// Returns the SiteSummaryStatsMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSiteSummaryStats(from filename: String) -> SiteSummaryStats? {
+    func mapSiteSummaryStats(from filename: String) async -> SiteSummaryStats? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! SiteSummaryStatsMapper(siteID: sampleSiteID).map(response: response)
+        return try! await SiteSummaryStatsMapper(siteID: sampleSiteID).map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/SiteVisitStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteVisitStatsMapperTests.swift
@@ -9,8 +9,8 @@ class SiteVisitStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the day unit SiteVisitStats fields are parsed correctly.
     ///
-    func test_day_unit_stat_fields_are_properly_parsed() {
-        guard let dayStats = mapSiteVisitStatsWithDayUnitResponse() else {
+    func test_day_unit_stat_fields_are_properly_parsed() async {
+        guard let dayStats = await mapSiteVisitStatsWithDayUnitResponse() else {
             XCTFail()
             return
         }
@@ -33,8 +33,8 @@ class SiteVisitStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the week unit SiteVisitStats fields are parsed correctly.
     ///
-    func test_week_unit_stat_fields_are_properly_parsed() {
-        guard let weekStats = mapSiteVisitStatsWithWeekUnitResponse() else {
+    func test_week_unit_stat_fields_are_properly_parsed() async {
+        guard let weekStats = await mapSiteVisitStatsWithWeekUnitResponse() else {
             XCTFail()
             return
         }
@@ -57,8 +57,8 @@ class SiteVisitStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the month unit SiteVisitStats fields are parsed correctly.
     ///
-    func test_month_unit_stat_fields_are_properly_parsed() {
-        guard let monthStats = mapSiteVisitStatsWithMonthUnitResponse() else {
+    func test_month_unit_stat_fields_are_properly_parsed() async {
+        guard let monthStats = await mapSiteVisitStatsWithMonthUnitResponse() else {
             XCTFail()
             return
         }
@@ -81,8 +81,8 @@ class SiteVisitStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the year unit SiteVisitStats fields are parsed correctly.
     ///
-    func test_year_unit_stat_fields_are_properly_parsed() {
-        guard let yearStats = mapSiteVisitStatsWithYearUnitResponse() else {
+    func test_year_unit_stat_fields_are_properly_parsed() async {
+        guard let yearStats = await mapSiteVisitStatsWithYearUnitResponse() else {
             XCTFail()
             return
         }
@@ -111,35 +111,35 @@ private extension SiteVisitStatsMapperTests {
 
     /// Returns the SiteVisitStatsMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSiteVisitStatItems(from filename: String) -> SiteVisitStats? {
+    func mapSiteVisitStatItems(from filename: String) async -> SiteVisitStats? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! SiteVisitStatsMapper(siteID: sampleSiteID).map(response: response)
+        return try! await SiteVisitStatsMapper(siteID: sampleSiteID).map(response: response)
     }
 
     /// Returns the SiteVisitStatsMapper output upon receiving `site-visits-day`
     ///
-    func mapSiteVisitStatsWithDayUnitResponse() -> SiteVisitStats? {
-        return mapSiteVisitStatItems(from: "site-visits-day")
+    func mapSiteVisitStatsWithDayUnitResponse() async -> SiteVisitStats? {
+        await mapSiteVisitStatItems(from: "site-visits-day")
     }
 
     /// Returns the SiteVisitStatsMapper output upon receiving `site-visits-week`
     ///
-    func mapSiteVisitStatsWithWeekUnitResponse() -> SiteVisitStats? {
-        return mapSiteVisitStatItems(from: "site-visits-week")
+    func mapSiteVisitStatsWithWeekUnitResponse() async -> SiteVisitStats? {
+        await mapSiteVisitStatItems(from: "site-visits-week")
     }
 
     /// Returns the SiteVisitStatsMapper output upon receiving `site-visits-month`
     ///
-    func mapSiteVisitStatsWithMonthUnitResponse() -> SiteVisitStats? {
-        return mapSiteVisitStatItems(from: "site-visits-month")
+    func mapSiteVisitStatsWithMonthUnitResponse() async -> SiteVisitStats? {
+        await mapSiteVisitStatItems(from: "site-visits-month")
     }
 
     /// Returns the SiteVisitStatsMapper output upon receiving `site-visits-year`
     ///
-    func mapSiteVisitStatsWithYearUnitResponse() -> SiteVisitStats? {
-        return mapSiteVisitStatItems(from: "site-visits-year")
+    func mapSiteVisitStatsWithYearUnitResponse() async -> SiteVisitStats? {
+        await mapSiteVisitStatItems(from: "site-visits-year")
     }
 }

--- a/Networking/NetworkingTests/Mapper/StoreOnboardingTaskListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/StoreOnboardingTaskListMapperTests.swift
@@ -4,8 +4,8 @@ import XCTest
 /// StoreOnboardingTaskListMapper Unit Tests
 ///
 final class StoreOnboardingTaskListMapperTests: XCTestCase {
-    func test_onboarding_tasks_response_is_properly_parsed() throws {
-        guard let tasks = mapStoreOnboardingTasksResponse() else {
+    func test_onboarding_tasks_response_is_properly_parsed() async throws {
+        guard let tasks = await mapStoreOnboardingTasksResponse() else {
             XCTFail()
             return
         }
@@ -15,8 +15,8 @@ final class StoreOnboardingTaskListMapperTests: XCTestCase {
         XCTAssertEqual(task.type, .addFirstProduct)
     }
 
-    func test_onboarding_tasks_response_without_data_envelope_is_properly_parsed() throws {
-        guard let tasks = mapStoreOnboardingTasksResponseWithoutDataEnvelope() else {
+    func test_onboarding_tasks_response_without_data_envelope_is_properly_parsed() async throws {
+        guard let tasks = await mapStoreOnboardingTasksResponseWithoutDataEnvelope() else {
             XCTFail()
             return
         }
@@ -38,19 +38,19 @@ final class StoreOnboardingTaskListMapperTests: XCTestCase {
 // MARK: - Private Methods.
 //
 private extension StoreOnboardingTaskListMapperTests {
-    func mapStoreOnboardingTasksResponse() -> [StoreOnboardingTask]? {
+    func mapStoreOnboardingTasksResponse() async -> [StoreOnboardingTask]? {
         guard let response = Loader.contentsOf("store-onboarding-tasks") else {
             return nil
         }
 
-        return try? StoreOnboardingTaskListMapper().map(response: response)
+        return try? await StoreOnboardingTaskListMapper().map(response: response)
     }
 
-    func mapStoreOnboardingTasksResponseWithoutDataEnvelope() -> [StoreOnboardingTask]? {
+    func mapStoreOnboardingTasksResponseWithoutDataEnvelope() async -> [StoreOnboardingTask]? {
         guard let response = Loader.contentsOf("store-onboarding-tasks-without-data") else {
             return nil
         }
 
-        return try? StoreOnboardingTaskListMapper().map(response: response)
+        return try? await StoreOnboardingTaskListMapper().map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/SubscriptionListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SubscriptionListMapperTests.swift
@@ -5,25 +5,25 @@ final class SubscriptionListMapperTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 12983476
 
-    func test_SubscriptionList_map_parses_all_subscriptions_in_response() throws {
+    func test_SubscriptionList_map_parses_all_subscriptions_in_response() async throws {
         // Given
-        let subscriptions = try mapLoadSubscriptionListResponseWithDataEnvelope()
+        let subscriptions = try await mapLoadSubscriptionListResponseWithDataEnvelope()
 
         // Then
         XCTAssertEqual(subscriptions.count, 2)
     }
 
-    func test_SubscriptionList_map_parses_all_coupons_in_response_without_data_envelope() throws {
+    func test_SubscriptionList_map_parses_all_coupons_in_response_without_data_envelope() async throws {
         // Given
-        let subscriptions = try mapLoadSubscriptionListResponseWithoutDataEnvelope()
+        let subscriptions = try await mapLoadSubscriptionListResponseWithoutDataEnvelope()
 
         // Then
         XCTAssertEqual(subscriptions.count, 2)
     }
 
-    func test_SubscriptionList_map_includes_siteID_in_parsed_results() throws {
+    func test_SubscriptionList_map_includes_siteID_in_parsed_results() async throws {
         // Given
-        let subscriptions = try mapLoadSubscriptionListResponseWithDataEnvelope()
+        let subscriptions = try await mapLoadSubscriptionListResponseWithDataEnvelope()
 
         // Then
         XCTAssertTrue(subscriptions.count > 0)
@@ -32,9 +32,9 @@ final class SubscriptionListMapperTests: XCTestCase {
         }
     }
 
-    func test_SubscriptionList_map_parses_all_fields_in_result() throws {
+    func test_SubscriptionList_map_parses_all_fields_in_result() async throws {
         // Given
-        let subscriptions = try mapLoadSubscriptionListResponseWithDataEnvelope()
+        let subscriptions = try await mapLoadSubscriptionListResponseWithDataEnvelope()
         let subscription = subscriptions[0]
 
         // Then
@@ -63,23 +63,23 @@ private extension SubscriptionListMapperTests {
 
     /// Returns the SubscriptionListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSubscriptions(from filename: String) throws -> [Subscription] {
+    func mapSubscriptions(from filename: String) async throws -> [Subscription] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try SubscriptionListMapper(siteID: sampleSiteID).map(response: response)
+        return try await SubscriptionListMapper(siteID: sampleSiteID).map(response: response)
     }
 
     /// Returns the SubscriptionListMapper output from `subscription-list.json`
     ///
-    func mapLoadSubscriptionListResponseWithDataEnvelope() throws -> [Subscription] {
-        return try mapSubscriptions(from: "subscription-list")
+    func mapLoadSubscriptionListResponseWithDataEnvelope() async throws -> [Subscription] {
+        return try await mapSubscriptions(from: "subscription-list")
     }
 
     /// Returns the SubscriptionListMapper output from `subscription-list-without-data.json`
     ///
-    func mapLoadSubscriptionListResponseWithoutDataEnvelope() throws -> [Subscription] {
-        return try mapSubscriptions(from: "subscription-list-without-data")
+    func mapLoadSubscriptionListResponseWithoutDataEnvelope() async throws -> [Subscription] {
+        return try await mapSubscriptions(from: "subscription-list-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SubscriptionMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SubscriptionMapperTests.swift
@@ -5,33 +5,33 @@ final class SubscriptionMapperTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 12983476
 
-    func test_Subscription_map_parses_subscription_in_response() throws {
+    func test_Subscription_map_parses_subscription_in_response() async throws {
         // Given
-        let subscription = try mapLoadSubscriptionResponseWithDataEnvelope()
+        let subscription = try await mapLoadSubscriptionResponseWithDataEnvelope()
 
         // Then
         XCTAssertNotNil(subscription)
     }
 
-    func test_Subscription_map_parses_subscription_in_response_without_data_envelope() throws {
+    func test_Subscription_map_parses_subscription_in_response_without_data_envelope() async throws {
         // Given
-        let subscription = try mapLoadSubscriptionResponseWithoutDataEnvelope()
+        let subscription = try await mapLoadSubscriptionResponseWithoutDataEnvelope()
 
         // Then
         XCTAssertNotNil(subscription)
     }
 
-    func test_Subscription_map_includes_siteID_in_parsed_result() throws {
+    func test_Subscription_map_includes_siteID_in_parsed_result() async throws {
         // Given
-        let subscription = try mapLoadSubscriptionResponseWithDataEnvelope()
+        let subscription = try await mapLoadSubscriptionResponseWithDataEnvelope()
 
         // Then
         XCTAssertEqual(subscription.siteID, sampleSiteID)
     }
 
-    func test_Subscription_map_parses_all_fields_in_result() throws {
+    func test_Subscription_map_parses_all_fields_in_result() async throws {
         // Given
-        let subscription = try mapLoadSubscriptionResponseWithDataEnvelope()
+        let subscription = try await mapLoadSubscriptionResponseWithDataEnvelope()
 
         // Then
         let expectedSubscription = Subscription(siteID: sampleSiteID,
@@ -56,24 +56,24 @@ private extension SubscriptionMapperTests {
 
     /// Returns the SubscriptionMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSubscription(from filename: String) throws -> Subscription {
+    func mapSubscription(from filename: String) async throws -> Subscription {
         guard let response = Loader.contentsOf(filename) else {
             throw FileNotFoundError()
         }
 
-        return try SubscriptionMapper(siteID: sampleSiteID).map(response: response)
+        return try await SubscriptionMapper(siteID: sampleSiteID).map(response: response)
     }
 
     /// Returns the SubscriptionMapper output from `subscription.json`
     ///
-    func mapLoadSubscriptionResponseWithDataEnvelope() throws -> Subscription {
-        return try mapSubscription(from: "subscription")
+    func mapLoadSubscriptionResponseWithDataEnvelope() async throws -> Subscription {
+        try await mapSubscription(from: "subscription")
     }
 
     /// Returns the SubscriptionMapper output from `subscription-without-data.json`
     ///
-    func mapLoadSubscriptionResponseWithoutDataEnvelope() throws -> Subscription {
-        return try mapSubscription(from: "subscription-without-data")
+    func mapLoadSubscriptionResponseWithoutDataEnvelope() async throws -> Subscription {
+        try await mapSubscription(from: "subscription-without-data")
     }
 
     struct FileNotFoundError: Error {}

--- a/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
@@ -11,7 +11,7 @@ final class SystemPluginMapperTests: XCTestCase {
 
     /// Verifies the SystemPlugin fields are parsed correctly for an active plugin
     ///
-    func test_active_plugin_fields_are_properly_parsed() throws {
+    func test_active_plugin_fields_are_properly_parsed() async throws {
         // Given
         let expectedSiteId: Int64 = 999999
         let expectedPlugin = "woocommerce/woocommerce.php"
@@ -25,7 +25,7 @@ final class SystemPluginMapperTests: XCTestCase {
         let expectedActive = true
 
         // When
-        let systemPlugins = try mapLoadSystemStatusResponse()
+        let systemPlugins = try await mapLoadSystemStatusResponse()
 
         // Then
         XCTAssertEqual(systemPlugins.count, 6)
@@ -46,7 +46,7 @@ final class SystemPluginMapperTests: XCTestCase {
 
     /// Verifies the SystemPlugin fields are parsed correctly for an inactive plugin
     ///
-    func test_inactive_plugin_fields_are_properly_parsed() throws {
+    func test_inactive_plugin_fields_are_properly_parsed() async throws {
         // Given
         let expectedSiteId: Int64 = 999999
         let expectedPlugin = "hello.php"
@@ -60,7 +60,7 @@ final class SystemPluginMapperTests: XCTestCase {
         let expectedActive = false
 
         // When
-        let systemPlugins = try mapLoadSystemStatusResponse()
+        let systemPlugins = try await mapLoadSystemStatusResponse()
 
         // Then
         XCTAssertEqual(systemPlugins.count, 6)
@@ -79,9 +79,9 @@ final class SystemPluginMapperTests: XCTestCase {
         XCTAssertEqual(systemPlugin.active, expectedActive)
     }
 
-    func test_plugins_are_parsed_successfully_when_response_has_no_data_envelope() throws {
+    func test_plugins_are_parsed_successfully_when_response_has_no_data_envelope() async throws {
         // When
-        let plugins = try mapLoadSystemStatusResponseWithoutDataEnvelope()
+        let plugins = try await mapLoadSystemStatusResponseWithoutDataEnvelope()
 
         // Then
         XCTAssertEqual(plugins.count, 2)
@@ -105,24 +105,24 @@ private extension SystemPluginMapperTests {
 
     /// Returns the SystemStatusMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapPlugins(from filename: String) throws -> [SystemPlugin] {
+    func mapPlugins(from filename: String) async throws -> [SystemPlugin] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try SystemPluginMapper(siteID: dummySiteID).map(response: response)
+        return try await SystemPluginMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the SystemStatusMapper output upon receiving `systemStatusWithPluginsOnly`
     ///
-    func mapLoadSystemStatusResponse() throws -> [SystemPlugin] {
-        return try mapPlugins(from: "systemStatusWithPluginsOnly")
+    func mapLoadSystemStatusResponse() async throws -> [SystemPlugin] {
+        return try await mapPlugins(from: "systemStatusWithPluginsOnly")
     }
 
     /// Returns the SystemStatusMapper output upon receiving
     /// `systemStatusWithPluginsOnly-without-data`
     ///
-    func mapLoadSystemStatusResponseWithoutDataEnvelope() throws -> [SystemPlugin] {
-        return try mapPlugins(from: "systemStatusWithPluginsOnly-without-data")
+    func mapLoadSystemStatusResponseWithoutDataEnvelope() async throws -> [SystemPlugin] {
+        return try await mapPlugins(from: "systemStatusWithPluginsOnly-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
@@ -9,9 +9,9 @@ final class SystemStatusMapperTests: XCTestCase {
     ///
     private let dummySiteID: Int64 = 999999
 
-    func test_system_status_fields_are_properly_parsed() throws {
+    func test_system_status_fields_are_properly_parsed() async throws {
         // When
-        let report = try mapLoadSystemStatusResponse()
+        let report = try await mapLoadSystemStatusResponse()
 
         // Then
         XCTAssertEqual(report.environment?.homeURL, "https://additional-beetle.jurassic.ninja")
@@ -59,9 +59,9 @@ final class SystemStatusMapperTests: XCTestCase {
         XCTAssertEqual(report.postTypeCounts.count, 3)
     }
 
-    func test_system_status_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+    func test_system_status_fields_are_properly_parsed_when_response_has_no_data_envelope() async throws {
         // When
-        let report = try mapLoadSystemStatusResponseWithoutDataEnvelope()
+        let report = try await mapLoadSystemStatusResponseWithoutDataEnvelope()
 
         // Then
         XCTAssertEqual(report.environment?.homeURL, "https://additional-beetle.jurassic.ninja")
@@ -114,23 +114,23 @@ private extension SystemStatusMapperTests {
 
     /// Returns the SystemStatusMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapReport(from filename: String) throws -> SystemStatus {
+    func mapReport(from filename: String) async throws -> SystemStatus {
         guard let response = Loader.contentsOf(filename) else {
             throw NetworkError.notFound()
         }
 
-        return try SystemStatusMapper(siteID: dummySiteID).map(response: response)
+        return try await SystemStatusMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the SystemStatus output upon receiving `systemStatus.json`
     ///
-    func mapLoadSystemStatusResponse() throws -> SystemStatus {
-        return try mapReport(from: "systemStatus")
+    func mapLoadSystemStatusResponse() async throws -> SystemStatus {
+        try await mapReport(from: "systemStatus")
     }
 
     /// Returns the SystemStatus output upon receiving `systemStatus-without-data.json`
     ///
-    func mapLoadSystemStatusResponseWithoutDataEnvelope() throws -> SystemStatus {
-        return try mapReport(from: "systemStatus-without-data")
+    func mapLoadSystemStatusResponseWithoutDataEnvelope() async throws -> SystemStatus {
+        try await mapReport(from: "systemStatus-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/TaxClassListMapperTest.swift
+++ b/Networking/NetworkingTests/Mapper/TaxClassListMapperTest.swift
@@ -12,8 +12,8 @@ final class TaxClassListMapperTest: XCTestCase {
 
     /// Verifies that all of the Tax Class Fields are parsed correctly.
     ///
-    func test_TaxClass_fields_are_properly_parsed() {
-        let taxClasses = mapLoadAllTaxClassResponse()
+    func test_TaxClass_fields_are_properly_parsed() async {
+        let taxClasses = await mapLoadAllTaxClassResponse()
         XCTAssertEqual(taxClasses.count, 3)
 
 
@@ -25,8 +25,8 @@ final class TaxClassListMapperTest: XCTestCase {
 
     /// Verifies that all of the Tax Class Fields are parsed correctly.
     ///
-    func test_TaxClass_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let taxClasses = mapLoadAllTaxClassResponseWithoutDataEnvelope()
+    func test_TaxClass_fields_are_properly_parsed_when_response_has_no_data_envelope() async {
+        let taxClasses = await mapLoadAllTaxClassResponseWithoutDataEnvelope()
         XCTAssertEqual(taxClasses.count, 3)
 
 
@@ -44,23 +44,23 @@ private extension TaxClassListMapperTest {
 
     /// Returns the TaxClassListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapTaxClasses(from filename: String) -> [TaxClass] {
+    func mapTaxClasses(from filename: String) async -> [TaxClass] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! TaxClassListMapper(siteID: sampleSiteID).map(response: response)
+        return try! await TaxClassListMapper(siteID: sampleSiteID).map(response: response)
     }
 
     /// Returns the TaxClassListMapper output upon receiving `taxes-classes`
     ///
-    func mapLoadAllTaxClassResponse() -> [TaxClass] {
-        return mapTaxClasses(from: "taxes-classes")
+    func mapLoadAllTaxClassResponse() async -> [TaxClass] {
+        await mapTaxClasses(from: "taxes-classes")
     }
 
     /// Returns the TaxClassListMapper output upon receiving `taxes-classes-without-data`
     ///
-    func mapLoadAllTaxClassResponseWithoutDataEnvelope() -> [TaxClass] {
-        return mapTaxClasses(from: "taxes-classes-without-data")
+    func mapLoadAllTaxClassResponseWithoutDataEnvelope() async -> [TaxClass] {
+        await mapTaxClasses(from: "taxes-classes-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/TopEarnerStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/TopEarnerStatsMapperTests.swift
@@ -9,8 +9,8 @@ class TopEarnerStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the day unit TopEarnerStats fields are parsed correctly.
     ///
-    func test_day_unit_stat_fields_are_properly_parsed() {
-        guard let dayStats = mapTopEarnerStatsWithDayUnitResponse() else {
+    func test_day_unit_stat_fields_are_properly_parsed() async {
+        guard let dayStats = await mapTopEarnerStatsWithDayUnitResponse() else {
             XCTFail()
             return
         }
@@ -33,8 +33,8 @@ class TopEarnerStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the week unit TopEarnerStats fields are parsed correctly.
     ///
-    func test_week_unit_stat_fields_are_properly_parsed() {
-        guard let weekStats = mapTopEarnerStatsWithWeekUnitResponse() else {
+    func test_week_unit_stat_fields_are_properly_parsed() async {
+        guard let weekStats = await mapTopEarnerStatsWithWeekUnitResponse() else {
             XCTFail()
             return
         }
@@ -66,8 +66,8 @@ class TopEarnerStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the month unit TopEarnerStats fields are parsed correctly.
     ///
-    func test_month_unit_stat_fields_are_properly_parsed() {
-        guard let monthStats = mapTopEarnerStatsWithMonthUnitResponse() else {
+    func test_month_unit_stat_fields_are_properly_parsed() async {
+        guard let monthStats = await mapTopEarnerStatsWithMonthUnitResponse() else {
             XCTFail()
             return
         }
@@ -99,8 +99,8 @@ class TopEarnerStatsMapperTests: XCTestCase {
 
     /// Verifies that all of the year unit TopEarnerStats fields are parsed correctly.
     ///
-    func test_year_unit_stat_fields_are_properly_parsed() {
-        guard let yearStats = mapTopEarnerStatsWithYearUnitResponse() else {
+    func test_year_unit_stat_fields_are_properly_parsed() async {
+        guard let yearStats = await mapTopEarnerStatsWithYearUnitResponse() else {
             XCTFail()
             return
         }
@@ -138,35 +138,35 @@ private extension TopEarnerStatsMapperTests {
 
     /// Returns the TopEarnerStatsMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapStatItems(from filename: String) -> TopEarnerStats? {
+    func mapStatItems(from filename: String) async -> TopEarnerStats? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! TopEarnerStatsMapper(siteID: sampleSiteID).map(response: response)
+        return try! await TopEarnerStatsMapper(siteID: sampleSiteID).map(response: response)
     }
 
     /// Returns the TopEarnerStatsMapper output upon receiving `top-performers-day`
     ///
-    func mapTopEarnerStatsWithDayUnitResponse() -> TopEarnerStats? {
-        return mapStatItems(from: "top-performers-day")
+    func mapTopEarnerStatsWithDayUnitResponse() async -> TopEarnerStats? {
+        await mapStatItems(from: "top-performers-day")
     }
 
     /// Returns the TopEarnerStatsMapper output upon receiving `top-performers-week`
     ///
-    func mapTopEarnerStatsWithWeekUnitResponse() -> TopEarnerStats? {
-        return mapStatItems(from: "top-performers-week")
+    func mapTopEarnerStatsWithWeekUnitResponse() async -> TopEarnerStats? {
+        await mapStatItems(from: "top-performers-week")
     }
 
     /// Returns the TopEarnerStatsMapper output upon receiving `top-performers-month`
     ///
-    func mapTopEarnerStatsWithMonthUnitResponse() -> TopEarnerStats? {
-        return mapStatItems(from: "top-performers-month")
+    func mapTopEarnerStatsWithMonthUnitResponse() async -> TopEarnerStats? {
+        await mapStatItems(from: "top-performers-month")
     }
 
     /// Returns the TopEarnerStatsMapper output upon receiving `top-performers-year`
     ///
-    func mapTopEarnerStatsWithYearUnitResponse() -> TopEarnerStats? {
-        return mapStatItems(from: "top-performers-year")
+    func mapTopEarnerStatsWithYearUnitResponse() async -> TopEarnerStats? {
+        await mapStatItems(from: "top-performers-year")
     }
 }

--- a/Networking/NetworkingTests/Mapper/UserMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/UserMapperTests.swift
@@ -7,8 +7,8 @@ import XCTest
 final class UserMapperTests: XCTestCase {
     private let testSiteID: Int64 = 123
 
-    func test_User_fields_are_properly_parsed_with_data_envelope() {
-        guard let user = mapUserFromMockResponseWithDataEnvelope() else {
+    func test_User_fields_are_properly_parsed_with_data_envelope() async {
+        guard let user = await mapUserFromMockResponseWithDataEnvelope() else {
             XCTFail()
             return
         }
@@ -23,8 +23,8 @@ final class UserMapperTests: XCTestCase {
         XCTAssertEqual(user.siteID, testSiteID)
     }
 
-    func test_User_fields_are_properly_parsed_without_data_envelope() {
-        guard let user = mapUserFromMockResponseWithoutDataEnvelope() else {
+    func test_User_fields_are_properly_parsed_without_data_envelope() async {
+        guard let user = await mapUserFromMockResponseWithoutDataEnvelope() else {
             XCTFail()
             return
         }
@@ -41,23 +41,23 @@ final class UserMapperTests: XCTestCase {
 }
 
 private extension UserMapperTests {
-    func mapUserFromMockResponseWithDataEnvelope() -> User? {
+    func mapUserFromMockResponseWithDataEnvelope() async -> User? {
         // Note: the JSON content is shortened due to the "fields" parameter
         // usage in UserRemote.
         guard let response = Loader.contentsOf("user-complete") else {
             return nil
         }
 
-        return try? UserMapper(siteID: testSiteID).map(response: response)
+        return try? await UserMapper(siteID: testSiteID).map(response: response)
     }
 
-    func mapUserFromMockResponseWithoutDataEnvelope() -> User? {
+    func mapUserFromMockResponseWithoutDataEnvelope() async -> User? {
         // Note: the JSON content is shortened due to the "fields" parameter
         // usage in UserRemote.
         guard let response = Loader.contentsOf("user-complete-without-data") else {
             return nil
         }
 
-        return try? UserMapper(siteID: testSiteID).map(response: response)
+        return try? await UserMapper(siteID: testSiteID).map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/WCAnalyticsCustomerMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WCAnalyticsCustomerMapperTests.swift
@@ -6,7 +6,7 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
     ///
     private let dummySiteID: Int64 = 123
 
-    func test_WCAnalyticsCustomer_array_is_correctly_mapped_from_encoded_data() {
+    func test_WCAnalyticsCustomer_array_is_correctly_mapped_from_encoded_data() async throws {
         // Given
         let mapper = WCAnalyticsCustomerMapper(siteID: dummySiteID)
 
@@ -17,10 +17,11 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
         }
 
         // Then
-        XCTAssertNotNil(try? mapper.map(response: data))
+        let parsed = try await mapper.map(response: data)
+        XCTAssertNotNil(parsed)
     }
 
-    func test_WCAnalyticsCustomer_array_maps_all_available_entities() {
+    func test_WCAnalyticsCustomer_array_maps_all_available_entities() async throws {
         // Given
         let mapper = WCAnalyticsCustomerMapper(siteID: dummySiteID)
         var customers: [WCAnalyticsCustomer] = []
@@ -32,13 +33,13 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
             XCTFail("Data couldn't be loaded")
             return
         }
-        customers = try! mapper.map(response: data)
+        customers = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(customers.count, 4)
     }
 
-    func test_WCAnalyticsCustomer_array_response_values_are_correctly_parsed() {
+    func test_WCAnalyticsCustomer_array_response_values_are_correctly_parsed() async throws {
         // Given
         let mapper = WCAnalyticsCustomerMapper(siteID: dummySiteID)
 
@@ -47,7 +48,7 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
             XCTFail("Data couldn't be loaded")
             return
         }
-        let customers = try! mapper.map(response: data)
+        let customers = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(customers[0].userID, 0)
@@ -60,7 +61,7 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
         XCTAssertEqual(customers[3].name, "John Doe")
     }
 
-    func test_WCAnalyticsCustomer_array_maps_all_available_entities_if_response_has_no_data_envelope() {
+    func test_WCAnalyticsCustomer_array_maps_all_available_entities_if_response_has_no_data_envelope() async throws {
         // Given
         let mapper = WCAnalyticsCustomerMapper(siteID: dummySiteID)
         var customers: [WCAnalyticsCustomer] = []
@@ -72,7 +73,7 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
             XCTFail("Data couldn't be loaded")
             return
         }
-        customers = try! mapper.map(response: data)
+        customers = try await mapper.map(response: data)
 
         // Then
         XCTAssertEqual(customers.count, 2)

--- a/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
@@ -8,29 +8,29 @@ class WCPayChargeMapperTests: XCTestCase {
 
     /// Verifies that the WCPayCharge is parsed.
     ///
-    func test_WCPayCharge_map_parses_data_in_response() throws {
-        let wcpayCharge = try mapRetrieveWCPayChargeResponse()
+    func test_WCPayCharge_map_parses_data_in_response() async throws {
+        let wcpayCharge = try await mapRetrieveWCPayChargeResponse()
         XCTAssertNotNil(wcpayCharge)
     }
 
     /// Verifies that the WCPayCharge is parsed.
     ///
-    func test_WCPayCharge_map_parses_data_in_response_without_data_envelope() throws {
-        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .cardPresentWithoutDataEnvelope)
+    func test_WCPayCharge_map_parses_data_in_response_without_data_envelope() async throws {
+        let wcpayCharge = try await mapRetrieveWCPayChargeResponse(responseName: .cardPresentWithoutDataEnvelope)
         XCTAssertNotNil(wcpayCharge)
     }
 
     /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint
     ///
-    func test_WCPayCharge_map_includes_siteID_in_parsed_results() throws {
-        let wcpayCharge = try mapRetrieveWCPayChargeResponse()
+    func test_WCPayCharge_map_includes_siteID_in_parsed_results() async throws {
+        let wcpayCharge = try await mapRetrieveWCPayChargeResponse()
         XCTAssertEqual(wcpayCharge.siteID, dummySiteID)
     }
 
     /// Verifies that the fields are all parsed correctly for a card present payment
     ///
-    func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present() throws {
-        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .cardPresent)
+    func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present() async throws {
+        let wcpayCharge = try await mapRetrieveWCPayChargeResponse(responseName: .cardPresent)
 
         let expectedCreatedDate = Date.init(timeIntervalSince1970: 1643280767) //2022-01-27 10:52:47 UTC
 
@@ -62,8 +62,8 @@ class WCPayChargeMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly for an interac present payment
     ///
-    func test_WCPayCharge_map_parses_all_fields_in_result_for_interac_present() throws {
-        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .interacPresent)
+    func test_WCPayCharge_map_parses_all_fields_in_result_for_interac_present() async throws {
+        let wcpayCharge = try await mapRetrieveWCPayChargeResponse(responseName: .interacPresent)
 
         let expectedCreatedDate = Date.init(timeIntervalSince1970: 1647257154) //2022-03-14 11:25:54 UTC
 
@@ -95,8 +95,8 @@ class WCPayChargeMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly for a card present payment
     ///
-    func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present_with_nulls() throws {
-        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .cardPresentMinimal)
+    func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present_with_nulls() async throws {
+        let wcpayCharge = try await mapRetrieveWCPayChargeResponse(responseName: .cardPresentMinimal)
 
         let expectedCreatedDate = Date.init(timeIntervalSince1970: 1643799478) //2022-02-02 10:57:58 UTC
 
@@ -128,8 +128,8 @@ class WCPayChargeMapperTests: XCTestCase {
 
     /// Verifies that the fields are all parsed correctly for a card payment
     ///
-    func test_WCPayCharge_map_parses_all_fields_in_result_for_card() throws {
-        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .card)
+    func test_WCPayCharge_map_parses_all_fields_in_result_for_card() async throws {
+        let wcpayCharge = try await mapRetrieveWCPayChargeResponse(responseName: .card)
 
         let expectedCreatedDate = Date.init(timeIntervalSince1970: 1643378348) //2022-01-28 13:59:08 UTC
 
@@ -162,18 +162,18 @@ private extension WCPayChargeMapperTests {
 
     /// Returns the CouponMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapWCPayCharge(from filename: String) throws -> WCPayCharge {
+    func mapWCPayCharge(from filename: String) async throws -> WCPayCharge {
         guard let response = Loader.contentsOf(filename) else {
             throw FileNotFoundError()
         }
 
-        return try WCPayChargeMapper(siteID: dummySiteID).map(response: response)
+        return try await WCPayChargeMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the CouponMapper output from `coupon.json`
     ///
-    func mapRetrieveWCPayChargeResponse(responseName: ChargeResponse = .cardPresent) throws -> WCPayCharge {
-        return try mapWCPayCharge(from: responseName.rawValue)
+    func mapRetrieveWCPayChargeResponse(responseName: ChargeResponse = .cardPresent) async throws -> WCPayCharge {
+        try await mapWCPayCharge(from: responseName.rawValue)
     }
 
     struct FileNotFoundError: Error {}

--- a/Networking/NetworkingTests/Mapper/WordPressSiteMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressSiteMapperTests.swift
@@ -6,8 +6,8 @@ import XCTest
 ///
 final class WordPressSiteMapperTests: XCTestCase {
 
-    func test_response_is_properly_parsed() throws {
-        let site = try XCTUnwrap(mapWordPressSiteInfoResponse())
+    func test_response_is_properly_parsed() async throws {
+        let site = try await mapWordPressSiteInfoResponse()
         XCTAssertEqual(site.name, "My WordPress Site")
         XCTAssertEqual(site.description, "Just another WordPress site")
         XCTAssertEqual(site.url, "https://test.com")
@@ -24,11 +24,13 @@ private extension WordPressSiteMapperTests {
 
     /// Returns the WordPressSiteMapper output upon receiving success response
     ///
-    func mapWordPressSiteInfoResponse() -> WordPressSite? {
+    func mapWordPressSiteInfoResponse() async throws -> WordPressSite {
         guard let response = Loader.contentsOf("wordpress-site-info") else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try? WordPressSiteMapper().map(response: response)
+        return try await WordPressSiteMapper().map(response: response)
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressThemeListMapperTests.swift
@@ -5,8 +5,8 @@ final class WordPressThemeListMapperTests: XCTestCase {
 
     /// Verifies that the whole list is parsed.
     ///
-    func test_WordPressThemeListMapper_parses_all_contents_in_response() throws {
-        let themes = try mapLoadWordPressThemeListResponse()
+    func test_WordPressThemeListMapper_parses_all_contents_in_response() async throws {
+        let themes = try await mapLoadWordPressThemeListResponse()
         XCTAssertEqual(themes.count, 2)
 
         let item = try XCTUnwrap(themes.first)
@@ -24,17 +24,17 @@ private extension WordPressThemeListMapperTests {
 
     /// Returns the WordPressThemeListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapWordPressThemeList(from filename: String) throws -> [WordPressTheme] {
+    func mapWordPressThemeList(from filename: String) async throws -> [WordPressTheme] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try WordPressThemeListMapper().map(response: response)
+        return try await WordPressThemeListMapper().map(response: response)
     }
 
     /// Returns the WordPressThemeListMapper output from `theme-list-success.json`
     ///
-    func mapLoadWordPressThemeListResponse() throws -> [WordPressTheme] {
-        return try mapWordPressThemeList(from: "theme-list-success")
+    func mapLoadWordPressThemeListResponse() async throws -> [WordPressTheme] {
+        try await mapWordPressThemeList(from: "theme-list-success")
     }
 }

--- a/Networking/NetworkingTests/Mapper/WordPressThemeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressThemeMapperTests.swift
@@ -5,8 +5,8 @@ final class WordPressThemeMapperTests: XCTestCase {
 
     /// Verifies that the object is parsed.
     ///
-    func test_WordPressThemeMapper_parses_all_contents_in_response() throws {
-        let theme = try XCTUnwrap(mapLoadWordPressThemeResponse())
+    func test_WordPressThemeMapper_parses_all_contents_in_response() async throws {
+        let theme = try await mapLoadWordPressThemeResponse()
 
         XCTAssertEqual(theme.id, "maywood")
         XCTAssertEqual(theme.name, "Maywood")
@@ -22,17 +22,19 @@ private extension WordPressThemeMapperTests {
 
     /// Returns the WordPressThemeMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapWordPressTheme(from filename: String) throws -> WordPressTheme? {
+    func mapWordPressTheme(from filename: String) async throws -> WordPressTheme {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            throw FileNotFoundError()
         }
 
-        return try WordPressThemeMapper().map(response: response)
+        return try await WordPressThemeMapper().map(response: response)
     }
 
     /// Returns the WordPressThemeMapper output from `theme-mine-success.json`
     ///
-    func mapLoadWordPressThemeResponse() throws -> WordPressTheme? {
-        return try mapWordPressTheme(from: "theme-mine-success")
+    func mapLoadWordPressThemeResponse() async throws -> WordPressTheme {
+        try await mapWordPressTheme(from: "theme-mine-success")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -8,7 +8,6 @@ import TestKit
 
 /// Remote UnitTests
 ///
-@MainActor
 final class RemoteTests: XCTestCase {
 
     /// Sample Request
@@ -1026,7 +1025,7 @@ private class DummyMapper: Mapper {
     ///
     var input: Data?
 
-    func map(response: Data) throws -> Any {
+    func map(response: Data) async throws -> Any {
         input = response
         return response
     }
@@ -1036,7 +1035,7 @@ private class DummyMapper: Mapper {
 ///
 private class FailingDummyMapper: Mapper {
 
-    func map(response: Data) throws -> Any {
+    func map(response: Data) async throws -> Any {
         let decoder = JSONDecoder()
         return try decoder.decode(String.self, from: Data())
     }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Payments menu: restored the ability to search for Payments in device Spotlight. [https://github.com/woocommerce/woocommerce-ios/pull/11343]
 - [*] Payments menu: show the selected payment gateway when there's more than one to choose from [https://github.com/woocommerce/woocommerce-ios/pull/11345]
 - [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience. [https://github.com/woocommerce/woocommerce-ios/pull/11350]
+- [internal] Map network response from background thread to avoid blocking main thread. [https://github.com/woocommerce/woocommerce-ios/pull/11375]
 
 16.5
 -----

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -368,7 +368,6 @@
 		028B68C32A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
-		028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */; };
 		028E19BA28053443001C36E0 /* MockOrderDetailsPaymentAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E19B928053443001C36E0 /* MockOrderDetailsPaymentAlerts.swift */; };
 		028E19BC2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E19BB2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift */; };
 		028E1F702833DD0A001F8829 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */; };
@@ -2960,7 +2959,6 @@
 		028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModelTests.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
-		028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
 		028E19B928053443001C36E0 /* MockOrderDetailsPaymentAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrderDetailsPaymentAlerts.swift; sourceTree = "<group>"; };
 		028E19BB2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundSubmissionUseCaseTests.swift; sourceTree = "<group>"; };
 		028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
@@ -10100,7 +10098,6 @@
 				B9B6DEEE283F8B9F00901FB7 /* Site+URL.swift */,
 				021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */,
 				DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */,
-				028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */,
 				DE4D239729ADF8E3003A4B5D /* WordPressAuthenticator+Woo.swift */,
 				EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */,
 				02D29A9129F7C39200473D6D /* UIImage+Text.swift */,
@@ -13981,7 +13978,6 @@
 				DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */,
 				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
-				028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
 				020DD0AF294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Model/NoteWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/NoteWooTests.swift
@@ -10,15 +10,14 @@ class NoteWooTests: XCTestCase {
 
     /// Sample Notes
     ///
-    private lazy var sampleNotes: [Note] = {
-        return try! mapNotes(from: "notifications-load-all")
-    }()
-
+    private func sampleNotes() async throws -> [Note] {
+        try await mapNotes(from: "notifications-load-all")
+    }
 
     /// Verifies that `blockForSubject` returns the first block in the `.subject` collection.
     ///
-    func test_blockForSubject_returns_the_first_block_in_the_subject_array() {
-        for note in sampleNotes {
+    func test_blockForSubject_returns_the_first_block_in_the_subject_array() async throws {
+        for note in try await sampleNotes() {
             XCTAssertEqual(note.blockForSubject, note.subject.first)
         }
     }
@@ -26,8 +25,8 @@ class NoteWooTests: XCTestCase {
     /// Verifies that `blockForSnippet` returns the last block in the `.subject` collection, whenever there's at least 2 subject
     /// blocks.
     ///
-    func test_blockForSnippet_returns_the_last_subject_block_whenever_there_is_more_than_one_entity_in_such_array() {
-        for note in sampleNotes {
+    func test_blockForSnippet_returns_the_last_subject_block_whenever_there_is_more_than_one_entity_in_such_array() async throws {
+        for note in try await sampleNotes() {
             let expected = (note.subject.count > 1) ? note.subject.last : nil
             XCTAssertEqual(note.blockForSnippet, expected)
         }
@@ -35,8 +34,8 @@ class NoteWooTests: XCTestCase {
 
     /// Verifies that the Product Metadata is successfully extracted from Store Review Notifications.
     ///
-    func test_product_metadata_is_successfully_extracted_from_store_review_notification() {
-        guard let reviewNote = sampleNotes.first(where: { $0.subkind == .storeReview }), let product = reviewNote.product else {
+    func test_product_metadata_is_successfully_extracted_from_store_review_notification() async throws {
+        guard let reviewNote = try await sampleNotes().first(where: { $0.subkind == .storeReview }), let product = reviewNote.product else {
             XCTFail()
             return
         }
@@ -47,16 +46,16 @@ class NoteWooTests: XCTestCase {
 
     /// Verifies that no Product Metadata can be extracted from non Store Review Notifications.
     ///
-    func test_product_metadata_is_null_for_non_review_notifications() {
-        for note in sampleNotes where note.subkind != .storeReview {
+    func test_product_metadata_is_null_for_non_review_notifications() async throws {
+        for note in try await sampleNotes() where note.subkind != .storeReview {
             XCTAssertNil(note.product)
         }
     }
 
     /// Verifies that the Star Rating property can be effectively extracted from Store Review Notifications.
     ///
-    func test_starRating_is_successfully_extracted_from_store_review_notification() {
-        guard let reviewNote = sampleNotes.first(where: { $0.subkind == .storeReview }) else {
+    func test_starRating_is_successfully_extracted_from_store_review_notification() async throws {
+        guard let reviewNote = try await sampleNotes().first(where: { $0.subkind == .storeReview }) else {
             XCTFail()
             return
         }
@@ -66,8 +65,8 @@ class NoteWooTests: XCTestCase {
 
     /// Verifies that no Star Rating can be extracted from non Store Review Notifications.
     ///
-    func test_starRating_calculated_property_returns_nil_whenever_the_receiver_is_not_a_store_review_note() {
-        for note in sampleNotes where note.subkind != .storeReview {
+    func test_starRating_calculated_property_returns_nil_whenever_the_receiver_is_not_a_store_review_note() async throws {
+        for note in try await sampleNotes() where note.subkind != .storeReview {
             XCTAssertNil(note.starRating)
         }
     }
@@ -80,8 +79,8 @@ private extension NoteWooTests {
 
     /// Returns the NoteListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapNotes(from filename: String) throws -> [Note] {
+    func mapNotes(from filename: String) async throws -> [Note] {
         let response = Loader.contentsOf(filename)!
-        return try NoteListMapper().map(response: response)
+        return try await NoteListMapper().map(response: response)
     }
 }

--- a/WooCommerce/WooCommerceTests/Model/OrderNoteWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/OrderNoteWooTests.swift
@@ -7,16 +7,10 @@ import Foundation
 /// OrderNote+Woo Tests
 ///
 class OrderNoteWooTests: XCTestCase {
-
-    /// Sample OrderNotes
-    ///
-    private lazy var sampleOrderNotes: [OrderNote] = {
-        return try! mapOrderNotes(from: "order-notes")
-    }()
-
     /// Verifies the `isSystemNote` calculated property returns `true` when the author is system.
     ///
-    func test_is_system_note_calculated_property_returns_true_for_system_authors() {
+    func test_is_system_note_calculated_property_returns_true_for_system_authors() async throws {
+        let sampleOrderNotes = try await mapOrderNotes(from: "order-notes")
         for orderNote in sampleOrderNotes where orderNote.author == "system" {
             XCTAssertTrue(orderNote.isSystemAuthor)
         }
@@ -24,7 +18,8 @@ class OrderNoteWooTests: XCTestCase {
 
     /// Verifies the `isSystemNote` calculated property returns `false` when the author is NOT system.
     ///
-    func test_is_system_note_calculated_property_returns_false_for_non_system_authors() {
+    func test_is_system_note_calculated_property_returns_false_for_non_system_authors() async throws {
+        let sampleOrderNotes = try await mapOrderNotes(from: "order-notes")
         for orderNote in sampleOrderNotes where orderNote.author != "system" {
             XCTAssertFalse(orderNote.isSystemAuthor)
         }
@@ -38,8 +33,8 @@ private extension OrderNoteWooTests {
 
     /// Returns the OrderNotesMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapOrderNotes(from filename: String) throws -> [OrderNote] {
+    func mapOrderNotes(from filename: String) async throws -> [OrderNote] {
         let response = Loader.contentsOf(filename)!
-        return try OrderNotesMapper().map(response: response)
+        return try await OrderNotesMapper().map(response: response)
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -18,8 +18,8 @@ final class AggregateDataHelperTests: XCTestCase {
 
     /// Verifies all refunds are loaded
     ///
-    func testRefundsCount() {
-        let refunds = mapLoadAllRefundsResponse()
+    func testRefundsCount() async {
+        let refunds = await mapLoadAllRefundsResponse()
         let expected = 4
         let actual = refunds.count
 
@@ -28,8 +28,8 @@ final class AggregateDataHelperTests: XCTestCase {
 
     /// Verifies refunded products are calculated correctly.
     ///
-    func testRefundedProductsCount() {
-        let refunds = mapLoadAllRefundsResponse()
+    func testRefundedProductsCount() async {
+        let refunds = await mapLoadAllRefundsResponse()
         let expected = Decimal(8)
         let actual = AggregateDataHelper.refundedProductsCount(from: refunds)
 
@@ -38,12 +38,12 @@ final class AggregateDataHelperTests: XCTestCase {
 
     /// Verifies refunded products are combined and sorted correctly.
     ///
-    func testRefundedProductsSortedSuccessfully() {
+    func testRefundedProductsSortedSuccessfully() async {
         let productID: Int64 = 1
         // The itemID (63 in this case) is relevant to retrieve the attributes. A refund order item has in its properties the refunded item id, to be used
         // to query the attibutes from the order items.
         let orderItems = [MockOrderItem.sampleItem(itemID: 63, productID: productID, quantity: 3, attributes: testOrderItemAttributes)]
-        let refunds = mapLoadAllRefundsResponse()
+        let refunds = await mapLoadAllRefundsResponse()
         let expectedProducts = expectedRefundedProducts()
 
         guard let actualProducts = AggregateDataHelper.combineRefundedProducts(from: refunds, orderItems: orderItems) else {
@@ -67,15 +67,15 @@ final class AggregateDataHelperTests: XCTestCase {
 
     /// Verifies that aggregate order items filter out objects with zero quantities.
     ///
-    func testAggregateOrderItemsFilterOutZeroQuantities() {
-        let orders = mapLoadAllOrdersResponse()
+    func testAggregateOrderItemsFilterOutZeroQuantities() async {
+        let orders = await mapLoadAllOrdersResponse()
 
         guard let order = orders.first(where: { $0.orderID == orderID }) else {
             XCTFail("Error: could not find order with the specified orderID.")
             return
         }
 
-        let refunds = mapLoadAllRefundsResponse()
+        let refunds = await mapLoadAllRefundsResponse()
         let expectedCount = 7
         let actual = AggregateDataHelper.combineOrderItems(order.items, with: refunds)
 
@@ -194,34 +194,34 @@ private extension AggregateDataHelperTests {
 
     /// Returns the OrderListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapOrders(from filename: String) -> [Order] {
+    func mapOrders(from filename: String) async -> [Order] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! OrderListMapper(siteID: dummySiteID).map(response: response)
+        return try! await OrderListMapper(siteID: dummySiteID).map(response: response)
     }
 
     /// Returns the RefundListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapRefunds(from filename: String) -> [Refund] {
+    func mapRefunds(from filename: String) async -> [Refund] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! RefundListMapper(siteID: dummySiteID, orderID: orderID).map(response: response)
+        return try! await RefundListMapper(siteID: dummySiteID, orderID: orderID).map(response: response)
     }
 
     /// Returns the OrderListMapper output upon receiving `orders-load-all`
     ///
-    func mapLoadAllOrdersResponse() -> [Order] {
-        return mapOrders(from: "orders-load-all")
+    func mapLoadAllOrdersResponse() async -> [Order] {
+        await mapOrders(from: "orders-load-all")
     }
 
     /// Returns the RefundListMapper output upon receiving `order-560-all-refunds`
     ///
-    func mapLoadAllRefundsResponse() -> [Refund] {
-        return mapRefunds(from: "order-560-all-refunds")
+    func mapLoadAllRefundsResponse() async -> [Refund] {
+        await mapRefunds(from: "order-560-all-refunds")
     }
 
     /// Returns the sorted, expected array of refunded products

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -9,12 +9,17 @@ import WooFoundation
 class CurrencyFormatterTests: XCTestCase {
     private let sampleLocale = Locale(identifier: "en")
 
-    private lazy var sampleCurrencySettings = CurrencySettings(siteSettings: setUpSampleSiteSettings())
+    private var sampleCurrencySettings: CurrencySettings!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sampleCurrencySettings = CurrencySettings(siteSettings: await setUpSampleSiteSettings())
+    }
 
     /// Sample Site Settings
     ///
-    private func setUpSampleSiteSettings() -> [SiteSetting] {
-        let settings = mapLoadGeneralSiteSettingsResponse()
+    private func setUpSampleSiteSettings() async -> [SiteSetting] {
+        let settings = await mapLoadGeneralSiteSettingsResponse()
         var siteSettings: [SiteSetting] = []
 
         siteSettings.append(settings[14])
@@ -508,17 +513,17 @@ class CurrencyFormatterTests: XCTestCase {
 extension CurrencyFormatterTests {
     /// Returns the SiteSettings output upon receiving `filename` (Data Encoded)
     ///
-    func mapGeneralSettings(from filename: String) -> [SiteSetting] {
+    func mapGeneralSettings(from filename: String) async -> [SiteSetting] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! SiteSettingsMapper(siteID: 123, settingsGroup: SiteSettingGroup.general).map(response: response)
+        return try! await SiteSettingsMapper(siteID: 123, settingsGroup: SiteSettingGroup.general).map(response: response)
     }
 
     /// Returns the OrderNotesMapper output upon receiving `settings-general`
     ///
-    func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
-        return mapGeneralSettings(from: "settings-general")
+    func mapLoadGeneralSiteSettingsResponse() async -> [SiteSetting] {
+        await mapGeneralSettings(from: "settings-general")
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/SiteAddressTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/SiteAddressTests.swift
@@ -4,9 +4,9 @@ import XCTest
 
 final class SiteAddressTests: XCTestCase {
 
-    func test_the_address_fields_returns_the_expected_values() {
+    func test_the_address_fields_returns_the_expected_values() async {
         // Arrange
-        let siteSettings = mapLoadGeneralSiteSettingsResponse()
+        let siteSettings = await mapLoadGeneralSiteSettingsResponse()
 
         // Act
         let siteAddress = SiteAddress(siteSettings: siteSettings)
@@ -26,17 +26,17 @@ final class SiteAddressTests: XCTestCase {
 private extension SiteAddressTests {
     /// Returns the SiteSettings output upon receiving `filename` (Data Encoded)
     ///
-    func mapGeneralSettings(from filename: String) -> [SiteSetting] {
+    func mapGeneralSettings(from filename: String) async -> [SiteSetting] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! SiteSettingsMapper(siteID: 123, settingsGroup: SiteSettingGroup.general).map(response: response)
+        return try! await SiteSettingsMapper(siteID: 123, settingsGroup: SiteSettingGroup.general).map(response: response)
     }
 
     /// Returns the SiteSetting array as output upon receiving `settings-general`
     ///
-    func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
-        return mapGeneralSettings(from: "settings-general")
+    func mapLoadGeneralSiteSettingsResponse() async -> [SiteSetting] {
+        await mapGeneralSettings(from: "settings-general")
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
@@ -562,13 +562,17 @@ final class ShipmentStoreTests: XCTestCase {
         let mockTrackingID = "f2e7783b40837b9e1ec503a149dab4a1"
         let mockDateShipped = "2019-04-01"
 
-        shipmentStore.addTracking(siteID: sampleSiteID,
-                                  orderID: sampleOrderID,
-                                  providerGroupName: mockGroupName,
-                                  providerName: mockProviderName,
-                                  trackingNumber: mockTrackingNumber, dateShipped: mockDateShipped) { error in
-                                    XCTAssertNil(error)
+        let error = waitFor { promise in
+            shipmentStore.addTracking(siteID: self.sampleSiteID,
+                                      orderID: self.sampleOrderID,
+                                      providerGroupName: mockGroupName,
+                                      providerName: mockProviderName,
+                                      trackingNumber: mockTrackingNumber, dateShipped: mockDateShipped) { error in
+                promise(error)
+            }
         }
+
+        XCTAssertNil(error)
 
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ShipmentTracking.self), 1)
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -127,7 +127,7 @@ a  concrete `Mapper` implementation:
     ```
     protocol Mapper {
         associatedtype Output
-        func map(response: Data) throws -> Output
+        func map(response: Data) async throws -> Output
     }
     ```
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11255
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

### What? 

The networking layer Mappers parses a networking response into models from the main thread.

### Why?

When a large network response is mapped from the main thread, the main thread gets blocked.

A blocked main thread results in app hangs and the watchdog can terminate the app if the main thread is blocked for a significant amount of time.

### How? 

Process the network response from the background thread.

**Changes**
1. Make `map` function async and update all mapper files.
2. Process network response in `Remote` inside a `Task`.
3. Update unit tests. 

⚠️ Sorry for the 500+ changes. I had to update all the mapper-related unit tests in the same PR. 

## Testing instructions

Smoke test the app using both WPCOM and wporg login and ensure that it works as before.

## Screenshots
NA

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
