### PR TITLE
Create Product Sheet: System image crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience. [https://github.com/woocommerce/woocommerce-ios/pull/11350]
 - [internal] Process network response in background thread to avoid blocking main thread. [https://github.com/woocommerce/woocommerce-ios/pull/11381]
 - [**] Attempted to fix a crash that has been occurring for some users during magic link login. [https://github.com/woocommerce/woocommerce-ios/pull/11373]
+- [*] Fixed a crash due to using unavailable system image in devices below iOS 16.0. [https://github.com/woocommerce/woocommerce-ios/pull/11394]
 
 16.5
 -----

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -398,9 +398,12 @@ extension UIImage {
     /// Subscription Product
     ///
     static var variableSubscriptionProductImage: UIImage {
-        return UIImage(systemName: "square.3.layers.3d")!
+        if #available(iOS 16.0, *) {
+            return UIImage(systemName: "square.3.layers.3d")!
+        } else {
+            return UIImage(systemName: "square.stack.3d.up")!
+        }
     }
-
 
     /// Filter Icon
     ///


### PR DESCRIPTION
Closes: #11376 

## Description

Fix crash in devices running iOS 16.0 or less due to a unsupported system image. 

Discussion: peaMlT-jY-p2

#### What?

We are using `"square.3.layers.3d"` system image in the product sheet which is iOS 16.0+. This causes a crash on devices running below iOS 16.0. 

This crash is occurring if the following conditions are met.
- Installed Woo Subscriptions plugin
- Device running < iOS 16.0

#### Why? 

Our current deployment target is iOS 15.0. And `"square.3.layers.3d"` image is supported only in iOS 16.0 and above.

#### How?

Use a fallback image `square.3.stack.3d` in devices running iOS below iOS 16.0.

I decided to fallback to `square.3.stack.3d` because,
1. `square.3.stack.3d` is supported in iOS 14.0+.
1. SF Symbols mac app suggests this when we view `square.3.layers.3d`. 

Image availability
<img width="193" alt="Screenshot 2023-12-08 at 8 19 09 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/6d3488de-60bf-4880-be76-7005541f7297">

## Testing instructions

**Prerequisites**
Create a JN site and Install Woo Subscription plugin on your store.

**Steps**
1. Launch the app in iOS device or simulator running version less than iOS 16.0
1. Login into the app using the JN site.
1. Navigate to Products tab
1. Tap `+` and a sheet should be presented with the "Variable subscription product" option
1. Note that `square.3.stack.3d` is used for variable subscription product option instead of `square.3.layers.3d`.
1. There should be no crash.
1. Launch the app in iOS 16+ device/simulator and verify that it works as before. 
## Screenshots

| iOS 16 and above | < iOS 16 |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-12-08 at 20 14 42](https://github.com/woocommerce/woocommerce-ios/assets/524475/133e0ead-1699-40d2-91bd-ba3c14e47acb) | ![Simulator Screenshot - iPhone 6s - 2023-12-08 at 20 01 56](https://github.com/woocommerce/woocommerce-ios/assets/524475/636d4672-0c0b-4b52-a946-a48a152876e7) | 




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
