### PR TITLE
[Order form] Extract logic for `CollapsibleProductCardPriceSummary` into separate view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -157,7 +157,7 @@ private struct CollapsibleProductRowCard: View {
                             .font(.subheadline)
                             .foregroundColor(Color(.text))
                             .renderedIf(!isCollapsed)
-                        CollapsibleProductCardPriceSummary(viewModel: viewModel.productViewModel)
+                        CollapsibleProductCardPriceSummary(viewModel: viewModel.priceSummaryViewModel)
                             .font(.subheadline)
                             .renderedIf(isCollapsed)
                     }
@@ -179,7 +179,7 @@ private struct CollapsibleProductRowCard: View {
 
                 HStack {
                     Text(Localization.priceLabel)
-                    CollapsibleProductCardPriceSummary(viewModel: viewModel.productViewModel)
+                    CollapsibleProductCardPriceSummary(viewModel: viewModel.priceSummaryViewModel)
                 }
                 .frame(minHeight: Layout.rowMinHeight)
 
@@ -300,31 +300,6 @@ private extension CollapsibleProductRowCard {
                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
             }
             .renderedIf(shouldDisallowDiscounts)
-        }
-    }
-}
-
-struct CollapsibleProductCardPriceSummary: View {
-
-    @ObservedObject var viewModel: ProductRowViewModel
-
-    init(viewModel: ProductRowViewModel) {
-        self.viewModel = viewModel
-    }
-
-    var body: some View {
-        HStack {
-            HStack {
-                Text(viewModel.priceQuantityLine)
-                    .foregroundColor(.secondary)
-                Spacer()
-            }
-            if let price = viewModel.priceBeforeDiscountsLabel {
-                Text(price)
-                    .if(!viewModel.pricedIndividually) {
-                        $0.foregroundColor(.secondary)
-                    }
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCardPriceSummary.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCardPriceSummary.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct CollapsibleProductCardPriceSummary: View {
+
+    private let viewModel: CollapsibleProductCardPriceSummaryViewModel
+
+    init(viewModel: CollapsibleProductCardPriceSummaryViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        HStack {
+            HStack {
+                Text(viewModel.priceQuantityLine)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+            if let price = viewModel.priceBeforeDiscountsLabel {
+                Text(price)
+                    .if(!viewModel.pricedIndividually) {
+                        $0.foregroundColor(.secondary)
+                    }
+            }
+        }
+    }
+}
+
+struct CollapsibleProductCardPriceSummary_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: true, quantity: 2, price: "5")
+        let bundleViewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: false, quantity: 2, price: "0")
+        CollapsibleProductCardPriceSummary(viewModel: viewModel)
+            .previewDisplayName("Priced individually")
+        CollapsibleProductCardPriceSummary(viewModel: bundleViewModel)
+            .previewDisplayName("Bundled price")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCardPriceSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCardPriceSummaryViewModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import WooFoundation
+
+/// View model for `CollapsibleProductCardPriceSummary`
+///
+struct CollapsibleProductCardPriceSummaryViewModel {
+    /// Whether the product is priced individually. Defaults to `true`.
+    ///
+    /// Used to control how the price is displayed, e.g. when a product is part of a bundle.
+    ///
+    let pricedIndividually: Bool
+
+    /// Unformatted product price
+    ///
+    private let price: String?
+
+    /// Quantity of product in the order. The source of truth is from the the quantity stepper view model `stepperViewModel`.
+    ///
+    private let quantity: Decimal
+
+    private let currencyFormatter: CurrencyFormatter
+
+    init(pricedIndividually: Bool,
+         quantity: Decimal,
+         price: String?,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        self.pricedIndividually = pricedIndividually
+        self.quantity = quantity
+        self.price = pricedIndividually ? price : "0"
+        self.currencyFormatter = currencyFormatter
+    }
+}
+
+extension CollapsibleProductCardPriceSummaryViewModel {
+    /// Formatted price label based on a product's price and quantity.
+    /// Reads as '8 x $10.00'
+    ///
+    var priceQuantityLine: String {
+        let formattedQuantity = quantity.formatted()
+        let formattedPrice = {
+            guard let price = pricedIndividually ? price : "0",
+                    let formattedPrice = currencyFormatter.formatAmount(price) else {
+                return "-"
+            }
+            return formattedPrice
+        }()
+        return String.localizedStringWithFormat(Localization.priceQuantityLine, formattedQuantity, formattedPrice)
+    }
+
+    /// Formatted price label from multiplying product's price and quantity.
+    ///
+    var priceBeforeDiscountsLabel: String? {
+        guard let price = pricedIndividually ? price : "0" else {
+            return nil
+        }
+        let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
+        return currencyFormatter.formatAmount(productSubtotal)
+    }
+}
+
+private extension CollapsibleProductCardPriceSummaryViewModel {
+    enum Localization {
+        static let priceQuantityLine = NSLocalizedString(
+            "collapsibleProductCardPriceSummaryViewModel.priceQuantityLine",
+            value: "%@ × %@",
+            comment: "Formatted price label based on a product's price and quantity. Reads as '8 x $10.00'. " +
+            "Please take care to use the multiplication symbol ×, not a letter x, where appropriate.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
@@ -42,6 +42,7 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
 
     let productViewModel: ProductRowViewModel
     let stepperViewModel: ProductStepperViewModel
+    let priceSummaryViewModel: CollapsibleProductCardPriceSummaryViewModel
 
     private let currencyFormatter: CurrencyFormatter
     private let analytics: Analytics
@@ -58,6 +59,9 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
         self.isReadOnly = isReadOnly
         self.productViewModel = productViewModel
         self.stepperViewModel = stepperViewModel
+        self.priceSummaryViewModel = .init(pricedIndividually: productViewModel.pricedIndividually,
+                                           quantity: stepperViewModel.quantity,
+                                           price: productViewModel.price)
         self.currencyFormatter = currencyFormatter
         self.analytics = analytics
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
@@ -6,6 +6,7 @@ struct ProductDiscountView: View {
     private let name: String
     private let stockLabel: String
     private let productRowViewModel: ProductRowViewModel
+    private let priceSummaryViewModel: CollapsibleProductCardPriceSummaryViewModel
 
     private let minusSign: String = NumberFormatter().minusSign
 
@@ -23,6 +24,9 @@ struct ProductDiscountView: View {
         self.stockLabel = stockLabel
         self.productRowViewModel = productRowViewModel
         self.discountViewModel = discountViewModel
+        self.priceSummaryViewModel = .init(pricedIndividually: productRowViewModel.pricedIndividually,
+                                           quantity: productRowViewModel.quantity,
+                                           price: productRowViewModel.price)
     }
 
     var body: some View {
@@ -36,7 +40,7 @@ struct ProductDiscountView: View {
                                           foregroundColor: Color(UIColor.listSmallIcon))
                     VStack(alignment: .leading) {
                         Text(name)
-                        CollapsibleProductCardPriceSummary(viewModel: productRowViewModel)
+                        CollapsibleProductCardPriceSummary(viewModel: priceSummaryViewModel)
                     }
                 }
                 .padding()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -90,16 +90,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         return currencyFormatter.formatAmount(price)
     }
 
-    /// Formatted price label from multiplying product's price and quantity.
-    ///
-    var priceBeforeDiscountsLabel: String? {
-        guard let price = price else {
-            return nil
-        }
-        let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
-        return currencyFormatter.formatAmount(productSubtotal)
-    }
-
     /// Formatted price label based on a product's price and quantity. Accounting for discounts, if any.
     /// e.g: If price is $5 and discount is $1, outputs "$5.00 - $1.00"
     ///
@@ -133,15 +123,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         let priceAfterDiscount = priceDecimal.subtracting((discount ?? Decimal.zero) as NSDecimalNumber)
 
         return currencyFormatter.formatAmount(priceAfterDiscount) ?? ""
-    }
-
-    /// Formatted price label based on a product's price and quantity.
-    /// Reads as '8 x $10.00'
-    ///
-    var priceQuantityLine: String {
-        let quantity = quantity.formatted()
-        let price = priceLabel ?? "-"
-        return String.localizedStringWithFormat(Localization.priceQuantityLine, quantity, price)
     }
 
     private(set) var discount: Decimal?
@@ -448,11 +429,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
 private extension ProductRowViewModel {
     enum Localization {
-        static let priceQuantityLine = NSLocalizedString(
-            "productRowViewModel.priceQuantityLine",
-            value: "%@ × %@",
-            comment: "Formatted price label based on a product's price and quantity. Reads as '8 x $10.00'. " +
-            "Please take care to use the multiplication symbol ×, not a letter x, where appropriate.")
         static let stockFormat = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown during order creation")
         static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
         static let singleVariation = NSLocalizedString("%ld variation",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1975,6 +1975,9 @@
 		CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */; };
 		CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */; };
 		CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
+		CE55F2D42B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D32B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift */; };
+		CE55F2D62B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D52B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift */; };
+		CE55F2D82B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D72B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift */; };
 		CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0321076C0100D73C1C /* NewNoteViewController.swift */; };
 		CE583A072107849F00D73C1C /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A052107849F00D73C1C /* SwitchTableViewCell.swift */; };
 		CE583A082107849F00D73C1C /* SwitchTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE583A062107849F00D73C1C /* SwitchTableViewCell.xib */; };
@@ -4582,6 +4585,9 @@
 		CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CNContact+Helpers.swift"; sourceTree = "<group>"; };
 		CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatterTests.swift; sourceTree = "<group>"; };
 		CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Helpers.swift"; sourceTree = "<group>"; };
+		CE55F2D32B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummaryViewModel.swift; sourceTree = "<group>"; };
+		CE55F2D52B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummary.swift; sourceTree = "<group>"; };
+		CE55F2D72B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		CE583A0321076C0100D73C1C /* NewNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteViewController.swift; sourceTree = "<group>"; };
 		CE583A052107849F00D73C1C /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchTableViewCell.swift; sourceTree = "<group>"; };
 		CE583A062107849F00D73C1C /* SwitchTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SwitchTableViewCell.xib; sourceTree = "<group>"; };
@@ -9487,6 +9493,7 @@
 			isa = PBXGroup;
 			children = (
 				B9FECD842A6043FD003D98B7 /* ProductInOrderViewModelTests.swift */,
+				CE55F2D72B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift */,
 			);
 			path = ProductsSection;
 			sourceTree = "<group>";
@@ -9981,6 +9988,8 @@
 				68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */,
 				B99B87A62AEFCF0A006B8AB1 /* Order+Empty.swift */,
 				02C7EE8B2B22B21D008B7DF8 /* CollapsibleProductRowCardViewModel.swift */,
+				CE55F2D52B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift */,
+				CE55F2D32B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift */,
 			);
 			path = "Order Creation";
 			sourceTree = "<group>";
@@ -13547,6 +13556,7 @@
 				B90DACC02A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift in Sources */,
 				D85A3C5626C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift in Sources */,
 				26B233D12A14208800926EAD /* PrivacyBannerPresenter.swift in Sources */,
+				CE55F2D62B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,
 				B958A7C928B3D47B00823EEF /* Route.swift in Sources */,
 				CC53FB3A275697B000C4CA4F /* ProductRowViewModel.swift in Sources */,
@@ -13664,6 +13674,7 @@
 				02F67FEE25805F9C00C3BAD2 /* ShippingLabelTrackingURLGenerator.swift in Sources */,
 				0269A63C2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift in Sources */,
 				3188533C2639FE5800F66A9C /* PaymentSettingsFlowPresentedViewModel.swift in Sources */,
+				CE55F2D42B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift in Sources */,
 				DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */,
 				02B41A96296D09D100FE3311 /* DomainSettingsListView.swift in Sources */,
 				029F29FE24DA5B2D004751CA /* ProductInventorySettingsViewModel.swift in Sources */,
@@ -14098,6 +14109,7 @@
 				B57C5C9F21B80E8300FF82B2 /* SampleError.swift in Sources */,
 				CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */,
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,
+				CE55F2D82B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift in Sources */,
 				025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */,
 				0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */,
 				D88100D3257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -400,68 +400,6 @@ final class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
-    func test_product_row_priceQuantityLine_returns_properly_formatted_priceQuantityLine() {
-        // Given
-        let price = "10.71"
-        let quantity: Decimal = 8
-        let product = Product.fake().copy(price: price)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product, quantity: quantity)
-
-        // Then
-        assertEqual("8 × $10.71", viewModel.priceQuantityLine)
-    }
-
-    func test_priceQuantityLine_returns_properly_formatted_priceQuantityLine_for_product_not_pricedIndividually() {
-        // Given
-        let price = "10.71"
-        let quantity: Decimal = 8
-        let product = Product.fake().copy(price: price)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product, quantity: quantity, pricedIndividually: false)
-
-        // Then
-        assertEqual("8 × $0.00", viewModel.priceQuantityLine)
-    }
-
-    func test_priceBeforeDiscountsLabel_returns_expected_price_for_product_pricedIndividually() {
-        // Given
-        let price = "10.71"
-        let product = Product.fake().copy(price: price)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product, pricedIndividually: true)
-
-        // Then
-        assertEqual(price, viewModel.price)
-    }
-
-    func test_priceBeforeDiscountsLabel_returns_expected_price_for_product_not_pricedIndividually() {
-        // Given
-        let price = "10.71"
-        let product = Product.fake().copy(price: price)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product, pricedIndividually: false)
-
-        // Then
-        assertEqual("0", viewModel.price)
-    }
-
-    func test_product_row_priceQuantityLine_when_product_has_no_price_then_returns_properly_formatted_priceQuantityLine() {
-        // Given
-        let quantity: Decimal = 8
-        let product = Product.fake().copy()
-
-        // When
-        let viewModel = ProductRowViewModel(product: product, quantity: quantity)
-
-        // Then
-        assertEqual("8 × -", viewModel.priceQuantityLine)
-    }
-
     // MARK: - `isConfigurable`
 
     func test_isConfigurable_is_false_for_bundle_product_when_feature_flag_is_disabled() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/CollapsibleProductCardPriceSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductsSection/CollapsibleProductCardPriceSummaryViewModelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import WooCommerce
+
+final class CollapsibleProductCardPriceSummaryViewModelTests: XCTestCase {
+
+    func test_priceQuantityLine_returns_properly_formatted_priceQuantityLine() {
+        // Given
+        let price = "10.71"
+        let quantity: Decimal = 8
+
+        // When
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: true, quantity: quantity, price: price)
+
+        // Then
+        assertEqual("8 × $10.71", viewModel.priceQuantityLine)
+    }
+
+    func test_priceQuantityLine_returns_properly_formatted_priceQuantityLine_for_product_not_pricedIndividually() {
+        // Given
+        let price = "10.71"
+        let quantity: Decimal = 8
+
+        // When
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: false, quantity: quantity, price: price)
+
+        // Then
+        assertEqual("8 × $0.00", viewModel.priceQuantityLine)
+    }
+
+    func test_priceQuantityLine_when_price_is_nil_then_returns_properly_formatted_priceQuantityLine() {
+        // Given
+        let quantity: Decimal = 8
+
+        // When
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: true, quantity: quantity, price: nil)
+
+        // Then
+        assertEqual("8 × -", viewModel.priceQuantityLine)
+    }
+
+    func test_priceBeforeDiscountsLabel_multiplies_price_by_quantity() {
+        // Given
+        let price = "10.71"
+        let quantity: Decimal = 8
+
+        // When
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: true, quantity: quantity, price: price)
+
+        // Then
+        assertEqual("$85.68", viewModel.priceBeforeDiscountsLabel)
+    }
+
+    func test_priceBeforeDiscountsLabel_returns_expected_price_when_pricedIndividually_is_true() {
+        // Given
+        let price = "10.71"
+
+        // When
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: true, quantity: 1, price: price)
+
+        // Then
+        assertEqual("$10.71", viewModel.priceBeforeDiscountsLabel)
+    }
+
+    func test_priceBeforeDiscountsLabel_returns_expected_price_when_pricedIndividually_is_false() {
+        // Given
+        let price = "10.71"
+
+        // When
+        let viewModel = CollapsibleProductCardPriceSummaryViewModel(pricedIndividually: false, quantity: 1, price: price)
+
+        // Then
+        assertEqual("$0.00", viewModel.priceBeforeDiscountsLabel)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11396
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
This extracts the logic for `CollapsibleProductCardPriceSummary` into a separate view model. This is another step toward disentangling the logic used in `CollapsibleProductCard` from `ProductRowViewModel`, eventually allowing the quantity and price in the order form (including the discount view) to be displayed using `OrderItem` data.

## How

* `CollapsibleProductCardPriceSummary` is now separated from `CollapsibleProductCard` for clarity, since it's being used in other views (`ProductDiscountView`).
* Adds `CollapsibleProductCardPriceSummaryViewModel` with the logic used in `CollapsibleProductCardPriceSummary`, and removes that logic from `ProductRowViewModel`.
* Moves the relevant unit tests to `CollapsibleProductCardPriceSummaryViewModelTests`.
* For now, the new view model is being initialized mostly from data in `ProductRowViewModel`. This can be updated when `CollapsibleProductRowCardViewModel` contains the required data (part of #11389) and that view model no longer needs to rely on `ProductRowViewModel`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

No changes on the order form UX are expected. This view is used in both the collapsible card on the order form and the add discount view, so both are tested:

- Go to the Orders tab
- Tap on `+` to create an order
- Add at least one product to the order --> the price row should have a quantity of 1 with the product price
- Expand any product card --> the price row should have a quantity of 1 with the product price
- Tap to increment the product quantity --> the quantity and total product price in the price row should also be updated
- Tap "Add discount" --> the price row (under the product name) should show the updated quantity and price
- After the payments section is synced, tap `Create` to create the order --> the created order should have the recently set quantity for each product
- Tap `Edit` to edit the order --> the price row for each product should match what was set previously (quantity and total price)
- Tap to increment the product quantity --> after syncing, the quantity label in the price in the product card should be updated
- Tap `Done` --> the updated order should have the recently set quantity for each product 

Note: On the "Add discount" screen, the "Price after discount" label will not reflect the price multiplied by the quantity. This is unrelated to these changes (see https://github.com/woocommerce/woocommerce-ios/issues/11393)

---

- [x] @rachelmcr tests prices for product bundles in the order form

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
