### PR TITLE
Remove IPP Feedback banner

### DIFF
--- a/Storage/Storage/Model/Feature Announcements/FeatureAnnouncementCampaign.swift
+++ b/Storage/Storage/Model/Feature Announcements/FeatureAnnouncementCampaign.swift
@@ -3,9 +3,6 @@ import Foundation
 public enum FeatureAnnouncementCampaign: String, Codable, Equatable {
     case linkedProductsPromo = "linked_products_promo"
     case productsOnboarding = "products_onboarding_first_product"
-    case inPersonPaymentsCashOnDelivery = "ipp_not_user"
-    case inPersonPaymentsFirstTransaction = "ipp_new_user"
-    case inPersonPaymentsPowerUsers = "ipp_power_user"
     case tapToPayHubMenuBadge = "tap_to_pay_hub_menu_badge"
 
     /// Added for use in `test_setFeatureAnnouncementDismissed_with_another_campaign_previously_dismissed_keeps_values_for_both`

--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -16,8 +16,4 @@ public enum FeedbackType: String, Codable {
     /// Identifier for the orders creation feedback survey
     ///
     case ordersCreation
-
-    /// Identifier for the In-Person Payments feedback survey
-    ///
-    case inPersonPayments
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -76,12 +76,6 @@ extension WooAnalyticsEvent {
         case orderCreation = "order_creation"
         /// Shown in beta feature banner for coupon management.
         case couponManagement = "coupon_management"
-        /// Shown in IPP banner for eligible merchants with no IPP transactions.
-        case inPersonPaymentsCashOnDeliveryBanner
-        /// Shown in IPP banner for eligible merchants with a few IPP transactions.
-        case inPersonPaymentsFirstTransactionBanner
-        /// Shown in IPP banner for eligible merchants with a significant number of IPP transactions.
-        case inPersonPaymentsPowerUsersBanner
         /// Shown in store setup task list
         case storeSetup = "store_setup"
         /// Tap to Pay on iPhone feedback button shown in the Payments menu after the first payment with TTP

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -185,26 +185,6 @@ extension WooConstants {
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
 #endif
 
-        /// URL for the IPP feedback survey for testing purposes
-        ///
-#if DEBUG
-        case inPersonPaymentsCashOnDeliveryFeedback = "https://automattic.survey.fm/woo-app-–-cod-survey"
-        case inPersonPaymentsFirstTransactionFeedback = "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
-        case inPersonPaymentsPowerUsersFeedback = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
-#else
-        /// URL for the IPP feedback survey (COD case). Used when merchants have COD enabled, but no IPP transactions.
-        ///
-        case inPersonPaymentsCashOnDeliveryFeedback = "https://automattic.survey.fm/woo-app-–-cod-survey"
-
-        /// URL for IPP feedback survey (First Transaction case). Used when merchants have only a few IPP transactions.
-        ///
-        case inPersonPaymentsFirstTransactionFeedback = "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
-
-        /// URL for IPP feedback survey (Power Users case).  Used when merchants have a significant number of IPP transactions.
-        ///
-        case inPersonPaymentsPowerUsersFeedback = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
-#endif
-
         /// URL for the Tap to Pay first payment survey
         ///
 #if DEBUG

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -881,40 +881,9 @@ private extension OrderListViewController {
 
         static let markCompleted = NSLocalizedString("Mark Completed", comment: "Title for the swipe order action to mark it as completed")
 
-        static let inPersonPaymentsCashOnDeliveryBannerTitle = NSLocalizedString("Let us know how we can help",
-                                                           comment: "Title of the In-Person Payments feedback banner in the Orders tab"
-        )
-
-        static let inPersonPaymentsFirstTransactionBannerTitle = NSLocalizedString("Enjoyed your in-person payment?",
-                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
-        )
-
-        static let inPersonPaymentsPowerUsersBannerTitle = NSLocalizedString("Let us know what you think",
-                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
-        )
-
-        static let inPersonPaymentsCashOnDeliveryBannerContent = NSLocalizedString("Share your own experience or how you collect in-person payments.",
-                                                             comment: "Content of the In-Person Payments feedback banner in the Orders tab"
-        )
-
-        static let inPersonPaymentsFirstTransactionBannerContent = NSLocalizedString("Rate your first in-person payment experience.",
-                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
-        )
-
-        static let inPersonPaymentsPowerUsersBannerContent = NSLocalizedString("Tell us all about your experience with in-person payments.",
-                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
-        )
-
         static let shareFeedbackButton = NSLocalizedString("Share feedback",
                                                            comment: "Title of the feedback action button on the In-Person Payments feedback banner"
         )
-
-        static let dismissTitle = NSLocalizedString("Give feedback",
-                                                    comment: "Title of the modal confirmation screen when the In-Person Payments feedback banner is dismissed"
-        )
-
-        static let dismissMessage = NSLocalizedString("No worries! You can always go to Settings in the Menu to send us feedback.",
-                    comment: "Message of the modal confirmation screen when the In-Person Payments feedback banner is dismissed")
 
         static let remindMeLater = NSLocalizedString("Remind me later",
                                                      comment: "Title of the button shown when the In-Person Payments feedback banner is dismissed."

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -265,12 +265,6 @@ private extension OrderListViewController {
                     self.setErrorTopBanner(for: error)
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
-                case .inPersonPaymentsFeedback(let survey):
-                    if self.inPersonPaymentsSurveyVariation != survey {
-                        self.inPersonPaymentsSurveyVariation = survey
-                        self.viewModel.trackInPersonPaymentsFeedbackBannerShown(for: survey)
-                    }
-                    self.setIPPFeedbackTopBanner(survey: survey)
                 }
             }
             .store(in: &cancellables)
@@ -843,81 +837,6 @@ private extension OrderListViewController {
             self?.present(surveyNavigation, animated: true, completion: nil)
         })
         showTopBannerView()
-    }
-
-    /// Sets the `topBannerView` property to an IPP feedback banner.
-    ///
-    func setIPPFeedbackTopBanner(survey: SurveyViewController.Source) {
-        topBannerView = createIPPFeedbackTopBanner(survey: survey)
-        showTopBannerView()
-    }
-
-    private func createIPPFeedbackTopBanner(survey: SurveyViewController.Source) -> TopBannerView {
-        var bannerTitle = ""
-        var bannerText = ""
-        var campaign: FeatureAnnouncementCampaign = .inPersonPaymentsCashOnDelivery
-
-        switch survey {
-        case .inPersonPaymentsCashOnDelivery :
-            bannerTitle = Localization.inPersonPaymentsCashOnDeliveryBannerTitle
-            bannerText = Localization.inPersonPaymentsCashOnDeliveryBannerContent
-            campaign = .inPersonPaymentsCashOnDelivery
-        case .inPersonPaymentsFirstTransaction:
-            bannerTitle = Localization.inPersonPaymentsFirstTransactionBannerTitle
-            bannerTitle = Localization.inPersonPaymentsFirstTransactionBannerContent
-            campaign = .inPersonPaymentsFirstTransaction
-        case .inPersonPaymentsPowerUsers:
-            bannerTitle = Localization.inPersonPaymentsPowerUsersBannerTitle
-            bannerTitle = Localization.inPersonPaymentsPowerUsersBannerContent
-            campaign = .inPersonPaymentsPowerUsers
-        default:
-            break
-        }
-
-        let shareIPPFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.shareFeedbackButton, action: { [weak self] _ in
-            self?.displayIPPFeedbackBannerSurvey(survey: survey)
-            self?.viewModel.IPPFeedbackBannerCTATapped(for: campaign)
-            self?.viewModel.IPPFeedbackBannerWasSubmitted()
-        })
-
-        let viewModel = TopBannerViewModel(
-            title: bannerTitle,
-            infoText: bannerText,
-            icon: UIImage.commentContent,
-            isExpanded: true,
-            topButton: .dismiss(handler: {
-                self.showIPPFeedbackDismissAlert(survey: survey, campaign: campaign)
-            }),
-            actionButtons: [shareIPPFeedbackAction]
-        )
-        let topBannerView = TopBannerView(viewModel: viewModel)
-        topBannerView.translatesAutoresizingMaskIntoConstraints = false
-        return topBannerView
-    }
-
-    private func displayIPPFeedbackBannerSurvey(survey: SurveyViewController.Source) {
-        let surveyNavigation = SurveyCoordinatingController(survey: survey)
-        self.present(surveyNavigation, animated: true, completion: nil)
-    }
-
-    private func showIPPFeedbackDismissAlert(survey: SurveyViewController.Source, campaign: FeatureAnnouncementCampaign ) {
-        let actionSheet = UIAlertController(
-            title: Localization.dismissTitle,
-            message: Localization.dismissMessage,
-            preferredStyle: .alert
-        )
-
-        let remindMeLaterAction = UIAlertAction( title: Localization.remindMeLater, style: .default) { [weak self] _ in
-            self?.viewModel.IPPFeedbackBannerRemindMeLaterTapped(for: campaign)
-        }
-        actionSheet.addAction(remindMeLaterAction)
-
-        let dontShowAgainAction = UIAlertAction( title: Localization.dontShowAgain, style: .default) { [weak self] _ in
-            self?.viewModel.IPPFeedbackBannerDontShowAgainTapped(for: campaign)
-        }
-        actionSheet.addAction(dontShowAgainAction)
-
-        self.present(actionSheet, animated: true)
     }
 
     func allViewModels() -> [OrderDetailsViewModel] {

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -68,9 +68,6 @@ extension SurveyViewController {
         case addOnsI1
         case orderCreation
         case couponManagement
-        case inPersonPaymentsCashOnDelivery
-        case inPersonPaymentsFirstTransaction
-        case inPersonPaymentsPowerUsers
         case storeSetup
         case tapToPayFirstPayment
 
@@ -107,21 +104,6 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
-            case .inPersonPaymentsCashOnDelivery:
-                return WooConstants.URLs.inPersonPaymentsCashOnDeliveryFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-            case .inPersonPaymentsFirstTransaction:
-                return WooConstants.URLs.inPersonPaymentsFirstTransactionFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-            case .inPersonPaymentsPowerUsers:
-                return WooConstants.URLs.inPersonPaymentsPowerUsersFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
             case .storeSetup:
                 return WooConstants.URLs.storeSetupFeedback
                     .asURL()
@@ -137,7 +119,7 @@ extension SurveyViewController {
 
         fileprivate var title: String {
             switch self {
-            case .inAppFeedback, .inPersonPaymentsCashOnDelivery, .inPersonPaymentsFirstTransaction, .inPersonPaymentsPowerUsers:
+            case .inAppFeedback:
                 return Localization.title
             case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .storeSetup, .tapToPayFirstPayment:
                 return Localization.giveFeedback
@@ -159,12 +141,6 @@ extension SurveyViewController {
                 return .orderCreation
             case .couponManagement:
                 return .couponManagement
-            case .inPersonPaymentsCashOnDelivery:
-                return .inPersonPaymentsCashOnDeliveryBanner
-            case .inPersonPaymentsFirstTransaction:
-                return .inPersonPaymentsFirstTransactionBanner
-            case .inPersonPaymentsPowerUsers:
-                return .inPersonPaymentsPowerUsersBanner
             case .storeSetup:
                 return .storeSetup
             case .tapToPayFirstPayment:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -241,7 +241,7 @@ final class OrderListViewModelTests: XCTestCase {
 
     // MARK: - Banner visibility
 
-    func test_when_having_no_error_and_orders_banner_should_not_be_shown_shows_nothing() {
+    func test_when_having_no_error_and_orders_banner_should_not_be_shown_then_shows_nothing() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
@@ -256,7 +256,6 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.updateBannerVisibility()
-        viewModel.hideIPPFeedbackBanner = true
 
         // Then
         waitUntil {
@@ -264,36 +263,7 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_when_having_no_error_and_IPP_banner_should_be_shown_shows_IPP_banner() {
-        // Given
-        insertCODPaymentGateway()
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .US),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadFeedbackVisibility(.inPersonPayments, onCompletion):
-                onCompletion(.success(true))
-            default:
-                break
-            }
-        }
-        viewModel.activate()
-
-        // When
-        viewModel.updateBannerVisibility()
-        viewModel.hideIPPFeedbackBanner = false
-
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .inPersonPaymentsFeedback(.inPersonPaymentsCashOnDelivery)
-        }
-    }
-
-    func test_when_having_no_error_and_orders_banner_should_be_shown_shows_orders_banner() {
+    func test_when_having_no_error_and_orders_banner_should_be_shown_then_shows_orders_banner() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
@@ -308,40 +278,10 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.updateBannerVisibility()
-        viewModel.hideIPPFeedbackBanner = true
 
         // Then
         waitUntil {
             viewModel.topBanner == .orderCreation
-        }
-    }
-
-    func test_when_having_no_error_and_orders_banner_or_IPP_banner_should_be_shown_shows_correct_banner() {
-        // Given
-        insertCODPaymentGateway()
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .US),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadFeedbackVisibility(.ordersCreation, onCompletion):
-                onCompletion(.success(true))
-            default:
-                break
-            }
-        }
-        viewModel.activate()
-
-        // When
-        viewModel.updateBannerVisibility()
-
-        // Then
-        viewModel.hideIPPFeedbackBanner = false
-        waitUntil {
-            viewModel.topBanner == .inPersonPaymentsFeedback(.inPersonPaymentsCashOnDelivery)
         }
     }
 
@@ -384,14 +324,13 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_dismissing_banners_does_not_show_banners() {
+    func test_when_dismissing_banners_then_does_not_show_banners() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
         viewModel.activate()
 
         // When
         viewModel.updateBannerVisibility()
-        viewModel.hideIPPFeedbackBanner = true
         viewModel.hideOrdersBanners = true
 
         // Then
@@ -455,426 +394,6 @@ final class OrderListViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertFalse(resynchronizeRequested)
-    }
-
-// MARK: - In-Person Payments feedback banner tracks
-
-    func test_trackInPersonPaymentsFeedbackBannerShown_tracks_event_and_properties_correctly() {
-        // Given
-        let expectedEvent = WooAnalyticsStat.inPersonPaymentsBannerShown
-        let expectedCampaign = FeatureAnnouncementCampaign.inPersonPaymentsCashOnDelivery
-        let expectedSource = WooAnalyticsEvent.InPersonPaymentsFeedbackBanner.Source.orderList.rawValue
-
-        // When
-        let viewModel = OrderListViewModel(siteID: siteID, analytics: analytics, filters: nil)
-        viewModel.trackInPersonPaymentsFeedbackBannerShown(for: .inPersonPaymentsCashOnDelivery)
-
-        // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.first, expectedEvent.rawValue)
-        guard let actualProperties = analyticsProvider.receivedProperties.first(
-            where: { $0.keys.contains("source") }) else {
-            return XCTFail("Expected properties were not tracked"
-            )}
-        assertEqual(expectedCampaign.rawValue, actualProperties["campaign"] as? String)
-        assertEqual(expectedSource, actualProperties["source"] as? String)
-    }
-
-    func test_IPPFeedbackBannerCTATapped_tracks_event_and_properties_correctly() {
-        // Given
-        let expectedEvent = WooAnalyticsStat.inPersonPaymentsBannerTapped
-        let expectedCampaign = FeatureAnnouncementCampaign.inPersonPaymentsCashOnDelivery
-        let expectedSource = WooAnalyticsEvent.InPersonPaymentsFeedbackBanner.Source.orderList.rawValue
-
-        // When
-        let viewModel = OrderListViewModel(siteID: siteID, analytics: analytics, filters: nil)
-        viewModel.IPPFeedbackBannerCTATapped(for: .inPersonPaymentsCashOnDelivery)
-
-        // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.first, expectedEvent.rawValue)
-        guard let actualProperties = analyticsProvider.receivedProperties.first(
-            where: { $0.keys.contains("source") }) else {
-            return XCTFail("Expected properties were not tracked"
-            )}
-        assertEqual(expectedCampaign.rawValue, actualProperties["campaign"] as? String)
-        assertEqual(expectedSource, actualProperties["source"] as? String)
-    }
-
-    func test_IPPFeedbackBannerDontShowAgainTapped_tracks_dismiss_event_and_properties_correctly() {
-        // Given
-        let expectedEvent = WooAnalyticsStat.inPersonPaymentsBannerDismissed
-        let expectedCampaign = FeatureAnnouncementCampaign.inPersonPaymentsCashOnDelivery
-        let expectedSource = WooAnalyticsEvent.InPersonPaymentsFeedbackBanner.Source.orderList.rawValue
-        let expectedRemindLater = false
-
-        // When
-        let viewModel = OrderListViewModel(siteID: siteID, analytics: analytics, filters: nil)
-        viewModel.IPPFeedbackBannerDontShowAgainTapped(for: .inPersonPaymentsCashOnDelivery)
-
-        // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.first, expectedEvent.rawValue)
-        guard let actualProperties = analyticsProvider.receivedProperties.first(
-            where: { $0.keys.contains("source") }) else {
-            return XCTFail("Expected properties were not tracked"
-            )}
-        assertEqual(expectedCampaign.rawValue, actualProperties["campaign"] as? String)
-        assertEqual(expectedSource, actualProperties["source"] as? String)
-        assertEqual(expectedRemindLater, actualProperties["remind_later"] as? Bool)
-    }
-
-    func test_IPPFeedbackBannerRemindMeLaterTapped_tracks_dismiss_event_and_properties_correctly() {
-        // Given
-        let expectedEvent = WooAnalyticsStat.inPersonPaymentsBannerDismissed
-        let expectedCampaign = FeatureAnnouncementCampaign.inPersonPaymentsCashOnDelivery
-        let expectedSource = WooAnalyticsEvent.InPersonPaymentsFeedbackBanner.Source.orderList.rawValue
-        let expectedRemindLater = true
-
-        // When
-        let viewModel = OrderListViewModel(siteID: siteID, analytics: analytics, filters: nil)
-        viewModel.IPPFeedbackBannerRemindMeLaterTapped(for: .inPersonPaymentsCashOnDelivery)
-
-        // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.first, expectedEvent.rawValue)
-        guard let actualProperties = analyticsProvider.receivedProperties.first(
-            where: { $0.keys.contains("source") }) else {
-            return XCTFail("Expected properties were not tracked"
-            )}
-        assertEqual(expectedCampaign.rawValue, actualProperties["campaign"] as? String)
-        assertEqual(expectedSource, actualProperties["source"] as? String)
-        assertEqual(expectedRemindLater, actualProperties["remind_later"] as? Bool)
-    }
-
-// MARK: - In-Person Payments feedback banner survey
-
-    func test_feedbackBannerSurveySource_Cash_on_Delivery_store_in_an_IPP_country_with_non_WCPay_IPP_orders_is_shown_inPersonPaymentsCashOnDelivery_survey() {
-        // Given
-        insertCODPaymentGateway()
-
-        // This is not a WCPay order, so receipt_url does not denote an IPP order in this case
-        let _ = insertOrder(
-            id: 123,
-            status: .completed,
-            dateCreated: Date(),
-            datePaid: Date(),
-            customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/1902384")]
-        )
-
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .US),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.inPersonPaymentsCashOnDelivery, survey)
-    }
-
-    func test_feedbackBannerSurveySource_non_Cash_on_Delivery_store_in_an_IPP_country_without_WCPay_IPP_orders_is_not_shown_a_survey() {
-        // Given
-        // This is not a WCPay order, so receipt_url does not denote an IPP order in this case
-        let _ = insertOrder(
-            id: 123,
-            status: .completed,
-            dateCreated: Date(),
-            datePaid: Date(),
-            customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/1902384")]
-        )
-
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .US),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.none, survey)
-    }
-
-    func test_feedbackBannerSurveySource_Cash_on_Delivery_store_in_a_non_IPP_country_is_not_shown_a_survey() {
-        // Given
-        insertCODPaymentGateway()
-
-        // This is not a WCPay order, so receipt_url does not denote an IPP order in this case
-        let _ = insertOrder(
-            id: 123,
-            status: .completed,
-            dateCreated: Date(),
-            datePaid: Date(),
-            customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/1902384")]
-        )
-
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .AQ), // Antarctica ;)
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.none, survey)
-    }
-
-    func test_feedbackBannerSurveySource_Cash_on_Delivery_store_in_an_IPP_country_with_only_WCPay_web_orders_is_shown_inPersonPaymentsCashOnDelivery_survey() {
-        // Given
-        insertCODPaymentGateway()
-
-        // This is not an IPP order, as it has no receipt_url
-        let _ = insertOrder(
-            id: 123,
-            status: .completed,
-            dateCreated: Date(),
-            datePaid: Date(),
-            customFields: [],
-            paymentMethodID: "woocommerce_payments"
-        )
-
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .US),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.inPersonPaymentsCashOnDelivery, survey)
-    }
-
-    func test_feedbackBannerSurveySource_when_there_are_less_than_ten_wcpay_orders_then_assigns_inPersonPaymentsFirstTransaction_survey() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .CA),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        let _ = (0..<9).map { orderID in
-            let metaDataID = Int64(orderID + 100)
-            return insertOrder(
-                id: Int64(orderID),
-                status: .completed,
-                dateCreated: Date(),
-                datePaid: Date(),
-                customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
-                paymentMethodID: "woocommerce_payments"
-            )
-        }
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 9)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.inPersonPaymentsFirstTransaction, survey)
-    }
-
-    func test_feedbackBannerSurveySource_when_there_are_less_than_ten_wcpay_orders_all_older_than_30_days_then_no_survey() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .CA),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        let thirtyOneDaysAgo = Date().adding(days: -31) ?? Date()
-        let _ = (0..<9).map { orderID in
-            let metaDataID = Int64(orderID + 100)
-            return insertOrder(
-                id: Int64(orderID),
-                status: .completed,
-                dateCreated: thirtyOneDaysAgo,
-                datePaid: thirtyOneDaysAgo,
-                customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
-                paymentMethodID: "woocommerce_payments"
-            )
-        }
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 9)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.none, survey)
-    }
-
-    func test_feedbackBannerSurveySource_when_there_are_more_than_ten_wcpay_orders_then_assigns_inPersonPaymentsPowerUsers_survey() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .CA),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        let _ = (0..<15).map { orderID in
-            let metaDataID = Int64(orderID + 100)
-            return insertOrder(
-                id: Int64(orderID),
-                status: .completed,
-                dateCreated: Date(),
-                datePaid: Date(),
-                customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
-                paymentMethodID: "woocommerce_payments"
-            )
-        }
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 15)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.inPersonPaymentsPowerUsers, survey)
-    }
-
-    func test_feedbackBannerSurveySource_when_there_are_ten_or_more_wcpay_ipp_orders_all_older_than_30_days_then_assigns_inPersonPaymentsPowerUsers_survey() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           cardPresentPaymentsConfiguration: .init(country: .CA),
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           filters: nil)
-
-        let thirtyOneDaysAgo = Date().adding(days: -31) ?? Date()
-        let _ = (0..<10).map { orderID in
-            let metaDataID = Int64(orderID + 100)
-            return insertOrder(
-                id: Int64(orderID),
-                status: .completed,
-                dateCreated: thirtyOneDaysAgo,
-                datePaid: thirtyOneDaysAgo,
-                customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
-                paymentMethodID: "woocommerce_payments"
-            )
-        }
-
-        // Confidence check
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 10)
-
-        // When
-        let survey = viewModel.feedbackBannerSurveySource()
-
-        // Then
-        assertEqual(.inPersonPaymentsPowerUsers, survey)
-    }
-
-    func test_IPPFeedbackBannerWasSubmitted_hides_banner_after_being_called() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID, filters: nil)
-
-        // When
-        viewModel.IPPFeedbackBannerWasSubmitted()
-        viewModel.dataLoadingError = nil
-        viewModel.hideOrdersBanners = true
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .none
-        }
-    }
-
-    func test_IPPFeedbackBannerWasSubmitted_then_it_calls_updateFeedbackStatus_with_right_parameters() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
-        var updatedFeedbackStatus: FeedbackSettings.Status?
-        var receivedFeedbackType: FeedbackType?
-
-        // When
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .updateFeedbackStatus(type, status, onCompletion):
-                receivedFeedbackType = type
-                updatedFeedbackStatus = status
-                onCompletion(.success(()))
-            default:
-                break
-            }
-        }
-
-        viewModel.activate()
-        viewModel.IPPFeedbackBannerWasSubmitted()
-
-        // Then
-        XCTAssertTrue(viewModel.hideIPPFeedbackBanner)
-
-        XCTAssertEqual(receivedFeedbackType, .inPersonPayments)
-
-        switch updatedFeedbackStatus {
-        case .given:
-            break
-        default:
-            XCTFail()
-        }
-    }
-
-    func test_IPPFeedbackBannerWasSubmitted_then_it_calls_setFeatureAnnouncementDismissed_with_right_parameters() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
-        var receivedCampaign: FeatureAnnouncementCampaign?
-        var receivedRemindAfterDays: Int?
-
-        // When
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .setFeatureAnnouncementDismissed(campaign, remindAfterDays, _):
-                receivedRemindAfterDays = remindAfterDays
-                receivedCampaign = campaign
-            default:
-                break
-            }
-        }
-
-        viewModel.activate()
-        viewModel.IPPFeedbackBannerWasSubmitted()
-
-        // Then
-        XCTAssertEqual(receivedCampaign, .inPersonPaymentsPowerUsers)
-        XCTAssertNil(receivedRemindAfterDays)
-    }
-
-    func test_feedback_status_when_IPPFeedbackBannerWasSubmitted_is_not_called_then_feedback_status_is_nil() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
-        var feedbackStatus: FeedbackSettings.Status?
-
-        // When
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .updateFeedbackStatus(.inPersonPayments, status, onCompletion):
-                feedbackStatus = status
-                onCompletion(.success(()))
-            default:
-                break
-            }
-        }
-        viewModel.activate()
-
-        // Then
-        assertEqual(nil, feedbackStatus)
     }
 
     // MARK: - `shouldEnableTestOrder`

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,7 +37,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .shippingLabelsRelease3, .couponManagement, .ordersCreation, .inPersonPayments:
+        case .shippingLabelsRelease3, .couponManagement, .ordersCreation:
             return settings.feedbackStatus(of: feedbackType) == .pending
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11276
Apologies for the large PR, ~500 lines of it belongs to test removal and cannot be done on a separate PR.

## Description
This PR removes the IPP feedback banner from the Order view which was shown to merchants based on different scenarios. This was a temporary feature to gather feedback, and now it's a good time to remove it:

> We implemented it with the plan to remove it a couple months later. The solution uses several workarounds and is far from perfect. Since it’s also the only place where we use receipt_url order metadata which we might want to remove from the backend, I think removing its usage in the apps would be a good first step.

## Changes
- Removed logic from `OrderListViewModel` and `OrderListViewController`, so the banner is only used for other feedback types (order creation, and displaying errors)
- Removed track events and survey links to the different IPP merchants categories (CashOnDeliveryFeedback, FirstTransactionFeedback, PowerUsersFeedback)
- Updated Unit Tests

## Testing instructions
1. On a fresh store (I believe this is the only requirement), confirm that the Order creation banner still appears and works (screenshot 1). On an unrelated note, it might also be a good time to remove this one. Opened discussion here: p91TBi-aPz-p2
2. On any store, with connectivity off, confirm that the error banner still appears and works (screenshot 2)

## Screenshots
| Order creation banner | Error banner |
|--------|--------|
| <img width="800" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/356a13a1-8bb9-439b-8d32-477ba9cd9db3"> | <img width=800 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/7aead7c6-01f7-412b-948d-8a67d2fea958"> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.