### PR TITLE
Product Subscriptions: One time shipping label

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 16.7
 -----
 - [*] Edit Products: category list is now searchable. [https://github.com/woocommerce/woocommerce-ios/pull/11380]
+- [*] Show one time shipping setting status in product details screen. [https://github.com/woocommerce/woocommerce-ios/pull/11403]
 
 
 16.6

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -367,6 +367,11 @@ private extension DefaultProductFormTableViewModel {
             }
         }
 
+        // One time shipping
+        if product.subscription?.oneTimeShipping == true {
+            shippingDetails.append(Localization.oneTimeShippingEnabled)
+        }
+
         let details: String? = shippingDetails.isEmpty ? nil: shippingDetails.joined(separator: "\n")
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
@@ -691,6 +696,11 @@ extension DefaultProductFormTableViewModel {
         static let neverExpire = NSLocalizedString("defaultProductFormTableViewModel.neverExpire",
                                                    value: "Never expires",
                                                    comment: "Display label when a subscription never expires.")
+
+        // Shipping
+        static let oneTimeShippingEnabled = NSLocalizedString("defaultProductFormTableViewModel.shipping.oneTimeShippingEnabled",
+                                                          value: "One time shipping: Enabled",
+                                                          comment: "Text to show that one time shipping is enabled for this product.")
 
         /// Localized string describing when the subscription expires.
         ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -414,8 +414,16 @@ private extension ProductFormActionsFactory {
             let hasStockData = product.manageStock ? product.stockQuantity != nil: true
             return product.sku != nil || hasStockData
         case .shippingSettings:
-            return product.weight.isNilOrEmpty == false ||
-                product.dimensions.height.isNotEmpty || product.dimensions.width.isNotEmpty || product.dimensions.length.isNotEmpty
+            let shouldShowOneTimeShipping = {
+                guard product.productType == .subscription || product.productType == .variableSubscription else {
+                    return false
+                }
+                return product.subscription?.oneTimeShipping == true
+            }()
+
+            return product.weight.isNilOrEmpty == false
+            || product.dimensions.height.isNotEmpty || product.dimensions.width.isNotEmpty || product.dimensions.length.isNotEmpty
+            || shouldShowOneTimeShipping
         case .addOns:
             return addOnsFeatureEnabled && product.hasAddOns
         case .categories:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -170,6 +170,136 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         XCTAssertEqual(shippingViewModel?.details, "Weight: 1,6\(weightUnit)\nDimensions: 2,9 x 1,1 x 113 \(dimensionUnit)")
     }
 
+    func test_shipping_settings_row_displays_one_time_shipping_text_for_subscription_product_if_setting_enabled() {
+        // Given
+        let product = Product.fake()
+            .copy(productTypeKey: ProductType.subscription.rawValue,
+                  subscription: .fake().copy(trialLength: "0",
+                                             oneTimeShipping: true,
+                                             paymentSyncDate: "0"))
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "",
+                                                              isDescriptionAIEnabled: true)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var shippingViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .shipping(viewModel, _) = row {
+                shippingViewModel = viewModel
+                break
+            }
+        }
+
+        XCTAssertTrue(shippingViewModel?.details?.contains(DefaultProductFormTableViewModel.Localization.oneTimeShippingEnabled) == true)
+    }
+
+    func test_shipping_settings_row_displays_one_time_shipping_text_for_variable_subscription_product_if_setting_enabled() {
+        // Given
+        let product = Product.fake()
+            .copy(productTypeKey: ProductType.variableSubscription.rawValue,
+                  subscription: .fake().copy(trialLength: "0",
+                                             oneTimeShipping: true,
+                                             paymentSyncDate: "0"))
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "",
+                                                              isDescriptionAIEnabled: true)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var shippingViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .shipping(viewModel, _) = row {
+                shippingViewModel = viewModel
+                break
+            }
+        }
+
+        XCTAssertTrue(shippingViewModel?.details?.contains(DefaultProductFormTableViewModel.Localization.oneTimeShippingEnabled) == true)
+    }
+
+    func test_shipping_settings_row_does_not_display_one_time_shipping_text_for_subscription_product_if_setting_disabled() {
+        // Given
+        let product = Product.fake()
+            .copy(productTypeKey: ProductType.subscription.rawValue,
+                  subscription: .fake().copy(trialLength: "0",
+                                             oneTimeShipping: false,
+                                             paymentSyncDate: "0"))
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "",
+                                                              isDescriptionAIEnabled: true)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var shippingViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .shipping(viewModel, _) = row {
+                shippingViewModel = viewModel
+                break
+            }
+        }
+
+        let hasOneTimeShippingEnabledLabel = shippingViewModel?.details?.contains(DefaultProductFormTableViewModel.Localization.oneTimeShippingEnabled) ?? false
+        XCTAssertFalse(hasOneTimeShippingEnabledLabel)
+    }
+
+    func test_shipping_settings_row_does_not_display_one_time_shipping_text_for_non_subscription_product_types() {
+        // Given
+        let product = Product.fake()
+            .copy(productTypeKey: ProductType.simple.rawValue,
+                  subscription: .fake().copy(trialLength: "0",
+                                             oneTimeShipping: true,
+                                             paymentSyncDate: "0"))
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "",
+                                                              isDescriptionAIEnabled: true)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var shippingViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .shipping(viewModel, _) = row {
+                shippingViewModel = viewModel
+                break
+            }
+        }
+
+        let hasOneTimeShippingEnabledLabel = shippingViewModel?.details?.contains(DefaultProductFormTableViewModel.Localization.oneTimeShippingEnabled) ?? false
+        XCTAssertFalse(hasOneTimeShippingEnabledLabel)
+    }
+
     // MARK: Subscription free trial
 
     func test_subscription_free_trial_row_returns_expected_details_with_singular_format() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11401 

## Description

This PR adds a new label "One time shipping: Enabled" to the settings section of the product form if the following conditions are met. 
1. Product is of subscription or variable subscription type.
2. One time shipping setting is turned on. 

## Testing instructions

Prerequisite
Create a JN site, install Woo Subscriptions plugin and create a subscriptions product.

Steps
- Login into the app using the above JN site
- Open a subscription product.
- Turn on the "One time shipping" setting (from Add more details -> Shipping)
- Go back to the product details form.
- Confirm that the "Shipping" section displays "One time shipping: Enabled" text in it.
- Turn off the "One time shipping" setting and ensure that "One time shipping: Enabled" text is not displayed anymore

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| One time shipping ON | One time shipping OFF |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-12-11 at 10 52 29](https://github.com/woocommerce/woocommerce-ios/assets/524475/518ca272-d4f7-42f7-8b80-e4e6cf6159fe) | ![Simulator Screenshot - iPhone 14 Pro - 2023-12-11 at 10 52 24](https://github.com/woocommerce/woocommerce-ios/assets/524475/c183985b-7e04-4350-9d7d-95ae0f36fb3a) | 


https://github.com/woocommerce/woocommerce-ios/assets/524475/b012e68c-290d-4792-bbf1-8b14fb4c443f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
