### PR TITLE
[Order form] Remove unused `canChangeQuantity` property from `CollapsibleProductRowCardViewModel`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -379,8 +379,7 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
     static var previews: some View {
         let product = Product.swiftUIPreviewSample()
         let productViewModel = ProductRowViewModel(product: product)
-        let rowViewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                              hasParentProduct: false,
+        let rowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                               isReadOnly: false,
                                                               productViewModel: productViewModel,
                                                               stepperViewModel: .init(quantity: 1,
@@ -388,20 +387,18 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
                                                                                       quantityUpdatedCallback: { _ in }))
         let viewModel = CollapsibleProductCardViewModel(productRow: rowViewModel, childProductRows: [])
 
-        let readOnlyRowViewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                              hasParentProduct: false,
-                                                              isReadOnly: true,
-                                                              productViewModel: productViewModel,
-                                                              stepperViewModel: .init(quantity: 1,
-                                                                                      name: "",
-                                                                                      quantityUpdatedCallback: { _ in }))
+        let readOnlyRowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
+                                                                      isReadOnly: true,
+                                                                      productViewModel: productViewModel,
+                                                                      stepperViewModel: .init(quantity: 1,
+                                                                                              name: "",
+                                                                                              quantityUpdatedCallback: { _ in }))
         let readOnlyViewModel = CollapsibleProductCardViewModel(productRow: readOnlyRowViewModel, childProductRows: [])
 
         let childViewModels = [ProductRowViewModel(id: 2, product: product),
                                ProductRowViewModel(id: 3, product: product)]
             .map {
-                CollapsibleProductRowCardViewModel(canChangeQuantity: false,
-                                                   hasParentProduct: true,
+                CollapsibleProductRowCardViewModel(hasParentProduct: true,
                                                    isReadOnly: false,
                                                    productViewModel: $0,
                                                    stepperViewModel: .init(quantity: 1,
@@ -412,8 +409,7 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
                                                            product: product
             .copy(productTypeKey: ProductType.bundle.rawValue, bundledItems: [.swiftUIPreviewSample()]),
                                                            configure: {})
-        let bundleParentRowViewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                                          hasParentProduct: false,
+        let bundleParentRowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                                           isReadOnly: false,
                                                                           productViewModel: bundleParentProductViewModel,
                                                                           stepperViewModel: .init(quantity: 1,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
@@ -28,10 +28,6 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
         productViewModel.id
     }
 
-    /// Whether the product quantity can be changed.
-    /// Controls whether the stepper is rendered.
-    let canChangeQuantity: Bool
-
     /// Whether a product in an order item has a parent order item
     let hasParentProduct: Bool
 
@@ -46,14 +42,12 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
     private let currencyFormatter: CurrencyFormatter
     private let analytics: Analytics
 
-    init(canChangeQuantity: Bool,
-         hasParentProduct: Bool = false,
+    init(hasParentProduct: Bool = false,
          isReadOnly: Bool = false,
          productViewModel: ProductRowViewModel,
          stepperViewModel: ProductStepperViewModel,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics) {
-        self.canChangeQuantity = canChangeQuantity
         self.hasParentProduct = hasParentProduct
         self.isReadOnly = isReadOnly
         self.productViewModel = productViewModel

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -22,25 +22,21 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let childProductRows = [ProductRowViewModel(product: .fake()),
                                 ProductRowViewModel(product: .fake())]
             .map {
-                CollapsibleProductRowCardViewModel(canChangeQuantity: false,
-                                                   productViewModel: $0,
+                CollapsibleProductRowCardViewModel(productViewModel: $0,
                                                    stepperViewModel: .init(quantity: 1,
                                                                            name: "",
                                                                            quantityUpdatedCallback: { _ in }))
             }
 
         // When
-        let rowViewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                              productViewModel: .init(product: product),
+        let rowViewModel = CollapsibleProductRowCardViewModel(productViewModel: .init(product: product),
                                                               stepperViewModel: .init(quantity: 1,
                                                                                       name: "",
                                                                                       quantityUpdatedCallback: { _ in }))
         let viewModel = CollapsibleProductCardViewModel(productRow: rowViewModel, childProductRows: childProductRows)
 
         // Then
-        XCTAssertTrue(viewModel.productRow.canChangeQuantity)
         XCTAssertEqual(viewModel.childProductRows.count, 2)
-        XCTAssertFalse(try XCTUnwrap(viewModel.childProductRows[0]).canChangeQuantity)
     }
 
     func test_view_model_updates_price_label_when_quantity_changes() {
@@ -49,8 +45,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: false,
-                                                           productViewModel: .init(product: product, currencyFormatter: currencyFormatter),
+        let viewModel = CollapsibleProductRowCardViewModel(productViewModel: .init(product: product, currencyFormatter: currencyFormatter),
                                                            stepperViewModel: .init(quantity: 1,
                                                                                    name: "",
                                                                                    quantityUpdatedCallback: { _ in }))
@@ -64,8 +59,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_isReadOnly_and_hasParentProduct_are_false_by_default() {
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           productViewModel: .init(product: .fake()),
+        let viewModel = CollapsibleProductRowCardViewModel(productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 1,
                                                                                    name: "",
                                                                                    quantityUpdatedCallback: { _ in }))
@@ -79,8 +73,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_ProductStepperViewModel_and_ProductRowViewModel_quantity_have_the_same_initial_value() {
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
@@ -94,8 +87,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_ProductStepperViewModel_quantity_change_updates_ProductRowViewModel_quantity() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
@@ -114,8 +106,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_productRow_when_add_discount_button_is_tapped_then_orderProductDiscountAddButtonTapped_is_tracked() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
@@ -132,8 +123,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_productRow_when_edit_discount_button_is_tapped_then_orderProductDiscountEditButtonTapped_is_tracked() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
@@ -156,8 +146,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: product, discount: nil, quantity: 1),
                                                            stepperViewModel: .init(quantity: 2,
@@ -175,8 +164,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: product, discount: discount, quantity: 1),
                                                            stepperViewModel: .init(quantity: 2,
@@ -196,8 +184,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: product, discount: discount, quantity: 1),
                                                            stepperViewModel: .init(quantity: 1,
@@ -216,8 +203,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(canChangeQuantity: true,
-                                                           hasParentProduct: false,
+        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
                                                            productViewModel: .init(product: product, discount: discount, quantity: quantity),
                                                            stepperViewModel: .init(quantity: quantity,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11392 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As @rachelmcr pointed out in https://github.com/woocommerce/woocommerce-ios/pull/11383#discussion_r1420342141, the `canChangeQuantity` property is no longer needed now that the responsibility of determining whether the quantity stepper is shown has been moved out of the product row. This PR removes the `canChangeQuantity` property from `CollapsibleProductRowCardViewModel` as the view model uses `isReadOnly` to show the quantity stepper instead.

## How

The changes are relatively more straightforward than the previous PRs, as they are mostly about the removal of the property/parameter and no views depend on it.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

No changes on the order form UX are expected. For confidence checks, we can test the following:

- The product rows are not editable when the order is readonly
- The quantity cannot be changed for child product rows of a bundle product in an order

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
