### PR TITLE
[Scan to update inventory M1] Displays notice on update inventory success, and error

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -297,10 +297,17 @@ private extension ProductsViewController {
 
                 do {
                     let scannedItem = try await self.viewModel.handleScannedBarcode(scannedBarcode)
-                    self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem, 
+                    self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem,
                                                                                           siteID: self.viewModel.siteID,
                                                                                           onUpdatedInventory: {
-                        self.presentNotice(title: "Quantity updated") })), animated: true)
+                        var stockQuantity: String {
+                            guard let stock = scannedItem.inventoryItem.stockQuantity else {
+                                return ""
+                            }
+                            return "\(stock)"
+                        }
+
+                        self.presentNotice(title: "Quantity updated: \(stockQuantity)")})), animated: true)
                 } catch {
                     DDLogError("There was an error when attempting to update inventory via scanner: \(error)")
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -298,10 +298,12 @@ private extension ProductsViewController {
                 do {
                     let scannedItem = try await self.viewModel.handleScannedBarcode(scannedBarcode)
                     self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem,
-                                                                                          siteID: self.viewModel.siteID)),
-                                 animated: true)
+                                                                                          siteID: self.viewModel.siteID, 
+                                                                                          onUpdatedInventory: {
+                        self.presentNotice(title: "Quantity updated")
+                    })), animated: true)
                 } catch {
-                    // TODO: Show error notices
+                    DDLogError("There was an error when attempting to update inventory via scanner: \(error)")
                 }
             }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1474,7 +1474,8 @@ private extension ProductsViewController {
         static let updateErrorNotice = NSLocalizedString("Cannot update products",
                                                          comment: "Title of the notice when there is an error updating selected products")
         static let updateInventoryNotice = NSLocalizedString(
-            "Quantity updated: %@",
+            "updateInventoryNotice.scanProducts.createAddOrderByProductScanningButtonItem",
+            value: "Quantity updated: %@",
             comment: "Message of the notice when inventory is updated successfully. Style may vary based on store settings." +
             "Reads like: 'Quantity updated: 2,345'"
         )

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -297,11 +297,10 @@ private extension ProductsViewController {
 
                 do {
                     let scannedItem = try await self.viewModel.handleScannedBarcode(scannedBarcode)
-                    self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem,
-                                                                                          siteID: self.viewModel.siteID, 
+                    self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem, 
+                                                                                          siteID: self.viewModel.siteID,
                                                                                           onUpdatedInventory: {
-                        self.presentNotice(title: "Quantity updated")
-                    })), animated: true)
+                        self.presentNotice(title: "Quantity updated") })), animated: true)
                 } catch {
                     DDLogError("There was an error when attempting to update inventory via scanner: \(error)")
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -299,8 +299,8 @@ private extension ProductsViewController {
                     let scannedItem = try await self.viewModel.handleScannedBarcode(scannedBarcode)
                     self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem,
                                                                                           siteID: self.viewModel.siteID,
-                                                                                          onUpdatedInventory: {
-                        let noticeMessage = self.prepareNotice(forStockQuantity: scannedItem.inventoryItem.stockQuantity)
+                                                                                          onUpdatedInventory: { newQuantity in
+                        let noticeMessage = String.localizedStringWithFormat(Localization.updateInventoryNotice, newQuantity)
                         self.presentNotice(title: noticeMessage)
                     })), animated: true)
                 } catch {
@@ -318,14 +318,6 @@ private extension ProductsViewController {
 
     @objc func addProduct(_ sender: UIBarButtonItem) {
         addProduct(sourceBarButtonItem: sender, isFirstProduct: false)
-    }
-
-    private func prepareNotice(forStockQuantity stockQuantity: Decimal? = nil) -> String {
-        guard let stockQuantity = stockQuantity else {
-            return Localization.updateInventoryNotice
-        }
-        let stockQuantityToString = "\(stockQuantity)"
-        return String.localizedStringWithFormat(Localization.updateInventoryNotice, stockQuantityToString)
     }
 
     func addProduct(sourceBarButtonItem: UIBarButtonItem? = nil,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -300,14 +300,9 @@ private extension ProductsViewController {
                     self.present(UIHostingController(rootView: UpdateProductInventoryView(inventoryItem: scannedItem.inventoryItem,
                                                                                           siteID: self.viewModel.siteID,
                                                                                           onUpdatedInventory: {
-                        var stockQuantity: String {
-                            guard let stock = scannedItem.inventoryItem.stockQuantity else {
-                                return ""
-                            }
-                            return "\(stock)"
-                        }
-
-                        self.presentNotice(title: "Quantity updated: \(stockQuantity)")})), animated: true)
+                        let noticeMessage = self.prepareNotice(forStockQuantity: scannedItem.inventoryItem.stockQuantity)
+                        self.presentNotice(title: noticeMessage)
+                    })), animated: true)
                 } catch {
                     DDLogError("There was an error when attempting to update inventory via scanner: \(error)")
                 }
@@ -323,6 +318,14 @@ private extension ProductsViewController {
 
     @objc func addProduct(_ sender: UIBarButtonItem) {
         addProduct(sourceBarButtonItem: sender, isFirstProduct: false)
+    }
+
+    private func prepareNotice(forStockQuantity stockQuantity: Decimal? = nil) -> String {
+        guard let stockQuantity = stockQuantity else {
+            return Localization.updateInventoryNotice
+        }
+        let stockQuantityToString = "\(stockQuantity)"
+        return String.localizedStringWithFormat(Localization.updateInventoryNotice, stockQuantityToString)
     }
 
     func addProduct(sourceBarButtonItem: UIBarButtonItem? = nil,
@@ -1430,7 +1433,6 @@ private extension ProductsViewController {
     }
 
     enum Localization {
-
         static let bulkEditingNavBarButtonTitle = NSLocalizedString("Edit products", comment: "Action to start bulk editing of products")
         static let bulkEditingNavBarButtonHint = NSLocalizedString(
             "Edit status or price for multiple products at once",
@@ -1471,5 +1473,10 @@ private extension ProductsViewController {
                                                            comment: "Title of the notice when a user updated price for selected products")
         static let updateErrorNotice = NSLocalizedString("Cannot update products",
                                                          comment: "Title of the notice when there is an error updating selected products")
+        static let updateInventoryNotice = NSLocalizedString(
+            "Quantity updated: %@",
+            comment: "Message of the notice when inventory is updated successfully. Style may vary based on store settings." +
+            "Reads like: 'Quantity updated: 2,345'"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -98,8 +98,14 @@ struct UpdateProductInventoryView: View {
 
                             Button(Localization.increaseStockOnceButtonTitle) {
                                 Task { @MainActor in
-                                    await viewModel.onTapIncreaseStockQuantityOnce()
-                                    dismiss()
+                                    do {
+                                        try await viewModel.onTapIncreaseStockQuantityOnce()
+                                        onUpdatedInventory(viewModel.quantity)
+                                        dismiss()
+                                    } catch {
+                                        let productName = viewModel.name
+                                        displayErrorNotice(productName, error)
+                                    }
                                 }
                             }
                             .renderedIf(viewModel.updateQuantityButtonMode == .increaseOnce)

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -19,9 +19,12 @@ struct UpdateProductInventoryView: View {
         viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, siteID: siteID)
     }
 
-    private func displayErrorNotice() {
-        // Assign notice
-        viewModel.displayErrorNotice()
+    private func displayErrorNotice(_ productName: String, _ error: Error? = nil) {
+        if let error = error {
+            DDLogError("Update inventory error: \(error)")
+        }
+        viewModel.displayErrorNotice(productName)
+
         // Hide keyboard
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
                                         to: nil, from: nil, for: nil)
@@ -86,7 +89,8 @@ struct UpdateProductInventoryView: View {
                                         onUpdatedInventory()
                                         dismiss()
                                     } catch {
-                                        displayErrorNotice()
+                                        let productName = viewModel.name
+                                        displayErrorNotice(productName, error)
                                     }
                                 }
                             }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -12,7 +12,10 @@ struct UpdateProductInventoryView: View {
 
     @State private var isKeyboardVisible = false
 
-    init(inventoryItem: InventoryItem, siteID: Int64) {
+    var onUpdatedInventory: (() -> ())
+
+    init(inventoryItem: InventoryItem, siteID: Int64, onUpdatedInventory: @escaping (() -> ())) {
+        self.onUpdatedInventory = onUpdatedInventory
         viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, siteID: siteID)
     }
 
@@ -80,6 +83,7 @@ struct UpdateProductInventoryView: View {
                                 Task { @MainActor in
                                     do {
                                         try await viewModel.onTapUpdateStockQuantity()
+                                        onUpdatedInventory()
                                         dismiss()
                                     } catch {
                                         displayErrorNotice()

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -16,6 +16,14 @@ struct UpdateProductInventoryView: View {
         viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, siteID: siteID)
     }
 
+    private func displayErrorNotice() {
+        // Assign notice
+        viewModel.notice = viewModel.makeNotice()
+        // Hide keyboard
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                        to: nil, from: nil, for: nil)
+    }
+
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
@@ -70,8 +78,12 @@ struct UpdateProductInventoryView: View {
                         Group {
                             Button(Localization.updateQuantityButtonTitle) {
                                 Task { @MainActor in
-                                    await viewModel.onTapUpdateStockQuantity()
-                                    dismiss()
+                                    do {
+                                        try await viewModel.onTapUpdateStockQuantity()
+                                        dismiss()
+                                    } catch {
+                                        displayErrorNotice()
+                                    }
                                 }
                             }
                             .renderedIf(viewModel.updateQuantityButtonMode == .customQuantity)
@@ -102,6 +114,7 @@ struct UpdateProductInventoryView: View {
                     .onReceive(Publishers.keyboardHeight) { keyboardHeight in
                         isKeyboardVisible = keyboardHeight > 0
                     }
+                    .notice($viewModel.notice)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -13,7 +13,7 @@ struct UpdateProductInventoryView: View {
     @State private var isKeyboardVisible = false
 
     init(inventoryItem: InventoryItem, siteID: Int64, onUpdatedInventory: @escaping ((String) -> ())) {
-        viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, 
+        viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem,
                                                     siteID: siteID,
                                                     onUpdatedInventory: onUpdatedInventory)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -12,9 +12,9 @@ struct UpdateProductInventoryView: View {
 
     @State private var isKeyboardVisible = false
 
-    var onUpdatedInventory: (() -> ())
+    var onUpdatedInventory: ((String) -> ())
 
-    init(inventoryItem: InventoryItem, siteID: Int64, onUpdatedInventory: @escaping (() -> ())) {
+    init(inventoryItem: InventoryItem, siteID: Int64, onUpdatedInventory: @escaping ((String) -> ())) {
         self.onUpdatedInventory = onUpdatedInventory
         viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, siteID: siteID)
     }
@@ -86,7 +86,7 @@ struct UpdateProductInventoryView: View {
                                 Task { @MainActor in
                                     do {
                                         try await viewModel.onTapUpdateStockQuantity()
-                                        onUpdatedInventory()
+                                        onUpdatedInventory(viewModel.quantity)
                                         dismiss()
                                     } catch {
                                         let productName = viewModel.name

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -21,7 +21,7 @@ struct UpdateProductInventoryView: View {
 
     private func displayErrorNotice() {
         // Assign notice
-        viewModel.notice = viewModel.makeNotice()
+        viewModel.displayErrorNotice()
         // Hide keyboard
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
                                         to: nil, from: nil, for: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -12,11 +12,10 @@ struct UpdateProductInventoryView: View {
 
     @State private var isKeyboardVisible = false
 
-    var onUpdatedInventory: ((String) -> ())
-
     init(inventoryItem: InventoryItem, siteID: Int64, onUpdatedInventory: @escaping ((String) -> ())) {
-        self.onUpdatedInventory = onUpdatedInventory
-        viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, siteID: siteID)
+        viewModel = UpdateProductInventoryViewModel(inventoryItem: inventoryItem, 
+                                                    siteID: siteID,
+                                                    onUpdatedInventory: onUpdatedInventory)
     }
 
     private func displayErrorNotice(_ productName: String, _ error: Error? = nil) {
@@ -86,7 +85,6 @@ struct UpdateProductInventoryView: View {
                                 Task { @MainActor in
                                     do {
                                         try await viewModel.onTapUpdateStockQuantity()
-                                        onUpdatedInventory(viewModel.quantity)
                                         dismiss()
                                     } catch {
                                         let productName = viewModel.name
@@ -100,7 +98,6 @@ struct UpdateProductInventoryView: View {
                                 Task { @MainActor in
                                     do {
                                         try await viewModel.onTapIncreaseStockQuantityOnce()
-                                        onUpdatedInventory(viewModel.quantity)
                                         dismiss()
                                     } catch {
                                         let productName = viewModel.name

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -104,11 +104,15 @@ final class UpdateProductInventoryViewModel: ObservableObject {
     let inventoryItem: InventoryItem
     private let stores: StoresManager
 
+    var onUpdatedInventory: ((String) -> ())
+
     init(inventoryItem: InventoryItem,
          siteID: Int64,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         onUpdatedInventory: @escaping ((String) -> ())) {
         self.inventoryItem = inventoryItem
         self.stores = stores
+        self.onUpdatedInventory = onUpdatedInventory
 
         quantity = inventoryItem.stockQuantity?.formatted() ?? ""
 
@@ -187,6 +191,7 @@ private extension UpdateProductInventoryViewModel {
 
         do {
             try await inventoryItem.updateStockQuantity(with: newQuantity, stores: stores)
+            onUpdatedInventory(newQuantity.formatted())
         } catch {
             isPrimaryButtonLoading = false
             throw UpdateInventoryError.generic

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -175,8 +175,8 @@ final class UpdateProductInventoryViewModel: ObservableObject {
     }
 
     func displayErrorNotice(_ productName: String) {
-        notice =  Notice(title: "Update Inventory Error",
-                         message: "There was an error updating \(productName). Please try again.",
+        notice =  Notice(title: Localization.errorNoticetitle,
+                         message: String.localizedStringWithFormat(Localization.errorNoticeMessage, productName),
                          feedbackType: .error)
     }
 }
@@ -194,5 +194,19 @@ private extension UpdateProductInventoryViewModel {
 
         isPrimaryButtonLoading = false
         updateQuantityButtonMode = .increaseOnce
+    }
+}
+
+private extension UpdateProductInventoryViewModel {
+    struct Localization {
+        static let errorNoticetitle = NSLocalizedString(
+            "errorNoticeTitle.displayErrorNotice.UpdateProductInventoryViewModel",
+            value: "Update Inventory Error",
+            comment: "Title of the notice when inventory fails to be updated.")
+        static let errorNoticeMessage = NSLocalizedString(
+            "errorNoticeMessage.displayErrorNotice.UpdateProductInventoryViewModel",
+            value: "There was an error updating %@. Please try again.",
+            comment: "Message of the notice when inventory fails to be updated" +
+            "Reads like: 'There was an error updating My Product Name. Please try again.'")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -155,27 +155,17 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         guard let quantityDecimal = Decimal(string: quantity) else {
             return
         }
-
         let newQuantity = quantityDecimal + 1
         quantity = newQuantity.formatted()
 
-        do {
-            try await updateStockQuantity(with: newQuantity)
-        } catch {
-            throw UpdateInventoryError.generic
-        }
+        try await updateStockQuantity(with: newQuantity)
     }
 
     func onTapUpdateStockQuantity() async throws {
         guard let quantityDecimal = Decimal(string: quantity) else {
             throw UpdateInventoryError.nonSupportedQuantity
         }
-
-        do {
-            try await updateStockQuantity(with: quantityDecimal)
-        } catch {
-            throw UpdateInventoryError.generic
-        }
+        try await updateStockQuantity(with: quantityDecimal)
     }
 
     func displayErrorNotice(_ productName: String) {

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -147,7 +147,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         inventoryItem.imageURL
     }
 
-    func onTapIncreaseStockQuantityOnce() async {
+    func onTapIncreaseStockQuantityOnce() async throws {
         guard let quantityDecimal = Decimal(string: quantity) else {
             return
         }
@@ -158,7 +158,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         do {
             try await updateStockQuantity(with: newQuantity)
         } catch {
-            DDLogError("\(error)")
+            throw UpdateInventoryError.generic
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -137,6 +137,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
     @Published var showLoadingName: Bool = true
     @Published var name: String = ""
     @Published var updateQuantityButtonMode: UpdateQuantityButtonMode = .increaseOnce
+    @Published var notice: Notice?
 
     var sku: String {
         inventoryItem.sku ?? ""
@@ -145,8 +146,6 @@ final class UpdateProductInventoryViewModel: ObservableObject {
     var imageURL: URL? {
         inventoryItem.imageURL
     }
-
-    @Published var notice: Notice?
 
     func onTapIncreaseStockQuantityOnce() async {
         guard let quantityDecimal = Decimal(string: quantity) else {
@@ -175,8 +174,8 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         }
     }
 
-    func makeNotice() -> Notice {
-        Notice(title: "oopsie", feedbackType: .error)
+    func displayErrorNotice() {
+        notice = Notice(title: "There was an error updating ", feedbackType: .error)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -176,7 +176,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
 
     func displayErrorNotice(_ productName: String) {
         notice =  Notice(title: "Update Inventory Error",
-                         message: "There was an error updating \(productName). Please try again",
+                         message: "There was an error updating \(productName). Please try again.",
                          feedbackType: .error)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -145,7 +145,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
     var imageURL: URL? {
         inventoryItem.imageURL
     }
-    
+
     @Published var notice: Notice?
 
     func onTapIncreaseStockQuantityOnce() async {

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -174,8 +174,10 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         }
     }
 
-    func displayErrorNotice() {
-        notice = Notice(title: "There was an error updating ", feedbackType: .error)
+    func displayErrorNotice(_ productName: String) {
+        notice =  Notice(title: "Update Inventory Error",
+                         message: "There was an error updating \(productName). Please try again",
+                         feedbackType: .error)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
@@ -68,6 +68,20 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.imageURL?.absoluteString, url)
     }
 
+    func test_notice_when_displayErrorNotice_then_displays_notice() {
+        // Given
+        let product = Product.fake()
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+
+        XCTAssertNil(viewModel.notice, "Precondition: Notice should be nil on init")
+
+        // When
+        viewModel.displayErrorNotice()
+
+        // Then
+        XCTAssertNotNil(viewModel.notice)
+    }
+
     func test_name_when_we_pass_a_product_it_shows_right_name() {
         // Given
         let name = "test-name"
@@ -183,7 +197,7 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
 
         // When
         viewModel.quantity = stockQuantity.formatted()
-        await viewModel.onTapUpdateStockQuantity()
+        try await viewModel.onTapUpdateStockQuantity()
 
         // Then
         XCTAssertEqual(passedStockQuantity, stockQuantity)
@@ -210,7 +224,7 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
 
         // When
         viewModel.quantity = stockQuantity.formatted()
-        await viewModel.onTapUpdateStockQuantity()
+        try await viewModel.onTapUpdateStockQuantity()
 
         // Then
         XCTAssertEqual(passedStockQuantity, stockQuantity)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
@@ -12,7 +12,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Given
         let stockQuantity = Decimal(12)
         let product = Product.fake().copy(siteID: siteID, stockQuantity: stockQuantity)
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.quantity, stockQuantity.formatted())
@@ -22,7 +24,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Given
         let stockQuantity = Decimal(12)
         let variation = ProductVariation.fake().copy(siteID: siteID, stockQuantity: stockQuantity)
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.quantity, stockQuantity.formatted())
@@ -32,7 +36,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Given
         let sku = "test-sku"
         let product = Product.fake().copy(siteID: siteID, sku: sku)
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.sku, sku)
@@ -42,7 +48,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Given
         let sku = "test-sku"
         let variation = ProductVariation.fake().copy(siteID: siteID, sku: sku)
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.sku, sku)
@@ -52,7 +60,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Given
         let url = "www.picture.com"
         let product = Product.fake().copy(siteID: siteID, images: [ProductImage.fake().copy(src: url)])
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.imageURL?.absoluteString, url)
@@ -62,7 +72,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Given
         let url = "www.picture.com"
         let variation = ProductVariation.fake().copy(siteID: siteID, image: ProductImage.fake().copy(src: url))
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.imageURL?.absoluteString, url)
@@ -71,7 +83,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
     func test_notice_when_displayErrorNotice_in_invoked_then_displays_correct_error_notice() {
         // Given
         let product = Product.fake().copy(name: "Some Product")
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         XCTAssertNil(viewModel.notice, "Precondition: Notice should be nil on init")
 
@@ -89,7 +103,9 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Given
         let name = "test-name"
         let product = Product.fake().copy(siteID: siteID, name: name)
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product,
+                                                        siteID: siteID,
+                                                        onUpdatedInventory: { _ in })
 
         waitUntil {
             viewModel.name == name
@@ -115,8 +131,11 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
             }
         }
 
-        let product = ProductVariation.fake().copy(siteID: siteID, productID: parentProductID)
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID, stores: stores)
+        let variation = ProductVariation.fake().copy(siteID: siteID, productID: parentProductID)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation,
+                                                        siteID: siteID,
+                                                        stores: stores,
+                                                        onUpdatedInventory: { _ in })
 
         waitUntil {
             viewModel.name == name
@@ -139,7 +158,10 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID, stores: stores)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product,
+                                                        siteID: siteID,
+                                                        stores: stores,
+                                                        onUpdatedInventory: { _ in })
 
         // When
         viewModel.quantity = previousStockQuantity.formatted()
@@ -168,7 +190,10 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID, stores: stores)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation,
+                                                        siteID: siteID,
+                                                        stores: stores,
+                                                        onUpdatedInventory: { _ in })
 
         // When
         viewModel.quantity = previousStockQuantity.formatted()
@@ -196,7 +221,10 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID, stores: stores)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: product,
+                                                        siteID: siteID,
+                                                        stores: stores,
+                                                        onUpdatedInventory: { _ in })
 
         // When
         viewModel.quantity = stockQuantity.formatted()
@@ -223,7 +251,10 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation, siteID: siteID, stores: stores)
+        let viewModel = UpdateProductInventoryViewModel(inventoryItem: variation,
+                                                        siteID: siteID,
+                                                        stores: stores,
+                                                        onUpdatedInventory: { _ in })
 
         // When
         viewModel.quantity = stockQuantity.formatted()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
@@ -81,7 +81,7 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(viewModel.notice)
         XCTAssertEqual(viewModel.notice?.title, "Update Inventory Error")
-        XCTAssertEqual(viewModel.notice?.message, "There was an error updating Some Product. Please try again")
+        XCTAssertEqual(viewModel.notice?.message, "There was an error updating Some Product. Please try again.")
         XCTAssertEqual(viewModel.notice?.feedbackType, .error)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
@@ -68,18 +68,21 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.imageURL?.absoluteString, url)
     }
 
-    func test_notice_when_displayErrorNotice_then_displays_notice() {
+    func test_notice_when_displayErrorNotice_in_invoked_then_displays_correct_error_notice() {
         // Given
-        let product = Product.fake()
+        let product = Product.fake().copy(name: "Some Product")
         let viewModel = UpdateProductInventoryViewModel(inventoryItem: product, siteID: siteID)
 
         XCTAssertNil(viewModel.notice, "Precondition: Notice should be nil on init")
 
         // When
-        viewModel.displayErrorNotice()
+        viewModel.displayErrorNotice(product.name)
 
         // Then
         XCTAssertNotNil(viewModel.notice)
+        XCTAssertEqual(viewModel.notice?.title, "Update Inventory Error")
+        XCTAssertEqual(viewModel.notice?.message, "There was an error updating Some Product. Please try again")
+        XCTAssertEqual(viewModel.notice?.feedbackType, .error)
     }
 
     func test_name_when_we_pass_a_product_it_shows_right_name() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
@@ -143,7 +143,7 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
 
         // When
         viewModel.quantity = previousStockQuantity.formatted()
-        await viewModel.onTapIncreaseStockQuantityOnce()
+        try await viewModel.onTapIncreaseStockQuantityOnce()
 
         // Then
         XCTAssertEqual(viewModel.quantity, passedStockQuantity?.formatted())
@@ -172,7 +172,7 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
 
         // When
         viewModel.quantity = previousStockQuantity.formatted()
-        await viewModel.onTapIncreaseStockQuantityOnce()
+        try await viewModel.onTapIncreaseStockQuantityOnce()
 
         // Then
         XCTAssertEqual(viewModel.quantity, passedStockQuantity?.formatted())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
Closes https://github.com/woocommerce/woocommerce-ios/issues/11413
Partially addresses #11405 

This PR adds a notice when the inventory update is completed either with success or failure, and deals with navigation by dismissing the current view upon success, or keeping the view upon failure, so we can retry to scan to update inventory.

Since we do not have specific designs for these notices, for the moment we go with the minimum necessary to convey feedback:

In the case of successful update (happy path) we want to:
1. Dismiss the current `UpdateProductInventoryView`.
2. Show a "Quantity updated" notice on the Product List view

In the case of failure to update (unhappy path) we want to:
1. `UpdateProductInventoryView` is not dismissed, remains in place.
2. Show a notice regarding update inventory failure

| Successful update | Failed update |
|--------|--------|
| ![success update](https://github.com/woocommerce/woocommerce-ios/assets/3812076/83fd78ca-58c7-4603-92d9-4b3e8267c88a)| ![fail to update](https://github.com/woocommerce/woocommerce-ios/assets/3812076/f3beb84b-2bb3-46cc-a242-9de0c4c2ac9b) | 

## Testing instructions
### Success:
1. In Menu > Products > Tap the "Scanner" icon on the left-top corner > Scan an existing product > Update the quantity > tap `Update Quantity" button
2. Observe that the view is dismissed, and a "Quantity updated" notice shows up.

### Failure:
1. The easiest way to force a failure is to modify the `updateStockQuantity` method to resume with an error (be sure to edit the method for products or variations depending on which one you're scanning):
``` diff
    func updateStockQuantity(with newQuantity: Decimal, stores: StoresManager) async throws {
        return try await withCheckedThrowingContinuation { continuation in
            let newProduct = copy(stockQuantity: newQuantity)

            let action = ProductAction.updateProduct(product: newProduct) { _ in
+                continuation.resume(throwing: UpdateInventoryError.generic)
-                switch result {
-                case .success(_):
-                    continuation.resume(with: .success(()))
-                case let .failure(error):
-                    continuation.resume(throwing: error)
-                }
            }

            Task { @MainActor in
                stores.dispatch(action)
            }
        }
    }
```
2. As before, go to Menu > Products > Tap the "Scanner" icon on the left-top corner > Scan an existing product > Update the quantity > tap `Update Quantity" button
4. Observe that the view is not dismissed, the keyboard is dismissed, and an error notice shows up.
