### PR TITLE
[Scan to update inventory M1] Navigation to product/variation details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderView.swift
@@ -1,0 +1,22 @@
+import UIKit
+import SwiftUI
+
+struct ProductLoaderView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = UINavigationController
+
+    let model: ProductLoaderViewController.Model
+    let siteID: Int64
+    let forceReadOnly: Bool
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let viewController = ProductLoaderViewController(model: model,
+                                                         siteID: siteID,
+                                                         forceReadOnly: forceReadOnly)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        return navigationController
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+        // nothing to do here
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -93,11 +93,11 @@ struct UpdateProductInventoryView: View {
                         Button(Localization.viewProductDetailsButtonTitle) {
                             isPresentingDetailsView = true
                         }
-                            .buttonStyle(SecondaryButtonStyle())
-                            .padding(.bottom)
-                            .sheet(isPresented: $isPresentingDetailsView) {
-                                viewModel.productDetailsView()
-                            }
+                        .buttonStyle(SecondaryButtonStyle())
+                        .padding(.bottom)
+                        .sheet(isPresented: $isPresentingDetailsView) {
+                            viewModel.productDetailsView()
+                        }
                     }
                     .padding()
                     .frame(minHeight: geometry.size.height)

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -10,6 +10,8 @@ struct UpdateProductInventoryView: View {
 
     @Environment(\.dismiss) private var dismiss
 
+    @State private var isPresentingDetailsView = false
+
     @State private var isKeyboardVisible = false
 
     init(inventoryItem: InventoryItem, siteID: Int64) {
@@ -88,9 +90,14 @@ struct UpdateProductInventoryView: View {
                         .disabled(!viewModel.enableQuantityButton)
                         .padding(.bottom, Layout.mediumSpacing)
 
-                        Button(Localization.viewProductDetailsButtonTitle) {}
+                        Button(Localization.viewProductDetailsButtonTitle) {
+                            isPresentingDetailsView = true
+                        }
                             .buttonStyle(SecondaryButtonStyle())
                             .padding(.bottom)
+                            .sheet(isPresented: $isPresentingDetailsView) {
+                                viewModel.productDetailsView()
+                            }
                     }
                     .padding()
                     .frame(minHeight: geometry.size.height)

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import Yosemite
+import SwiftUI
 
 /// An item whose inventory can be displayed and managed
 ///
@@ -11,6 +12,7 @@ protocol InventoryItem {
 
     func retrieveName(with stores: StoresManager, siteID: Int64) async throws -> String
     func updateStockQuantity(with newQuantity: Decimal, stores: StoresManager) async throws
+    func detailsView() -> ProductLoaderView
 }
 
 extension SKUSearchResult {
@@ -46,6 +48,10 @@ extension Product: InventoryItem {
                 stores.dispatch(action)
             }
         }
+    }
+
+    func detailsView() -> ProductLoaderView {
+        ProductLoaderView(model: .product(productID: productID), siteID: siteID, forceReadOnly: true)
     }
 }
 
@@ -86,6 +92,10 @@ extension ProductVariation: InventoryItem {
                 stores.dispatch(action)
             }
         }
+    }
+
+    func detailsView() -> ProductLoaderView {
+        ProductLoaderView(model: .productVariation(productID: productID, variationID: productVariationID), siteID: siteID, forceReadOnly: true)
     }
 }
 
@@ -158,6 +168,10 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         }
 
         try? await updateStockQuantity(with: quantityDecimal)
+    }
+
+    func productDetailsView() -> some View {
+        inventoryItem.detailsView()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1753,6 +1753,7 @@
 		B98C6D502B149C3900A243E1 /* UINavigationItem+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */; };
 		B98D425B2AF9374400973C76 /* LargeHeightLeftImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98D425A2AF9374400973C76 /* LargeHeightLeftImageTableViewCell.swift */; };
 		B98D425D2AF9400900973C76 /* LargeHeightLeftImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B98D425C2AF9400900973C76 /* LargeHeightLeftImageTableViewCell.xib */; };
+		B98DA0AE2B275F45008A3607 /* ProductLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98DA0AD2B275F45008A3607 /* ProductLoaderView.swift */; };
 		B98FF4402AAA096200326D16 /* AddressWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98FF43F2AAA096200326D16 /* AddressWooTests.swift */; };
 		B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */; };
 		B99686E02A13C8CC00D1AF62 /* ScanToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99686DF2A13C8CC00D1AF62 /* ScanToPayView.swift */; };
@@ -4365,6 +4366,7 @@
 		B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Configuration.swift"; sourceTree = "<group>"; };
 		B98D425A2AF9374400973C76 /* LargeHeightLeftImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeHeightLeftImageTableViewCell.swift; sourceTree = "<group>"; };
 		B98D425C2AF9400900973C76 /* LargeHeightLeftImageTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LargeHeightLeftImageTableViewCell.xib; sourceTree = "<group>"; };
+		B98DA0AD2B275F45008A3607 /* ProductLoaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductLoaderView.swift; sourceTree = "<group>"; };
 		B98FF43F2AAA096200326D16 /* AddressWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressWooTests.swift; sourceTree = "<group>"; };
 		B991D3942A4EC0F800D886ED /* CouponLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineViewModel.swift; sourceTree = "<group>"; };
 		B99686DF2A13C8CC00D1AF62 /* ScanToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanToPayView.swift; sourceTree = "<group>"; };
@@ -6030,6 +6032,7 @@
 				74EC34A4225FE21F004BBC2E /* ProductLoaderViewController.swift */,
 				0279F0DE252DC12D0098D7DE /* ProductLoaderViewControllerModel+Init.swift */,
 				0279F0E3252DC9670098D7DE /* ProductVariationLoadUseCase.swift */,
+				B98DA0AD2B275F45008A3607 /* ProductLoaderView.swift */,
 			);
 			path = "Product Loader";
 			sourceTree = "<group>";
@@ -12990,6 +12993,7 @@
 				02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */,
 				DE279BB126EA184A002BA963 /* ShippingLabelPackageListViewModel.swift in Sources */,
 				68D5094E2AD39BC900B6FFD5 /* DiscountLineDetailsView.swift in Sources */,
+				B98DA0AE2B275F45008A3607 /* ProductLoaderView.swift in Sources */,
 				02B1AFEC24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift in Sources */,
 				0206E296299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift in Sources */,
 				26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11405
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the navigation to the product or variation details from the quick inventory screen. For now, the details screens are read-only, which means that the users cannot edit the details there. Doing that would require syncing the product changes in the quick inventory screen, which might be complex for now. We can iterate in the future to achieve this.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to products
2. Tap the barcode scanner button on the left corner.
3. Scan a product barcode
4. When the quick inventory screen appears, tap on "Product Details".
5. See that the product details are shown in read-only mode. Make sure that everything works properly.

Repeat with a product variation.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/e6ed56d9-fdf0-451c-97af-a9cba88662aa



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
