### PR TITLE
[Order form] Extract properties (marked with TODO) from `ProductRowViewModel`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -198,12 +198,12 @@ private struct CollapsibleProductRowCard: View {
                 .renderedIf(viewModel.hasDiscount && !viewModel.isReadOnly)
 
                 Button(Localization.configureBundleProduct) {
-                    viewModel.productViewModel.configure?()
+                    viewModel.configure?()
                     ServiceLocator.analytics.track(event: .Orders.orderFormBundleProductConfigureCTATapped(flow: flow, source: .productCard))
                 }
                 .buttonStyle(IconButtonStyle(icon: .cogImage))
                 .frame(minHeight: Layout.rowMinHeight)
-                .renderedIf(viewModel.productViewModel.isConfigurable)
+                .renderedIf(viewModel.isConfigurable)
                 .onAppear {
                     guard !hasTrackedBundleProductConfigureCTAShownEvent else {
                         return
@@ -382,14 +382,15 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
             }
         let bundleParentProductViewModel = ProductRowViewModel(id: 1,
                                                            product: product
-            .copy(productTypeKey: ProductType.bundle.rawValue, bundledItems: [.swiftUIPreviewSample()]),
-                                                           configure: {})
+            .copy(productTypeKey: ProductType.bundle.rawValue, bundledItems: [.swiftUIPreviewSample()]))
         let bundleParentRowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                                           isReadOnly: false,
+                                                                          isConfigurable: true,
                                                                           productViewModel: bundleParentProductViewModel,
                                                                           stepperViewModel: .init(quantity: 1,
                                                                                                   name: "",
-                                                                                                  quantityUpdatedCallback: { _ in }))
+                                                                                                  quantityUpdatedCallback: { _ in }),
+                                                                          configure: {})
         let bundleParentViewModel = CollapsibleProductCardViewModel(productRow: bundleParentRowViewModel,
                                                                     childProductRows: childViewModels)
         VStack {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -150,7 +150,7 @@ private struct CollapsibleProductRowCard: View {
                         Text(viewModel.productViewModel.name)
                             .font(viewModel.hasParentProduct ? .subheadline : .none)
                             .foregroundColor(Color(.text))
-                        Text(viewModel.productViewModel.orderProductDetailsLabel)
+                        Text(viewModel.productDetailsLabel)
                             .font(.subheadline)
                             .foregroundColor(isCollapsed ? Color(.textSubtle) : Color(.text))
                         Text(viewModel.productViewModel.skuLabel)
@@ -356,6 +356,11 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
         let productViewModel = ProductRowViewModel(product: product)
         let rowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                               isReadOnly: false,
+                                                              productTypeDescription: product.productType.description,
+                                                              attributes: [],
+                                                              stockStatus: product.productStockStatus,
+                                                              stockQuantity: product.stockQuantity,
+                                                              manageStock: product.manageStock,
                                                               productViewModel: productViewModel,
                                                               stepperViewModel: .init(quantity: 1,
                                                                                       name: "",
@@ -364,10 +369,15 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
 
         let readOnlyRowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                                       isReadOnly: true,
+                                                                      productTypeDescription: product.productType.description,
+                                                                      attributes: [],
+                                                                      stockStatus: product.productStockStatus,
+                                                                      stockQuantity: product.stockQuantity,
+                                                                      manageStock: product.manageStock,
                                                                       productViewModel: productViewModel,
                                                                       stepperViewModel: .init(quantity: 1,
-                                                                                              name: "",
-                                                                                              quantityUpdatedCallback: { _ in }))
+                                                                                      name: "",
+                                                                                      quantityUpdatedCallback: { _ in }))
         let readOnlyViewModel = CollapsibleProductCardViewModel(productRow: readOnlyRowViewModel, childProductRows: [])
 
         let childViewModels = [ProductRowViewModel(id: 2, product: product),
@@ -375,6 +385,11 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
             .map {
                 CollapsibleProductRowCardViewModel(hasParentProduct: true,
                                                    isReadOnly: false,
+                                                   productTypeDescription: product.productType.description,
+                                                   attributes: [],
+                                                   stockStatus: product.productStockStatus,
+                                                   stockQuantity: product.stockQuantity,
+                                                   manageStock: product.manageStock,
                                                    productViewModel: $0,
                                                    stepperViewModel: .init(quantity: 1,
                                                                            name: "",
@@ -386,6 +401,11 @@ struct CollapsibleProductCard_Previews: PreviewProvider {
         let bundleParentRowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                                           isReadOnly: false,
                                                                           isConfigurable: true,
+                                                                          productTypeDescription: product.productType.description,
+                                                                          attributes: [],
+                                                                          stockStatus: product.productStockStatus,
+                                                                          stockQuantity: product.stockQuantity,
+                                                                          manageStock: product.manageStock,
                                                                           productViewModel: bundleParentProductViewModel,
                                                                           stepperViewModel: .init(quantity: 1,
                                                                                                   name: "",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
@@ -36,6 +36,12 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
     /// Used to remove product editing controls for read-only order items (e.g. child items of a product bundle).
     let isReadOnly: Bool
 
+    /// Whether a product in an order item is configurable
+    let isConfigurable: Bool
+
+    /// Closure to configure a product if it is configurable.
+    let configure: (() -> Void)?
+
     let productViewModel: ProductRowViewModel
     let stepperViewModel: ProductStepperViewModel
     let priceSummaryViewModel: CollapsibleProductCardPriceSummaryViewModel
@@ -45,12 +51,16 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
 
     init(hasParentProduct: Bool = false,
          isReadOnly: Bool = false,
+         isConfigurable: Bool = false,
          productViewModel: ProductRowViewModel,
          stepperViewModel: ProductStepperViewModel,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         configure: (() -> Void)? = nil) {
         self.hasParentProduct = hasParentProduct
         self.isReadOnly = isReadOnly
+        self.isConfigurable = configure != nil ? isConfigurable : false
+        self.configure = configure
         self.productViewModel = productViewModel
         self.stepperViewModel = stepperViewModel
         self.priceSummaryViewModel = .init(pricedIndividually: productViewModel.pricedIndividually,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
@@ -42,6 +42,11 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
     /// Closure to configure a product if it is configurable.
     let configure: (() -> Void)?
 
+    /// Label showing product details for an order item.
+    /// Can include product type (if the row is configurable), variation attributes (if available), and stock status.
+    ///
+    let productDetailsLabel: String
+
     let productViewModel: ProductRowViewModel
     let stepperViewModel: ProductStepperViewModel
     let priceSummaryViewModel: CollapsibleProductCardPriceSummaryViewModel
@@ -52,6 +57,11 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
     init(hasParentProduct: Bool = false,
          isReadOnly: Bool = false,
          isConfigurable: Bool = false,
+         productTypeDescription: String,
+         attributes: [VariationAttributeViewModel],
+         stockStatus: ProductStockStatus,
+         stockQuantity: Decimal?,
+         manageStock: Bool,
          productViewModel: ProductRowViewModel,
          stepperViewModel: ProductStepperViewModel,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
@@ -61,6 +71,12 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
         self.isReadOnly = isReadOnly
         self.isConfigurable = configure != nil ? isConfigurable : false
         self.configure = configure
+        productDetailsLabel = CollapsibleProductRowCardViewModel.createProductDetailsLabel(isConfigurable: isConfigurable,
+                                                                                           productTypeDescription: productTypeDescription,
+                                                                                           attributes: attributes,
+                                                                                           stockStatus: stockStatus,
+                                                                                           stockQuantity: stockQuantity,
+                                                                                           manageStock: manageStock)
         self.productViewModel = productViewModel
         self.stepperViewModel = stepperViewModel
         self.priceSummaryViewModel = .init(pricedIndividually: productViewModel.pricedIndividually,
@@ -111,8 +127,49 @@ extension CollapsibleProductRowCardViewModel {
 }
 
 private extension CollapsibleProductRowCardViewModel {
+    /// Creates the label showing product details for an order item.
+    /// Can include product type (if the row is configurable), variation attributes (if available), and stock status.
+    ///
+    static func createProductDetailsLabel(isConfigurable: Bool,
+                                          productTypeDescription: String,
+                                          attributes: [VariationAttributeViewModel] = [],
+                                          stockStatus: ProductStockStatus,
+                                          stockQuantity: Decimal?,
+                                          manageStock: Bool) -> String {
+        let productTypeLabel: String? = isConfigurable ? productTypeDescription : nil
+        let attributesLabel: String? = attributes.isNotEmpty ? attributes.map { $0.nameOrValue }.joined(separator: ", ") : nil
+        let stockLabel = createStockText(stockStatus: stockStatus, stockQuantity: stockQuantity, manageStock: manageStock)
+
+        return [productTypeLabel, attributesLabel, stockLabel]
+            .compactMap({ $0 })
+            .filter { $0.isNotEmpty }
+            .joined(separator: " • ")
+    }
+
+    /// Creates the stock text based on a product's stock status/quantity.
+    ///
+    static func createStockText(stockStatus: ProductStockStatus, stockQuantity: Decimal?, manageStock: Bool) -> String {
+        switch (stockStatus, stockQuantity, manageStock) {
+        case (.inStock, .some(let stockQuantity), true):
+            let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
+            return String.localizedStringWithFormat(Localization.stockFormat, localizedStockQuantity)
+        default:
+            return stockStatus.description
+        }
+    }
+}
+
+private extension CollapsibleProductRowCardViewModel {
     func observeProductQuantityFromStepperViewModel() {
         stepperViewModel.$quantity
             .assign(to: &productViewModel.$quantity)
+    }
+}
+
+private extension CollapsibleProductRowCardViewModel {
+    enum Localization {
+        static let stockFormat = NSLocalizedString("CollapsibleProductRowCardViewModel.stockFormat",
+                                                   value: "%1$@ in stock",
+                                                   comment: "Label about product's inventory stock status shown during order creation")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -605,6 +605,11 @@ final class EditableOrderViewModel: ObservableObject {
             })
             let rowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: item.parent != nil,
                                                                   isReadOnly: isReadOnly,
+                                                                  productTypeDescription: ProductType.variable.description,
+                                                                  attributes: attributes,
+                                                                  stockStatus: variation.stockStatus,
+                                                                  stockQuantity: variation.stockQuantity,
+                                                                  manageStock: variation.manageStock,
                                                                   productViewModel: productViewModel,
                                                                   stepperViewModel: stepperViewModel,
                                                                   analytics: analytics)
@@ -639,6 +644,11 @@ final class EditableOrderViewModel: ObservableObject {
             let rowViewModel = CollapsibleProductRowCardViewModel(hasParentProduct: item.parent != nil,
                                                                   isReadOnly: isReadOnly,
                                                                   isConfigurable: isProductConfigurable,
+                                                                  productTypeDescription: product.productType.description,
+                                                                  attributes: [],
+                                                                  stockStatus: product.productStockStatus,
+                                                                  stockQuantity: product.stockQuantity,
+                                                                  manageStock: product.manageStock,
                                                                   productViewModel: productViewModel,
                                                                   stepperViewModel: stepperViewModel,
                                                                   analytics: analytics,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -142,24 +142,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             .joined(separator: " • ")
     }
 
-    // TODO: 11357 - move this property to `CollapsibleProductRowCardViewModel`
-    /// Label showing product details for a product in an order.
-    /// Can include product type (if the row is configurable), variation attributes (if available), and stock status.
-    ///
-    var orderProductDetailsLabel: String {
-        let attributesLabel: String? = {
-            guard case let .attributes(attributes) = variationDisplayMode else {
-                return nil
-            }
-            return createAttributesText(from: attributes)
-        }()
-        let stockLabel = createStockText()
-        return [productTypeLabel, attributesLabel, stockLabel]
-            .compactMap({ $0 })
-            .filter { $0.isNotEmpty }
-            .joined(separator: " • ")
-    }
-
     private let productTypeLabel: String?
 
     /// Label showing product SKU

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -27,7 +27,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     let name: String
 
-    // TODO: 11357 - move this property to `CollapsibleProductRowCardViewModel`
     /// Whether a product in an order item is configurable
     ///
     let isConfigurable: Bool
@@ -200,7 +199,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     ///
     @Published var quantity: Decimal
 
-    // TODO: 11357 - move this property to `CollapsibleProductRowCardViewModel`
     /// Closure to configure a product if it is configurable.
     let configure: (() -> Void)?
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -108,22 +108,6 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         return priceLabelComponent + " - " + discountLabelComponent
     }
 
-    // TODO: 11357 - move this property to `CollapsibleProductRowCardViewModel`
-    /// Formatted price label based on a product's price. Accounting for discounts, if any.
-    /// e.g: If price is $5 and discount is $1, outputs "$4.00"
-    ///
-    var priceAfterDiscountLabel: String? {
-        guard let price = price else {
-            return nil
-        }
-        guard let priceDecimal = currencyFormatter.convertToDecimal(price) else {
-            return nil
-        }
-        let priceAfterDiscount = priceDecimal.subtracting((discount ?? Decimal.zero) as NSDecimalNumber)
-
-        return currencyFormatter.formatAmount(priceAfterDiscount) ?? ""
-    }
-
     private(set) var discount: Decimal?
 
     /// Whether product discounts are disallowed,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -22,14 +22,24 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let childProductRows = [ProductRowViewModel(product: .fake()),
                                 ProductRowViewModel(product: .fake())]
             .map {
-                CollapsibleProductRowCardViewModel(productViewModel: $0,
+                CollapsibleProductRowCardViewModel(productTypeDescription: product.productType.description,
+                                                   attributes: [],
+                                                   stockStatus: product.productStockStatus,
+                                                   stockQuantity: product.stockQuantity,
+                                                   manageStock: product.manageStock,
+                                                   productViewModel: $0,
                                                    stepperViewModel: .init(quantity: 1,
                                                                            name: "",
                                                                            quantityUpdatedCallback: { _ in }))
             }
 
         // When
-        let rowViewModel = CollapsibleProductRowCardViewModel(productViewModel: .init(product: product),
+        let rowViewModel = CollapsibleProductRowCardViewModel(productTypeDescription: product.productType.description,
+                                                              attributes: [],
+                                                              stockStatus: product.productStockStatus,
+                                                              stockQuantity: product.stockQuantity,
+                                                              manageStock: product.manageStock,
+                                                              productViewModel: .init(product: product),
                                                               stepperViewModel: .init(quantity: 1,
                                                                                       name: "",
                                                                                       quantityUpdatedCallback: { _ in }))
@@ -45,7 +55,12 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(productViewModel: .init(product: product, currencyFormatter: currencyFormatter),
+        let viewModel = CollapsibleProductRowCardViewModel(productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
+                                                           productViewModel: .init(product: product, currencyFormatter: currencyFormatter),
                                                            stepperViewModel: .init(quantity: 1,
                                                                                    name: "",
                                                                                    quantityUpdatedCallback: { _ in }))
@@ -59,7 +74,12 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_isReadOnly_and_hasParentProduct_are_false_by_default() {
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(productViewModel: .init(product: .fake()),
+        let viewModel = CollapsibleProductRowCardViewModel(productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
+                                                           productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 1,
                                                                                    name: "",
                                                                                    quantityUpdatedCallback: { _ in }))
@@ -75,6 +95,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // When
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
                                                                                    name: "",
@@ -89,6 +114,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // Given
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
                                                                                    name: "",
@@ -108,6 +138,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // Given
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
                                                                                    name: "",
@@ -125,6 +160,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // Given
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 2,
                                                                                    name: "",
@@ -148,6 +188,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // When
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: product, discount: nil, quantity: 1),
                                                            stepperViewModel: .init(quantity: 2,
                                                                                    name: "",
@@ -166,6 +211,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // When
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: product, discount: discount, quantity: 1),
                                                            stepperViewModel: .init(quantity: 2,
                                                                                    name: "",
@@ -186,6 +236,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // When
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: product, discount: discount, quantity: 1),
                                                            stepperViewModel: .init(quantity: 1,
                                                                                    name: "",
@@ -205,6 +260,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // When
         let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
                                                            isReadOnly: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: product, discount: discount, quantity: quantity),
                                                            stepperViewModel: .init(quantity: quantity,
                                                                                    name: "",
@@ -219,6 +279,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
     func test_isConfigurable_set_to_false_if_true_and_configure_is_nil() {
         // Given
         let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }))
 
@@ -229,6 +294,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
     func test_isConfigurable_set_to_true_if_true_and_configure_is_not_nil() {
         // Given
         let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
                                                            configure: {})
@@ -240,11 +310,80 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
     func test_isConfigurable_set_to_false_if_false() {
         // Given
         let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: false,
+                                                           productTypeDescription: "",
+                                                           attributes: [],
+                                                           stockStatus: .inStock,
+                                                           stockQuantity: nil,
+                                                           manageStock: false,
                                                            productViewModel: .init(product: .fake()),
                                                            stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
                                                            configure: {})
 
         // Then
         XCTAssertFalse(viewModel.isConfigurable)
+    }
+
+    // MARK: - `productDetailsLabel`
+
+    func test_productDetailsLabel_is_stock_status_for_non_configurable_product() {
+        // Given
+        let stockStatus = ProductStockStatus.inStock
+        let product = Product.fake().copy(stockStatusKey: stockStatus.rawValue)
+
+        // When
+        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: false,
+                                                           productTypeDescription: product.productType.description,
+                                                           attributes: [],
+                                                           stockStatus: product.productStockStatus,
+                                                           stockQuantity: product.stockQuantity,
+                                                           manageStock: product.manageStock,
+                                                           productViewModel: .init(product: product),
+                                                           stepperViewModel: .init(quantity: 1, name: product.name, quantityUpdatedCallback: { _ in }))
+
+        // Then
+        assertEqual(stockStatus.description, viewModel.productDetailsLabel)
+    }
+
+    func test_productDetailsLabel_contains_attributes_and_stock_status_for_non_configurable_product_variation() {
+        // Given
+        let stockStatus = ProductStockStatus.inStock
+        let variationAttribute = "Blue"
+        let variation = ProductVariation.fake().copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: variationAttribute)],
+                                                     stockStatus: stockStatus)
+        let attributes = [VariationAttributeViewModel(name: "Color", value: "Blue"), VariationAttributeViewModel(name: "Size")]
+
+        // When
+        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: false,
+                                                           productTypeDescription: ProductType.variable.description,
+                                                           attributes: attributes,
+                                                           stockStatus: variation.stockStatus,
+                                                           stockQuantity: variation.stockQuantity,
+                                                           manageStock: variation.manageStock,
+                                                           productViewModel: .init(productVariation: variation, name: "", displayMode: .attributes(attributes)),
+                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }))
+
+        // Then
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(variationAttribute), "Label should contain variation attribute")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(stockStatus.description), "Label should contain stock status")
+    }
+
+    func test_productDetailsLabel_contains_product_type_and_stock_status_for_configurable_bundle_product() {
+        // Given
+        let stockStatus = ProductStockStatus.inStock
+        let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, stockStatusKey: stockStatus.rawValue, bundledItems: [.fake()])
+
+        // When
+        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
+                                                           productTypeDescription: product.productType.description,
+                                                           attributes: [],
+                                                           stockStatus: product.productStockStatus,
+                                                           stockQuantity: product.stockQuantity,
+                                                           manageStock: product.manageStock,
+                                                           productViewModel: .init(product: product),
+                                                           stepperViewModel: .init(quantity: 1, name: product.name, quantityUpdatedCallback: { _ in }))
+
+        // Then
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(ProductType.bundle.description), "Label should contain product type (Bundle)")
+        XCTAssertTrue(viewModel.productDetailsLabel.contains(stockStatus.description), "Label should contain stock status")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -213,4 +213,38 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         // Then
         assertEqual("$24.50", viewModel.totalPriceAfterDiscountLabel)
     }
+
+    // MARK: - `isConfigurable`
+
+    func test_isConfigurable_set_to_false_if_true_and_configure_is_nil() {
+        // Given
+        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
+                                                           productViewModel: .init(product: .fake()),
+                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }))
+
+        // Then
+        XCTAssertFalse(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_set_to_true_if_true_and_configure_is_not_nil() {
+        // Given
+        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
+                                                           productViewModel: .init(product: .fake()),
+                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
+                                                           configure: {})
+
+        // Then
+        XCTAssertTrue(viewModel.isConfigurable)
+    }
+
+    func test_isConfigurable_set_to_false_if_false() {
+        // Given
+        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: false,
+                                                           productViewModel: .init(product: .fake()),
+                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
+                                                           configure: {})
+
+        // Then
+        XCTAssertFalse(viewModel.isConfigurable)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -18,7 +18,6 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_viewModel_is_created_with_correct_initial_values_from_product_with_child_product_rows() {
         // Given
-        let product = Product.fake()
         let childProductRows = [createViewModel(), createViewModel()]
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -19,30 +19,10 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
     func test_viewModel_is_created_with_correct_initial_values_from_product_with_child_product_rows() {
         // Given
         let product = Product.fake()
-        let childProductRows = [ProductRowViewModel(product: .fake()),
-                                ProductRowViewModel(product: .fake())]
-            .map {
-                CollapsibleProductRowCardViewModel(productTypeDescription: product.productType.description,
-                                                   attributes: [],
-                                                   stockStatus: product.productStockStatus,
-                                                   stockQuantity: product.stockQuantity,
-                                                   manageStock: product.manageStock,
-                                                   productViewModel: $0,
-                                                   stepperViewModel: .init(quantity: 1,
-                                                                           name: "",
-                                                                           quantityUpdatedCallback: { _ in }))
-            }
+        let childProductRows = [createViewModel(), createViewModel()]
 
         // When
-        let rowViewModel = CollapsibleProductRowCardViewModel(productTypeDescription: product.productType.description,
-                                                              attributes: [],
-                                                              stockStatus: product.productStockStatus,
-                                                              stockQuantity: product.stockQuantity,
-                                                              manageStock: product.manageStock,
-                                                              productViewModel: .init(product: product),
-                                                              stepperViewModel: .init(quantity: 1,
-                                                                                      name: "",
-                                                                                      quantityUpdatedCallback: { _ in }))
+        let rowViewModel = createViewModel()
         let viewModel = CollapsibleProductCardViewModel(productRow: rowViewModel, childProductRows: childProductRows)
 
         // Then
@@ -55,15 +35,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Defaults to US currency & format
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: product, currencyFormatter: currencyFormatter),
-                                                           stepperViewModel: .init(quantity: 1,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(productViewModel: .init(product: product, currencyFormatter: currencyFormatter))
         viewModel.stepperViewModel.incrementQuantity()
 
         // Then
@@ -93,17 +65,9 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_ProductStepperViewModel_and_ProductRowViewModel_quantity_have_the_same_initial_value() {
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: .fake()),
-                                                           stepperViewModel: .init(quantity: 2,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(stepperViewModel: .init(quantity: 2,
+                                                                name: "",
+                                                                quantityUpdatedCallback: { _ in }))
 
         // Then
         XCTAssertEqual(viewModel.stepperViewModel.quantity, 2)
@@ -112,17 +76,9 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_ProductStepperViewModel_quantity_change_updates_ProductRowViewModel_quantity() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: .fake()),
-                                                           stepperViewModel: .init(quantity: 2,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(stepperViewModel: .init(quantity: 2,
+                                                                name: "",
+                                                                quantityUpdatedCallback: { _ in }))
 
         // When
         viewModel.stepperViewModel.incrementQuantity()
@@ -136,18 +92,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_productRow_when_add_discount_button_is_tapped_then_orderProductDiscountAddButtonTapped_is_tracked() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: .fake()),
-                                                           stepperViewModel: .init(quantity: 2,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }),
-                                                           analytics: WooAnalytics(analyticsProvider: analytics))
+        let viewModel = createViewModel(analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
         viewModel.trackAddDiscountTapped()
@@ -158,18 +103,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_productRow_when_edit_discount_button_is_tapped_then_orderProductDiscountEditButtonTapped_is_tracked() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: .fake()),
-                                                           stepperViewModel: .init(quantity: 2,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }),
-                                                           analytics: WooAnalytics(analyticsProvider: analytics))
+        let viewModel = createViewModel(analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
         viewModel.trackEditDiscountTapped()
@@ -186,17 +120,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: product, discount: nil, quantity: 1),
-                                                           stepperViewModel: .init(quantity: 2,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(productViewModel: .init(product: product, discount: nil, quantity: 1))
 
         // Then
         XCTAssertFalse(viewModel.hasDiscount)
@@ -209,17 +133,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: product, discount: discount, quantity: 1),
-                                                           stepperViewModel: .init(quantity: 2,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(productViewModel: .init(product: product, discount: discount, quantity: 1))
 
         // Then
         XCTAssertTrue(viewModel.hasDiscount)
@@ -234,17 +148,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: product, discount: discount, quantity: 1),
-                                                           stepperViewModel: .init(quantity: 1,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(productViewModel: .init(product: product, discount: discount, quantity: 1))
 
         // Then
         assertEqual("$2.00", viewModel.totalPriceAfterDiscountLabel)
@@ -258,17 +162,10 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(price: price)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(hasParentProduct: false,
-                                                           isReadOnly: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: product, discount: discount, quantity: quantity),
-                                                           stepperViewModel: .init(quantity: quantity,
-                                                                                   name: "",
-                                                                                   quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(productViewModel: .init(product: product, discount: discount, quantity: quantity),
+                                        stepperViewModel: .init(quantity: quantity,
+                                                                name: "",
+                                                                quantityUpdatedCallback: { _ in }))
 
         // Then
         assertEqual("$24.50", viewModel.totalPriceAfterDiscountLabel)
@@ -278,14 +175,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_isConfigurable_set_to_false_if_true_and_configure_is_nil() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: .fake()),
-                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(isConfigurable: true)
 
         // Then
         XCTAssertFalse(viewModel.isConfigurable)
@@ -293,14 +183,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_isConfigurable_set_to_true_if_true_and_configure_is_not_nil() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: .fake()),
-                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
+        let viewModel = createViewModel(isConfigurable: true,
                                                            configure: {})
 
         // Then
@@ -309,15 +192,8 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_isConfigurable_set_to_false_if_false() {
         // Given
-        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: false,
-                                                           productTypeDescription: "",
-                                                           attributes: [],
-                                                           stockStatus: .inStock,
-                                                           stockQuantity: nil,
-                                                           manageStock: false,
-                                                           productViewModel: .init(product: .fake()),
-                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
-                                                           configure: {})
+        let viewModel = createViewModel(isConfigurable: false,
+                                        configure: {})
 
         // Then
         XCTAssertFalse(viewModel.isConfigurable)
@@ -331,14 +207,12 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(stockStatusKey: stockStatus.rawValue)
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: false,
-                                                           productTypeDescription: product.productType.description,
-                                                           attributes: [],
-                                                           stockStatus: product.productStockStatus,
-                                                           stockQuantity: product.stockQuantity,
-                                                           manageStock: product.manageStock,
-                                                           productViewModel: .init(product: product),
-                                                           stepperViewModel: .init(quantity: 1, name: product.name, quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(productTypeDescription: product.productType.description,
+                                        attributes: [],
+                                        stockStatus: product.productStockStatus,
+                                        stockQuantity: product.stockQuantity,
+                                        manageStock: product.manageStock,
+                                        productViewModel: .init(product: product))
 
         // Then
         assertEqual(stockStatus.description, viewModel.productDetailsLabel)
@@ -353,14 +227,11 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let attributes = [VariationAttributeViewModel(name: "Color", value: "Blue"), VariationAttributeViewModel(name: "Size")]
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: false,
-                                                           productTypeDescription: ProductType.variable.description,
-                                                           attributes: attributes,
-                                                           stockStatus: variation.stockStatus,
-                                                           stockQuantity: variation.stockQuantity,
-                                                           manageStock: variation.manageStock,
-                                                           productViewModel: .init(productVariation: variation, name: "", displayMode: .attributes(attributes)),
-                                                           stepperViewModel: .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(productTypeDescription: ProductType.variable.description,
+                                        attributes: attributes,
+                                        stockStatus: variation.stockStatus,
+                                        stockQuantity: variation.stockQuantity,
+                                        manageStock: variation.manageStock)
 
         // Then
         XCTAssertTrue(viewModel.productDetailsLabel.contains(variationAttribute), "Label should contain variation attribute")
@@ -373,17 +244,45 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
         let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, stockStatusKey: stockStatus.rawValue, bundledItems: [.fake()])
 
         // When
-        let viewModel = CollapsibleProductRowCardViewModel(isConfigurable: true,
-                                                           productTypeDescription: product.productType.description,
-                                                           attributes: [],
-                                                           stockStatus: product.productStockStatus,
-                                                           stockQuantity: product.stockQuantity,
-                                                           manageStock: product.manageStock,
-                                                           productViewModel: .init(product: product),
-                                                           stepperViewModel: .init(quantity: 1, name: product.name, quantityUpdatedCallback: { _ in }))
+        let viewModel = createViewModel(isConfigurable: true,
+                                        productTypeDescription: product.productType.description,
+                                        attributes: [],
+                                        stockStatus: product.productStockStatus,
+                                        stockQuantity: product.stockQuantity,
+                                        manageStock: product.manageStock)
 
         // Then
         XCTAssertTrue(viewModel.productDetailsLabel.contains(ProductType.bundle.description), "Label should contain product type (Bundle)")
         XCTAssertTrue(viewModel.productDetailsLabel.contains(stockStatus.description), "Label should contain stock status")
+    }
+}
+
+private extension CollapsibleProductRowCardViewModelTests {
+    func createViewModel(hasParentProduct: Bool = false,
+                         isReadOnly: Bool = false,
+                         isConfigurable: Bool = false,
+                         productTypeDescription: String = "",
+                         attributes: [VariationAttributeViewModel] = [],
+                         stockStatus: ProductStockStatus = .inStock,
+                         stockQuantity: Decimal? = nil,
+                         manageStock: Bool = false,
+                         productViewModel: ProductRowViewModel = .init(product: .fake()),
+                         stepperViewModel: ProductStepperViewModel = .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
+                         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()),
+                         analytics: Analytics = ServiceLocator.analytics,
+                         configure: (() -> Void)? = nil) -> CollapsibleProductRowCardViewModel {
+        CollapsibleProductRowCardViewModel(hasParentProduct: hasParentProduct,
+                                           isReadOnly: isReadOnly,
+                                           isConfigurable: isConfigurable,
+                                           productTypeDescription: productTypeDescription,
+                                           attributes: attributes,
+                                           stockStatus: stockStatus,
+                                           stockQuantity: stockQuantity,
+                                           manageStock: manageStock,
+                                           productViewModel: productViewModel,
+                                           stepperViewModel: stepperViewModel,
+                                           currencyFormatter: currencyFormatter,
+                                           analytics: analytics,
+                                           configure: configure)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -271,48 +271,6 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.secondaryProductDetailsLabel, ProductType.bundle.description)
     }
 
-    func test_orderProductDetailsLabel_is_stock_status_for_non_configurable_product() {
-        // Given
-        let stockStatus = ProductStockStatus.inStock
-        let product = Product.fake().copy(stockStatusKey: stockStatus.rawValue)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product)
-
-        // Then
-        assertEqual(stockStatus.description, viewModel.orderProductDetailsLabel)
-    }
-
-    func test_orderProductDetailsLabel_contains_attributes_and_stock_status_for_non_configurable_product_variation() {
-        // Given
-        let stockStatus = ProductStockStatus.inStock
-        let variationAttribute = "Blue"
-        let variation = ProductVariation.fake().copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: variationAttribute)],
-                                                     stockStatus: stockStatus)
-        let attributes = [VariationAttributeViewModel(name: "Color", value: "Blue"), VariationAttributeViewModel(name: "Size")]
-
-        // When
-        let viewModel = ProductRowViewModel(productVariation: variation, name: "", displayMode: .attributes(attributes))
-
-        // Then
-        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(variationAttribute), "Label should contain variation attribute")
-        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(stockStatus.description), "Label should contain stock status")
-    }
-
-    func test_orderProductDetailsLabel_contains_product_type_and_stock_status_for_configurable_bundle_product() {
-        // Given
-        let stockStatus = ProductStockStatus.inStock
-        let product = Product.fake().copy(productTypeKey: ProductType.bundle.rawValue, stockStatusKey: stockStatus.rawValue, bundledItems: [.fake()])
-        let featureFlagService = MockFeatureFlagService(productBundlesInOrderForm: true)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product, featureFlagService: featureFlagService, configure: {})
-
-        // Then
-        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(ProductType.bundle.description), "Label should contain product type (Bundle)")
-        XCTAssertTrue(viewModel.orderProductDetailsLabel.contains(stockStatus.description), "Label should contain stock status")
-    }
-
     func test_productAccessibilityLabel_is_created_with_expected_details_from_product() {
         // Given
         let product = Product.fake().copy(name: "Test Product", sku: "123456", price: "10", stockStatusKey: "instock", variations: [1, 2])


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11412
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
This extracts properties (previously marked with TODO) used in `CollapsibleProductRowCardViewModel` from `ProductRowViewModel`. This is another step toward disentangling the logic used in `CollapsibleProductCard` from `ProductRowViewModel`, eventually allowing the products section in the order form to be displayed using `OrderItem` data.

## How
There were four properties marked with TODO:

- Configurable properties: These were not removed from `ProductRowViewModel` because it uses them in the product selector to configure a bundle before adding it to an order.
   -  `isConfigurable`: This property is used to determine if an order item can be configured (e.g. a product bundle).
   -  `configure`: This property is used to configure a configurable order item.
-  `priceAfterDiscountLabel`: This was an unused property, which was removed. (`CollapsibleProductRowCard` uses the `totalPriceAfterDiscountLabel` property, which is already part of the VM.)
-  `orderProductDetailsLabel`: This property displays details about the order item product or variation (the product type, attributes, and/or stock.)

The last property was moved in 86454d5d836ebd8c5de5eb98fa3ace7e8a8fd038. This label depends on properties of the product/variation related to the order item. Rather than adding all of the product properties it depends on to `CollapsibleProductRowCardViewModel`, I decided to keep the VM simple by only adding the label property (`productDetailsLabel`) and creating the label text when the view model is initialized.

For now, there are no changes to what data is displayed in that label — this PR only extracts the properties as-is to the new VM — but in #11389 we can update it to get the attributes directly from the `OrderItem` instead of the `ProductVariation`. (It probably makes sense to add convenience initializers that take a `Product` or `ProductVariation`, as well as the `OrderItem`, rather than using individual parameters like it does now. I thought we could wait until we're sure which data we want to get from the product/variation vs. the order item first.)

## Testing instructions

Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with non-empty items.

No changes on the order form UX are expected:

- Go to the Orders tab
- Tap `+` to create an order
- Tap `Add Products` and select a non-bundle product and a non-bundle product variation
- Select a bundle product from the prerequisite
- Configure the bundle
- Add the products to the order
- On the order form, confirm the product details include a "Bundle" label for the parent bundle product and the variation attributes for any selected product variations. Confirm non-bundle, non-variation products in the order show only the stock status on that line.
- Tap to expand the bundle product and confirm you can re-configure the bundle and your new configuration is saved.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.