### PR TITLE
[UI Tests] - Fix failing/flaky tests on iPad CI

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -50,7 +50,7 @@ public final class PasswordScreen: ScreenObject {
         continueButton.tap()
 
         // As of Xcode 14.3, the Simulator might ask to save the password which, of course, we don't want to do.
-        if app.buttons["Save Password"].waitForExistence(timeout: 10) {
+        if app.buttons["Save Password"].waitForExistence(timeout: 15) {
             // There should be no need to wait for this button to exist since it's part of the same
             // alert where "Save Password" is.
             app.buttons["Not Now"].tap()

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -92,14 +92,14 @@ public final class PaymentsScreen: ScreenObject {
     @discardableResult
     public func verifyOrderCompletedToastDisplayed() throws -> Self {
         let orderCompletedToast = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Order completed'")).firstMatch
-        XCTAssertTrue(orderCompletedToast.waitForExistence(timeout: 5))
+        XCTAssertTrue(orderCompletedToast.waitForExistence(timeout: 8))
 
         return self
     }
 
     @discardableResult
     public func verifyPaymentsScreenLoaded() throws -> PaymentsScreen {
-        XCTAssertTrue(collectPaymentButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(collectPaymentButton.waitForExistence(timeout: 8))
         return self
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -92,7 +92,7 @@ public final class PaymentsScreen: ScreenObject {
     @discardableResult
     public func verifyOrderCompletedToastDisplayed() throws -> Self {
         let orderCompletedToast = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Order completed'")).firstMatch
-        XCTAssertTrue(orderCompletedToast.exists)
+        XCTAssertTrue(orderCompletedToast.waitForExistence(timeout: 5))
 
         return self
     }


### PR DESCRIPTION
### Description
`test_complete_cash_simple_payment()` in `PaymentsTests` started failing in `trunk` (example failures: [1](https://buildkite.com/automattic/woocommerce-ios/builds/17974#018c5bdb-ef63-4f2e-85e2-978f486f368c), [2](https://buildkite.com/automattic/woocommerce-ios/builds/17973#018c5bd0-6eef-479d-9a17-3d91f32006b6), [3](https://buildkite.com/automattic/woocommerce-ios/builds/17969#018c5ba7-a450-47c9-806d-628b1ebc840b)).

Investigation shows that it's because it seems like the test is now taking a longer time in CI to display the "Order Completed" toast after making a cash payment. The failure was not reproducible locally. The fix is to use `waitForExistence` instead of `exists` so that the test would wait up to 8 seconds (if it happens quicker than 8 seconds, the test will continue) instead of immediately failing the test if the element does not exist. 

I also updated some of the timeout values to cater to this slowness seen recently.

### Testing
iPad run in CI should be 🟢 and `test_complete_cash_simple_payment()` in `PaymentsTests` should pass.