### PR TITLE
[Scan to update inventory M1] Hide inventory scan button when WooCommerce Square plugin is activated

### DIFF
--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -9,5 +9,6 @@ extension SitePlugin {
         public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
         public static let WCProductBundles = "WooCommerce Product Bundles"
         public static let WCCompositeProducts = "WooCommerce Composite Products"
+        public static let square = "WooCommerce Square"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -2,27 +2,10 @@ import Foundation
 import Yosemite
 import Experiments
 
-final class MockProductListViewModel: ProductsListViewModelProtocol {
-    private(set) var scanToUpdateInventoryShouldBeVisible: Bool = false
-    private let featureFlagService: FeatureFlagService
-
-    init(featureFlagService: FeatureFlagService) {
-        self.featureFlagService = featureFlagService
-    }
-
-    func scanToUpdateInventoryButtonShouldBeVisible(completion: @escaping (Bool) -> (Void)) {
-        guard self.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory) else {
-            scanToUpdateInventoryShouldBeVisible = false
-            return completion(false)
-        }
-        scanToUpdateInventoryShouldBeVisible = true
-        completion(true)
-    }
-}
-
 protocol ProductsListViewModelProtocol {
     func scanToUpdateInventoryButtonShouldBeVisible(completion: @escaping (Bool) -> (Void))
 }
+
 /// View model for `ProductsViewController`. Has stores logic related to Bulk Editing and Woo Subscriptions.
 ///
 final class ProductListViewModel: ProductsListViewModelProtocol {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Yosemite
-import protocol Storage.StorageManagerType
 import Experiments
 
 /// View model for `ProductsViewController`. Has stores logic related to Bulk Editing and Woo Subscriptions.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -2,9 +2,30 @@ import Foundation
 import Yosemite
 import Experiments
 
+final class MockProductListViewModel: ProductsListViewModelProtocol {
+    private(set) var scanToUpdateInventoryShouldBeVisible: Bool = false
+    private let featureFlagService: FeatureFlagService
+
+    init(featureFlagService: FeatureFlagService) {
+        self.featureFlagService = featureFlagService
+    }
+
+    func scanToUpdateInventoryButtonShouldBeVisible(completion: @escaping (Bool) -> (Void)) {
+        guard self.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory) else {
+            scanToUpdateInventoryShouldBeVisible = false
+            return completion(false)
+        }
+        scanToUpdateInventoryShouldBeVisible = true
+        completion(true)
+    }
+}
+
+protocol ProductsListViewModelProtocol {
+    func scanToUpdateInventoryButtonShouldBeVisible(completion: @escaping (Bool) -> (Void))
+}
 /// View model for `ProductsViewController`. Has stores logic related to Bulk Editing and Woo Subscriptions.
 ///
-class ProductListViewModel {
+final class ProductListViewModel: ProductsListViewModelProtocol {
 
     enum BulkEditError: Error {
         case noProductsSelected
@@ -206,6 +227,6 @@ class ProductListViewModel {
         let action = SystemStatusAction.fetchSystemPluginListWithNameList(siteID: siteID, systemPluginNameList: [plugin]) { plugin in
             completion(plugin?.active == true)
         }
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1161,6 +1161,9 @@ private extension ProductsViewController {
     }
 
     func configureLeftBarBarButtomItemAsScanningButtonIfApplicable() {
+        // The feature breaks if the Square plugin is active, since modifies inventory management logic
+        // If the plugin is active, we'll hide the inventory scanner button
+        // More details: https://wp.me/pdfdoF-2Nq
         isPluginActive(SitePlugin.SupportedPlugin.square) { result in
             switch result {
             case true:
@@ -1176,7 +1179,7 @@ private extension ProductsViewController {
         }
     }
 
-    private func isPluginActive(_ plugin: String, completion: @escaping (Bool) -> (Void)) {
+    func isPluginActive(_ plugin: String, completion: @escaping (Bool) -> (Void)) {
         let action = SystemStatusAction.fetchSystemPluginListWithNameList(siteID: siteID, systemPluginNameList: [plugin]) { plugin in
             completion(plugin?.active == true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1161,13 +1161,26 @@ private extension ProductsViewController {
     }
 
     func configureLeftBarBarButtomItemAsScanningButtonIfApplicable() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory),
-              UIImagePickerController.isSourceTypeAvailable(.camera) else {
-            navigationItem.leftBarButtonItem = nil
-            return
+        isPluginActive(SitePlugin.SupportedPlugin.square) { result in
+            switch result {
+            case true:
+                self.navigationItem.leftBarButtonItem = nil
+            case false:
+                guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory),
+                      UIImagePickerController.isSourceTypeAvailable(.camera) else {
+                    self.navigationItem.leftBarButtonItem = nil
+                    return
+                }
+                self.navigationItem.leftBarButtonItem = self.createAddOrderByProductScanningButtonItem()
+            }
         }
+    }
 
-        navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
+    private func isPluginActive(_ plugin: String, completion: @escaping (Bool) -> (Void)) {
+        let action = SystemStatusAction.fetchSystemPluginListWithNameList(siteID: siteID, systemPluginNameList: [plugin]) { plugin in
+            completion(plugin?.active == true)
+        }
+        ServiceLocator.stores.dispatch(action)
     }
 
     func createAddOrderByProductScanningButtonItem() -> UIBarButtonItem {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1161,29 +1161,14 @@ private extension ProductsViewController {
     }
 
     func configureLeftBarBarButtomItemAsScanningButtonIfApplicable() {
-        // The feature breaks if the Square plugin is active, since modifies inventory management logic
-        // If the plugin is active, we'll hide the inventory scanner button
-        // More details: https://wp.me/pdfdoF-2Nq
-        isPluginActive(SitePlugin.SupportedPlugin.square) { result in
-            switch result {
+        viewModel.scanToUpdateInventoryButtonShouldBeVisible(completion: { shouldBeVisible in
+            switch shouldBeVisible {
             case true:
-                self.navigationItem.leftBarButtonItem = nil
-            case false:
-                guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory),
-                      UIImagePickerController.isSourceTypeAvailable(.camera) else {
-                    self.navigationItem.leftBarButtonItem = nil
-                    return
-                }
                 self.navigationItem.leftBarButtonItem = self.createAddOrderByProductScanningButtonItem()
+            case false:
+                self.navigationItem.leftBarButtonItem = nil
             }
-        }
-    }
-
-    func isPluginActive(_ plugin: String, completion: @escaping (Bool) -> (Void)) {
-        let action = SystemStatusAction.fetchSystemPluginListWithNameList(siteID: siteID, systemPluginNameList: [plugin]) { plugin in
-            completion(plugin?.active == true)
-        }
-        ServiceLocator.stores.dispatch(action)
+        })
     }
 
     func createAddOrderByProductScanningButtonItem() -> UIBarButtonItem {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1318,6 +1318,7 @@
 		6881CCC42A5EE6BF00AEDE36 /* WooPlanCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */; };
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
 		6888A2CA2A66C42C0026F5C0 /* FullFeatureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */; };
+		68A38DF52B293B030090C263 /* MockProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A38DF42B293B030090C263 /* MockProductListViewModel.swift */; };
 		68A905012ACCFC13004C71D3 /* CollapsibleProductCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */; };
 		68AC9D292ACE598B0042F784 /* ProductImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC9D282ACE598B0042F784 /* ProductImageThumbnail.swift */; };
 		68B6F22B2ADE7ED500D171FC /* TooltipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B6F22A2ADE7ED500D171FC /* TooltipView.swift */; };
@@ -3890,6 +3891,7 @@
 		6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPlanCardView.swift; sourceTree = "<group>"; };
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
 		6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListViewModel.swift; sourceTree = "<group>"; };
+		68A38DF42B293B030090C263 /* MockProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductListViewModel.swift; sourceTree = "<group>"; };
 		68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCard.swift; sourceTree = "<group>"; };
 		68AC9D282ACE598B0042F784 /* ProductImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageThumbnail.swift; sourceTree = "<group>"; };
 		68B6F22A2ADE7ED500D171FC /* TooltipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipView.swift; sourceTree = "<group>"; };
@@ -8261,6 +8263,7 @@
 				EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */,
 				202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */,
 				20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */,
+				68A38DF42B293B030090C263 /* MockProductListViewModel.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14666,6 +14669,7 @@
 				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */,
 				EE7707CB2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift in Sources */,
+				68A38DF52B293B030090C263 /* MockProductListViewModel.swift in Sources */,
 				261E91A329C9882600A5C118 /* SubscriptionsViewModelTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,
 				4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,6 +22,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
     private let isLightweightStorefrontEnabled: Bool
+    private let isScanToUpdateInventoryEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -42,7 +43,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          productCreationAI: Bool = false,
          productBundles: Bool = false,
          productBundlesInOrderForm: Bool = false,
-         isLightweightStorefrontEnabled: Bool = false) {
+         isLightweightStorefrontEnabled: Bool = false,
+         isScanToUpdateInventoryEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -63,6 +65,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
         self.isLightweightStorefrontEnabled = isLightweightStorefrontEnabled
+        self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -105,6 +108,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return productBundlesInOrderForm
         case .lightweightStorefront:
             return isLightweightStorefrontEnabled
+        case .scanToUpdateInventory:
+            return isScanToUpdateInventoryEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductListViewModel.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductListViewModel.swift
@@ -1,0 +1,22 @@
+@testable import WooCommerce
+import Foundation
+import Yosemite
+import Experiments
+
+final class MockProductListViewModel: ProductsListViewModelProtocol {
+    private(set) var scanToUpdateInventoryShouldBeVisible: Bool = false
+    private let featureFlagService: FeatureFlagService
+
+    init(featureFlagService: FeatureFlagService) {
+        self.featureFlagService = featureFlagService
+    }
+
+    func scanToUpdateInventoryButtonShouldBeVisible(completion: @escaping (Bool) -> (Void)) {
+        guard self.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory) else {
+            scanToUpdateInventoryShouldBeVisible = false
+            return completion(false)
+        }
+        scanToUpdateInventoryShouldBeVisible = true
+        completion(true)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -312,9 +312,7 @@ final class ProductListViewModelTests: XCTestCase {
     func test_scanToUpdateInventoryButton_when_isScanToUpdateInventoryEnabled_is_true_then_should_be_visible() {
         // Given
         let featureFlagService = MockFeatureFlagService(isScanToUpdateInventoryEnabled: true)
-        let viewModel = ProductListViewModel(siteID: sampleSiteID,
-                                             stores: storesManager,
-                                             featureFlagService: featureFlagService)
+        let viewModel = MockProductListViewModel(featureFlagService: featureFlagService)
 
         // When
         let result = waitFor { promise in
@@ -330,11 +328,9 @@ final class ProductListViewModelTests: XCTestCase {
     func test_scanToUpdateInventoryButton_when_isScanToUpdateInventoryEnabled_is_false_then_should_not_be_visible() {
         // Given
         let featureFlagService = MockFeatureFlagService(isScanToUpdateInventoryEnabled: false)
-        let viewModel = ProductListViewModel(siteID: sampleSiteID,
-                                             stores: storesManager,
-                                             featureFlagService: featureFlagService)
+        let viewModel = MockProductListViewModel(featureFlagService: featureFlagService)
 
-        // When
+        // Then
         let result = waitFor { promise in
             viewModel.scanToUpdateInventoryButtonShouldBeVisible { result in
                 promise(result)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -308,4 +308,40 @@ final class ProductListViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
     }
+
+    func test_scanToUpdateInventoryButton_when_isScanToUpdateInventoryEnabled_is_true_then_should_be_visible() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isScanToUpdateInventoryEnabled: true)
+        let viewModel = ProductListViewModel(siteID: sampleSiteID,
+                                             stores: storesManager,
+                                             featureFlagService: featureFlagService)
+
+        // When
+        let result = waitFor { promise in
+            viewModel.scanToUpdateInventoryButtonShouldBeVisible { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func test_scanToUpdateInventoryButton_when_isScanToUpdateInventoryEnabled_is_false_then_should_not_be_visible() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isScanToUpdateInventoryEnabled: false)
+        let viewModel = ProductListViewModel(siteID: sampleSiteID,
+                                             stores: storesManager,
+                                             featureFlagService: featureFlagService)
+
+        // When
+        let result = waitFor { promise in
+            viewModel.scanToUpdateInventoryButtonShouldBeVisible { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertFalse(result)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11419

## Description
This PR hides the inventory scanner button when the Square plugin is active, this is done as a workaround to the existing issues with inventory sync when the plugin is active, since these haven't been addressed yet we've opted for hiding the feature to these merchants. More context on pdfdoF-2Nq-p2

## Testing instructions
1. On a store without `WooCommerce Square` installed and active, go to Products and confirm that the button appears in the top left corner.
2. On a store with `WooCommerce Square` installed and active ( you can use https://indiemelon.mystagingwebsite.com/), go to Products and confirm that the button does not appear in the top left corner.