### PR TITLE
[Scan to Update Inventory M1] Decimal bug

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -115,7 +115,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         self.inventoryItem = inventoryItem
         self.stores = stores
 
-        quantity = inventoryItem.stockQuantity?.formatted() ?? ""
+        quantity = "\(inventoryItem.stockQuantity ?? 0)"
 
         Task { @MainActor in
             name = try await inventoryItem.retrieveName(with: stores, siteID: siteID)
@@ -157,7 +157,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
         }
 
         let newQuantity = quantityDecimal + 1
-        quantity = newQuantity.formatted()
+        quantity = "\(newQuantity)"
 
         try? await updateStockQuantity(with: newQuantity)
     }


### PR DESCRIPTION
…ses issues when adding separators

<!-- Remember about a good descriptive title. -->

Closes: #11417 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix issues caused by using the `formatted` function of `Decimal`. Instead, we use here interpolation to convert the `Decimal` into `String`, which is the [same](https://github.com/woocommerce/woocommerce-ios/blob/ad113138e29a7b21ac05a28f66d0fd4a439e8324/WooCommerce/Classes/ViewRelated/Products/Edit%20Product/Inventory%20Settings/Product%2BInventorySettingsViewModels.swift#L17) we do when editing the stock quantity in product details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. In Menu > Products > Tap the "Scanner" icon on the left-top corner > Scan an existing product >
2. Update inventory to a number to the thousands, for example 1234. Tap Update Quantity button.
3. Scan the same product again, the view displays the product inventory as 1234, without a separator. The button shows Quantity+1. Update the quantity.
5. Scan the same product again, the view shows the right quantity.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/4c85518a-317f-42f0-8c4a-5dd861233aaa





---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
