### PR TITLE
Networking & Yosemite: Support installing theme

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -952,6 +952,8 @@
 		EE62EE61295ACF8D009C965B /* RequestConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */; };
 		EE62EE63295AD45E009C965B /* String+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE62295AD45E009C965B /* String+URL.swift */; };
 		EE62EE65295AD46D009C965B /* String+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE64295AD46D009C965B /* String+URLTests.swift */; };
+		EE66BB022B2893AF00518DAF /* theme-install-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB012B2893AF00518DAF /* theme-install-success.json */; };
+		EE66BB042B28975B00518DAF /* theme-install-already-installed.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB032B28975B00518DAF /* theme-install-already-installed.json */; };
 		EE6FDCFC2966A70400E1CECF /* product-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE6FDCFB2966A70400E1CECF /* product-without-data.json */; };
 		EE71CC3D2951A8EA0074D908 /* ApplicationPasswordStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */; };
 		EE71CC412951CE700074D908 /* generate-application-password-using-wporg-creds-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */; };
@@ -1977,6 +1979,8 @@
 		EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConverterTests.swift; sourceTree = "<group>"; };
 		EE62EE62295AD45E009C965B /* String+URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URL.swift"; sourceTree = "<group>"; };
 		EE62EE64295AD46D009C965B /* String+URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLTests.swift"; sourceTree = "<group>"; };
+		EE66BB012B2893AF00518DAF /* theme-install-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-install-success.json"; sourceTree = "<group>"; };
+		EE66BB032B28975B00518DAF /* theme-install-already-installed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-install-already-installed.json"; sourceTree = "<group>"; };
 		EE6FDCFB2966A70400E1CECF /* product-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-without-data.json"; sourceTree = "<group>"; };
 		EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordStorage.swift; sourceTree = "<group>"; };
 		EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-application-password-using-wporg-creds-success.json"; sourceTree = "<group>"; };
@@ -2593,6 +2597,8 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				EE66BB032B28975B00518DAF /* theme-install-already-installed.json */,
+				EE66BB012B2893AF00518DAF /* theme-install-success.json */,
 				DEDA8DB62B187E770076BF0F /* theme-mine-success.json */,
 				DED91DDE2AD63C2800CDCC53 /* blaze-campaigns-success.json */,
 				DEDA8DA42B1839320076BF0F /* theme-list-success.json */,
@@ -3783,6 +3789,7 @@
 				B554FA8D2180B59700C54DFF /* notifications-load-hashes.json in Resources */,
 				022902D622E2436400059692 /* no_stats_permission_error.json in Resources */,
 				FE28F6E826842D57004465C7 /* user-complete.json in Resources */,
+				EE66BB022B2893AF00518DAF /* theme-install-success.json in Resources */,
 				02EF1670292F0CF400D90AD6 /* create-cart-success.json in Resources */,
 				261CF2CB255C50010090D8D3 /* payment-gateway-list-half.json in Resources */,
 				02C254D72563999300A04423 /* order-shipping-labels.json in Resources */,
@@ -3903,6 +3910,7 @@
 				DE4F2A3F29750EF400B0701C /* inbox-note-list-without-data.json in Resources */,
 				7497376A2141F2BE0008C490 /* top-performers-week-alt.json in Resources */,
 				DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */,
+				EE66BB042B28975B00518DAF /* theme-install-already-installed.json in Resources */,
 				D865CE61278CA1AE002C8520 /* stripe-payment-intent-processing.json in Resources */,
 				743E84F222172D0A00FAC9D7 /* shipment_tracking_plugin_not_active.json in Resources */,
 				68CB801628D8A39700E169F8 /* customer.json in Resources */,

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -11,9 +11,9 @@ public protocol WordPressThemeRemoteProtocol {
     ///
     func loadCurrentTheme(siteID: Int64) async throws -> WordPressTheme
 
-    /// Installs the given theme for the site with the specified ID.
+    /// Installs the theme with the given ID for the site with the specified ID.
     ///
-    func installTheme(_ theme: WordPressTheme,
+    func installTheme(themeID: String,
                       siteID: Int64) async throws -> WordPressTheme
 }
 
@@ -37,9 +37,9 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
         return try await enqueue(request, mapper: WordPressThemeMapper())
     }
 
-    public func installTheme(_ theme: WordPressTheme,
+    public func installTheme(themeID: String,
                              siteID: Int64) async throws -> WordPressTheme {
-        let path = Paths.install(theme: theme, for: siteID)
+        let path = Paths.install(themeID: themeID, for: siteID)
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
         do {
             return try await enqueue(request, mapper: WordPressThemeMapper())
@@ -80,9 +80,9 @@ private extension WordPressThemeRemote {
             "sites/\(siteID)/themes/mine"
         }
 
-        static func install(theme: WordPressTheme,
+        static func install(themeID: String,
                             for siteID: Int64) -> String {
-            "sites/\(siteID)/themes/\(theme.id)/install/"
+            "sites/\(siteID)/themes/\(themeID)/install/"
         }
     }
 

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -10,6 +10,11 @@ public protocol WordPressThemeRemoteProtocol {
     /// Loads the current theme for the site with the specified ID.
     ///
     func loadCurrentTheme(siteID: Int64) async throws -> WordPressTheme
+
+    /// Installs the given theme for the site with the specified ID.
+    ///
+    func installTheme(_ theme: WordPressTheme,
+                      siteID: Int64) async throws -> WordPressTheme
 }
 
 /// WordPressThemes: Remote Endpoints
@@ -31,6 +36,41 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path)
         return try await enqueue(request, mapper: WordPressThemeMapper())
     }
+
+    public func installTheme(_ theme: WordPressTheme,
+                             siteID: Int64) async throws -> WordPressTheme {
+        let path = Paths.install(theme: theme, for: siteID)
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
+        do {
+            return try await enqueue(request, mapper: WordPressThemeMapper())
+        } catch {
+            throw InstallThemeError(error) ?? error
+        }
+    }
+}
+
+/// Possible theme installation errors in the Networking layer.
+///
+public enum InstallThemeError: Error {
+    case themeAlreadyInstalled
+
+    init?(_ error: Error) {
+        guard let dotcomError = error as? DotcomError,
+              case let .unknown(code, _) = dotcomError else {
+            return nil
+        }
+
+        switch code {
+        case Constants.themeAlreadyInstalled:
+            self = .themeAlreadyInstalled
+        default:
+            return nil
+        }
+    }
+
+    private enum Constants {
+        static let themeAlreadyInstalled = "theme_already_installed"
+    }
 }
 
 private extension WordPressThemeRemote {
@@ -38,6 +78,11 @@ private extension WordPressThemeRemote {
         static let suggestedThemes = "themes?filter=subject:store&number=100"
         static func currentThemePath(for siteID: Int64) -> String {
             "sites/\(siteID)/themes/mine"
+        }
+
+        static func install(theme: WordPressTheme,
+                            for siteID: Int64) -> String {
+            "sites/\(siteID)/themes/\(theme.id)/install/"
         }
     }
 

--- a/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
@@ -99,4 +99,65 @@ final class WordPressThemeRemoteTests: XCTestCase {
             XCTAssertEqual(error as? NetworkError, expectedError)
         }
     }
+
+    // MARK: - installTheme tests
+
+    func test_installTheme_returns_installed_theme() async throws {
+        // Given
+        let remote = WordPressThemeRemote(network: network)
+
+        let sampleTheme = WordPressTheme.fake().copy(id: "maywood")
+        let suffix = "sites/\(sampleSiteID)/themes/\(sampleTheme.id)/install/"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "theme-install-success")
+
+        // When
+        let theme = try await remote.installTheme(sampleTheme, siteID: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(theme.id, sampleTheme.id)
+        XCTAssertEqual(theme.name, "Maywood")
+        XCTAssertEqual(theme.description, "Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.")
+    }
+
+    func test_installTheme_properly_relays_themeAlreadyInstalled_error() async {
+        // Given
+        let remote = WordPressThemeRemote(network: network)
+
+        let expectedError = InstallThemeError.themeAlreadyInstalled
+        let sampleTheme = WordPressTheme.fake().copy(id: "maywood")
+        let suffix = "sites/\(sampleSiteID)/themes/\(sampleTheme.id)/install/"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "theme-install-already-installed")
+
+        do {
+            // When
+            _ = try await remote.installTheme(sampleTheme, siteID: sampleSiteID)
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? InstallThemeError, expectedError)
+        }
+    }
+
+    func test_installTheme_properly_relays_networking_errors() async {
+        // Given
+        let remote = WordPressThemeRemote(network: network)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        let sampleTheme = WordPressTheme.fake().copy(id: "maywood")
+        let suffix = "sites/\(sampleSiteID)/themes/\(sampleTheme.id)/install/"
+        network.simulateError(requestUrlSuffix: suffix, error: expectedError)
+
+        do {
+            // When
+            _ = try await remote.installTheme(sampleTheme, siteID: sampleSiteID)
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+    }
 }

--- a/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
@@ -111,7 +111,7 @@ final class WordPressThemeRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: suffix, filename: "theme-install-success")
 
         // When
-        let theme = try await remote.installTheme(sampleTheme, siteID: sampleSiteID)
+        let theme = try await remote.installTheme(themeID: sampleTheme.id, siteID: sampleSiteID)
 
         // Then
         XCTAssertEqual(theme.id, sampleTheme.id)
@@ -130,7 +130,7 @@ final class WordPressThemeRemoteTests: XCTestCase {
 
         do {
             // When
-            _ = try await remote.installTheme(sampleTheme, siteID: sampleSiteID)
+            _ = try await remote.installTheme(themeID: sampleTheme.id, siteID: sampleSiteID)
 
             // Then
             XCTFail("Request should fail")
@@ -151,7 +151,7 @@ final class WordPressThemeRemoteTests: XCTestCase {
 
         do {
             // When
-            _ = try await remote.installTheme(sampleTheme, siteID: sampleSiteID)
+            _ = try await remote.installTheme(themeID: sampleTheme.id, siteID: sampleSiteID)
 
             // Then
             XCTFail("Request should fail")

--- a/Networking/NetworkingTests/Responses/theme-install-already-installed.json
+++ b/Networking/NetworkingTests/Responses/theme-install-already-installed.json
@@ -1,0 +1,4 @@
+{
+  "error": "theme_already_installed",
+  "message": "The theme is already installed"
+}

--- a/Networking/NetworkingTests/Responses/theme-install-success.json
+++ b/Networking/NetworkingTests/Responses/theme-install-success.json
@@ -1,0 +1,7 @@
+{
+    "id": "maywood",
+    "screenshot": "//i0.wp.com/example.com/wp-content/themes/maywood/screenshot.png?ssl=1",
+    "name": "Maywood",
+    "theme_uri": "https://wordpress.com/theme/maywood",
+    "description": "Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look."
+}

--- a/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
@@ -20,4 +20,15 @@ public enum WordPressThemeAction: Action {
     ///     - `result.failure(Error)`: error indicates issues loading themes.
     ///
     case loadCurrentTheme(siteID: Int64, onCompletion: (Result<WordPressTheme, Error>) -> Void)
+
+    /// Installs the given theme ID for a site.
+    /// - `theme`: ID of the theme to be installed.
+    /// - `siteID`: ID of the current site.
+    /// - `onCompletion`: invoked when the theme installation operation finishes.
+    ///     - `result.success(WordPressTheme)`: the installed theme's details.
+    ///     - `result.failure(Error)`: error indicates issues installing themes.
+    ///
+    case installTheme(_ theme: WordPressTheme,
+                      siteID: Int64,
+                      onCompletion: (Result<WordPressTheme, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
@@ -22,13 +22,13 @@ public enum WordPressThemeAction: Action {
     case loadCurrentTheme(siteID: Int64, onCompletion: (Result<WordPressTheme, Error>) -> Void)
 
     /// Installs the given theme ID for a site.
-    /// - `theme`: ID of the theme to be installed.
+    /// - `themeID`: ID of the theme to be installed.
     /// - `siteID`: ID of the current site.
     /// - `onCompletion`: invoked when the theme installation operation finishes.
     ///     - `result.success(WordPressTheme)`: the installed theme's details.
     ///     - `result.failure(Error)`: error indicates issues installing themes.
     ///
-    case installTheme(_ theme: WordPressTheme,
+    case installTheme(themeID: String,
                       siteID: Int64,
                       onCompletion: (Result<WordPressTheme, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
@@ -50,6 +50,8 @@ public final class WordPressThemeStore: Store {
             loadSuggestedThemes(onCompletion: onCompletion)
         case let .loadCurrentTheme(siteID, onCompletion):
             loadCurrentTheme(siteID: siteID, onCompletion: onCompletion)
+        case let .installTheme(theme, siteID, onCompletion):
+            installTheme(theme, siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -71,6 +73,19 @@ private extension WordPressThemeStore {
         Task { @MainActor in
             do {
                 let theme = try await remote.loadCurrentTheme(siteID: siteID)
+                onCompletion(.success(theme))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func installTheme(_ theme: WordPressTheme,
+                      siteID: Int64,
+                      onCompletion: @escaping (Result<WordPressTheme, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let theme = try await remote.installTheme(theme, siteID: siteID)
                 onCompletion(.success(theme))
             } catch {
                 onCompletion(.failure(error))

--- a/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
@@ -50,8 +50,8 @@ public final class WordPressThemeStore: Store {
             loadSuggestedThemes(onCompletion: onCompletion)
         case let .loadCurrentTheme(siteID, onCompletion):
             loadCurrentTheme(siteID: siteID, onCompletion: onCompletion)
-        case let .installTheme(theme, siteID, onCompletion):
-            installTheme(theme, siteID: siteID, onCompletion: onCompletion)
+        case let .installTheme(themeID, siteID, onCompletion):
+            installTheme(themeID: themeID, siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -80,12 +80,12 @@ private extension WordPressThemeStore {
         }
     }
 
-    func installTheme(_ theme: WordPressTheme,
+    func installTheme(themeID: String,
                       siteID: Int64,
                       onCompletion: @escaping (Result<WordPressTheme, Error>) -> Void) {
         Task { @MainActor in
             do {
-                let theme = try await remote.installTheme(theme, siteID: siteID)
+                let theme = try await remote.installTheme(themeID: themeID, siteID: siteID)
                 onCompletion(.success(theme))
             } catch {
                 onCompletion(.failure(error))

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
@@ -10,6 +10,9 @@ final class MockWordPressThemeRemote {
     private var stubbedCurrentTheme: WordPressTheme?
     private var stubbedCurrentThemeError: Error?
 
+    private var stubbedInstallTheme: WordPressTheme?
+    private var stubbedInstallThemeError: Error?
+
     func whenLoadingSuggestedTheme(thenReturn result: Result<[Networking.WordPressTheme], Error>) {
         switch result {
         case .success(let themes):
@@ -25,6 +28,15 @@ final class MockWordPressThemeRemote {
             stubbedCurrentTheme = theme
         case .failure(let error):
             stubbedCurrentThemeError = error
+        }
+    }
+
+    func whenInstallingTheme(thenReturn result: Result<Networking.WordPressTheme, Error>) {
+        switch result {
+        case .success(let theme):
+            stubbedInstallTheme = theme
+        case .failure(let error):
+            stubbedInstallThemeError = error
         }
     }
 }
@@ -45,5 +57,15 @@ extension MockWordPressThemeRemote: WordPressThemeRemoteProtocol {
             throw NetworkError.notFound()
         }
         return stubbedCurrentTheme
+    }
+
+    func installTheme(_ theme: Networking.WordPressTheme, siteID: Int64) async throws -> WordPressTheme {
+        if let stubbedInstallThemeError {
+            throw stubbedInstallThemeError
+        }
+        guard let stubbedInstallTheme else {
+            throw NetworkError.notFound()
+        }
+        return stubbedInstallTheme
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
@@ -59,7 +59,7 @@ extension MockWordPressThemeRemote: WordPressThemeRemoteProtocol {
         return stubbedCurrentTheme
     }
 
-    func installTheme(_ theme: Networking.WordPressTheme, siteID: Int64) async throws -> WordPressTheme {
+    func installTheme(themeID: String, siteID: Int64) async throws -> WordPressTheme {
         if let stubbedInstallThemeError {
             throw stubbedInstallThemeError
         }

--- a/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
@@ -115,4 +115,48 @@ final class WordPressThemeStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
+
+    // MARK: - installTheme tests
+
+    func test_installTheme_returns_installed_theme_on_success() throws {
+        // Given
+        let sampleTheme = WordPressTheme.fake().copy(name: "Tsubaki")
+        remote.whenInstallingTheme(thenReturn: .success(sampleTheme))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.installTheme(sampleTheme, siteID: 123, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let theme = try result.get()
+        XCTAssertEqual(theme.name, "Tsubaki")
+    }
+
+    func test_installTheme_returns_error_on_failure() throws {
+        // Given
+        remote.whenInstallingTheme(thenReturn: .failure(NetworkError.timeout()))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.installTheme(.fake(), siteID: 123, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
 }

--- a/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
@@ -129,7 +129,7 @@ final class WordPressThemeStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(WordPressThemeAction.installTheme(sampleTheme, siteID: 123, onCompletion: { result in
+            store.onAction(WordPressThemeAction.installTheme(themeID: sampleTheme.id, siteID: 123, onCompletion: { result in
                 promise(result)
             }))
         }
@@ -150,7 +150,7 @@ final class WordPressThemeStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(WordPressThemeAction.installTheme(.fake(), siteID: 123, onCompletion: { result in
+            store.onAction(WordPressThemeAction.installTheme(themeID: "123", siteID: 123, onCompletion: { result in
                 promise(result)
             }))
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11323 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates Networking and Yosemite layers to support installing theme.

### Changes include:
- Updated `WordPressThemeRemote` with a new endpoint to install a theme. 
- Updated `WordPressThemeAction` and store to support installing a theme.

## Testing instructions
CI passing is sufficient.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
