### PR TITLE
Networking & Yosemite: Support activating theme

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -954,6 +954,7 @@
 		EE62EE65295AD46D009C965B /* String+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE64295AD46D009C965B /* String+URLTests.swift */; };
 		EE66BB022B2893AF00518DAF /* theme-install-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB012B2893AF00518DAF /* theme-install-success.json */; };
 		EE66BB042B28975B00518DAF /* theme-install-already-installed.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB032B28975B00518DAF /* theme-install-already-installed.json */; };
+		EE66BB062B29791500518DAF /* theme-activate-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB052B29791500518DAF /* theme-activate-success.json */; };
 		EE6FDCFC2966A70400E1CECF /* product-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE6FDCFB2966A70400E1CECF /* product-without-data.json */; };
 		EE71CC3D2951A8EA0074D908 /* ApplicationPasswordStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */; };
 		EE71CC412951CE700074D908 /* generate-application-password-using-wporg-creds-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */; };
@@ -1981,6 +1982,7 @@
 		EE62EE64295AD46D009C965B /* String+URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLTests.swift"; sourceTree = "<group>"; };
 		EE66BB012B2893AF00518DAF /* theme-install-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-install-success.json"; sourceTree = "<group>"; };
 		EE66BB032B28975B00518DAF /* theme-install-already-installed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-install-already-installed.json"; sourceTree = "<group>"; };
+		EE66BB052B29791500518DAF /* theme-activate-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-activate-success.json"; sourceTree = "<group>"; };
 		EE6FDCFB2966A70400E1CECF /* product-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-without-data.json"; sourceTree = "<group>"; };
 		EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordStorage.swift; sourceTree = "<group>"; };
 		EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-application-password-using-wporg-creds-success.json"; sourceTree = "<group>"; };
@@ -2598,6 +2600,7 @@
 			isa = PBXGroup;
 			children = (
 				EE66BB032B28975B00518DAF /* theme-install-already-installed.json */,
+				EE66BB052B29791500518DAF /* theme-activate-success.json */,
 				EE66BB012B2893AF00518DAF /* theme-install-success.json */,
 				DEDA8DB62B187E770076BF0F /* theme-mine-success.json */,
 				DED91DDE2AD63C2800CDCC53 /* blaze-campaigns-success.json */,
@@ -3644,6 +3647,7 @@
 				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
 				68C87B342862D40E00A99054 /* setting-all-except-countries.json in Resources */,
 				EE28C7DB2AC17961004A69F4 /* generate-product-invalid-token.json in Resources */,
+				EE66BB062B29791500518DAF /* theme-activate-success.json in Resources */,
 				CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */,
 				3158FE6026129ADD00E566B9 /* wcpay-account-none.json in Resources */,
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,

--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -60,11 +60,7 @@ public final class WordPressThemeRemote: Remote, WordPressThemeRemoteProtocol {
             ParameterKey.theme: themeID,
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
-        do {
-            return try await enqueue(request, mapper: WordPressThemeMapper())
-        } catch {
-            throw InstallThemeError(error) ?? error
-        }
+        return try await enqueue(request, mapper: WordPressThemeMapper())
     }
 }
 

--- a/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressThemeRemoteTests.swift
@@ -160,4 +160,44 @@ final class WordPressThemeRemoteTests: XCTestCase {
             XCTAssertEqual(error as? NetworkError, expectedError)
         }
     }
+
+    // MARK: - activateTheme tests
+
+    func test_activateTheme_returns_activated_theme() async throws {
+        // Given
+        let remote = WordPressThemeRemote(network: network)
+
+        let sampleTheme = WordPressTheme.fake().copy(id: "maywood")
+        let suffix = "sites/\(sampleSiteID)/themes/mine"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "theme-activate-success")
+
+        // When
+        let theme = try await remote.activateTheme(themeID: sampleTheme.id, siteID: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(theme.id, sampleTheme.id)
+        XCTAssertEqual(theme.name, "Maywood")
+        XCTAssertEqual(theme.description, "Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.")
+    }
+
+    func test_activateTheme_properly_relays_networking_errors() async {
+        // Given
+        let remote = WordPressThemeRemote(network: network)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        let sampleTheme = WordPressTheme.fake().copy(id: "maywood")
+        let suffix = "sites/\(sampleSiteID)/themes/mine"
+        network.simulateError(requestUrlSuffix: suffix, error: expectedError)
+
+        do {
+            // When
+            _ = try await remote.activateTheme(themeID: sampleTheme.id, siteID: sampleSiteID)
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+    }
 }

--- a/Networking/NetworkingTests/Responses/theme-activate-success.json
+++ b/Networking/NetworkingTests/Responses/theme-activate-success.json
@@ -1,0 +1,7 @@
+{
+    "id": "maywood",
+    "screenshot": "//i0.wp.com/example.com/wp-content/themes/maywood/screenshot.png?ssl=1",
+    "name": "Maywood",
+    "theme_uri": "https://wordpress.com/theme/maywood",
+    "description": "Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look."
+}

--- a/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
@@ -31,4 +31,15 @@ public enum WordPressThemeAction: Action {
     case installTheme(themeID: String,
                       siteID: Int64,
                       onCompletion: (Result<WordPressTheme, Error>) -> Void)
+
+    /// Activates the given theme ID for a site.
+    /// - `themeID`: ID of the theme to be installed.
+    /// - `siteID`: ID of the current site.
+    /// - `onCompletion`: invoked when the theme installation operation finishes.
+    ///     - `result.success(WordPressTheme)`: the installed theme's details.
+    ///     - `result.failure(Error)`: error indicates issues installing themes.
+    ///
+    case activateTheme(themeID: String,
+                       siteID: Int64,
+                       onCompletion: (Result<WordPressTheme, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressThemeAction.swift
@@ -33,11 +33,11 @@ public enum WordPressThemeAction: Action {
                       onCompletion: (Result<WordPressTheme, Error>) -> Void)
 
     /// Activates the given theme ID for a site.
-    /// - `themeID`: ID of the theme to be installed.
+    /// - `themeID`: ID of the theme to be activated.
     /// - `siteID`: ID of the current site.
-    /// - `onCompletion`: invoked when the theme installation operation finishes.
-    ///     - `result.success(WordPressTheme)`: the installed theme's details.
-    ///     - `result.failure(Error)`: error indicates issues installing themes.
+    /// - `onCompletion`: invoked when the theme activation operation finishes.
+    ///     - `result.success(WordPressTheme)`: the activated theme's details.
+    ///     - `result.failure(Error)`: error indicates issues activating themes.
     ///
     case activateTheme(themeID: String,
                        siteID: Int64,

--- a/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressThemeStore.swift
@@ -52,6 +52,8 @@ public final class WordPressThemeStore: Store {
             loadCurrentTheme(siteID: siteID, onCompletion: onCompletion)
         case let .installTheme(themeID, siteID, onCompletion):
             installTheme(themeID: themeID, siteID: siteID, onCompletion: onCompletion)
+        case let .activateTheme(themeID, siteID, onCompletion):
+            activateTheme(themeID: themeID, siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -86,6 +88,19 @@ private extension WordPressThemeStore {
         Task { @MainActor in
             do {
                 let theme = try await remote.installTheme(themeID: themeID, siteID: siteID)
+                onCompletion(.success(theme))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func activateTheme(themeID: String,
+                       siteID: Int64,
+                       onCompletion: @escaping (Result<WordPressTheme, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let theme = try await remote.activateTheme(themeID: themeID, siteID: siteID)
                 onCompletion(.success(theme))
             } catch {
                 onCompletion(.failure(error))

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWordPressThemeRemote.swift
@@ -13,6 +13,9 @@ final class MockWordPressThemeRemote {
     private var stubbedInstallTheme: WordPressTheme?
     private var stubbedInstallThemeError: Error?
 
+    private var stubbedActivateTheme: WordPressTheme?
+    private var stubbedActivateThemeError: Error?
+
     func whenLoadingSuggestedTheme(thenReturn result: Result<[Networking.WordPressTheme], Error>) {
         switch result {
         case .success(let themes):
@@ -37,6 +40,15 @@ final class MockWordPressThemeRemote {
             stubbedInstallTheme = theme
         case .failure(let error):
             stubbedInstallThemeError = error
+        }
+    }
+
+    func whenActivatingTheme(thenReturn result: Result<Networking.WordPressTheme, Error>) {
+        switch result {
+        case .success(let theme):
+            stubbedActivateTheme = theme
+        case .failure(let error):
+            stubbedActivateThemeError = error
         }
     }
 }
@@ -67,5 +79,15 @@ extension MockWordPressThemeRemote: WordPressThemeRemoteProtocol {
             throw NetworkError.notFound()
         }
         return stubbedInstallTheme
+    }
+
+    func activateTheme(themeID: String, siteID: Int64) async throws -> WordPressTheme {
+        if let stubbedActivateThemeError {
+            throw stubbedActivateThemeError
+        }
+        guard let stubbedActivateTheme else {
+            throw NetworkError.notFound()
+        }
+        return stubbedActivateTheme
     }
 }

--- a/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressThemeStoreTests.swift
@@ -159,4 +159,48 @@ final class WordPressThemeStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
+
+    // MARK: - activateTheme tests
+
+    func test_activateTheme_returns_activated_theme_on_success() throws {
+        // Given
+        let sampleTheme = WordPressTheme.fake().copy(name: "Tsubaki")
+        remote.whenActivatingTheme(thenReturn: .success(sampleTheme))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.activateTheme(themeID: sampleTheme.id, siteID: 123, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let theme = try result.get()
+        XCTAssertEqual(theme.name, "Tsubaki")
+    }
+
+    func test_activateTheme_returns_error_on_failure() throws {
+        // Given
+        remote.whenActivatingTheme(thenReturn: .failure(NetworkError.timeout()))
+        let store = WordPressThemeStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(WordPressThemeAction.activateTheme(themeID: "123", siteID: 123, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11323 

## Description
This PR updates Networking and Yosemite layers to support activating a theme.

### Changes include:
- Updated `WordPressThemeRemote` with a new endpoint to activate a theme. 
- Updated `WordPressThemeAction` and store to support activating a theme.

## Testing instructions
CI passing is sufficient.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
