### PR TITLE
[Order form] Remove extra spacing at the trailing edge of the discount price label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -292,12 +292,14 @@ private extension CollapsibleProductRowCard {
                 // This avoids showing an out-of-date discount while hasn't synched
                 .redacted(reason: shouldDisableDiscountEditing ? .placeholder : [] )
             }
-            Spacer()
-            Button {
-                shouldShowInfoTooltip.toggle()
-            } label: {
-                Image(systemName: "questionmark.circle")
-                    .foregroundColor(Color(.wooCommercePurple(.shade60)))
+            Group {
+                Spacer()
+                Button {
+                    shouldShowInfoTooltip.toggle()
+                } label: {
+                    Image(systemName: "questionmark.circle")
+                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                }
             }
             .renderedIf(shouldDisallowDiscounts)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11435 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I noticed a visual issue on the discount view while testing a PR related to discount, and was afraid that it was caused by my order form refactoring earlier because this issue does not occur in the production release 16.4. It turned out to be a quick fix, the root cause is from a `Spacer` that's always shown while its visibility should be bound with the discount info tooltip button.

## How

This PR moved the `Spacer` to a `Group` with the info tooltip button under the same rendering condition.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the Orders tab
- Tap `+`
- Tap `Add Products`, select at least one product and confirm
- Tap to expand a product card
- Tap `Add discount`, enter an amount then tap `Add` --> there shouldn't be extra padding on the trailing edge of the discount price

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after | with info tooltip (discount disallowed)
-- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/962cb9f9-2a7e-4ca5-a847-d362d127662f" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/2715b966-05b3-44ed-a4c5-a3e943dd887e" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/cc1619de-e3d2-422e-a5ae-8499004f7116" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
