### PR TITLE
[Scan to Update Inventory M1] Make scan button loading indicator when scanning is in progress. Show notice if fails.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -312,7 +312,7 @@ private extension ProductsViewController {
                     if let presentedViewController = self.presentedViewController as? InProgressViewController {
                         await self.dismiss(animated: true)
                     }
-                    self.presentNotice(title: "error")
+                    self.presentNotice(title: Localization.scannerErrorNotice)
                 }
             }
 
@@ -325,8 +325,8 @@ private extension ProductsViewController {
     }
 
     private func displayInProgressView() -> InProgressViewController {
-        let title = "Loading"
-        let message = "Wait while loading..."
+        let title = Localization.progressViewTitle
+        let message = Localization.progressViewMessage
         let viewProperties = InProgressViewProperties(title: title, message: message)
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
         
@@ -1489,5 +1489,17 @@ private extension ProductsViewController {
             comment: "Message of the notice when inventory is updated successfully. Style may vary based on store settings." +
             "Reads like: 'Quantity updated: 2,345'"
         )
+        static let progressViewTitle = NSLocalizedString(
+            "progressViewTitle.scanProducts.displayInProgressView",
+            value: "Loading...",
+            comment: "Title of the loading screen when a product is scanned for updating inventory.")
+        static let progressViewMessage = NSLocalizedString(
+            "progressViewMessage.scanProducts.displayInProgressView",
+            value: "Scanning barcode. Please wait.",
+            comment: "Message of the loading screen when a product is scanned for updating inventory.")
+        static let scannerErrorNotice = NSLocalizedString(
+            "scannerErrorNotice.scanProducts.createAddOrderByProductScanningButtonItem",
+            value: "There was an error when attempting to scan the barcode. Please try again.",
+            comment: "Error notice when an attempt to scanned to update inventory fails to find the product.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -329,7 +329,7 @@ private extension ProductsViewController {
         let message = Localization.progressViewMessage
         let viewProperties = InProgressViewProperties(title: title, message: message)
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
-        
+
         return inProgressViewController
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -305,7 +305,10 @@ private extension ProductsViewController {
                     })), animated: true)
                 } catch {
                     DDLogError("There was an error when attempting to update inventory via scanner: \(error)")
-                    self.presentNotice(title: Localization.scannerErrorNotice)
+                    let errorNotice = BarcodeSKUScannerErrorNoticeFactory.notice(for: error,
+                                                                            code: scannedBarcode,
+                                                                            actionHandler: { })
+                    self.presentNotice(notice: errorNotice)
                 }
                 // Reset button state on finishing the task
                 self.configureLeftBarBarButtomItemAsScanningButtonIfApplicable()
@@ -525,6 +528,15 @@ private extension ProductsViewController {
             return noticePresenter
         }()
         contextNoticePresenter.enqueue(notice: .init(title: title))
+    }
+
+    func presentNotice(notice: Notice) {
+        let contextNoticePresenter: NoticePresenter = {
+            let noticePresenter = DefaultNoticePresenter()
+            noticePresenter.presentingViewController = tabBarController
+            return noticePresenter
+        }()
+        contextNoticePresenter.enqueue(notice: notice)
     }
 }
 
@@ -1475,9 +1487,5 @@ private extension ProductsViewController {
             comment: "Message of the notice when inventory is updated successfully. Style may vary based on store settings." +
             "Reads like: 'Quantity updated: 2,345'"
         )
-        static let scannerErrorNotice = NSLocalizedString(
-            "scannerErrorNotice.scanProducts.createAddOrderByProductScanningButtonItem",
-            value: "There was an error when attempting to scan the barcode. Please try again.",
-            comment: "Error notice when an attempt to scanned to update inventory fails to find the product.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -306,8 +306,10 @@ private extension ProductsViewController {
                 } catch {
                     DDLogError("There was an error when attempting to update inventory via scanner: \(error)")
                     let errorNotice = BarcodeSKUScannerErrorNoticeFactory.notice(for: error,
-                                                                            code: scannedBarcode,
-                                                                            actionHandler: { })
+                                                                                 code: scannedBarcode,
+                                                                                 actionHandler: {
+                        self.scanProducts()
+                    })
                     self.presentNotice(notice: errorNotice)
                 }
                 // Reset button state on finishing the task


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11427

## Description
This PR updates the "_scan to update inventory_" button logic to display as a loading indicator while the scanner is handling the SKU search, or display as a normal button when it's not. 

We also add an error notice to the view when the scanning fails, so merchants are informed.

### Changes
- The logic for the loading indicator button was already in place, but we happened to override it in the immediate task, when configuring the left button. We move the button configuration outside of the task, and make it as loading indicator inside of it.
- Adds a notice when an error is catched

## Testing instructions

### Success case:
- Go through the scan to update inventory normal flow, for an existing product. Notice how the button becomes a loading indicator just after successfully scanning a product, and before the inventory view is shown

### Fail case:
- Update `ProductListViewModel.handleScannedBarcode()` logic to force throw an error:
```diff
    func handleScannedBarcode(_ scannedBarcode: ScannedBarcode) async throws -> SKUSearchResult {
+        throw UpdateInventoryError.generic
-        do {
-            return try await barcodeSKUScannerItemFinder.searchBySKU(from: scannedBarcode, siteID: siteID, source: .productList)
-        } catch {
-            DDLogInfo("SKU search failed with error: \(error)")
-            throw error
-        }
    }
```
- Go through the scan to update inventory normal flow, for an existing product. See how the scanner is dismissed, and a notice appears in the product list informing about an error:

<img width="1045" alt="Screenshot 2023-12-13 at 16 42 05" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/5696c798-bdaa-4ed4-bc46-e0658c3464f7">
