### PR TITLE
Lightweight Storefront: Add step to edit theme to the store creation profiler flow

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
@@ -62,7 +62,9 @@ struct StoreCreationProfilerQuestionContainerView: View {
                     }
                 }, onSupport: onSupport))
             case .theme:
-                ProfilerThemesPickerView(carouselViewModel: viewModel.themesCarouselViewModel, onSkip: {
+                ProfilerThemesPickerView(carouselViewModel: viewModel.themesCarouselViewModel, onSelectedTheme: { theme in
+                    viewModel.saveTheme(theme)
+                }, onSkip: {
                     viewModel.saveTheme(nil)
                 })
             }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
@@ -61,6 +61,10 @@ struct StoreCreationProfilerQuestionContainerView: View {
                         viewModel.saveCountry(answer)
                     }
                 }, onSupport: onSupport))
+            case .theme:
+                ProfilerThemesPickerView(carouselViewModel: viewModel.themesCarouselViewModel, onSkip: {
+                    viewModel.saveTheme(nil)
+                })
             }
         }
         .onAppear() {

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -99,8 +99,8 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
         currentQuestion = .theme
     }
 
-    func saveTheme(_ id: String?) {
-        if id != nil {
+    func saveTheme(_ theme: WordPressTheme?) {
+        if theme != nil {
             // TODO
         }
         handleCompletion()

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -6,6 +6,7 @@ enum StoreCreationProfilerQuestion: Int, CaseIterable {
     case sellingStatus = 1
     case category
     case country
+    case theme
 
     /// Progress to display for the profiler flow
     var progress: Double {
@@ -22,6 +23,7 @@ enum StoreCreationProfilerQuestion: Int, CaseIterable {
 final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
 
     let storeName: String
+    let themesCarouselViewModel: ThemesCarouselViewModel
     private let analytics: Analytics
     private let completionHandler: () -> Void
 
@@ -54,6 +56,7 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
     @Published private(set) var currentQuestion: StoreCreationProfilerQuestion = .sellingStatus
 
     init(storeName: String,
+         stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping () -> Void,
          uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCaseProtocol) {
@@ -61,6 +64,7 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
         self.analytics = analytics
         self.completionHandler = onCompletion
         self.uploadAnswersUseCase = uploadAnswersUseCase
+        self.themesCarouselViewModel = .init(mode: .storeCreationProfiler, stores: stores)
     }
 
     func onAppear() {
@@ -92,6 +96,13 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
 
     func saveCountry(_ answer: CountryCode) {
         storeCountry = answer
+        currentQuestion = .theme
+    }
+
+    func saveTheme(_ id: String?) {
+        if id != nil {
+            // TODO
+        }
         handleCompletion()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -52,7 +52,10 @@ struct ThemeSettingView: View {
                 Section(Localization.tryOtherLook) {
                     VStack {
                         Spacer()
-                        ThemesCarouselView(viewModel: viewModel.carouselViewModel)
+                        ThemesCarouselView(viewModel: viewModel.carouselViewModel,
+                                           onSelectedTheme: { theme in
+                            viewModel.updateCurrentTheme(theme)
+                        })
                         Spacer()
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -30,6 +30,10 @@ final class ThemeSettingViewModel: ObservableObject {
         loadingCurrentTheme = false
         carouselViewModel.updateCurrentTheme(id: theme?.id)
     }
+
+    func updateCurrentTheme(_ theme: WordPressTheme) {
+        currentThemeName = theme.name
+    }
 }
 
 private extension ThemeSettingViewModel {

--- a/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
@@ -7,9 +7,11 @@ struct ProfilerThemesPickerView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     private let carouselViewModel: ThemesCarouselViewModel
+    private let onSkip: () -> Void
 
-    init(carouselViewModel: ThemesCarouselViewModel) {
+    init(carouselViewModel: ThemesCarouselViewModel, onSkip: @escaping () -> Void) {
         self.carouselViewModel = carouselViewModel
+        self.onSkip = onSkip
     }
 
     var body: some View {
@@ -36,9 +38,7 @@ struct ProfilerThemesPickerView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(Localization.skipButtonTitle) {
-                    // TODO: Setup toolbar.
-                }
+                Button(Localization.skipButtonTitle, action: onSkip)
             }
         }
         // Disables large title to avoid a large gap below the navigation bar.
@@ -48,7 +48,7 @@ struct ProfilerThemesPickerView: View {
 
 struct ProfilerThemesPickerView_Previews: PreviewProvider {
     static var previews: some View {
-        ProfilerThemesPickerView(carouselViewModel: .init(mode: .storeCreationProfiler))
+        ProfilerThemesPickerView(carouselViewModel: .init(mode: .storeCreationProfiler), onSkip: {})
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Kingfisher
+import struct Yosemite.WordPressTheme
 
 /// View for picking themes in the store creation flow.
 struct ProfilerThemesPickerView: View {
@@ -7,10 +8,14 @@ struct ProfilerThemesPickerView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     private let carouselViewModel: ThemesCarouselViewModel
+    private let onSelectedTheme: (WordPressTheme) -> Void
     private let onSkip: () -> Void
 
-    init(carouselViewModel: ThemesCarouselViewModel, onSkip: @escaping () -> Void) {
+    init(carouselViewModel: ThemesCarouselViewModel,
+         onSelectedTheme: @escaping (WordPressTheme) -> Void,
+         onSkip: @escaping () -> Void) {
         self.carouselViewModel = carouselViewModel
+        self.onSelectedTheme = onSelectedTheme
         self.onSkip = onSkip
     }
 
@@ -31,7 +36,7 @@ struct ProfilerThemesPickerView: View {
 
                 Spacer()
 
-                ThemesCarouselView(viewModel: carouselViewModel)
+                ThemesCarouselView(viewModel: carouselViewModel, onSelectedTheme: onSelectedTheme)
 
                 Spacer()
             }
@@ -48,7 +53,7 @@ struct ProfilerThemesPickerView: View {
 
 struct ProfilerThemesPickerView_Previews: PreviewProvider {
     static var previews: some View {
-        ProfilerThemesPickerView(carouselViewModel: .init(mode: .storeCreationProfiler), onSkip: {})
+        ProfilerThemesPickerView(carouselViewModel: .init(mode: .storeCreationProfiler), onSelectedTheme: { _ in }, onSkip: {})
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -7,13 +7,14 @@ import struct Yosemite.WordPressTheme
 struct ThemesCarouselView: View {
 
     @ObservedObject private var viewModel: ThemesCarouselViewModel
-
+    private let onSelectedTheme: (WordPressTheme) -> Void
 
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
-    init(viewModel: ThemesCarouselViewModel) {
+    init(viewModel: ThemesCarouselViewModel, onSelectedTheme: @escaping (WordPressTheme) -> Void) {
         self.viewModel = viewModel
+        self.onSelectedTheme = onSelectedTheme
     }
 
     var body: some View {
@@ -173,6 +174,6 @@ private extension ThemesCarouselView {
 
 struct ThemesCarouselView_Previews: PreviewProvider {
     static var previews: some View {
-        ThemesCarouselView(viewModel: .init(mode: .themeSettings))
+        ThemesCarouselView(viewModel: .init(mode: .themeSettings), onSelectedTheme: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -12,7 +12,8 @@ final class ThemesCarouselViewModel: ObservableObject {
     let mode: Mode
     private let stores: StoresManager
 
-    init(mode: Mode, stores: StoresManager = ServiceLocator.stores) {
+    init(mode: Mode,
+         stores: StoresManager = ServiceLocator.stores) {
         self.mode = mode
         self.stores = stores
         // current theme is only required for theme settings mode.

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -284,6 +284,7 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
         viewModel.saveCategory(.init(name: StoreCreationCategoryQuestionViewModel.Category.clothingAccessories.name,
                                      value: StoreCreationCategoryQuestionViewModel.Category.clothingAccessories.rawValue))
         viewModel.saveCountry(.US)
+        viewModel.saveTheme(nil)
 
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_profiler_data" }))

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -95,7 +95,20 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
         XCTAssertEqual(data.countryCode, "AG")
     }
 
-    func test_saveCountry_triggers_onCompletion() throws {
+    func test_saveCountry_updates_currentQuestion_to_theme() {
+        // Given
+        let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
+                                                                        onCompletion: {},
+                                                                        uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
+
+        // When
+        viewModel.saveCountry(.US)
+
+        // Then
+        XCTAssertEqual(viewModel.currentQuestion, .theme)
+    }
+
+    func test_saveTheme_triggers_onCompletion() throws {
         // Given
         var triggeredCompletion = false
         let viewModel = StoreCreationProfilerQuestionContainerViewModel(storeName: "Test",
@@ -103,7 +116,7 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
                                                                         uploadAnswersUseCase: MockStoreCreationProfilerUploadAnswersUseCase())
 
         // When
-        viewModel.saveCountry(.US)
+        viewModel.saveTheme(nil)
 
         // Then
         XCTAssertTrue(triggeredCompletion)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
@@ -49,4 +49,16 @@ final class ThemeSettingViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.currentThemeName, expectedName)
     }
+
+    func test_updateCurrentTheme_updates_currentThemeName() {
+        // Given
+        let viewModel = ThemeSettingViewModel(siteID: 123)
+        XCTAssertEqual(viewModel.currentThemeName, "")
+
+        // When
+        viewModel.updateCurrentTheme(.fake().copy(name: "tsubaki"))
+
+        // Then
+        XCTAssertEqual(viewModel.currentThemeName, "tsubaki")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11432 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the entry point to the theme picker from the store creation profiler flow. Changes include:
- Added a callback closure for a selected theme to `ThemesCarouselView`.
- Updated the entry point in the theme setting screen to include the new closure.
- Updated `StoreCreationProfilerQuestionContainerViewModel` to include a new step for theme. Theme selection should be handled in a separate PR.
- Added the `ProfilerThemesPickerView` to `StoreCreationProfilerQuestionContainerView`.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Since theme preview hasn't been implemented yet, we can only test the Skip button on the theme picker screen.
- Select store creation either from the store picker or from the account creation flow.
- Select the free trial flow from the store creation summary screen and go through the profiler flow.
- After the country step, notice that the final step is theme picking.
- Tap Skip, notice that the progress view is displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/woocommerce/woocommerce-ios/assets/5533851/60578ed4-cd71-4433-be06-72f735637476



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
