### PR TITLE
[Scan to Update Inventory M1] Manage stock errors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -89,7 +89,11 @@ struct UpdateProductInventoryView: View {
 
                         Button(Localization.manageStockButtonTitle) {
                             Task { @MainActor in
-                                try? await viewModel.onTapManageStock()
+                                do {
+                                    try await viewModel.onTapManageStock()
+                                } catch {
+                                    displayErrorNotice(viewModel.name, error)
+                                }
                             }
                         }
                         .buttonStyle(LinkLoadingButtonStyle(isLoading: viewModel.isManageStockButtonLoading))

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -218,6 +218,7 @@ final class UpdateProductInventoryViewModel: ObservableObject {
             refresh()
         } catch {
             isManageStockButtonLoading = false
+            throw UpdateInventoryError.generic
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11415 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this small PR we show an alert when we get an error enabling managing the stock for a product.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can quickly replicate an error by adding` throw UpdateInventoryError.generic` to `func onTapManageStock() async throws` in `UpdateProductInventoryViewModel`

1. Go to Products
2. Tap on the barcode scanner button
3. Scan a product barcode whose stock is not managed at the moment
4. The barcode scanner should dismiss and the product quick inventory screen open
5. Tap on Manage stock
6. The error notice shows

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/df39ef38-c4e5-4beb-a9fe-d64e600a5fa8



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
