### PR TITLE
Move "Add your first product" to the first item of onboarding task list

### DIFF
--- a/Networking/Networking/Model/StoreOnboardingTask.swift
+++ b/Networking/Networking/Model/StoreOnboardingTask.swift
@@ -54,11 +54,11 @@ public extension StoreOnboardingTask {
 private extension StoreOnboardingTask.TaskType {
     var sortOrder: Int {
         switch self {
-        case .storeName:
-            return 0
-        case .storeDetails:
-            return 1
         case .addFirstProduct:
+            return 0
+        case .storeName:
+            return 1
+        case .storeDetails:
             return 2
         case .woocommercePayments:
             return 3

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -243,10 +243,12 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         await sut.reloadTasks()
 
         // Then
-        XCTAssertEqual(sut.tasksForDisplay.map({ $0.task }), [.init(isComplete: false, type: .addFirstProduct),
-                                                              .init(isComplete: false, type: .storeName),
-                                                                                                                        .init(isComplete: false, type: .launchStore),
-                                                              .init(isComplete: false, type: .customizeDomains)])
+        XCTAssertEqual(sut.tasksForDisplay.map({ $0.task }), [
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .storeName),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: false, type: .customizeDomains)
+        ])
     }
 
     func test_launch_store_task_is_marked_as_complete_for_already_public_store() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -243,9 +243,9 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         await sut.reloadTasks()
 
         // Then
-        XCTAssertEqual(sut.tasksForDisplay.map({ $0.task }), [.init(isComplete: false, type: .storeName),
-                                                              .init(isComplete: false, type: .addFirstProduct),
-                                                              .init(isComplete: false, type: .launchStore),
+        XCTAssertEqual(sut.tasksForDisplay.map({ $0.task }), [.init(isComplete: false, type: .addFirstProduct),
+                                                              .init(isComplete: false, type: .storeName),
+                                                                                                                        .init(isComplete: false, type: .launchStore),
                                                               .init(isComplete: false, type: .customizeDomains)])
     }
 
@@ -293,8 +293,8 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Given
         sessionManager.defaultSite = .fake().copy(name: WooConstants.defaultStoreName, plan: freeTrialPlanSlug, isWordPressComStore: true, isPublic: true)
         mockLoadOnboardingTasks(result: .success([
-            .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .customizeDomains),
             .init(isComplete: false, type: .payments),
             .init(isComplete: false, type: .woocommercePayments),
@@ -601,8 +601,8 @@ final class StoreOnboardingViewModelTests: XCTestCase {
     func test_it_sends_network_request_when_completedAllStoreOnboardingTasks_is_nil() async {
         // Given
         let tasks: [StoreOnboardingTask] = [
-            .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .launchStore),
             .init(isComplete: true, type: .customizeDomains),
             .init(isComplete: false, type: .payments)
@@ -633,8 +633,8 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                            defaults: defaults,
                                            featureFlagService: MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: false))
         let tasks: [StoreOnboardingTask] = [
-            .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .launchStore),
             .init(isComplete: true, type: .customizeDomains),
             .init(isComplete: false, type: .payments)

--- a/Yosemite/YosemiteTests/Stores/StoreOnboardingTasksStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/StoreOnboardingTasksStoreTests.swift
@@ -78,8 +78,8 @@ final class StoreOnboardingTasksStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         let tasks = try XCTUnwrap(result.get())
-        XCTAssertEqual(tasks, [.init(isComplete: true, type: .storeDetails),
-                               .init(isComplete: true, type: .addFirstProduct),
+        XCTAssertEqual(tasks, [.init(isComplete: true, type: .addFirstProduct),
+                               .init(isComplete: true, type: .storeDetails),
                                .init(isComplete: true, type: .woocommercePayments),
                                .init(isComplete: true, type: .launchStore),
                                .init(isComplete: true, type: .customizeDomains),
@@ -107,8 +107,8 @@ final class StoreOnboardingTasksStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         let tasks = try XCTUnwrap(result.get())
-        XCTAssertEqual(tasks, [.init(isComplete: true, type: .storeDetails),
-                               .init(isComplete: true, type: .addFirstProduct),
+        XCTAssertEqual(tasks, [.init(isComplete: true, type: .addFirstProduct),
+                               .init(isComplete: true, type: .storeDetails),
                                .init(isComplete: true, type: .launchStore),
                                .init(isComplete: true, type: .customizeDomains),
                                .init(isComplete: true, type: .payments),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11449 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the order of onboarding tasks to display "Add your first product" as the first item in the list.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a free trial WooExpress store or create one.
- On the dashboard screen, notice that "Add your first product" is the first item, followed by "Name your store".
- If there's an item for adding product details, the item should be below "Add your first product" too. I'm not sure which condition would cause the API to return this item, so the updated tests should cover this case.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/4cb54482-f413-46d0-9e47-81c1a5a4876f" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
