### PR TITLE
[Scan to update inventory M1] Switch `scanToUpdateInventory` flag to true

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -85,7 +85,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .lightweightStorefront:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .scanToUpdateInventory:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Edit Products: make downloadable files more discoverable [https://github.com/woocommerce/woocommerce-ios/pull/11388]
 - [**] [internal] A minor refactor in authentication flow, including but not limited to social sign-in and two factor authentication. [https://github.com/woocommerce/woocommerce-ios/pull/11402]
 - [*] Login: after logging in from the `Create a New Store` CTA in the prologue screen, it should start the store creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/11385]
+- [*] Products: Merchants now can scan product barcodes directly from the Product list in order to update inventory [https://github.com/woocommerce/woocommerce-ios/pull/11457]
 
 16.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,7 +11,7 @@
 - [*] Edit Products: make downloadable files more discoverable [https://github.com/woocommerce/woocommerce-ios/pull/11388]
 - [**] [internal] A minor refactor in authentication flow, including but not limited to social sign-in and two factor authentication. [https://github.com/woocommerce/woocommerce-ios/pull/11402]
 - [*] Login: after logging in from the `Create a New Store` CTA in the prologue screen, it should start the store creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/11385]
-- [*] Products: Merchants now can scan product barcodes directly from the Product list in order to update inventory [https://github.com/woocommerce/woocommerce-ios/pull/11457]
+- [**] Products: Merchants now can scan product barcodes directly from the Product list in order to update inventory [https://github.com/woocommerce/woocommerce-ios/pull/11457]
 
 16.6
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11456 

## Description
This PR enables _"scan to update inventory"_ for release.

## Testing instructions
1. Run the app on release build. 
2. Confirm that the feature is available under Menu > Products

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
