### PR TITLE
[Dashboard] Fix 400 error on a products API request on app launch

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -377,7 +377,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.perPage: String(pageSize),
             ParameterKey.fields: ParameterKey.id,
             ParameterKey.productStatus: productStatus?.rawValue ?? ""
-        ]
+        ].filter({ $0.value.isEmpty == false })
 
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -668,6 +668,24 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    func test_loadProductIDs_removes_status_parameter_when_empty() throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-ids-only")
+
+        // When
+        waitForExpectation { expectation in
+            remote.loadProductIDs(for: sampleSiteID) { result in
+                expectation.fulfill()
+            }
+        }
+
+        // Assert
+        let queryParameters = try XCTUnwrap(network.queryParameters)
+        let emptyParam = "status="
+        XCTAssertFalse(queryParameters.contains(emptyParam), "Unexpected empty query param: \(emptyParam)")
+    }
+
     func test_create_template_product_returns_product_id() throws {
         // Given
         let remote = ProductsRemote(network: network)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11134
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
On app launch, there was a 400 error on a `/wc/v3/products` API request with empty status `{"page":"1","per_page":"1","status":"","_fields":"id"}`.

The API doesn't accept an empty `status` parameter; this parameter should be excluded from the request if there's no status provided.

## How
In `ProductsRemote`, this request now filters out any parameters with empty values.

## Testing instructions

Prerequisite: If you have any products loaded in storage, log out of the app to clear them from storage and then log in again. This will ensure the API request is fired when the app launches.

1. Relaunch the app in the logged-in state, and inspect the API requests --> notice a `/wc/v3/products` API request with no status parameter.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
