### PR TITLE
Product Subscriptions: Fix crash for `SubscriptionExpiryViewModel`

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -829,6 +829,7 @@
 		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
 		DE74F29E27E0A6800002FE59 /* SiteSettingMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29D27E0A6800002FE59 /* SiteSettingMapperTests.swift */; };
 		DE74F2A027E3137F0002FE59 /* setting-analytics.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29F27E3137F0002FE59 /* setting-analytics.json */; };
+		DE78DE4E2B2BF0EA002E58DE /* product-subscription-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */; };
 		DE97C3922861B8E20042E973 /* CouponEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DE9DEEF5291CF1B40070AD7C /* site-plugin-without-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */; };
@@ -1854,6 +1855,7 @@
 		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
 		DE74F29D27E0A6800002FE59 /* SiteSettingMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapperTests.swift; sourceTree = "<group>"; };
 		DE74F29F27E3137F0002FE59 /* setting-analytics.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-analytics.json"; sourceTree = "<group>"; };
+		DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-subscription-alternative-types.json"; sourceTree = "<group>"; };
 		DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponEncoderTests.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-plugin-without-envelope.json"; sourceTree = "<group>"; };
@@ -2798,6 +2800,7 @@
 				CC33754F29C88B920006A538 /* product-composite.json */,
 				02DD6491248A3EC00082523E /* product-external.json */,
 				CCFEB8F329E8504300537456 /* product-subscription.json */,
+				DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */,
 				EE98268F2B17189B00A3F57E /* product-subscription-sync-renewals-day-month-format.json */,
 				EE9826912B17569400A3F57E /* product-subscription-sync-renewals-day-month-format-int-values.json */,
 				4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */,
@@ -3928,6 +3931,7 @@
 				CE2678432A26102A00FD9AEB /* order-alternative-types.json in Resources */,
 				D865CE5B278CA10B002C8520 /* stripe-payment-intent-requires-payment-method.json in Resources */,
 				CC9A254626442CA7005DE56E /* shipping-label-eligibility-failure.json in Resources */,
+				DE78DE4E2B2BF0EA002E58DE /* product-subscription-alternative-types.json in Resources */,
 				4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */,
 				020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */,
 				3158FE7826129DF300E566B9 /* wcpay-account-restricted.json in Resources */,

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -62,12 +62,12 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        length = try container.decodeIfPresent(String.self, forKey: .length) ?? "0"
+        length = container.failsafeDecodeIfPresent(stringForKey: .length) ?? "0"
         period = try container.decodeIfPresent(SubscriptionPeriod.self, forKey: .period) ?? .month
-        periodInterval = try container.decodeIfPresent(String.self, forKey: .periodInterval) ?? "1"
-        price = try container.decodeIfPresent(String.self, forKey: .price) ?? "0"
-        signUpFee = try container.decodeIfPresent(String.self, forKey: .signUpFee) ?? "0"
-        trialLength = try container.decodeIfPresent(String.self, forKey: .trialLength) ?? "0"
+        periodInterval = container.failsafeDecodeIfPresent(stringForKey: .periodInterval) ?? "1"
+        price = container.failsafeDecodeIfPresent(stringForKey: .price) ?? "0"
+        signUpFee = container.failsafeDecodeIfPresent(stringForKey: .signUpFee) ?? "0"
+        trialLength = container.failsafeDecodeIfPresent(stringForKey: .trialLength) ?? "0"
         trialPeriod = try container.decodeIfPresent(SubscriptionPeriod.self, forKey: .trialPeriod) ?? .day
         oneTimeShipping = {
             guard let stringValue = try? container.decodeIfPresent(String.self, forKey: .oneTimeShipping) else {

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -64,7 +64,7 @@ public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, Gene
 
         length = try container.decodeIfPresent(String.self, forKey: .length) ?? "0"
         period = try container.decodeIfPresent(SubscriptionPeriod.self, forKey: .period) ?? .month
-        periodInterval = try container.decodeIfPresent(String.self, forKey: .periodInterval) ?? "0"
+        periodInterval = try container.decodeIfPresent(String.self, forKey: .periodInterval) ?? "1"
         price = try container.decodeIfPresent(String.self, forKey: .price) ?? "0"
         signUpFee = try container.decodeIfPresent(String.self, forKey: .signUpFee) ?? "0"
         trialLength = try container.decodeIfPresent(String.self, forKey: .trialLength) ?? "0"

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -387,6 +387,26 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.paymentSyncDate, "3")
     }
 
+    /// Test that subscription products with alternative numeric types are properly parsed.
+    ///
+    func test_subscription_products_with_alternative_numeric_types_are_properly_parsed() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadSubscriptionProductResponseWithAlternativeTypes())
+        let subscriptionSettings = try XCTUnwrap(product.subscription)
+
+        // Then
+        XCTAssertEqual(product.productType, .subscription)
+        XCTAssertEqual(subscriptionSettings.length, "2")
+        XCTAssertEqual(subscriptionSettings.period, .month)
+        XCTAssertEqual(subscriptionSettings.periodInterval, "1")
+        XCTAssertEqual(subscriptionSettings.price, "5")
+        XCTAssertEqual(subscriptionSettings.signUpFee, "")
+        XCTAssertEqual(subscriptionSettings.trialLength, "1")
+        XCTAssertEqual(subscriptionSettings.trialPeriod, .week)
+        XCTAssertTrue(subscriptionSettings.oneTimeShipping)
+        XCTAssertEqual(subscriptionSettings.paymentSyncDate, "3")
+    }
+
     /// Test that products with the `subscription` product type are properly parsed when sync renewal value is in dict format.
     ///
     func test_subscription_products_with_sync_renewals_in_dict_format_are_properly_parsed() throws {
@@ -518,6 +538,12 @@ private extension ProductMapperTests {
     ///
     func mapLoadSubscriptionProductResponse() -> Product? {
         return mapProduct(from: "product-subscription")
+    }
+
+    /// Returns the ProductMapper output upon receiving `product-subscription-alternative-types`
+    ///
+    func mapLoadSubscriptionProductResponseWithAlternativeTypes() -> Product? {
+        return mapProduct(from: "product-subscription-alternative-types")
     }
 
     /// Returns the ProductMapper output upon receiving `product-min-max-quantities`

--- a/Networking/NetworkingTests/Responses/product-subscription-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-subscription-alternative-types.json
@@ -1,0 +1,202 @@
+{
+    "data": {
+        "id": 198,
+        "name": "Coffee Subscription",
+        "slug": "coffee-subscription",
+        "permalink": "https://example.com/product/coffee-subscription/",
+        "date_created": "2023-01-24T18:14:18",
+        "date_created_gmt": "2023-01-24T18:14:18",
+        "date_modified": "2023-04-08T01:00:50",
+        "date_modified_gmt": "2023-04-08T00:00:50",
+        "type": "subscription",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "<p>A simple subscription for a regular delivery of the best coffee!</p>\n",
+        "short_description": "",
+        "sku": "",
+        "price": "5",
+        "regular_price": "5",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "on_sale": false,
+        "purchasable": true,
+        "total_sales": 0,
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "low_stock_amount": null,
+        "sold_individually": false,
+        "weight": "",
+        "dimensions": {
+            "length": "",
+            "width": "",
+            "height": ""
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": true,
+        "average_rating": "0.00",
+        "rating_count": 0,
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 0,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [
+            {
+                "id": 1407,
+                "name": "coffee",
+                "slug": "coffee"
+            }
+        ],
+        "images": [
+            {
+                "id": 199,
+                "date_created": "2023-01-24T18:16:07",
+                "date_created_gmt": "2023-01-24T18:16:07",
+                "date_modified": "2023-01-27T10:55:09",
+                "date_modified_gmt": "2023-01-27T10:55:09",
+                "src": "https://example.com/wp-content/uploads/2023/01/coffee-beans.jpg",
+                "name": "coffee-beans",
+                "alt": ""
+            }
+        ],
+        "attributes": [],
+        "default_attributes": [],
+        "variations": [],
+        "grouped_products": [],
+        "menu_order": 0,
+        "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>5.00</bdi></span> <span class=\"subscription-details\"> / month for 2 months</span>",
+        "related_ids": [],
+        "meta_data": [
+            {
+                "id": 4178,
+                "key": "_wpcom_is_markdown",
+                "value": "1"
+            },
+            {
+                "id": 4179,
+                "key": "_last_editor_used_jetpack",
+                "value": "classic-editor"
+            },
+            {
+                "id": 4183,
+                "key": "_product_addons",
+                "value": []
+            },
+            {
+                "id": 4184,
+                "key": "_product_addons_exclude_global",
+                "value": "0"
+            },
+            {
+                "id": 4210,
+                "key": "_subscription_payment_sync_date",
+                "value": "3"
+            },
+            {
+                "id": 4211,
+                "key": "_subscription_price",
+                "value": 5
+            },
+            {
+                "id": 4215,
+                "key": "_subscription_trial_length",
+                "value": 1
+            },
+            {
+                "id": 4216,
+                "key": "_subscription_sign_up_fee",
+                "value": ""
+            },
+            {
+                "id": 4217,
+                "key": "_subscription_period",
+                "value": "month"
+            },
+            {
+                "id": 4218,
+                "key": "_subscription_period_interval",
+                "value": 1
+            },
+            {
+                "id": 4219,
+                "key": "_subscription_length",
+                "value": 2
+            },
+            {
+                "id": 4220,
+                "key": "_subscription_trial_period",
+                "value": "week"
+            },
+            {
+                "id": 4221,
+                "key": "_subscription_limit",
+                "value": "no"
+            },
+            {
+                "id": 4222,
+                "key": "_subscription_one_time_shipping",
+                "value": "yes"
+            }
+        ],
+        "stock_status": "outofstock",
+        "has_options": true,
+        "composite_virtual": false,
+        "composite_layout": "",
+        "composite_add_to_cart_form_location": "",
+        "composite_editable_in_cart": false,
+        "composite_sold_individually_context": "",
+        "composite_shop_price_calc": "",
+        "composite_components": [],
+        "composite_scenarios": [],
+        "bundled_by": [
+            "129"
+        ],
+        "bundle_stock_status": "outofstock",
+        "bundle_stock_quantity": null,
+        "bundle_virtual": false,
+        "bundle_layout": "",
+        "bundle_add_to_cart_form_location": "",
+        "bundle_editable_in_cart": false,
+        "bundle_sold_individually_context": "",
+        "bundle_item_grouping": "",
+        "bundle_min_size": "",
+        "bundle_max_size": "",
+        "bundled_items": [],
+        "bundle_sell_ids": [],
+        "jetpack_publicize_connections": [],
+        "jetpack_sharing_enabled": true,
+        "jetpack_likes_enabled": true,
+        "brands": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/198"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/Expiry/SubscriptionExpiryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/Expiry/SubscriptionExpiryViewModel.swift
@@ -44,7 +44,7 @@ final class SubscriptionExpiryViewModel: ObservableObject {
         self.subscription = subscription
         self.onCompletion = completion
 
-        guard let periodInterval = Int(subscription.periodInterval) else {
+        guard let periodInterval = Int(subscription.periodInterval), periodInterval > 0 else {
             self.lengthOptions = [neverExpireOption]
             self.selectedLength = neverExpireOption
             return

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/SubscriptionExpiryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/SubscriptionExpiryViewModelTests.swift
@@ -15,6 +15,16 @@ final class SubscriptionExpiryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedLength.stringValue, "0")
     }
 
+    func test_selectedLength_and_lengthOptions_are_correct_if_periodInterval_is_0() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(periodInterval: "0")
+        let viewModel = SubscriptionExpiryViewModel(subscription: subscription) { _, _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.selectedLength.value, 0)
+        XCTAssertEqual(viewModel.lengthOptions.count, 1)
+    }
+
     func test_lengthOptions_has_values_based_on_period_and_periodInterval_for_day() throws {
         // Given
         let subscription = ProductSubscription.fake().copy(length: "1",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11458 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
On`SubscriptionExpiryViewModel` we are using `stride` to create a sequence from 2 values with steps defined by `periodInterval`. When `periodInterval` is 0, `stride` causes a crash since it cannot be created with the step's value being 0.

This PR fixes the crash by handling potential issues in two places:
- Decoder: we were using 0 for the default value for `periodInterval`. This was fixed by setting the value to 1 for parity with the [default empty product subscription](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Extensions/ProductSubscription%2BEmpty.swift).
- Also decoder: a potential cause for the failure of the decoder is that sites using plugins that alter the response of products. So instead of returning String for numbers like in the documentation, the response returns integers or doubles. I've updated the decoder to accept alternative types to avoid failures.
- `SubscriptionExpiryViewModel`: I added a check to ensure `periodInterval` is larger than 0 before proceeding to `stride`. If the value is 0, the selected length and length options are "Never expires".

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: make sure there is an existing product subscription on your store.

We don't know the exact plugins that can cause this behavior, but you can test using a tool like Charles Proxy or Proxyman to intercept and modify the response:

- Set a breakpoint in your tool of choice for requests to the /wc/v3/products endpoint.
- Build and run the app.
- Open the Products tab. 
- Modify the response to update the numeric values in `meta` from strings to integers for a subscription product (check `product-subscription-alternative-types.json` if you need an example).
- Execute the response.
- Select the updated subscription product. Confirm that all the subscription details are parsed correctly on the Price, Free Trial, Shipping, Expire after rows.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
