### PR TITLE
Update WordPressKit to the latest version

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
     - WordPressKit (~> 9.0.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (9.0.0):
+  - WordPressKit (9.0.1):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -132,7 +132,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: 076a963e784bd5c57f9fa979bcab2a67bd929abb
-  WordPressKit: 045acdc7378906a8319b3b16975905fff205b26b
+  WordPressKit: 5886168160050b55b20185850435b2a62ba56d21
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068


### PR DESCRIPTION
## Description

Include a bug fix in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/662, where a Swift type name may show up in an error alert during login.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
