### PR TITLE
Update CI release management pipelines

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+# RELEASE_VERSION is passed as an environment variable from fastlane to Buildkite
+#
+if [[ -z "${RELEASE_VERSION}" ]]; then
+    echo "RELEASE_VERSION is not set."
+    exit 1
+fi
+
+# Buildkite, by default, checks out a specific commit. For many release actions, we need to be
+# on a release branch instead.
+BRANCH_NAME="release/${RELEASE_VERSION}"
+git fetch origin "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"

--- a/.buildkite/commands/configure-environment.sh
+++ b/.buildkite/commands/configure-environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
-echo '--- :git: Configure Git for release management'
+echo '--- :git: Configure Git for Release Management'
 .buildkite/commands/configure-git-for-release-management.sh
 
-echo '--- :ruby: Setup Ruby tools'
+echo '--- :ruby: Setup Ruby Tools'
 install_gems

--- a/.buildkite/commands/configure-git-for-release-management.sh
+++ b/.buildkite/commands/configure-git-for-release-management.sh
@@ -2,7 +2,7 @@
 
 # Git command line client is not configured in Buildkite. Temporarily, we configure it in each step.
 # Later on, we should be able to configure the agent instead.
-curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
+add_host_to_ssh_known_hosts github.com
 git config --global user.email "mobile+wpmobilebot@automattic.com"
 git config --global user.name "Automattic Release Bot"
 

--- a/.buildkite/commands/configure-git-for-release-management.sh
+++ b/.buildkite/commands/configure-git-for-release-management.sh
@@ -5,6 +5,3 @@
 add_host_to_ssh_known_hosts github.com
 git config --global user.email "mobile+wpmobilebot@automattic.com"
 git config --global user.name "Automattic Release Bot"
-
-# Buildkite is currently using the https url to checkout. We need to override it to be able to use the deploy key.
-git remote set-url origin git@github.com:woocommerce/woocommerce-ios.git

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -14,8 +14,11 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
-      echo '--- :closed_lock_with_key: Access secrets'
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh
+
+      echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :snowflake: Complete code freeze'
+      echo '--- :snowflake: Complete Code Freeze'
       bundle exec fastlane complete_code_freeze skip_confirm:true

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -3,11 +3,11 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
       - automattic/git-s3-cache#1.1.4:
-        bucket: "a8c-repo-mirrors"
-        # This is not necessarily the actual name of the repo or the GitHub organization
-        # it belongs to. It is the key used in the bucket, which is set based on
-        # the Buildkite pipeline slug
-        repo: "automattic/woocommerce-ios/"
+          bucket: "a8c-repo-mirrors"
+          # This is not necessarily the actual name of the repo or the GitHub organization
+          # it belongs to. It is the key used in the bucket, which is set based on
+          # the Buildkite pipeline slug
+          repo: "automattic/woocommerce-ios/"
     env:
       # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
       IMAGE_ID: xcode-14.3.1

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -14,8 +14,11 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
-      echo '--- :closed_lock_with_key: Access secrets'
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh
+
+      echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :fire: Finalize hotfix release'
+      echo '--- :fire: Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -3,11 +3,11 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
       - automattic/git-s3-cache#1.1.4:
-        bucket: "a8c-repo-mirrors"
-        # This is not necessarily the actual name of the repo or the GitHub organization
-        # it belongs to. It is the key used in the bucket, which is set based on
-        # the Buildkite pipeline slug
-        repo: "automattic/woocommerce-ios/"
+          bucket: "a8c-repo-mirrors"
+          # This is not necessarily the actual name of the repo or the GitHub organization
+          # it belongs to. It is the key used in the bucket, which is set based on
+          # the Buildkite pipeline slug
+          repo: "automattic/woocommerce-ios/"
     env:
       # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
       IMAGE_ID: xcode-14.3.1

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -14,8 +14,11 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
-      echo '--- :closed_lock_with_key: Access secrets'
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh
+
+      echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :shipit: Finalize release'
+      echo '--- :shipit: Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -3,11 +3,11 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
       - automattic/git-s3-cache#1.1.4:
-        bucket: "a8c-repo-mirrors"
-        # This is not necessarily the actual name of the repo or the GitHub organization
-        # it belongs to. It is the key used in the bucket, which is set based on
-        # the Buildkite pipeline slug
-        repo: "automattic/woocommerce-ios/"
+          bucket: "a8c-repo-mirrors"
+          # This is not necessarily the actual name of the repo or the GitHub organization
+          # it belongs to. It is the key used in the bucket, which is set based on
+          # the Buildkite pipeline slug
+          repo: "automattic/woocommerce-ios/"
     env:
       # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
       IMAGE_ID: xcode-14.3.1

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -14,8 +14,11 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
-      echo '--- :closed_lock_with_key: Access secrets'
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh
+
+      echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :shipit: New beta release'
+      echo '--- :shipit: New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -3,11 +3,11 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
       - automattic/git-s3-cache#1.1.4:
-        bucket: "a8c-repo-mirrors"
-        # This is not necessarily the actual name of the repo or the GitHub organization
-        # it belongs to. It is the key used in the bucket, which is set based on
-        # the Buildkite pipeline slug
-        repo: "automattic/woocommerce-ios/"
+          bucket: "a8c-repo-mirrors"
+          # This is not necessarily the actual name of the repo or the GitHub organization
+          # it belongs to. It is the key used in the bucket, which is set based on
+          # the Buildkite pipeline slug
+          repo: "automattic/woocommerce-ios/"
     env:
       # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
       IMAGE_ID: xcode-14.3.1

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -14,8 +14,8 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
-      echo '--- :closed_lock_with_key: Access secrets'
+      echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :fire: Start new hotfix release'
+      echo '--- :fire: Start New Hotfix Release'
       bundle exec fastlane new_hotfix_release version:${VERSION} skip_confirm:true

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -3,11 +3,11 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
       - automattic/git-s3-cache#1.1.4:
-        bucket: "a8c-repo-mirrors"
-        # This is not necessarily the actual name of the repo or the GitHub organization
-        # it belongs to. It is the key used in the bucket, which is set based on
-        # the Buildkite pipeline slug
-        repo: "automattic/woocommerce-ios/"
+          bucket: "a8c-repo-mirrors"
+          # This is not necessarily the actual name of the repo or the GitHub organization
+          # it belongs to. It is the key used in the bucket, which is set based on
+          # the Buildkite pipeline slug
+          repo: "automattic/woocommerce-ios/"
     env:
       # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
       IMAGE_ID: xcode-14.3.1

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -14,8 +14,8 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
-      echo '--- :closed_lock_with_key: Access secrets'
+      echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :snowflake: Start code freeze'
+      echo '--- :snowflake: Start Code Freeze'
       bundle exec fastlane start_code_freeze skip_confirm:true

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -3,11 +3,11 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
       - automattic/git-s3-cache#1.1.4:
-        bucket: "a8c-repo-mirrors"
-        # This is not necessarily the actual name of the repo or the GitHub organization
-        # it belongs to. It is the key used in the bucket, which is set based on
-        # the Buildkite pipeline slug
-        repo: "automattic/woocommerce-ios/"
+          bucket: "a8c-repo-mirrors"
+          # This is not necessarily the actual name of the repo or the GitHub organization
+          # it belongs to. It is the key used in the bucket, which is set based on
+          # the Buildkite pipeline slug
+          repo: "automattic/woocommerce-ios/"
     env:
       # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
       IMAGE_ID: xcode-14.3.1

--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -14,8 +14,11 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
-      echo '--- :closed_lock_with_key: Access secrets'
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh
+
+      echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :shipit: Update release notes and other App Store metadata'
+      echo '--- :shipit: Update Release Notes and Other App Store Metadata'
       bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true

--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -3,11 +3,11 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
       - automattic/git-s3-cache#1.1.4:
-        bucket: "a8c-repo-mirrors"
-        # This is not necessarily the actual name of the repo or the GitHub organization
-        # it belongs to. It is the key used in the bucket, which is set based on
-        # the Buildkite pipeline slug
-        repo: "automattic/woocommerce-ios/"
+          bucket: "a8c-repo-mirrors"
+          # This is not necessarily the actual name of the repo or the GitHub organization
+          # it belongs to. It is the key used in the bucket, which is set based on
+          # the Buildkite pipeline slug
+          repo: "automattic/woocommerce-ios/"
     env:
       # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
       IMAGE_ID: xcode-14.3.1


### PR DESCRIPTION
This PR is a follow-up to #11367 to update several things: 
- Fixed indentation within the YML pipeline files that was causing errors
- In the git configuration script, use the CI Toolkit's `add_host_to_ssh_known_hosts` action
- In the git configuration script, remove an unneeded `set-url` command because we're already configuring it using Terraform
- Add the `checkout-release-branch.sh` script from WPAndroid so that the branch is correctly checked out in some of the pipelines

I'm merging this into the release branch so that it can continued to be tested. 