### PR TITLE
Lightweight storefront: Add tracking events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
@@ -1,5 +1,26 @@
 import Foundation
 
 extension WooAnalyticsEvent {
-    
+
+    enum Themes {
+        private enum Key: String {
+            case source
+            case theme
+            case layout
+            case page
+            case pageURL = "page_url"
+        }
+
+        enum Source: String {
+            case profiler
+            case settings
+        }
+
+        /// Tracks when the theme picker screen is displayed
+        static func pickerScreenDisplayed(source: Source) -> WooAnalyticsEvent {
+            .init(statName: .themePickerScreenDisplayed, properties: [
+                Key.source.rawValue: source.rawValue
+            ])
+        }
+    }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
@@ -16,11 +16,59 @@ extension WooAnalyticsEvent {
             case settings
         }
 
-        /// Tracks when the theme picker screen is displayed
+        /// Tracked when the theme picker screen is displayed
         static func pickerScreenDisplayed(source: Source) -> WooAnalyticsEvent {
             .init(statName: .themePickerScreenDisplayed, properties: [
                 Key.source.rawValue: source.rawValue
             ])
         }
-    }
+
+        /// Tracked when a theme screenshot is tapped on the theme picker screen
+        static func themeSelected(name: String) -> WooAnalyticsEvent {
+            .init(statName: .themePickerThemeSelected, properties: [
+                Key.theme.rawValue: name
+            ])
+        }
+
+        /// Tracked when the theme preview screen is displayed
+        static func previewScreenDisplayed() -> WooAnalyticsEvent {
+            .init(statName: .themePreviewScreenDisplayed, properties: [:])
+        }
+
+        /// Tracked when the user selected a layout to be previewed
+        static func previewLayoutSelected(layout: ThemesPreviewView.PreviewDevice) -> WooAnalyticsEvent {
+            .init(statName: .themePreviewLayoutSelected, properties: [
+                Key.layout.rawValue: layout.rawValue
+            ])
+        }
+
+        /// Tracked when the user selected a page to be previewed
+        static func previewPageSelected(page: String, url: String) -> WooAnalyticsEvent {
+            .init(statName: .themePreviewPageSelected, properties: [
+                Key.page.rawValue: page,
+                Key.pageURL.rawValue: url
+            ])
+        }
+
+        /// Tracked when the “Start with the theme” button on preview screen is tapped
+        static func startWithThemeButtonTapped(themeName: String) -> WooAnalyticsEvent {
+            .init(statName: .themePreviewStartWithThemeButtonTapped, properties: [
+                Key.theme.rawValue: themeName
+            ])
+        }
+
+        /// Tracked when app finishes installing a theme on the site
+        static func themeInstallationCompleted(themeName: String) -> WooAnalyticsEvent {
+            .init(statName: .themeInstallationCompleted, properties: [
+                Key.theme.rawValue: themeName
+            ])
+        }
+
+        /// Tracked when app failed to install a theme on the site
+        static func themeInstallationFailed(themeName: String) -> WooAnalyticsEvent {
+            .init(statName: .themeInstallationFailed, properties: [
+                Key.theme.rawValue: themeName
+            ])
+        }
+     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
@@ -24,9 +24,9 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when a theme screenshot is tapped on the theme picker screen
-        static func themeSelected(name: String) -> WooAnalyticsEvent {
+        static func themeSelected(id: String) -> WooAnalyticsEvent {
             .init(statName: .themePickerThemeSelected, properties: [
-                Key.theme.rawValue: name
+                Key.theme.rawValue: id
             ])
         }
 
@@ -51,24 +51,24 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when the “Start with the theme” button on preview screen is tapped
-        static func startWithThemeButtonTapped(themeName: String) -> WooAnalyticsEvent {
+        static func startWithThemeButtonTapped(themeID: String) -> WooAnalyticsEvent {
             .init(statName: .themePreviewStartWithThemeButtonTapped, properties: [
-                Key.theme.rawValue: themeName
+                Key.theme.rawValue: themeID
             ])
         }
 
         /// Tracked when app finishes installing a theme on the site
-        static func themeInstallationCompleted(themeName: String) -> WooAnalyticsEvent {
+        static func themeInstallationCompleted(themeID: String) -> WooAnalyticsEvent {
             .init(statName: .themeInstallationCompleted, properties: [
-                Key.theme.rawValue: themeName
+                Key.theme.rawValue: themeID
             ])
         }
 
         /// Tracked when app failed to install a theme on the site
-        static func themeInstallationFailed(themeName: String) -> WooAnalyticsEvent {
+        static func themeInstallationFailed(themeID: String, error: Error) -> WooAnalyticsEvent {
             .init(statName: .themeInstallationFailed, properties: [
-                Key.theme.rawValue: themeName
-            ])
+                Key.theme.rawValue: themeID
+            ], error: error)
         }
      }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Themes.swift
@@ -12,7 +12,7 @@ extension WooAnalyticsEvent {
         }
 
         enum Source: String {
-            case profiler
+            case storeCreation = "store_creation"
             case settings
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1118,6 +1118,16 @@ public enum WooAnalyticsStat: String {
     case localAnnouncementDisplayed = "local_announcement_displayed"
     case localAnnouncementCallToActionTapped = "local_announcement_cta_tapped"
     case localAnnouncementDismissTapped = "local_announcement_dismissed"
+
+    // MARK: Themes
+    case themePickerScreenDisplayed = "theme_picker_screen_displayed"
+    case themePickerThemeSelected = "theme_picker_theme_selected"
+    case themePreviewScreenDisplayed = "theme_preview_screen_displayed"
+    case themePreviewLayoutSelected = "theme_preview_layout_selected"
+    case themePreviewPageSelected = "theme_preview_page_selected"
+    case themePreviewStartWithThemeButtonTapped = "theme_preview_start_with_theme_button_tapped"
+    case themeInstallationCompleted = "theme_installation_completed"
+    case themeInstallationFailed = "theme_installation_failed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingView.swift
@@ -27,9 +27,6 @@ struct ThemeSettingView: View {
 
     init(viewModel: ThemeSettingViewModel) {
         self.viewModel = viewModel
-        Task {
-            await viewModel.updateCurrentThemeName()
-        }
     }
 
     var body: some View {
@@ -67,6 +64,12 @@ struct ThemeSettingView: View {
             }
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
+            .task {
+                await viewModel.updateCurrentThemeName()
+            }
+            .onAppear {
+                viewModel.trackViewAppear()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -44,7 +44,7 @@ final class ThemeSettingViewModel: ObservableObject {
     }
 
     func trackViewAppear() {
-        carouselViewModel.trackViewAppear(source: .settings)
+        carouselViewModel.trackViewAppear()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -10,17 +10,14 @@ final class ThemeSettingViewModel: ObservableObject {
 
     private let siteID: Int64
     private let stores: StoresManager
-    private let analytics: Analytics
     private(set) var carouselViewModel: ThemesCarouselViewModel
     private let themeInstaller: ThemeInstallerProtocol
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics,
          themeInstaller: ThemeInstallerProtocol = DefaultThemeInstaller()) {
         self.siteID = siteID
         self.stores = stores
-        self.analytics = analytics
         self.themeInstaller = themeInstaller
         self.carouselViewModel = .init(mode: .themeSettings, stores: stores)
 
@@ -43,6 +40,10 @@ final class ThemeSettingViewModel: ObservableObject {
 
     func updateCurrentTheme(_ theme: WordPressTheme) {
         currentThemeName = theme.name
+    }
+
+    func trackViewAppear() {
+        carouselViewModel.trackViewAppear(source: .settings)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
@@ -48,6 +48,9 @@ struct ProfilerThemesPickerView: View {
         }
         // Disables large title to avoid a large gap below the navigation bar.
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            carouselViewModel.trackViewAppear(source: .profiler)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ProfilerThemesPickerView.swift
@@ -49,7 +49,7 @@ struct ProfilerThemesPickerView: View {
         // Disables large title to avoid a large gap below the navigation bar.
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            carouselViewModel.trackViewAppear(source: .profiler)
+            carouselViewModel.trackViewAppear()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -111,7 +111,7 @@ private extension ThemesCarouselView {
                 ScrollView(.vertical) {
                     VStack {
                         Spacer()
-                        Text(viewModel.mode.moreThemesTitleText)
+                        Text(Localization.lookingForMore)
                             .bold()
                             .secondaryBodyStyle()
                             .padding(.horizontal, Layout.contentPadding)
@@ -119,7 +119,7 @@ private extension ThemesCarouselView {
                         Spacer()
                             .frame(height: Layout.contentPadding)
 
-                        Text(viewModel.mode.moreThemesSuggestionText)
+                        Text(Localization.findInWooThemeStore)
                             .foregroundColor(Color(.secondaryLabel))
                             .subheadlineStyle()
                                 .multilineTextAlignment(.center)
@@ -161,6 +161,17 @@ private extension ThemesCarouselView {
             "themesCarouselView.retry",
             value: "Retry",
             comment: "Button to reload themes in the themes carousel view"
+        )
+        static let lookingForMore = NSLocalizedString(
+            "themesCarouselView.lastMessageHeading",
+            value: "Looking for more?",
+            comment: "The heading of the message shown at the end of the themes carousel view"
+        )
+
+        static let findInWooThemeStore = NSLocalizedString(
+            "themesCarouselView.lastMessageContent",
+            value: "You can find your perfect theme in the WooCommerce Theme Store.",
+            comment: "The content of the message shown at the end of the themes carousel view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -51,7 +51,7 @@ struct ThemesCarouselView: View {
                         // Theme list
                         ForEach(themes) { theme in
                             Button(action: {
-                                viewModel.trackThemePreviewed()
+                                viewModel.trackThemeSelected(theme)
                                 selectedTheme = theme
                             }) {
                                 if let themeImageURL = theme.themeThumbnailURL {
@@ -76,10 +76,13 @@ struct ThemesCarouselView: View {
         }
         .sheet(item: $selectedTheme, content: { theme in
             ThemesPreviewView(theme: theme, onStart: {
-                viewModel.trackThemeSelected(theme)
+                viewModel.trackStartThemeButtonTapped(theme)
                 onSelectedTheme(theme)
             })
         })
+        .onAppear {
+            viewModel.trackViewAppear()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -75,7 +75,10 @@ struct ThemesCarouselView: View {
             await viewModel.fetchThemes(isReload: false)
         }
         .sheet(item: $selectedTheme, content: { theme in
-            ThemesPreviewView(theme: theme, onStart: { /* todo install theme */ } )
+            ThemesPreviewView(theme: theme, onStart: {
+                viewModel.trackThemeSelected(theme)
+                onSelectedTheme(theme)
+            })
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -51,7 +51,7 @@ struct ThemesCarouselView: View {
                         // Theme list
                         ForEach(themes) { theme in
                             Button(action: {
-                                onSelectedTheme(theme)
+                                viewModel.trackThemePreviewed()
                                 selectedTheme = theme
                             }) {
                                 if let themeImageURL = theme.themeThumbnailURL {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -106,7 +106,7 @@ extension ThemesCarouselViewModel {
             case .themeSettings:
                 return .settings
             case .storeCreationProfiler:
-                return .profiler
+                return .storeCreation
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -85,38 +85,5 @@ extension ThemesCarouselViewModel {
     enum Mode: Equatable {
         case themeSettings
         case storeCreationProfiler
-
-        var moreThemesSuggestionText: String {
-            switch self {
-            case .themeSettings:
-                return Localization.moreOnSettingsScreen
-            case .storeCreationProfiler:
-                return Localization.moreOnProfiler
-            }
-        }
-
-        var moreThemesTitleText: String {
-            Localization.lookingForMore
-        }
-
-        private enum Localization {
-            static let lookingForMore = NSLocalizedString(
-                "themesCarouselViewModel.lastMessageHeading",
-                value: "Looking for more?",
-                comment: "The heading of the message shown at the end of the carousel on the WordPress theme list"
-            )
-
-            static let moreOnSettingsScreen = NSLocalizedString(
-                "themesCarouselViewModel.themeSetting.lastMessageContent",
-                value: "Find your perfect theme in the WooCommerce Theme Store.",
-                comment: "The content of the message shown at the end of the carousel on the theme settings screen"
-            )
-
-            static let moreOnProfiler = NSLocalizedString(
-                "themesCarouselViewModel.profiler.lastMessageContent",
-                value: "Once your store is set up, find your perfect theme in the WooCommerce Theme Store.",
-                comment: "The content of the message shown at the end of carousel in the store creation profiler flow"
-            )
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -54,6 +54,10 @@ final class ThemesCarouselViewModel: ObservableObject {
     func trackViewAppear(source: WooAnalyticsEvent.Themes.Source) {
         analytics.track(event: .Themes.pickerScreenDisplayed(source: source))
     }
+
+    func trackThemePreviewed() {
+        analytics.track(event: .Themes.previewScreenDisplayed())
+    }
 }
 
 private extension ThemesCarouselViewModel {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -51,15 +51,16 @@ final class ThemesCarouselViewModel: ObservableObject {
         currentThemeID = id
     }
 
-    func trackViewAppear(source: WooAnalyticsEvent.Themes.Source) {
+    func trackViewAppear() {
+        let source = mode.analyticSource
         analytics.track(event: .Themes.pickerScreenDisplayed(source: source))
     }
 
-    func trackThemePreviewed() {
-        analytics.track(event: .Themes.previewScreenDisplayed())
+    func trackThemeSelected(_ theme: WordPressTheme) {
+        analytics.track(event: .Themes.themeSelected(id: theme.id))
     }
 
-    func trackThemeSelected(_ theme: WordPressTheme) {
+    func trackStartThemeButtonTapped(_ theme: WordPressTheme) {
         analytics.track(event: .Themes.startWithThemeButtonTapped(themeID: theme.id))
     }
 }
@@ -99,5 +100,14 @@ extension ThemesCarouselViewModel {
     enum Mode: Equatable {
         case themeSettings
         case storeCreationProfiler
+
+        var analyticSource: WooAnalyticsEvent.Themes.Source {
+            switch self {
+            case .themeSettings:
+                return .settings
+            case .storeCreationProfiler:
+                return .profiler
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -58,6 +58,10 @@ final class ThemesCarouselViewModel: ObservableObject {
     func trackThemePreviewed() {
         analytics.track(event: .Themes.previewScreenDisplayed())
     }
+
+    func trackThemeSelected(_ theme: WordPressTheme) {
+        analytics.track(event: .Themes.startWithThemeButtonTapped(themeName: theme.name))
+    }
 }
 
 private extension ThemesCarouselViewModel {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -11,11 +11,14 @@ final class ThemesCarouselViewModel: ObservableObject {
 
     let mode: Mode
     private let stores: StoresManager
+    private let analytics: Analytics
 
     init(mode: Mode,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.mode = mode
         self.stores = stores
+        self.analytics = analytics
         // current theme is only required for theme settings mode.
         if mode == .themeSettings {
             waitForCurrentThemeAndFinishLoading()
@@ -40,6 +43,10 @@ final class ThemesCarouselViewModel: ObservableObject {
 
     func updateCurrentTheme(id: String?) {
         currentThemeID = id
+    }
+
+    func trackViewAppear(source: WooAnalyticsEvent.Themes.Source) {
+        analytics.track(event: .Themes.pickerScreenDisplayed(source: source))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -60,7 +60,7 @@ final class ThemesCarouselViewModel: ObservableObject {
     }
 
     func trackThemeSelected(_ theme: WordPressTheme) {
-        analytics.track(event: .Themes.startWithThemeButtonTapped(themeName: theme.name))
+        analytics.track(event: .Themes.startWithThemeButtonTapped(themeID: theme.id))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -131,7 +131,6 @@ struct ThemesPreviewView: View {
     private func menuItem(for device: PreviewDevice) -> some View {
         Button {
             selectedDevice = device
-            ServiceLocator.analytics.track(event: .Themes.previewLayoutSelected(layout: device))
         } label: {
             Text(device.menuTitle)
             if selectedDevice == device {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -130,10 +130,11 @@ struct ThemesPreviewView: View {
 
     private func menuItem(for device: PreviewDevice) -> some View {
         Button {
-            self.selectedDevice = device
+            selectedDevice = device
+            ServiceLocator.analytics.track(event: .Themes.previewLayoutSelected(layout: device))
         } label: {
             Text(device.menuTitle)
-            if self.selectedDevice == device {
+            if selectedDevice == device {
                 Image(systemName: "checkmark")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -7,7 +7,7 @@ import struct Yosemite.WordPressTheme
 /// - Activate the previewed theme on the current site.
 ///
 struct ThemesPreviewView: View {
-    enum PreviewDevice: CaseIterable, Identifiable {
+    enum PreviewDevice: String, CaseIterable, Identifiable {
         var id: PreviewDevice { self }
 
         case mobile

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2360,6 +2360,7 @@
 		DEF99D852A5FE9BE004B5938 /* StoreCreationTimeoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF99D842A5FE9BE004B5938 /* StoreCreationTimeoutView.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
+		DEFC9BE22B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
@@ -4981,6 +4982,7 @@
 		DEF99D842A5FE9BE004B5938 /* StoreCreationTimeoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationTimeoutView.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
+		DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Themes.swift"; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
@@ -8316,6 +8318,7 @@
 				0210D8682A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift */,
 				DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */,
 				EEA1E20D2AC55F2200A37ADD /* WooAnalyticsEvent+ProductCreationAI.swift */,
+				DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -13821,6 +13824,7 @@
 				DEC6C51E27479280006832D3 /* JetpackInstallSteps.swift in Sources */,
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
 				DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */,
+				DEFC9BE22B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift in Sources */,
 				EE35AFA32B0491960074E7AC /* SubscriptionTrialViewModel.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
@@ -151,7 +151,7 @@ final class ThemesCarouselViewModelTests: XCTestCase {
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "theme_picker_screen_displayed"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
-        XCTAssertEqual(eventProperties["source"] as? String, "profiler")
+        XCTAssertEqual(eventProperties["source"] as? String, "store_creation")
     }
 
     func test_trackThemeSelected_tracks_theme_picker_theme_selected() throws {
@@ -167,7 +167,7 @@ final class ThemesCarouselViewModelTests: XCTestCase {
         XCTAssertEqual(eventProperties["theme"] as? String, "tsubaki")
     }
 
-    func test_trackStartThemeButtonTapped_tracks_theme_preview_start_with_theme_button_tapped() throws  {
+    func test_trackStartThemeButtonTapped_tracks_theme_preview_start_with_theme_button_tapped() throws {
         // Given
         let viewModel = ThemesCarouselViewModel(mode: .themeSettings, analytics: analytics)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
@@ -5,6 +5,22 @@ import XCTest
 @MainActor
 final class ThemesCarouselViewModelTests: XCTestCase {
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
     func test_state_is_loading_initially() {
         // Given
         let viewModel = ThemesCarouselViewModel(mode: .themeSettings)
@@ -110,5 +126,57 @@ final class ThemesCarouselViewModelTests: XCTestCase {
         waitUntil {
             viewModel.state == .error
         }
+    }
+
+    func test_trackViewAppear_tracks_theme_picker_screen_displayed_correctly_for_themeSettings_mode() throws {
+        // Given
+        let viewModel = ThemesCarouselViewModel(mode: .themeSettings, analytics: analytics)
+
+        // When
+        viewModel.trackViewAppear()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "theme_picker_screen_displayed"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["source"] as? String, "settings")
+    }
+
+    func test_trackViewAppear_tracks_theme_picker_screen_displayed_correctly_for_profiler_mode() throws {
+        // Given
+        let viewModel = ThemesCarouselViewModel(mode: .storeCreationProfiler, analytics: analytics)
+
+        // When
+        viewModel.trackViewAppear()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "theme_picker_screen_displayed"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["source"] as? String, "profiler")
+    }
+
+    func test_trackThemeSelected_tracks_theme_picker_theme_selected() throws {
+        // Given
+        let viewModel = ThemesCarouselViewModel(mode: .themeSettings, analytics: analytics)
+
+        // When
+        viewModel.trackThemeSelected(.fake().copy(id: "tsubaki"))
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "theme_picker_theme_selected"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["theme"] as? String, "tsubaki")
+    }
+
+    func test_trackStartThemeButtonTapped_tracks_theme_preview_start_with_theme_button_tapped() throws  {
+        // Given
+        let viewModel = ThemesCarouselViewModel(mode: .themeSettings, analytics: analytics)
+
+        // Then
+        viewModel.trackStartThemeButtonTapped(.fake().copy(id: "tsubaki"))
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "theme_preview_start_with_theme_button_tapped"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["theme"] as? String, "tsubaki")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11473 
Closes #11493 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking events following the tracking plan in pe5sF9-2g4-p2. Some properties are updated following the discussion p1702955464357419-slack-C03L1NF1EA3.

For now, only events related to the theme list screen and theme installation are integrated. Those related to the preview screen will be added in a separate PR to avoid code conflict.

## Testing instructions
<!-- Step by step testing instructions. When you need to break out individual scenarios that need testing, please feel free to include a checklist for the reviewer to go through. -->
- Log in to a WPCom store and navigate to the Menu tab.
- Select Settings > Themes.
- When the theme setting screen is presented, Xcode should log: `🔵 Tracked theme_picker_screen_displayed` with property `source` being `settings`.
- Select any theme, Xcode should log `🔵 Tracked theme_picker_theme_selected` with the correct ID for the property `theme.
- Tap `Start with this theme`, Xcode should log `🔵 Tracked theme_preview_start_with_theme_button_tapped`.

Since theme installation hasn't been integrated to the UI yet, it should be tested again after integration is done. For now, unit tests should pass.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.