### PR TITLE
Lightweight storefront: Update theme carousel UI and copy

### DIFF
--- a/Networking/Networking/Remote/WordPressThemeRemote.swift
+++ b/Networking/Networking/Remote/WordPressThemeRemote.swift
@@ -106,6 +106,6 @@ private extension WordPressThemeRemote {
     }
 
     enum Values {
-        static let filteredThemeIDs = ["tsubaki", "tazza", "amulet", "zaino", "thriving-artist", "attar"]
+        static let filteredThemeIDs = ["tsubaki", "tazza", "amulet", "zaino", "thriving-artist"]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -24,6 +24,7 @@ final class ThemeSettingViewModel: ObservableObject {
         self.themeInstaller = themeInstaller
         self.carouselViewModel = .init(mode: .themeSettings, stores: stores)
 
+        configureCarouselViewModel()
         /// Attempt to install and activate any pending theme selection
         /// to show correct current theme information
         ///
@@ -47,6 +48,15 @@ final class ThemeSettingViewModel: ObservableObject {
 }
 
 private extension ThemeSettingViewModel {
+    func configureCarouselViewModel() {
+        carouselViewModel.updateReloadBehavior { [weak self] in
+            guard let self else { return }
+            Task {
+                await self.updateCurrentThemeName()
+            }
+        }
+    }
+
     /// Installs pending theme for the current site
     ///
     func installPendingTheme() async {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Themes/ThemeSettingViewModel.swift
@@ -49,7 +49,7 @@ final class ThemeSettingViewModel: ObservableObject {
 
 private extension ThemeSettingViewModel {
     func configureCarouselViewModel() {
-        carouselViewModel.updateReloadBehavior { [weak self] in
+        carouselViewModel.onReload = { [weak self] in
             guard let self else { return }
             Task {
                 await self.updateCurrentThemeName()

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -64,7 +64,7 @@ struct ThemesCarouselView: View {
             }
         }
         .task {
-            await viewModel.fetchThemes()
+            await viewModel.fetchThemes(isReload: false)
         }
     }
 }
@@ -89,7 +89,7 @@ private extension ThemesCarouselView {
                 .secondaryBodyStyle()
             Button {
                 Task {
-                    await viewModel.fetchThemes()
+                    await viewModel.fetchThemes(isReload: true)
                 }
             } label: {
                 Label(Localization.retry, systemImage: "arrow.clockwise")

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -12,6 +12,24 @@ struct ThemesCarouselView: View {
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
+    let thumbnailErrorAttributedString: NSAttributedString = {
+        let font: UIFont = .subheadline
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+
+        let tapHereText = NSAttributedString(string: Localization.tapHere, attributes: [.foregroundColor: UIColor.accent.cgColor, .font: font])
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .paragraphStyle: paragraph,
+            .foregroundColor: UIColor.secondaryLabel.cgColor
+        ]
+        let message = NSMutableAttributedString(string: Localization.errorLoadingThumbnail, attributes: attributes)
+        message.replaceFirstOccurrence(of: "%@", with: tapHereText)
+
+        return message
+    }()
+
     init(viewModel: ThemesCarouselViewModel, onSelectedTheme: @escaping (WordPressTheme) -> Void) {
         self.viewModel = viewModel
         self.onSelectedTheme = onSelectedTheme
@@ -93,13 +111,16 @@ private extension ThemesCarouselView {
     }
 
     func themeNameCard(name: String) -> some View {
-        VStack {
+        VStack(spacing: Layout.contentPadding) {
             Text(name)
+                .fontWeight(.semibold)
+                .foregroundColor(.init(uiColor: .text))
+                .subheadlineStyle()
+            AttributedText(thumbnailErrorAttributedString)
         }
+        .padding(Layout.contentPadding)
         .frame(width: Layout.imageWidth, height: Layout.imageHeight)
-        .background(Color.withColorStudio(
-            name: .wooCommercePurple,
-            shade: .shade0))
+        .background(Color(uiColor: .systemBackground))
         .cornerRadius(Layout.cornerRadius)
         .shadow(radius: Layout.shadowRadius, x: 0, y: Layout.shadowYOffset)
         .padding(Layout.imagePadding)
@@ -172,6 +193,22 @@ private extension ThemesCarouselView {
             "themesCarouselView.lastMessageContent",
             value: "You can find your perfect theme in the WooCommerce Theme Store.",
             comment: "The content of the message shown at the end of the themes carousel view"
+        )
+
+        static let errorLoadingThumbnail = NSLocalizedString(
+            "themesCarouselView.thumbnailError",
+            value: "Sorry, it seems there is an issue with the template loading. " +
+            "Please %@ for a live demo",
+            comment: "Error message for when theme thumbnail cannot be loaded on the themes carousel view. " +
+            "%@ is the place holder for 'tap here'. " +
+            "Reads like: Sorry, it seems there is an issue with the template loading. " +
+            "Please tap here for a live demo"
+        )
+
+        static let tapHere = NSLocalizedString(
+            "themesCarouselView.thumbnailError.tapHere",
+            value: "tap here",
+            comment: "Action to show live demo on the themes carousel view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -111,7 +111,7 @@ private extension ThemesCarouselView {
                 ScrollView(.vertical) {
                     VStack {
                         Spacer()
-                        Text(viewModel.mode.moreThemesTitleText)
+                        Text(Localization.lookingForMore)
                             .bold()
                             .secondaryBodyStyle()
                             .padding(.horizontal, Layout.contentPadding)
@@ -119,7 +119,7 @@ private extension ThemesCarouselView {
                         Spacer()
                             .frame(height: Layout.contentPadding)
 
-                        Text(viewModel.mode.moreThemesSuggestionText)
+                        Text(Localization.findInWooThemeStore)
                             .foregroundColor(Color(.secondaryLabel))
                             .subheadlineStyle()
                                 .multilineTextAlignment(.center)
@@ -161,6 +161,17 @@ private extension ThemesCarouselView {
             "themesCarouselView.retry",
             value: "Retry",
             comment: "Button to reload themes in the themes carousel view"
+        )
+        static let lookingForMore = NSLocalizedString(
+            "themesCarouselView.lastMessageHeading",
+            value: "Looking for more?",
+            comment: "The heading of the message shown at the end of the themes carousel view"
+        )
+
+        static let findInWooThemeStore = NSLocalizedString(
+            "themesCarouselView.lastMessageContent",
+            value: "You can find your perfect theme in the WooCommerce Theme Store.",
+            comment: "The content of the message shown at the end of the themes carousel view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselView.swift
@@ -12,7 +12,7 @@ struct ThemesCarouselView: View {
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
-    let thumbnailErrorAttributedString: NSAttributedString = {
+    let imageErrorAttributedString: NSAttributedString = {
         let font: UIFont = .subheadline
 
         let paragraph = NSMutableParagraphStyle()
@@ -24,7 +24,7 @@ struct ThemesCarouselView: View {
             .paragraphStyle: paragraph,
             .foregroundColor: UIColor.secondaryLabel.cgColor
         ]
-        let message = NSMutableAttributedString(string: Localization.errorLoadingThumbnail, attributes: attributes)
+        let message = NSMutableAttributedString(string: Localization.errorLoadingImage, attributes: attributes)
         message.replaceFirstOccurrence(of: "%@", with: tapHereText)
 
         return message
@@ -116,7 +116,7 @@ private extension ThemesCarouselView {
                 .fontWeight(.semibold)
                 .foregroundColor(.init(uiColor: .text))
                 .subheadlineStyle()
-            AttributedText(thumbnailErrorAttributedString)
+            AttributedText(imageErrorAttributedString)
         }
         .padding(Layout.contentPadding)
         .frame(width: Layout.imageWidth, height: Layout.imageHeight)
@@ -195,11 +195,11 @@ private extension ThemesCarouselView {
             comment: "The content of the message shown at the end of the themes carousel view"
         )
 
-        static let errorLoadingThumbnail = NSLocalizedString(
+        static let errorLoadingImage = NSLocalizedString(
             "themesCarouselView.thumbnailError",
             value: "Sorry, it seems there is an issue with the template loading. " +
             "Please %@ for a live demo",
-            comment: "Error message for when theme thumbnail cannot be loaded on the themes carousel view. " +
+            comment: "Error message for when theme image cannot be loaded on the themes carousel view. " +
             "%@ is the place holder for 'tap here'. " +
             "Reads like: Sorry, it seems there is an issue with the template loading. " +
             "Please tap here for a live demo"

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -11,7 +11,9 @@ final class ThemesCarouselViewModel: ObservableObject {
 
     let mode: Mode
     private let stores: StoresManager
-    private var onReload: (() -> Void)?
+
+    /// Closure to be triggered when the theme list is reloaded.
+    var onReload: (() -> Void)?
 
     init(mode: Mode,
          stores: StoresManager = ServiceLocator.stores) {
@@ -44,10 +46,6 @@ final class ThemesCarouselViewModel: ObservableObject {
 
     func updateCurrentTheme(id: String?) {
         currentThemeID = id
-    }
-
-    func updateReloadBehavior(action: @escaping () -> Void) {
-        onReload = action
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -54,9 +54,9 @@ final class ThemesCarouselViewModel: ObservableObject {
 private extension ThemesCarouselViewModel {
     func waitForCurrentThemeAndFinishLoading() {
         $themes.combineLatest($currentThemeID.dropFirst())
-            .map { themes, currentThemeID in
+            .map { themes, currentThemeID -> State in
                 let filteredThemes = themes.filter { $0.id != currentThemeID }
-                return State.content(themes: filteredThemes)
+                return filteredThemes.isEmpty ? .error : .content(themes: filteredThemes)
             }
             .assign(to: &$state)
     }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -11,6 +11,7 @@ final class ThemesCarouselViewModel: ObservableObject {
 
     let mode: Mode
     private let stores: StoresManager
+    private var onReload: (() -> Void)?
 
     init(mode: Mode,
          stores: StoresManager = ServiceLocator.stores) {
@@ -23,7 +24,10 @@ final class ThemesCarouselViewModel: ObservableObject {
     }
 
     @MainActor
-    func fetchThemes() async {
+    func fetchThemes(isReload: Bool) async {
+        if isReload {
+            onReload?()
+        }
         state = .loading
         do {
             themes = try await loadSuggestedThemes()
@@ -40,6 +44,10 @@ final class ThemesCarouselViewModel: ObservableObject {
 
     func updateCurrentTheme(id: String?) {
         currentThemeID = id
+    }
+
+    func updateReloadBehavior(action: @escaping () -> Void) {
+        onReload = action
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesCarouselViewModel.swift
@@ -78,38 +78,5 @@ extension ThemesCarouselViewModel {
     enum Mode: Equatable {
         case themeSettings
         case storeCreationProfiler
-
-        var moreThemesSuggestionText: String {
-            switch self {
-            case .themeSettings:
-                return Localization.moreOnSettingsScreen
-            case .storeCreationProfiler:
-                return Localization.moreOnProfiler
-            }
-        }
-
-        var moreThemesTitleText: String {
-            Localization.lookingForMore
-        }
-
-        private enum Localization {
-            static let lookingForMore = NSLocalizedString(
-                "themesCarouselViewModel.lastMessageHeading",
-                value: "Looking for more?",
-                comment: "The heading of the message shown at the end of the carousel on the WordPress theme list"
-            )
-
-            static let moreOnSettingsScreen = NSLocalizedString(
-                "themesCarouselViewModel.themeSetting.lastMessageContent",
-                value: "Find your perfect theme in the WooCommerce Theme Store.",
-                comment: "The content of the message shown at the end of the carousel on the theme settings screen"
-            )
-
-            static let moreOnProfiler = NSLocalizedString(
-                "themesCarouselViewModel.profiler.lastMessageContent",
-                value: "Once your store is set up, find your perfect theme in the WooCommerce Theme Store.",
-                comment: "The content of the message shown at the end of carousel in the store creation profiler flow"
-            )
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
@@ -31,7 +31,7 @@ final class ThemesCarouselViewModelTests: XCTestCase {
                 break
             }
         }
-        await viewModel.fetchThemes()
+        await viewModel.fetchThemes(isReload: false)
 
         // Then
         XCTAssertEqual(viewModel.state, .content(themes: expectedThemes))
@@ -51,7 +51,7 @@ final class ThemesCarouselViewModelTests: XCTestCase {
                 break
             }
         }
-        await viewModel.fetchThemes()
+        await viewModel.fetchThemes(isReload: false)
 
         // Then
         XCTAssertEqual(viewModel.state, .error)
@@ -76,7 +76,7 @@ final class ThemesCarouselViewModelTests: XCTestCase {
                 break
             }
         }
-        await viewModel.fetchThemes()
+        await viewModel.fetchThemes(isReload: false)
         viewModel.updateCurrentTheme(id: theme1.id)
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
@@ -84,4 +84,31 @@ final class ThemesCarouselViewModelTests: XCTestCase {
             viewModel.state == .content(themes: [theme2])
         }
     }
+
+    func test_state_is_error_if_filtered_theme_list_is_empty() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = ThemesCarouselViewModel(mode: .themeSettings, stores: stores)
+        let theme1: WordPressTheme = .fake().copy(id: "tsubaki")
+        let expectedThemes: [WordPressTheme] = [theme1]
+
+        // When
+        stores.whenReceivingAction(ofType: WordPressThemeAction.self) { action in
+            switch action {
+            case .loadSuggestedThemes(let onCompletion):
+                onCompletion(.success(expectedThemes))
+            case let .loadCurrentTheme(_, onCompletion):
+                onCompletion(.success(theme1))
+            default:
+                break
+            }
+        }
+        await viewModel.fetchThemes(isReload: false)
+        viewModel.updateCurrentTheme(id: theme1.id)
+
+        // Then
+        waitUntil {
+            viewModel.state == .error
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11476 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the carousel UI following latest discussions on Figma and Slack:
- Removed Attar theme from the suggested list [p1702872388375549/1702868226.286629-slack-C03L1NF1EA3].
- Updated the copy for the last slide of the carousel view to "You can find your perfect theme in the WooCommerce Theme Store."
- Updated the UI when the theme thumbnail cannot be loaded.
- Fixed issue reloading themes on the theme setting screen upon retrying.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store and navigate to Menu tab.
- Select Settings > Themes.
- Notice that the Attar theme is no longer on the suggested list.
- Swipe to the end of the list, confirm that the text is correct. This should be the same if you open the theme picker from the profiler flow too.
- Turn off Internet connection and navigate to the theme setting screen again. Notice that the error state is displayed.
- Turn on Internet connection and tap Retry. Notice that the list and the current theme name is updated correctly.

It's not easy to test the theme image error case, so try replacing `themeImageCard` with `themeNameCard` in `ThemesCarouselView` to confirm that the error message is correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Theme image error | Last slide text |
| ----- | ----- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/ffcda4be-7a6c-4a0f-888c-12c502bdbbb7" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/92e60ff1-d599-4d95-8fe3-6b6541122a5e" width=320 /> |

Retry loading themes:
https://github.com/woocommerce/woocommerce-ios/assets/5533851/05bbe0c8-5582-4a94-b3c9-8bb2396e24d2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
