### PR TITLE
[Order Creation] Prepare to add Collect Payment to Order Form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+
+struct AddOrderComponentsSection: View {
+    /// View model to drive the view content
+    let viewModel: EditableOrderViewModel.PaymentDataViewModel
+
+    /// Indicates if the coupon line details screen should be shown or not.
+    ///
+    @State private var shouldShowAddCouponLineDetails: Bool = false
+
+    /// Indicates if the gift card code input sheet should be shown or not.
+    ///
+    @Binding private var shouldShowGiftCardForm: Bool
+
+    /// Indicates if the coupons informational tooltip should be shown or not.
+    ///
+    @Binding private var shouldShowCouponsInfoTooltip: Bool
+
+    /// Indicates if the go to coupons alert should be shown or not.
+    ///
+    @State private var shouldShowGoToCouponsAlert: Bool = false
+
+    /// Indicates if the shipping line details screen should be shown or not.
+    ///
+    @Binding private var shouldShowShippingLineDetails: Bool
+
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    init(viewModel: EditableOrderViewModel.PaymentDataViewModel,
+         shouldShowCouponsInfoTooltip: Binding<Bool>,
+         shouldShowShippingLineDetails: Binding<Bool>,
+         shouldShowGiftCardForm: Binding<Bool>) {
+        self.viewModel = viewModel
+        self._shouldShowCouponsInfoTooltip = shouldShowCouponsInfoTooltip
+        self._shouldShowShippingLineDetails = shouldShowShippingLineDetails
+        self._shouldShowGiftCardForm = shouldShowGiftCardForm
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: .zero) {
+            // "Add order components" rows
+            Group {
+                Divider()
+                    .padding(.leading, Constants.dividerLeadingPadding)
+
+                addShippingRow
+
+                addCouponRow
+
+                addGiftCardRow
+            }
+        }
+        .padding(.horizontal, insets: safeAreaInsets)
+    }
+}
+
+private extension AddOrderComponentsSection {
+    @ViewBuilder var addCouponRow: some View {
+        HStack(spacing: 0) {
+            Button(Localization.addCoupon) {
+                shouldShowAddCouponLineDetails = true
+            }
+            .buttonStyle(PlusButtonStyle())
+            .disabled(viewModel.shouldDisableAddingCoupons)
+            Button() {
+                shouldShowCouponsInfoTooltip.toggle()
+            } label: {
+                Image(systemName: "questionmark.circle")
+                    .resizable()
+                    .frame(width: Constants.sectionPadding, height: Constants.sectionPadding)
+                    .accessibilityLabel(Localization.couponTooltipInformationAccessibilityLabel)
+            }
+            .renderedIf(viewModel.shouldRenderCouponsInfoTooltip)
+        }
+        .padding()
+        .accessibilityIdentifier("add-coupon-button")
+        .overlay {
+            TooltipView(toolTipTitle: Localization.couponsTooltipTitle,
+                        toolTipDescription: Localization.couponsTooltipDescription,
+                        offset: CGSize(width: 0, height: (Constants.rowMinHeight * scale) + Constants.sectionPadding),
+                        safeAreaInsets: EdgeInsets())
+            .padding()
+            .renderedIf(shouldShowCouponsInfoTooltip)
+        }
+        // The use of zIndex is necessary in order to display the view overlay from the Coupon row correctly on top of the section,
+        // since this is build by multiple views. Otherwise we may see glitches in the UI when toggling the overlay.
+        .zIndex(1)
+        .sheet(isPresented: $shouldShowAddCouponLineDetails) {
+            NavigationView {
+                CouponListView(siteID: viewModel.siteID,
+                               emptyStateActionTitle: Localization.goToCoupons,
+                               emptyStateAction: {
+                    shouldShowGoToCouponsAlert = true
+                },
+                               onCouponSelected: { coupon in
+                    viewModel.addNewCouponLineClosure(coupon)
+                    shouldShowAddCouponLineDetails = false
+                })
+                .navigationTitle(Localization.addCoupon)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button(Localization.cancelButton) {
+                            shouldShowAddCouponLineDetails = false
+                        }
+                    }
+                }
+                .alert(isPresented: $shouldShowGoToCouponsAlert, content: {
+                    Alert(title: Text(Localization.goToCoupons),
+                          message: Text(Localization.goToCouponsAlertMessage),
+                          primaryButton: .default(Text(Localization.goToCouponsAlertButtonTitle), action: {
+                        viewModel.onGoToCouponsClosure()
+                        MainTabBarController.presentCoupons()
+                    }),
+                          secondaryButton: .cancel())
+                })
+            }
+        }
+    }
+
+    @ViewBuilder var addShippingRow: some View {
+        Button(Localization.addShipping) {
+            shouldShowShippingLineDetails = true
+        }
+        .buttonStyle(PlusButtonStyle())
+        .padding()
+        .accessibilityIdentifier("add-shipping-button")
+        .disabled(viewModel.orderIsEmpty)
+        .renderedIf(!viewModel.shouldShowShippingTotal)
+    }
+
+    @ViewBuilder var addGiftCardRow: some View {
+        Button(Localization.addGiftCard) {
+            shouldShowGiftCardForm = true
+            viewModel.addGiftCardClosure()
+        }
+        .buttonStyle(PlusButtonStyle())
+        .padding()
+        .accessibilityIdentifier("add-gift-card-button")
+        .disabled(!viewModel.isAddGiftCardActionEnabled)
+        .renderedIf(viewModel.isGiftCardEnabled && viewModel.giftCardToApply.isNilOrEmpty)
+        .sheet(isPresented: $shouldShowGiftCardForm) {
+            giftCardInput
+        }
+    }
+
+    @ViewBuilder var giftCardInput: some View {
+        GiftCardInputView(viewModel: .init(code: viewModel.giftCardToApply ?? "",
+                                           setGiftCard: { code in
+            viewModel.setGiftCardClosure(code)
+            shouldShowGiftCardForm = false
+        }, dismiss: {
+            shouldShowGiftCardForm = false
+        }))
+    }
+}
+
+// MARK: Constants
+private extension AddOrderComponentsSection {
+    enum Localization {
+        static let addCoupon = NSLocalizedString(
+            "order.form.coupon.add.button.title",
+            value: "Add Coupon",
+            comment: "Title for the Coupon screen during order creation")
+
+        static let addShipping = NSLocalizedString(
+            "order.form.shipping.add.button.title",
+            value: "Add Shipping",
+            comment: "Title text of the button that adds shipping line when creating a new order")
+
+        static let addGiftCard = NSLocalizedString(
+            "order.form.giftCard.add.button.title",
+            value: "Add Gift Card",
+            comment: "Title text of the button that adds shipping line when creating a new order")
+
+        static let couponsTooltipTitle = NSLocalizedString(
+            "order.form.coupon.unavailable.tooltip.title",
+            value: "Coupons unavailable",
+            comment: "Title text for the coupons row informational tooltip")
+
+        static let couponsTooltipDescription = NSLocalizedString(
+            "order.form.coupon.unavailable.tooltip.description",
+            value: "To add Coupons, please remove your Product Discounts",
+            comment: "Description text for the coupons row informational tooltip")
+
+        static let cancelButton = NSLocalizedString(
+            "order.form.coupon.cancel.button.title",
+            value: "Cancel",
+            comment: "Cancel button title when showing the coupon list selector")
+
+        static let goToCoupons = NSLocalizedString(
+            "order.form.coupon.empty.goToCoupons.button.title",
+            value: "Go to Coupons",
+            comment: "Button title on the Coupon screen empty state when adding coupons to a new order. " +
+            "The button navigates to the Coupons Section")
+
+        static let goToCouponsAlertMessage = NSLocalizedString(
+            "order.form.coupon.empty.goToCoupons.alert.message",
+            value: "Do you want to navigate to the Coupons Menu? These changes will be discarded.",
+            comment: "Confirm message for navigating to coupons when creating a new order")
+
+        static let goToCouponsAlertButtonTitle = NSLocalizedString(
+            "order.form.coupon.empty.goToCoupons.alert.confirm.button.title",
+            value: "Go",
+            comment: "Confirm button title for navigating to coupons when creating a new order")
+
+        static let couponTooltipInformationAccessibilityLabel = NSLocalizedString(
+            "order.form.coupon.moreInfo.accessibilityLabel",
+            value: "Coupon information",
+            comment: "An accessibility label for a More info button, rendered as a question mark icon, which shows coupon information.")
+
+    }
+
+    enum Constants {
+        static let emptyOrderTitleVerticalPadding: CGFloat = 8
+        static let emptyOrderTitleLockImageTrailingPadding: CGFloat = 16
+        static let giftCardsSectionVerticalSpacing: CGFloat = 8
+        static let taxesSectionVerticalSpacing: CGFloat = 8
+        static let taxRateAddedAutomaticallyRowHorizontalSpacing: CGFloat = 8
+        static let taxesAdaptativeStacksSpacing: CGFloat = 4
+        static let sectionPadding: CGFloat = 16
+        static let rowMinHeight: CGFloat = 44
+        static let infoTooltipCornerRadius: CGFloat = 4
+        static let dividerLeadingPadding: CGFloat = 16
+        static let orderTotalBottomPadding: CGFloat = 8
+    }
+}
+
+struct AddOrderComponentsSection_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = EditableOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00", orderTotal: "20.00")
+
+        AddOrderComponentsSection(viewModel: viewModel,
+                                  shouldShowCouponsInfoTooltip: .constant(true),
+                                  shouldShowShippingLineDetails: .constant(false),
+                                  shouldShowGiftCardForm: .constant(false))
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -766,7 +766,6 @@ final class EditableOrderViewModel: ObservableObject {
                 DDLogError("⛔️ Error creating new order: \(error)")
             }
         }
-        trackCreateButtonTapped()
     }
 
     /// Action triggered on `Done` button tap in order editing flow.
@@ -839,6 +838,11 @@ final class EditableOrderViewModel: ObservableObject {
     func onAddCustomAmountButtonTapped() {
         editingFee = nil
         analytics.track(.orderCreationAddCustomAmountTapped)
+    }
+
+    func onCreateOrderTapped() {
+        createOrder()
+        trackCreateButtonTapped()
     }
 
     func addCustomAmountViewModel(with option: OrderCustomAmountsSection.ConfirmationOption?) -> AddCustomAmountViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -245,7 +245,7 @@ struct OrderForm: View {
                 switch viewModel.navigationTrailingItem {
                 case .create:
                     Button(Localization.createButton) {
-                        viewModel.createOrder()
+                        viewModel.onCreateOrderTapped()
                     }
                     .id(navigationButtonID)
                     .accessibilityIdentifier(Accessibility.createButtonIdentifier)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -120,6 +120,10 @@ struct OrderForm: View {
 
     @State private var shouldShowInformationalCouponTooltip = false
 
+    @State private var shouldShowGiftCardForm = false
+
+    @State private var shouldShowShippingLineDetails = false
+
     var body: some View {
         GeometryReader { geometry in
             ScrollViewReader { scroll in
@@ -164,8 +168,16 @@ struct OrderForm: View {
 
                                 OrderPaymentSection(
                                     viewModel: viewModel.paymentDataViewModel,
-                                    shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip)
-                                    .disabled(viewModel.shouldShowNonEditableIndicators)
+                                    shouldShowShippingLineDetails: $shouldShowShippingLineDetails,
+                                    shouldShowGiftCardForm: $shouldShowGiftCardForm)
+                                .disabled(viewModel.shouldShowNonEditableIndicators)
+
+                                AddOrderComponentsSection(
+                                    viewModel: viewModel.paymentDataViewModel,
+                                    shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip,
+                                    shouldShowShippingLineDetails: $shouldShowShippingLineDetails,
+                                    shouldShowGiftCardForm: $shouldShowGiftCardForm)
+                                .disabled(viewModel.shouldShowNonEditableIndicators)
                             }
 
                             Spacer(minLength: Layout.sectionSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -9,19 +9,11 @@ struct OrderPaymentSection: View {
 
     /// Indicates if the shipping line details screen should be shown or not.
     ///
-    @State private var shouldShowShippingLineDetails: Bool = false
-
-    /// Indicates if the coupon line details screen should be shown or not.
-    ///
-    @State private var shouldShowAddCouponLineDetails: Bool = false
-
-    /// Indicates if the go to coupons alert should be shown or not.
-    ///
-    @State private var shouldShowGoToCouponsAlert: Bool = false
+    @Binding private var shouldShowShippingLineDetails: Bool
 
     /// Indicates if the gift card code input sheet should be shown or not.
     ///
-    @State private var shouldShowGiftCardForm: Bool = false
+    @Binding private var shouldShowGiftCardForm: Bool
 
     /// Indicates if the tax educational dialog should be shown or not.
     ///
@@ -31,15 +23,9 @@ struct OrderPaymentSection: View {
     ///
     @State private var selectedCouponLineDetailsViewModel: CouponLineDetailsViewModel? = nil
 
-    /// Indicates if the coupons informational tooltip should be shown or not.
-    ///
-    @Binding private var shouldShowCouponsInfoTooltip: Bool
-
     ///   Environment safe areas
     ///
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
-
-    @ScaledMetric private var scale: CGFloat = 1.0
 
     var giftCard: String? {
         guard let giftCard = viewModel.giftCardToApply,
@@ -50,9 +36,12 @@ struct OrderPaymentSection: View {
         return giftCard
     }
 
-    init(viewModel: EditableOrderViewModel.PaymentDataViewModel, shouldShowCouponsInfoTooltip: Binding<Bool>) {
+    init(viewModel: EditableOrderViewModel.PaymentDataViewModel,
+         shouldShowShippingLineDetails: Binding<Bool>,
+         shouldShowGiftCardForm: Binding<Bool>) {
         self.viewModel = viewModel
-        self._shouldShowCouponsInfoTooltip = shouldShowCouponsInfoTooltip
+        self._shouldShowShippingLineDetails = shouldShowShippingLineDetails
+        self._shouldShowGiftCardForm = shouldShowGiftCardForm
     }
 
     var body: some View {
@@ -83,18 +72,6 @@ struct OrderPaymentSection: View {
                 discountsTotalRow
 
                 orderTotalRow
-            }
-
-            // "Add order components" rows
-            Group {
-                Divider()
-                    .padding(.leading, Constants.dividerLeadingPadding)
-
-                addShippingRow
-
-                addCouponRow
-
-                addGiftCardRow
             }
         }
         .padding(.horizontal, insets: safeAreaInsets)
@@ -143,69 +120,6 @@ private extension OrderPaymentSection {
         .renderedIf(!viewModel.orderIsEmpty)
     }
 
-    @ViewBuilder var addCouponRow: some View {
-        HStack(spacing: 0) {
-            Button(Localization.addCoupon) {
-                shouldShowAddCouponLineDetails = true
-            }
-            .buttonStyle(PlusButtonStyle())
-            .disabled(viewModel.shouldDisableAddingCoupons)
-            Button() {
-                shouldShowCouponsInfoTooltip.toggle()
-            } label: {
-                Image(systemName: "questionmark.circle")
-                    .resizable()
-                    .frame(width: Constants.sectionPadding, height: Constants.sectionPadding)
-                    .accessibilityLabel(Localization.couponTooltipInformationAccessibilityLabel)
-            }
-            .renderedIf(viewModel.shouldRenderCouponsInfoTooltip)
-        }
-        .padding()
-        .accessibilityIdentifier("add-coupon-button")
-        .overlay {
-            TooltipView(toolTipTitle: Localization.couponsTooltipTitle,
-                        toolTipDescription: Localization.couponsTooltipDescription,
-                        offset: CGSize(width: 0, height: (Constants.rowMinHeight * scale) + Constants.sectionPadding),
-                        safeAreaInsets: EdgeInsets())
-            .padding()
-            .renderedIf(shouldShowCouponsInfoTooltip)
-        }
-        // The use of zIndex is necessary in order to display the view overlay from the Coupon row correctly on top of the section,
-        // since this is build by multiple views. Otherwise we may see glitches in the UI when toggling the overlay.
-            .zIndex(1)
-            .sheet(isPresented: $shouldShowAddCouponLineDetails) {
-                NavigationView {
-                    CouponListView(siteID: viewModel.siteID,
-                                   emptyStateActionTitle: Localization.goToCoupons,
-                                   emptyStateAction: {
-                        shouldShowGoToCouponsAlert = true
-                    },
-                                   onCouponSelected: { coupon in
-                        viewModel.addNewCouponLineClosure(coupon)
-                        shouldShowAddCouponLineDetails = false
-                    })
-                    .navigationTitle(Localization.addCoupon)
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button(Localization.cancelButton) {
-                                shouldShowAddCouponLineDetails = false
-                            }
-                        }
-                    }
-                    .alert(isPresented: $shouldShowGoToCouponsAlert, content: {
-                        Alert(title: Text(Localization.goToCoupons),
-                              message: Text(Localization.goToCouponsAlertMessage),
-                              primaryButton: .default(Text(Localization.goToCouponsAlertButtonTitle), action: {
-                            viewModel.onGoToCouponsClosure()
-                            MainTabBarController.presentCoupons()
-                        }),
-                              secondaryButton: .cancel())
-                    })
-                }
-            }
-    }
-
     @ViewBuilder var appliedCouponsRows: some View {
         VStack {
             ForEach(viewModel.couponLineViewModels, id: \.title) { viewModel in
@@ -220,17 +134,6 @@ private extension OrderPaymentSection {
         .sheet(item: $selectedCouponLineDetailsViewModel) { viewModel in
             CouponLineDetails(viewModel: viewModel)
         }
-    }
-
-    @ViewBuilder var addShippingRow: some View {
-        Button(Localization.addShipping) {
-            shouldShowShippingLineDetails = true
-        }
-        .buttonStyle(PlusButtonStyle())
-        .padding()
-        .accessibilityIdentifier("add-shipping-button")
-        .disabled(viewModel.orderIsEmpty)
-        .renderedIf(!viewModel.shouldShowShippingTotal)
     }
 
     @ViewBuilder var existingShippingRow: some View {
@@ -251,21 +154,6 @@ private extension OrderPaymentSection {
     @ViewBuilder var customAmountsRow: some View {
         TitleAndValueRow(title: Localization.customAmountsTotal, value: .content(viewModel.customAmountsTotal))
             .renderedIf(viewModel.shouldShowTotalCustomAmounts)
-    }
-
-    @ViewBuilder var addGiftCardRow: some View {
-        Button(Localization.addGiftCard) {
-            shouldShowGiftCardForm = true
-            viewModel.addGiftCardClosure()
-        }
-        .buttonStyle(PlusButtonStyle())
-        .padding()
-        .accessibilityIdentifier("add-gift-card-button")
-        .disabled(!viewModel.isAddGiftCardActionEnabled)
-        .renderedIf(viewModel.isGiftCardEnabled && giftCard == nil)
-        .sheet(isPresented: $shouldShowGiftCardForm) {
-            giftCardInput
-        }
     }
 
     @ViewBuilder func editGiftCardRow(giftCard: String) -> some View {
@@ -428,37 +316,18 @@ private extension OrderPaymentSection {
                                                      comment: "Label for the row showing the total cost of products in the order")
         static let orderTotal = NSLocalizedString("Order total", comment: "Label for the the row showing the total cost of the order")
         static let discountTotal = NSLocalizedString("Discount total", comment: "Label for the the row showing the total discount of the order")
-        static let addShipping = NSLocalizedString("Add Shipping", comment: "Title text of the button that adds shipping line when creating a new order")
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
-        static let addGiftCard = NSLocalizedString("Add Gift Card", comment: "Title text of the button that adds shipping line when creating a new order")
         static let customAmountsTotal = NSLocalizedString("orderPaymentSection.customAmounts",
                                                           value: "Custom amounts",
                                                           comment: "Label for the row showing the cost of fees in the order")
         static let taxes = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
-        static let addCoupon = NSLocalizedString("Add Coupon", comment: "Title for the Coupon screen during order creation")
         static let coupon = NSLocalizedString("Coupon", comment: "Label for the row showing the cost of coupon in the order")
-        static let goToCoupons = NSLocalizedString("Go to Coupons", comment: "Button title on the Coupon screen empty state" +
-                                                   "when creating a new order that navigates to the Coupons Section")
-        static let goToCouponsAlertMessage = NSLocalizedString("Do you want to navigate to the Coupons Menu? These changes will be discarded.",
-                                                               comment: "Confirm message for navigating to coupons when creating a new order")
-        static let goToCouponsAlertButtonTitle = NSLocalizedString("Go", comment: "Confirm button title for navigating to coupons when creating a new order")
-        static let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button title when showing the coupon list selector")
         static let taxRateAddedAutomaticallyRowText = NSLocalizedString("Tax rate location added automatically",
                                                                         comment: "Notice in editable order details when the tax rate was added to the order")
-        static let couponsTooltipTitle = NSLocalizedString(
-            "Coupons unavailable",
-            comment: "Title text for the coupons row informational tooltip")
-        static let couponsTooltipDescription = NSLocalizedString(
-            "To add Coupons, please remove your Product Discounts",
-            comment: "Description text for the coupons row informational tooltip")
         static let taxInformationAccessibilityLabel = NSLocalizedString(
             "order.form.paymentSection.taxes.moreInfo.accessibilityLabel",
             value: "Tax information",
             comment: "An accessibility label for a More info button, rendered as a question mark icon, which shows tax information.")
-        static let couponTooltipInformationAccessibilityLabel = NSLocalizedString(
-            "order.form.paymentSection.coupon.moreInfo.accessibilityLabel",
-            value: "Coupon information",
-            comment: "An accessibility label for a More info button, rendered as a question mark icon, which shows coupon information.")
     }
 
     enum Constants {
@@ -481,7 +350,8 @@ struct OrderPaymentSection_Previews: PreviewProvider {
         let viewModel = EditableOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00", orderTotal: "20.00")
 
         OrderPaymentSection(viewModel: viewModel,
-                            shouldShowCouponsInfoTooltip: .constant(true))
+                            shouldShowShippingLineDetails: .constant(false),
+                            shouldShowGiftCardForm: .constant(false))
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -624,8 +624,7 @@ private extension OrderDetailsViewController {
     private func collectPayment() {
         let paymentMethodsViewController = PaymentMethodsHostingController(viewModel: viewModel.paymentMethodsViewModel)
         paymentMethodsViewController.parentController = self
-        let paymentMethodsNavigationController = WooNavigationController(rootViewController: paymentMethodsViewController)
-        present(paymentMethodsNavigationController, animated: true)
+        present(paymentMethodsViewController, animated: true)
     }
 
     private func itemAddOnsButtonTapped(addOns: [OrderItemProductAddOn]) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
@@ -20,7 +20,7 @@ final class PaymentMethodsHostingController: UIHostingController<HostedPaymentMe
         super.viewDidLoad()
 
         // Needed to present IPP collect amount alerts, which are displayed in UIKit view controllers.
-        rootView.rootViewController = navigationController
+        rootView.rootViewController = self
 
         // Set presentation delegate to track the user dismiss flow event
         if let navigationController = navigationController {
@@ -49,6 +49,19 @@ struct HostedPaymentMethodsView: View {
     var viewModel: PaymentMethodsViewModel
 
     var body: some View {
+        if #available(iOS 16.0, *) {
+            NavigationStack {
+                paymentMethodsView
+            }
+        } else {
+            NavigationView {
+                paymentMethodsView
+            }
+            .navigationViewStyle(.stack)
+        }
+    }
+
+    private var paymentMethodsView: some View {
         PaymentMethodsView(dismiss: dismiss, rootViewController: rootViewController, viewModel: viewModel)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -60,8 +73,8 @@ struct HostedPaymentMethodsView: View {
                 }
             }
             .wooNavigationBarStyle()
+            .navigationBarTitleDisplayMode(.inline)
     }
-
 }
 
 private extension HostedPaymentMethodsView {
@@ -118,4 +131,17 @@ private extension PaymentMethodsHostingController {
 
         static let dismissOrder = NSLocalizedString("Dismiss Order", comment: "Title for dismiss the action when dragging the screen down.")
     }
+}
+
+struct PaymentMethodsHostingView: UIViewControllerRepresentable {
+    weak var parentController: UIViewController?
+    let viewModel: PaymentMethodsViewModel
+
+    func makeUIViewController(context: Context) -> PaymentMethodsHostingController {
+        let viewController = PaymentMethodsHostingController(viewModel: viewModel)
+        viewController.parentController = parentController
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: PaymentMethodsHostingController, context: Context) {}
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -733,6 +733,7 @@
 		20AE33C52B0510BF00527B60 /* PaymentsMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */; };
 		20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C62B0510D200527B60 /* HubMenuDestination.swift */; };
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
+		20BBD62C2B3060A300A903F6 /* AddOrderComponentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BBD62B2B3060A300A903F6 /* AddOrderComponentsSection.swift */; };
 		20BCF6EE2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */; };
 		20BCF6F02B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */; };
 		20BCF6F72B0E5AF000954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */; };
@@ -3341,6 +3342,7 @@
 		20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsMenuDestination.swift; sourceTree = "<group>"; };
 		20AE33C62B0510D200527B60 /* HubMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubMenuDestination.swift; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
+		20BBD62B2B3060A300A903F6 /* AddOrderComponentsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOrderComponentsSection.swift; sourceTree = "<group>"; };
 		20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModel.swift; sourceTree = "<group>"; };
 		20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModelTests.swift; sourceTree = "<group>"; };
 		20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusService.swift; sourceTree = "<group>"; };
@@ -6766,6 +6768,14 @@
 			path = Destinations;
 			sourceTree = "<group>";
 		};
+		20BBD62A2B30608200A903F6 /* AddOrderComponentsSection */ = {
+			isa = PBXGroup;
+			children = (
+				20BBD62B2B3060A300A903F6 /* AddOrderComponentsSection.swift */,
+			);
+			path = AddOrderComponentsSection;
+			sourceTree = "<group>";
+		};
 		20CCBF1F2B0E159D003102E6 /* Deposits Overview */ = {
 			isa = PBXGroup;
 			children = (
@@ -9986,6 +9996,7 @@
 		CCFC50532743BBBF001E505F /* Order Creation */ = {
 			isa = PBXGroup;
 			children = (
+				20BBD62A2B30608200A903F6 /* AddOrderComponentsSection */,
 				B9F148922AD43E05008FC795 /* CustomAmounts */,
 				B935D35A2A9F44A10067B927 /* Taxes */,
 				B958B4D82983E3E00010286B /* DurationRecorder */,
@@ -12814,6 +12825,7 @@
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
 				029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
+				20BBD62C2B3060A300A903F6 /* AddOrderComponentsSection.swift in Sources */,
 				D8C251D9230D256F00F49782 /* NoticePresenter.swift in Sources */,
 				02063C8929260AA000130906 /* StoreCreationSuccessView.swift in Sources */,
 				EEBA02A52ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11466
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR lays some groundwork to allow us to add the Collect Payment button to the Create Order form.

There are no functional changes in this PR, rather it improves modal presentation of the payment flows, and splits up the existing `OrderPaymentSection` to move the Add buttons, allowing them to be presented in different parts of the view from one another in future.



### Collect Payment
The existing `Collect Payment` button on Order Details uses the `PaymentMethodsHostingController` to present its payment flow UI. There are some small but important changes to the view controller hierarchy here, which will allow us in future to modally present the Payment Methods screen from SwiftUI, without breaking its ability to present the card payment flows modally.

This is still a sticking plaster, IMO, as we're repeatedly wrapping the SwiftUI views so that we have UIViewControllers that we can pass into the CollectPaymentUseCase for it to present its UI. Making this a SwiftUI-only flow would make it a lot easier to understand.

### Order Form
The `OrderPaymentSection` is now split into `OrderPaymentSection`, which contains the details of the payments & totals) and the `AddOrderComponentsSection`, which contains the `Add` buttons for Coupons, Shipping, and Gift Cards. They are still presented in exactly the same way, however there is some shared state between them, with bindings for some of the forms (edit is shown from the totals section) and a single view model. The latter can probably be split as well, but we'll do that in a later PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Collect Payment

⚠️ There's a bug where a "Connecting Reader Failed" error is shown during connection of either TTP or a card reader. This is quickly replaced with a working connection flow. Unfortunately this bug has made it to `trunk` from some other change; it's not part of this PR. I'll take a look at it separately.

1. Launch the app using a WooPayments US/UK store.
2. Navigate to the `Orders` tab
3. Create a new order, or open an existing unpaid order
4. On the Order Details screen, tap Collect Payment
5. Complete the flow, and observe that you're able to take a payment
6. Repeat for all payment methods

Simple Payments doesn't use the same presentation approach, and so should be unaffected by the change, but could be worth testing if you have the time.

### Order Form

⚠️ There's a bug where the tooltip which can be shown for coupons is clipped by the buttons below it.
This is pre-existing and reproducible on `trunk`. I'll catch it in the next PR, as some of the upcoming moves may resolve it anyway.

1. Launch the app using
2. Navigate to `Orders > +`
3. Add shipping, coupons, and if possible, a gift card to your order
4. Test the edit functions for each of the above
5. Observe that the form all works as you'd expect
6. Repeat using an existing order which you can edit.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/72d3968d-0471-4961-9c63-cd69687873d2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
