### PR TITLE
Store switch & Theme Install: Unit tests

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2503,6 +2503,7 @@
 		EEEDA916290A799E004B001D /* WordPressAuthenticator+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEDA915290A799E004B001D /* WordPressAuthenticator+Internal.swift */; };
 		EEFF472A2B2AB24D009BF302 /* StoreCreationStoreSwitchScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFF47292B2AB24D009BF302 /* StoreCreationStoreSwitchScheduler.swift */; };
 		EEFF472C2B2B2B06009BF302 /* DefaultStoreCreationStoreSwitchSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFF472B2B2B2B06009BF302 /* DefaultStoreCreationStoreSwitchSchedulerTests.swift */; };
+		EEFF47322B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */; };
 		F997170523DBB97500592D8E /* WooCommerceScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997170423DBB97500592D8E /* WooCommerceScreenshots.swift */; };
 		F997174B23DC10B300592D8E /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174A23DC10B300592D8E /* SnapshotHelper.swift */; };
 		FE28F6F4268477C1004465C7 /* RoleEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6F3268477C1004465C7 /* RoleEligibilityUseCase.swift */; };
@@ -5127,6 +5128,7 @@
 		EEEDA915290A799E004B001D /* WordPressAuthenticator+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAuthenticator+Internal.swift"; sourceTree = "<group>"; };
 		EEFF47292B2AB24D009BF302 /* StoreCreationStoreSwitchScheduler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreCreationStoreSwitchScheduler.swift; sourceTree = "<group>"; };
 		EEFF472B2B2B2B06009BF302 /* DefaultStoreCreationStoreSwitchSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStoreCreationStoreSwitchSchedulerTests.swift; sourceTree = "<group>"; };
+		EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreCreationStoreSwitchScheduler.swift; sourceTree = "<group>"; };
 		F317D86E54C611C83FD97DAB /* Pods-NotificationExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-NotificationExtension/Pods-NotificationExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
@@ -8284,6 +8286,7 @@
 				20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */,
 				68A38DF42B293B030090C263 /* MockProductListViewModel.swift */,
 				EE66BB112B29D65400518DAF /* MockThemeInstaller.swift */,
+				EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14432,6 +14435,7 @@
 				CC5BA5F5287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift in Sources */,
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,
 				0277AEA5256CAA4200F45C4A /* MockShippingLabel.swift in Sources */,
+				EEFF47322B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift in Sources */,
 				02BAB02324D0250300F8B06E /* ProductVariation+ProductFormTests.swift in Sources */,
 				028B68C32A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift in Sources */,
 				B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -587,6 +587,96 @@ final class AppCoordinatorTests: XCTestCase {
         }
         XCTAssertTrue(stores.needsDefaultStore)
     }
+
+    // MARK: Pending store switch
+    func test_starting_app_logged_in_with_selected_site_checks_for_pending_store_switch() throws {
+        // Given
+        let storeSwitcher = MockStoreCreationStoreSwitchScheduler()
+
+        stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            guard case let AppSettingsAction.loadEligibilityErrorInfo(completion) = action else {
+                return
+            }
+            // any failure except `.insufficientRole` will be treated as having an eligible status.
+            completion(.failure(SampleError.first))
+        }
+        sessionManager.defaultStoreID = 134
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             storeSwitcher: storeSwitcher)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        waitUntil {
+            storeSwitcher.isPendingStoreSwitchChecked == true
+        }
+    }
+
+    func test_starting_app_logged_in_with_selected_site_listens_to_store_status_when_there_is_a_pending_store_switch() throws {
+        // Given
+        let storeSwitcher = MockStoreCreationStoreSwitchScheduler()
+        storeSwitcher.isPendingStoreSwitchMockValue = true
+
+        stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            guard case let AppSettingsAction.loadEligibilityErrorInfo(completion) = action else {
+                return
+            }
+            // any failure except `.insufficientRole` will be treated as having an eligible status.
+            completion(.failure(SampleError.first))
+        }
+        sessionManager.defaultStoreID = 134
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             storeSwitcher: storeSwitcher)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        waitUntil {
+            storeSwitcher.listenToPendingStoreAndReturnSiteIDOnceReadyCalled == true
+        }
+    }
+
+    // MARK: Theme install
+    func test_starting_app_logged_in_with_selected_site_installs_pending_theme_when_there_is_a_pending_store_switch() throws {
+        // Given
+        let storeSwitcher = MockStoreCreationStoreSwitchScheduler()
+        storeSwitcher.isPendingStoreSwitchMockValue = true
+        storeSwitcher.siteIDMockValue = 123
+
+        let themeInstaller = MockThemeInstaller()
+
+        stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            guard case let AppSettingsAction.loadEligibilityErrorInfo(completion) = action else {
+                return
+            }
+            // any failure except `.insufficientRole` will be treated as having an eligible status.
+            completion(.failure(SampleError.first))
+        }
+        sessionManager.defaultStoreID = 134
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             storeSwitcher: storeSwitcher,
+                                             themeInstaller: themeInstaller)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        waitUntil {
+            themeInstaller.installPendingThemeCalled == true
+        }
+        XCTAssertEqual(try XCTUnwrap(themeInstaller.installPendingThemeCalledForSiteID), 123)
+    }
 }
 
 private extension AppCoordinatorTests {

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -600,7 +600,9 @@ private extension AppCoordinatorTests {
                          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
                          featureFlagService: FeatureFlagService = MockFeatureFlagService(),
                          upgradesViewPresentationCoordinator: UpgradesViewPresentationCoordinator = UpgradesViewPresentationCoordinator(),
-                         switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil
+                         switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil,
+                         storeSwitcher: StoreCreationStoreSwitchScheduler = DefaultStoreCreationStoreSwitchScheduler(),
+                         themeInstaller: ThemeInstaller = DefaultThemeInstaller()
     ) -> AppCoordinator {
         return AppCoordinator(window: window ?? self.window,
                               stores: stores ?? self.stores,
@@ -612,6 +614,8 @@ private extension AppCoordinatorTests {
                               pushNotesManager: pushNotesManager,
                               featureFlagService: featureFlagService,
                               upgradesViewPresentationCoordinator: upgradesViewPresentationCoordinator,
-                              switchStoreUseCase: switchStoreUseCase)
+                              switchStoreUseCase: switchStoreUseCase,
+                              storeSwitcher: storeSwitcher,
+                              themeInstaller: themeInstaller)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoreCreationStoreSwitchScheduler.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoreCreationStoreSwitchScheduler.swift
@@ -1,0 +1,26 @@
+@testable import WooCommerce
+import Foundation
+
+final class MockStoreCreationStoreSwitchScheduler: StoreCreationStoreSwitchScheduler {
+    func savePendingStoreSwitch(siteID: Int64, expectedStoreName: String) {
+        //no-op
+    }
+
+    func removePendingStoreSwitch() {
+        //no-op
+    }
+
+    var isPendingStoreSwitchMockValue = true
+    var isPendingStoreSwitchChecked = false
+    var isPendingStoreSwitch: Bool {
+        isPendingStoreSwitchChecked = true
+        return isPendingStoreSwitchMockValue
+    }
+
+    var listenToPendingStoreAndReturnSiteIDOnceReadyCalled = false
+    var siteIDMockValue: Int64 = 0
+    func listenToPendingStoreAndReturnSiteIDOnceReady() async throws -> Int64? {
+        listenToPendingStoreAndReturnSiteIDOnceReadyCalled = true
+        return siteIDMockValue
+    }
+}


### PR DESCRIPTION
Closes: #11323

## Description

Tests that `AppCoordinator` performs the following operations as expected.
1. Check pending store switch and listen to store status if needed.
2. Check pending store switch and install theme if needed.

🗒️  I tried adding unit tests to `StoreCreationCoordinator` to ensure that pending store switch info is saved and removed as expected. But I skipped it as writing tests for `StoreCreationCoordinator` isn't straightforward. 

## Testing instructions
CI passing is sufficient. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
