### PR TITLE
[Dashboard] Prevent decoding error on PaymentGateway title and description properties

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -707,6 +707,7 @@
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
 		CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
+		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */; };
 		CEE9188129F7DC23004B23FF /* order-with-gift-cards.json in Resources */ = {isa = PBXBuildFile; fileRef = CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */; };
 		CEF88DAB233E911A00BED485 /* order-fully-refunded.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF88DAA233E911A00BED485 /* order-fully-refunded.json */; };
@@ -1740,6 +1741,7 @@
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
 		CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundListMapperTests.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
+		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderGiftCard.swift; sourceTree = "<group>"; };
 		CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-gift-cards.json"; sourceTree = "<group>"; };
 		CEF88DAA233E911A00BED485 /* order-fully-refunded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-fully-refunded.json"; sourceTree = "<group>"; };
@@ -2805,6 +2807,7 @@
 				CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				0313651A28AE60E000EEE571 /* payment-gateway-cod.json */,
+				CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
 				DEC51A96274DD962009F3DF4 /* plugin.json */,
 				DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */,
@@ -3658,6 +3661,7 @@
 				EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
+				CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */,
 				DEC2B093297AA60D003923FB /* category-without-data.json in Resources */,
 				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
 				68C87B342862D40E00A99054 /* setting-all-except-countries.json in Resources */,

--- a/Networking/Networking/Model/PaymentGateway.swift
+++ b/Networking/Networking/Model/PaymentGateway.swift
@@ -95,8 +95,8 @@ extension PaymentGateway: Codable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let gatewayID = try container.decode(String.self, forKey: .gatewayID)
-        let title = try container.decode(String.self, forKey: .title)
-        let description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        let title = ( try? container.decode(String.self, forKey: .title) ) ?? ""
+        let description = ( try? container.decodeIfPresent(String.self, forKey: .description) ) ?? ""
         let enabled = try container.decode(Bool.self, forKey: .enabled)
         let features = try container.decode([Feature].self, forKey: .features)
 

--- a/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
@@ -52,6 +52,22 @@ final class PaymentGatewayMapperTests: XCTestCase {
 
         XCTAssertEqual(paymentGateway, expectedPaymentGateway)
     }
+
+    /// Verifies that the fields are all parsed correctly
+    ///
+    func test_PaymentGatewaysList_map_parses_all_fields_in_result_when_response_has_malformed_title_and_description() throws {
+        let paymentGateway = try mapRetrieveMalformedPaymentGatewayResponse()
+
+        let expectedPaymentGateway = PaymentGateway(siteID: dummySiteID,
+                                                    gatewayID: "cod",
+                                                    title: "",
+                                                    description: "",
+                                                    enabled: true,
+                                                    features: [.products],
+                                                    instructions: "Pay with cash upon delivery.")
+
+        assertEqual(expectedPaymentGateway, paymentGateway)
+    }
 }
 
 
@@ -79,6 +95,12 @@ private extension PaymentGatewayMapperTests {
     ///
     func mapRetrievePaymentGatewayResponseWithoutDataEnvelope() throws -> PaymentGateway {
         return try mapPaymentGateway(from: "payment-gateway-cod-without-data")
+    }
+
+    /// Returns the PaymentGateway output from `payment-gateway-cod-malformed.json`
+    ///
+    func mapRetrieveMalformedPaymentGatewayResponse() throws -> PaymentGateway {
+        return try mapPaymentGateway(from: "payment-gateway-cod-malformed")
     }
 
     struct FileNotFoundError: Error {}

--- a/Networking/NetworkingTests/Responses/payment-gateway-cod-malformed.json
+++ b/Networking/NetworkingTests/Responses/payment-gateway-cod-malformed.json
@@ -1,0 +1,71 @@
+{
+    "data": {
+        "id": "cod",
+        "title": false,
+        "description": 0,
+        "order": "",
+        "enabled": true,
+        "method_title": "Cash on delivery",
+        "method_description": "Have your customers pay with cash (or by other means) upon delivery.",
+        "method_supports": [
+            "products"
+        ],
+        "settings": {
+            "title": {
+                "id": "title",
+                "label": "Title",
+                "description": "Payment method description that the customer will see on your checkout.",
+                "type": "safe_text",
+                "value": "Cash on delivery",
+                "default": "Cash on delivery",
+                "tip": "Payment method description that the customer will see on your checkout.",
+                "placeholder": ""
+            },
+            "instructions": {
+                "id": "instructions",
+                "label": "Instructions",
+                "description": "Instructions that will be added to the thank you page.",
+                "type": "textarea",
+                "value": "Pay with cash upon delivery.",
+                "default": "Pay with cash upon delivery.",
+                "tip": "Instructions that will be added to the thank you page.",
+                "placeholder": ""
+            },
+            "enable_for_methods": {
+                "id": "enable_for_methods",
+                "label": "Enable for shipping methods",
+                "description": "If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.",
+                "type": "multiselect",
+                "value": "",
+                "default": "",
+                "tip": "If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.",
+                "placeholder": "",
+                "options": {
+                    "Flat rate": {
+                        "flat_rate": "Any &quot;Flat rate&quot; method",
+                        "flat_rate:1": "Other locations &ndash; Flat rate (#1)"
+                    },
+                    "Free shipping": {
+                        "free_shipping": "Any &quot;Free shipping&quot; method",
+                        "free_shipping:4": "Other locations &ndash; Free shipping (#4)"
+                    },
+                    "Local pickup": {
+                        "local_pickup": "Any &quot;Local pickup&quot; method"
+                    }
+                }
+            },
+            "enable_for_virtual": {
+                "id": "enable_for_virtual",
+                "label": "Accept COD if the order is virtual",
+                "description": "",
+                "type": "checkbox",
+                "value": "yes",
+                "default": "yes",
+                "tip": "",
+                "placeholder": ""
+            }
+        }
+    }
+}
+
+

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 16.8
 -----
 - [*] Store creation: Inform user once store ready if app killed while waiting for store to be ready. [https://github.com/woocommerce/woocommerce-ios/pull/11478]
+- [*] Dashboard: Resolves a decoding error with certain payment gateway plugins that previously caused an error loading data in the dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/11489]
 
 16.7
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11484
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
The entity with the most unresolved JSON decoding failures is currently `PaymentGateway` (137,929 errors affecting 11,683 users so far in December). These are from `title` and `description` fields that can't be decoded as strings.

We use these fields when adding a "Payment in Person" method for IPP, so we need to support them. However, we don't display them anywhere in the app so there should be no user-facing change if we fall back to an empty string if they can't be decoded from an API response. (This can happen with certain payment gateway plugins that don't set the expected title and/or description for new payment gateways.)

## How
This makes the decoding for `title` and `description` on `PaymentGateway` optional and uses an empty string as a fallback.

I decided not to use a `failsafeDecodeIfPresent` method here and just used an optional `try`. Unlike cases where we expect the string to contain a number (like a product price that we want to decode whether the API returns e.g. `"5"` or `5`), in this case we only want to decode the title or description if it's provided as a string.

## Testing instructions

Optional testing:

1. Enable a payment gateway plugin that causes a decoding error, e.g. [Mollie Payments for WooCommerce](https://en-gb.wordpress.org/plugins/mollie-payments-for-woocommerce/).
2. Build and run the app.
3. Confirm the dashboard loads without any errors loading data.

- [x] @rachelmcr tests with a plugin that causes a decoding error

## Screenshots

Before|After
-|-
![Simulator Screenshot - iPhone 14 Pro - 2023-12-18 at 16 10 20](https://github.com/woocommerce/woocommerce-ios/assets/8658164/a3f3dfa6-dda1-4340-893f-e04b0d329121)|![Simulator Screenshot - iPhone 14 Pro - 2023-12-18 at 16 11 01](https://github.com/woocommerce/woocommerce-ios/assets/8658164/8457e411-ecf8-40a6-8982-6e240c4e2949)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
