### PR TITLE
[Stats] Prevent decoding error for `ProductsReportItem` by removing unused property

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2008,7 +2008,6 @@ extension Networking.TopEarnerStatsItem {
             productID: .fake(),
             productName: .fake(),
             quantity: .fake(),
-            price: .fake(),
             total: .fake(),
             currency: .fake(),
             imageUrl: .fake()

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2712,7 +2712,6 @@ extension Networking.TopEarnerStatsItem {
         productID: CopiableProp<Int64> = .copy,
         productName: NullableCopiableProp<String> = .copy,
         quantity: CopiableProp<Int> = .copy,
-        price: CopiableProp<Double> = .copy,
         total: CopiableProp<Double> = .copy,
         currency: CopiableProp<String> = .copy,
         imageUrl: NullableCopiableProp<String> = .copy
@@ -2720,7 +2719,6 @@ extension Networking.TopEarnerStatsItem {
         let productID = productID ?? self.productID
         let productName = productName ?? self.productName
         let quantity = quantity ?? self.quantity
-        let price = price ?? self.price
         let total = total ?? self.total
         let currency = currency ?? self.currency
         let imageUrl = imageUrl ?? self.imageUrl
@@ -2729,7 +2727,6 @@ extension Networking.TopEarnerStatsItem {
             productID: productID,
             productName: productName,
             quantity: quantity,
-            price: price,
             total: total,
             currency: currency,
             imageUrl: imageUrl

--- a/Networking/Networking/Model/Stats/ProductsReportItem.swift
+++ b/Networking/Networking/Model/Stats/ProductsReportItem.swift
@@ -52,7 +52,7 @@ public struct ProductsReportItem: Decodable, Equatable {
         let extendedInfo = try container.nestedContainer(keyedBy: ExtendedInfoCodingKeys.self, forKey: .extendedInfo)
 
         let productName = try extendedInfo.decode(String.self, forKey: .productName)
-        let price = try extendedInfo.decode(Double.self, forKey: .price)
+        let price = (try? extendedInfo.decode(Double.self, forKey: .price)) ?? 0
 
         // Parse and extract the `src` string out of the image html using `Aztec parser`
         let imageUrl: String? = {

--- a/Networking/Networking/Model/Stats/ProductsReportItem.swift
+++ b/Networking/Networking/Model/Stats/ProductsReportItem.swift
@@ -18,10 +18,6 @@ public struct ProductsReportItem: Decodable, Equatable {
     ///
     public let quantity: Int
 
-    /// Price of item
-    ///
-    public let price: Double
-
     /// Net revenue from product
     ///
     public let total: Double
@@ -33,11 +29,10 @@ public struct ProductsReportItem: Decodable, Equatable {
 
     /// Designated Initializer.
     ///
-    public init(productID: Int64, productName: String, quantity: Int, price: Double, total: Double, imageUrl: String?) {
+    public init(productID: Int64, productName: String, quantity: Int, total: Double, imageUrl: String?) {
         self.productID = productID
         self.productName = productName
         self.quantity = quantity
-        self.price = price
         self.total = total
         self.imageUrl = imageUrl
     }
@@ -52,7 +47,6 @@ public struct ProductsReportItem: Decodable, Equatable {
         let extendedInfo = try container.nestedContainer(keyedBy: ExtendedInfoCodingKeys.self, forKey: .extendedInfo)
 
         let productName = try extendedInfo.decode(String.self, forKey: .productName)
-        let price = (try? extendedInfo.decode(Double.self, forKey: .price)) ?? 0
 
         // Parse and extract the `src` string out of the image html using `Aztec parser`
         let imageUrl: String? = {
@@ -64,7 +58,7 @@ public struct ProductsReportItem: Decodable, Equatable {
             return src
         }()
 
-        self.init(productID: productID, productName: productName, quantity: quantity, price: price, total: total, imageUrl: imageUrl)
+        self.init(productID: productID, productName: productName, quantity: quantity, total: total, imageUrl: imageUrl)
     }
 }
 
@@ -81,7 +75,6 @@ private extension ProductsReportItem {
 
     enum ExtendedInfoCodingKeys: String, CodingKey {
         case productName    = "name"
-        case price          = "price"
         case imageHTML      = "image"
     }
 }

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -17,10 +17,6 @@ public struct TopEarnerStatsItem: Decodable, Equatable, GeneratedCopiable, Gener
     ///
     public let quantity: Int
 
-    /// Average price of item
-    ///
-    public let price: Double
-
     /// Total revenue from product
     ///
     public let total: Double
@@ -36,11 +32,10 @@ public struct TopEarnerStatsItem: Decodable, Equatable, GeneratedCopiable, Gener
 
     /// Designated Initializer.
     ///
-    public init(productID: Int64, productName: String?, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
+    public init(productID: Int64, productName: String?, quantity: Int, total: Double, currency: String, imageUrl: String?) {
         self.productID = productID
         self.productName = productName ?? ""
         self.quantity = quantity
-        self.price = price
         self.total = total
         self.currency = currency
         self.imageUrl = imageUrl
@@ -56,7 +51,6 @@ private extension TopEarnerStatsItem {
         case productName = "name"
         case total = "total"
         case quantity = "quantity"
-        case price = "price"
         case imageUrl = "image"
         case currency = "currency"
     }

--- a/Networking/NetworkingTests/Mapper/ProductsReportMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductsReportMapperTests.swift
@@ -32,7 +32,6 @@ final class ProductsReportMapperTests: XCTestCase {
         let expectedProduct = ProductsReportItem(productID: 233,
                                                  productName: "Colorful Sunglasses Subscription",
                                                  quantity: 5,
-                                                 price: 5,
                                                  total: 177,
                                                  imageUrl: "https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg")
 

--- a/Networking/NetworkingTests/Mapper/TopEarnerStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/TopEarnerStatsMapperTests.swift
@@ -24,7 +24,6 @@ class TopEarnerStatsMapperTests: XCTestCase {
         let sampleItem1 = dayStats.items![0]
         XCTAssertEqual(sampleItem1.imageUrl, "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2017/05/hoodie-with-logo.jpg?w=801")
         XCTAssertEqual(sampleItem1.currency, "USD")
-        XCTAssertEqual(sampleItem1.price, 40.0)
         XCTAssertEqual(sampleItem1.productID, 296)
         XCTAssertEqual(sampleItem1.productName, "Funky Hoodie")
         XCTAssertEqual(sampleItem1.quantity, 1)
@@ -48,7 +47,6 @@ class TopEarnerStatsMapperTests: XCTestCase {
         let sampleItem1 = weekStats.items![0]
         XCTAssertEqual(sampleItem1.imageUrl, "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2017/05/hoodie-with-logo.jpg?w=801")
         XCTAssertEqual(sampleItem1.currency, "USD")
-        XCTAssertEqual(sampleItem1.price, 40.0)
         XCTAssertEqual(sampleItem1.productID, 296)
         XCTAssertEqual(sampleItem1.productName, "Funky Hoodie")
         XCTAssertEqual(sampleItem1.quantity, 1)
@@ -57,7 +55,6 @@ class TopEarnerStatsMapperTests: XCTestCase {
         let sampleItem2 = weekStats.items![2]
         XCTAssertEqual(sampleItem2.imageUrl, "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/04/smile.gif?w=480")
         XCTAssertEqual(sampleItem2.currency, "USD")
-        XCTAssertEqual(sampleItem2.price, 80.0)
         XCTAssertEqual(sampleItem2.productID, 1033)
         XCTAssertEqual(sampleItem2.productName, "Smile T-Shirt")
         XCTAssertEqual(sampleItem2.quantity, 2)
@@ -81,7 +78,6 @@ class TopEarnerStatsMapperTests: XCTestCase {
         let sampleItem1 = monthStats.items![0]
         XCTAssertEqual(sampleItem1.imageUrl, "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2017/08/freediving.jpg?w=768")
         XCTAssertEqual(sampleItem1.currency, "USD")
-        XCTAssertEqual(sampleItem1.price, 249.34)
         XCTAssertEqual(sampleItem1.productID, 601)
         XCTAssertEqual(sampleItem1.productName, "Ultimate Freediving Experience")
         XCTAssertEqual(sampleItem1.quantity, 5)
@@ -90,7 +86,6 @@ class TopEarnerStatsMapperTests: XCTestCase {
         let sampleItem2 = monthStats.items![3]
         XCTAssertEqual(sampleItem2.imageUrl, "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/08/00030000053201_CL___JPEG_3.jpg?w=500")
         XCTAssertEqual(sampleItem2.currency, "USD")
-        XCTAssertEqual(sampleItem2.price, 4.49)
         XCTAssertEqual(sampleItem2.productID, 1293)
         XCTAssertEqual(sampleItem2.productName, "Pancake Mix - 2lb")
         XCTAssertEqual(sampleItem2.quantity, 26)
@@ -114,7 +109,6 @@ class TopEarnerStatsMapperTests: XCTestCase {
         let sampleItem1 = yearStats.items![0]
         XCTAssertEqual(sampleItem1.imageUrl, "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2017/08/freediving.jpg?w=768")
         XCTAssertEqual(sampleItem1.currency, "USD")
-        XCTAssertEqual(sampleItem1.price, 249)
         XCTAssertEqual(sampleItem1.productID, 601)
         XCTAssertEqual(sampleItem1.productName, "Ultimate Freediving Experience")
         XCTAssertEqual(sampleItem1.quantity, 5)
@@ -123,7 +117,6 @@ class TopEarnerStatsMapperTests: XCTestCase {
         let sampleItem2 = yearStats.items![1]
         XCTAssertEqual(sampleItem2.imageUrl, "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2017/07/hm-black.jpg?w=640")
         XCTAssertEqual(sampleItem2.currency, "USD")
-        XCTAssertEqual(sampleItem2.price, -1234.23424)
         XCTAssertEqual(sampleItem2.productID, 373)
         XCTAssertEqual(sampleItem2.productName, "Black Dress (H&M)")
         XCTAssertEqual(sampleItem2.quantity, 1231323)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersView.swift
@@ -46,7 +46,6 @@ struct DashboardTopPerformersView_Previews: PreviewProvider {
         DashboardTopPerformersView(viewModel: .init(state: .loaded(rows: [.init(productID: 12,
                                                                                 productName: "Fun product",
                                                                                 quantity: 6,
-                                                                                price: 12.8,
                                                                                 total: 16.8,
                                                                                 currency: "USD",
                                                                                 imageUrl: nil)]), onTap: { _ in }))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
@@ -145,7 +145,6 @@ private extension ProductLoaderViewControllerModelTests {
         TopEarnerStatsItem(productID: productID,
                            productName: "Album",
                            quantity: 1,
-                           price: 15.0,
                            total: 15.99,
                            currency: "",
                            imageUrl: "https://dulces.mystagingwebsite.com/wp-content/uploads/2020/06/album-1.jpg")

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -490,7 +490,6 @@ extension MockObjectGraph {
             productID: product.productID,
             productName: product.name,
             quantity: quantity,
-            price: averagePrice,
             total: Double(quantity) * averagePrice,
             currency: "USD",
             imageUrl: product.images.first?.src

--- a/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
@@ -12,7 +12,6 @@ extension Storage.TopEarnerStatsItem: ReadOnlyConvertible {
         productID = statsItem.productID
         productName = statsItem.productName
         quantity = Int64(statsItem.quantity)
-        price = statsItem.price
         total = statsItem.total
         currency = statsItem.currency
         imageUrl = statsItem.imageUrl
@@ -24,7 +23,6 @@ extension Storage.TopEarnerStatsItem: ReadOnlyConvertible {
         return TopEarnerStatsItem(productID: productID,
                                   productName: productName ?? "",
                                   quantity: Int(quantity),
-                                  price: price,
                                   total: total,
                                   currency: currency ?? "",
                                   imageUrl: imageUrl ?? "")

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -457,7 +457,6 @@ private extension StatsStoreV4 {
             TopEarnerStatsItem(productID: product.productID,
                                productName: product.productName,
                                quantity: product.quantity,
-                               price: product.price,
                                total: product.total,
                                currency: "", // TODO: Remove currency https://github.com/woocommerce/woocommerce-ios/issues/2549
                                imageUrl: product.imageUrl)

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -736,7 +736,6 @@ private extension StatsStoreV4Tests {
         return TopEarnerStatsItem(productID: 233,
                                   productName: "Colorful Sunglasses Subscription",
                                   quantity: 5,
-                                  price: 5,
                                   total: 177,
                                   currency: "",
                                   imageUrl: "https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg")
@@ -746,7 +745,6 @@ private extension StatsStoreV4Tests {
         return TopEarnerStatsItem(productID: 27,
                                   productName: "Album",
                                   quantity: 1,
-                                  price: 15,
                                   total: 0,
                                   currency: "",
                                   imageUrl: "https://example.com/wp-content/uploads/2023/01/album-1-600x600.jpg")
@@ -764,7 +762,6 @@ private extension StatsStoreV4Tests {
         return TopEarnerStatsItem(productID: 233,
                                   productName: "Colorful Sunglasses Subscription",
                                   quantity: 8,
-                                  price: 5,
                                   total: 215,
                                   currency: "",
                                   imageUrl: "https://example.com/wp-content/uploads/2023/01/sunglasses-2-600x600.jpg")
@@ -774,7 +771,6 @@ private extension StatsStoreV4Tests {
         return TopEarnerStatsItem(productID: 27,
                                   productName: "Album",
                                   quantity: 4,
-                                  price: 15,
                                   total: 45,
                                   currency: "",
                                   imageUrl: "https://example.com/wp-content/uploads/2023/01/album-1-600x600.jpg")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11485
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
`ProductsReportItem` can fail to decode when the `price` key isn't present in `extended_info`. (This decoding error has occurred 25,988 times so far this month.)

We use `ProductsReportItem` to create the `TopEarnerStatsItem` used in the Top Performers section of the dashboard. Both of these entities currently have a `price` property that we get from `ProductsReportItem`. However, we don't use the `price` property for anything in the app, so it can be safely removed.

## How
Removes the `price` property from both `ProductsReportItem` and `TopEarnerStatsItem` entities.

We can also remove the `price` attribute from the `TopEarnerStatsItem` storage entity since it's no longer needed. I'll do that cleanup in a separate PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Optional testing:

1. Build and run the app.
2. Confirm the dashboard still loads, including the Top Performers section.

Note: I couldn't find a plugin that reproduces the original decoding error, but given that the decoding error is linked to the removed property, it should be sufficient to confirm the dashboard still loads with these changes.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
