### PR TITLE
Lightweight storefront: Add tracking for theme preview screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -153,6 +153,9 @@ struct ThemesPreviewView: View {
             pagesListSheet(pages: viewModel.pages)
         }
         .notice($viewModel.notice)
+        .onAppear {
+            viewModel.trackViewAppear()
+        }
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -204,6 +204,7 @@ struct ThemesPreviewView: View {
     private func menuItem(for device: PreviewDevice) -> some View {
         Button {
             selectedDevice = device
+            viewModel.trackLayoutSwitch(layout: device)
         } label: {
             Text(device.menuTitle)
             if selectedDevice == device {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
@@ -81,6 +81,10 @@ final class ThemesPreviewViewModel: ObservableObject {
             throw error
         }
     }
+
+    func trackViewAppear() {
+        analytics.track(event: .Themes.previewScreenDisplayed())
+    }
 }
 
 private extension ThemesPreviewViewModel {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
@@ -54,6 +54,7 @@ final class ThemesPreviewViewModel: ObservableObject {
 
     func setSelectedPage(page: WordPressPage) {
         selectedPage = page
+        analytics.track(event: .Themes.previewPageSelected(page: page.title, url: page.link))
     }
 
     @MainActor
@@ -84,6 +85,10 @@ final class ThemesPreviewViewModel: ObservableObject {
 
     func trackViewAppear() {
         analytics.track(event: .Themes.previewScreenDisplayed())
+    }
+
+    func trackLayoutSwitch(layout: ThemesPreviewView.PreviewDevice) {
+        analytics.track(event: .Themes.previewLayoutSelected(layout: layout))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesPreviewViewModelTests.swift
@@ -389,6 +389,54 @@ final class ThemesPreviewViewModelTests: XCTestCase {
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
         XCTAssertEqual(eventProperties["theme"] as? String, "tsubaki")
     }
+
+    func test_trackViewAppear_tracks_preview_screen_displayed() throws {
+        // Given
+        let viewModel = ThemesPreviewViewModel(siteID: 123,
+                                               mode: .storeCreationProfiler,
+                                               theme: .fake().copy(id: "tsubaki"),
+                                               stores: stores,
+                                               analytics: analytics)
+
+        // When
+        viewModel.trackViewAppear()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["theme_preview_screen_displayed"])
+    }
+
+    func test_trackLayoutSwitch_tracks_theme_preview_layout_selected() throws {
+        // Given
+        let viewModel = ThemesPreviewViewModel(siteID: 123,
+                                               mode: .storeCreationProfiler,
+                                               theme: .fake().copy(id: "tsubaki"),
+                                               analytics: analytics)
+
+        // When
+        viewModel.trackLayoutSwitch(layout: .tablet)
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "theme_preview_layout_selected"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["layout"] as? String, "tablet")
+    }
+
+    func test_setSelectedPage_tracks_theme_preview_page_selected() throws {
+        // Given
+        let viewModel = ThemesPreviewViewModel(siteID: 123,
+                                               mode: .storeCreationProfiler,
+                                               theme: .fake().copy(id: "tsubaki"),
+                                               analytics: analytics)
+
+        // When
+        viewModel.setSelectedPage(page: .fake().copy(title: "Test", link: "https://example.com"))
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "theme_preview_page_selected"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["page"] as? String, "Test")
+        XCTAssertEqual(eventProperties["page_url"] as? String, "https://example.com")
+    }
 }
 
 private extension ThemesPreviewViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11473 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds 3 missing events for the preview screen:

Event Name | Trigger | Properties
-- | -- | --
*_theme_preview_screen_displayed | When the theme preview screen is displayed |  
*_theme_preview_layout_selected | When the user selected a layout to be previewed | layout: mobile \| tablet \| desktop
*_theme_preview_page_selected | When the user selected a page to be previewed | page: page_title, page_url: url

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store and switch to the Menu tab.
- Select Settings > Themes.
- Select a theme in the carousel view. Xcode should log: `🔵 Tracked theme_preview_screen_displayed`.
- Tap the layout icon on the top right and select any layout. Xcode should log `🔵 Tracked theme_preview_layout_selected` with the correct `layout` property.
- Tap the navigation title and select any page. Xcode should log: `🔵 Tracked theme_preview_page_selected` with the correct `page` and `page_url` properties.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
