### PR TITLE
Add loading indicator to `WebView`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -19,14 +19,6 @@ struct WebView: UIViewRepresentable {
 
     private let url: URL
 
-    /// Optional URL or part of URL to trigger exit
-    ///
-    var urlToTriggerExit: String?
-
-    /// Callback that will be triggered if the destination url containts the `urlToTriggerExit`
-    ///
-    var exitTrigger: (() -> Void)?
-
     /// Callback that will be triggered in when the underlying `WKWebView` delegate method `didCommit` is triggered.
     /// This happens when the web view has received data and is starting to render the content.
     ///
@@ -87,13 +79,6 @@ struct WebView: UIViewRepresentable {
         func webView(_ webView: WKWebView, decidePolicyFor
                         navigationAction: WKNavigationAction,
                      decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-            if let url = webView.url?.absoluteString, let urlTrigger = parent.urlToTriggerExit, url.contains(urlTrigger) {
-                parent.exitTrigger?()
-                decisionHandler(.cancel)
-                webView.navigationDelegate = nil
-                return
-            }
-
             if navigationAction.navigationType == .linkActivated && parent.disableLinkClicking {
                 decisionHandler(.cancel)
                 return

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -52,17 +52,23 @@ struct WebView: UIViewRepresentable {
         WebViewCoordinator(self)
     }
 
-    func makeUIView(context: Context) -> WKWebView {
-        let webview = WKWebView()
-        webview.customUserAgent = UserAgent.defaultUserAgent
-        webview.navigationDelegate = context.coordinator
+    func makeUIView(context: Context) -> UIStackView {
+        let webView = WKWebView()
+        webView.customUserAgent = UserAgent.defaultUserAgent
+        webView.navigationDelegate = context.coordinator
 
-        webview.load(URLRequest(url: url))
-        return webview
+        webView.load(URLRequest(url: url))
+
+        let stackView = UIStackView(arrangedSubviews: [webView])
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        return stackView
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        uiView.load(URLRequest(url: url))
+    func updateUIView(_ uiView: UIStackView, context: Context) {
+        if let webView = uiView.arrangedSubviews.first as? WKWebView {
+            webView.load(URLRequest(url: url))
+        }
     }
 
     class WebViewCoordinator: NSObject, WKNavigationDelegate {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -14,8 +14,8 @@ struct WebView: UIViewRepresentable {
         }
     }
 
-    let webView: WKWebView = WKWebView()
-    let progressView: WebProgressView = WebProgressView()
+    private let webView = WKWebView()
+    private let progressView = WebProgressView()
 
     let url: URL
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -63,6 +63,7 @@ struct WebView: UIViewRepresentable {
         webView.load(URLRequest(url: url))
 
         // Progress view
+        progressView.startedLoading()
         progressView.observeProgress(webView: webView)
 
         let stackView = UIStackView(arrangedSubviews: [progressView, webView])

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -105,23 +105,5 @@ struct WebView: UIViewRepresentable {
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
             parent.onCommit?(webView)
         }
-
-        override func observeValue(forKeyPath keyPath: String?,
-                                   of object: Any?,
-                                   change: [NSKeyValueChangeKey: Any]?,
-                                   context: UnsafeMutableRawPointer?) {
-            guard let object = object as? WKWebView,
-                  object == parent.webView,
-                let keyPath = keyPath else {
-                    return
-            }
-            switch keyPath {
-                case #keyPath(WKWebView.estimatedProgress):
-                    parent.progressView.progress = Float(parent.webView.estimatedProgress)
-                    parent.progressView.isHidden = parent.webView.estimatedProgress == 1
-                default:
-                    assertionFailure("Observed change to web view that we are not handling")
-                }
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -16,7 +16,6 @@ struct WebView: UIViewRepresentable {
 
     let webView: WKWebView = WKWebView()
     let progressView: WebProgressView = WebProgressView()
-    @State var estimatedProgress: Float = 0.0
 
     let url: URL
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -67,7 +67,6 @@ struct WebView: UIViewRepresentable {
 
         let stackView = UIStackView(arrangedSubviews: [progressView, webView])
         stackView.axis = .vertical
-        stackView.alignment = .fill
         return stackView
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -17,7 +17,7 @@ struct WebView: UIViewRepresentable {
     private let webView = WKWebView()
     private let progressView = WebProgressView()
 
-    let url: URL
+    private let url: URL
 
     /// Optional URL or part of URL to trigger exit
     ///
@@ -30,12 +30,12 @@ struct WebView: UIViewRepresentable {
     /// Callback that will be triggered in when the underlying `WKWebView` delegate method `didCommit` is triggered.
     /// This happens when the web view has received data and is starting to render the content.
     ///
-    var onCommit: ((WKWebView) -> Void)?
+    private var onCommit: ((WKWebView) -> Void)?
 
     /// Check whether to prevent any link clicking to open the link.
     /// This is used in ThemesPreviewView, as it is intended to only display a single demo URL without allowing navigation to
     /// other webpages.
-    var disableLinkClicking: Bool
+    private var disableLinkClicking: Bool
 
     private let credentials = ServiceLocator.stores.sessionManager.defaultCredentials
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -117,8 +117,8 @@ struct WebView: UIViewRepresentable {
             }
             switch keyPath {
                 case #keyPath(WKWebView.estimatedProgress):
-                parent.progressView.progress = Float(parent.webView.estimatedProgress)
-                parent.progressView.isHidden = parent.webView.estimatedProgress == 1
+                    parent.progressView.progress = Float(parent.webView.estimatedProgress)
+                    parent.progressView.isHidden = parent.webView.estimatedProgress == 1
                 default:
                     assertionFailure("Observed change to web view that we are not handling")
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11499 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds a loading bar to show the URL loading progress on the `WebView`.

It is being worked on as part of the Lightweight Storefront project, but will also affect all other usages of `WebView` (for the better, hopefully, as it makes a better UX).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start with a WooExpress site,
2. Go to Menu > Settings > Themes,
3. Pick a theme and ensure the Preview screen is shown,
4. Ensure a loading bar indicator is shown at the top while the webpage is loading.
5. Ensure the loading bar indicator disappears once the loading is finished.
6. Play around with changing layout and changing Page, ensure that the loading indicator bar shows up properly each time.

## Video

https://github.com/woocommerce/woocommerce-ios/assets/266376/1f2d3e85-8b94-4284-8e3c-97bcce635c39

