### PR TITLE
Add 2faScreen step to login tests

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -30,10 +30,10 @@ public final class PasswordScreen: ScreenObject {
     }
 
     @discardableResult
-    public func enterValidPassword() throws -> MyStoreScreen {
+    public func enterValidPassword() throws -> TwoFAScreen {
         try proceedWith(password: "pw")
 
-        return try MyStoreScreen()
+        return try TwoFAScreen()
     }
 
     public func enterInvalidPassword() throws -> PasswordScreen {

--- a/WooCommerce/UITestsFoundation/Screens/Login/TwoFAScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/TwoFAScreen.swift
@@ -3,7 +3,7 @@ import XCTest
 
 public final class TwoFAScreen: ScreenObject {
 
-    private let two2FAFieldGetter: (XCUIApplication) -> XCUIElement = {
+    private let twoFAFieldGetter: (XCUIApplication) -> XCUIElement = {
         $0.textFields["Authentication code"]
     }
 
@@ -11,13 +11,13 @@ public final class TwoFAScreen: ScreenObject {
         $0.buttons["Continue Button"]
     }
 
-    private var twoFAField: XCUIElement { two2FAFieldGetter(app) }
+    private var twoFAField: XCUIElement { twoFAFieldGetter(app) }
     private var continueButton: XCUIElement { continueButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
-                two2FAFieldGetter,
+                twoFAFieldGetter,
                 continueButtonGetter
             ],
             app: app

--- a/WooCommerce/UITestsFoundation/Screens/Login/TwoFAScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/TwoFAScreen.swift
@@ -1,0 +1,38 @@
+import ScreenObject
+import XCTest
+
+public final class TwoFAScreen: ScreenObject {
+
+    private let two2FAFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Authentication code"]
+    }
+
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Continue Button"]
+    }
+
+    private var twoFAField: XCUIElement { two2FAFieldGetter(app) }
+    private var continueButton: XCUIElement { continueButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                two2FAFieldGetter,
+                continueButtonGetter
+            ],
+            app: app
+        )
+    }
+
+    @discardableResult
+    public func enterValidTwoFACode() throws -> MyStoreScreen {
+        try proceedWith(twoFACode: "123456")
+
+        return try MyStoreScreen()
+    }
+
+    public func proceedWith(twoFACode: String) throws {
+        twoFAField.enterText(text: twoFACode)
+        continueButton.tap()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -841,6 +841,7 @@
 		2679F0292AAA37D400AF80C5 /* images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2679F0282AAA37D400AF80C5 /* images.xcassets */; };
 		2679F02B2AAA601E00AF80C5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B56DB3D32049BFAA00D4AA8E /* Assets.xcassets */; };
 		2679F02D2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */; };
+		267B01662B338FF6007BD5E4 /* oauth2_token_2fa.json in Resources */ = {isa = PBXBuildFile; fileRef = 267B01652B338FF6007BD5E4 /* oauth2_token_2fa.json */; };
 		267C01CF29E89E1700FCC97B /* StorePlanSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */; };
 		267C01D129E9B18E00FCC97B /* StorePlanSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267C01D029E9B18E00FCC97B /* StorePlanSynchronizerTests.swift */; };
 		267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */; };
@@ -923,6 +924,7 @@
 		26ED9660274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */; };
 		26EE795F2AA795A000857293 /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5C3B5E220D189E60072CB9D /* Networking.framework */; };
 		26EE79602AA795EC00857293 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
+		26F300902B33C71B00EDE717 /* TwoFAScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F3008F2B33C71B00EDE717 /* TwoFAScreen.swift */; };
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
 		26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */; };
@@ -3448,6 +3450,7 @@
 		2679F0252AAA2A3200AF80C5 /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2679F0282AAA37D400AF80C5 /* images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = images.xcassets; sourceTree = "<group>"; };
 		2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationViewModel.swift; sourceTree = "<group>"; };
+		267B01652B338FF6007BD5E4 /* oauth2_token_2fa.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = oauth2_token_2fa.json; sourceTree = "<group>"; };
 		267C01CE29E89E1700FCC97B /* StorePlanSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanSynchronizer.swift; sourceTree = "<group>"; };
 		267C01D029E9B18E00FCC97B /* StorePlanSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanSynchronizerTests.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
@@ -3526,6 +3529,7 @@
 		26E7EE7329365F0700793045 /* TopPerformersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersView.swift; sourceTree = "<group>"; };
 		26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModel.swift; sourceTree = "<group>"; };
 		26EE795E2AA7924700857293 /* NotificationExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationExtension.entitlements; sourceTree = "<group>"; };
+		26F3008F2B33C71B00EDE717 /* TwoFAScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoFAScreen.swift; sourceTree = "<group>"; };
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
 		26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewController.swift; sourceTree = "<group>"; };
@@ -9842,6 +9846,7 @@
 			children = (
 				D8CD0604258B384E00B52D63 /* oauth2_token-error.json */,
 				CCFC00BC23E9BD5500157A78 /* oauth2_token.json */,
+				267B01652B338FF6007BD5E4 /* oauth2_token_2fa.json */,
 				CCFC00BD23E9BD5500157A78 /* auth_options.json */,
 			);
 			path = auth;
@@ -11704,6 +11709,7 @@
 				D8F3A972258862BE0085859B /* PrologueScreen.swift */,
 				D8F3A9782588659E0085859B /* GetStartedScreen.swift */,
 				D8F3A97E258865BD0085859B /* PasswordScreen.swift */,
+				26F3008F2B33C71B00EDE717 /* TwoFAScreen.swift */,
 				02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */,
 				80C5D4E429ED003B00352EC7 /* HelpScreen.swift */,
 			);
@@ -12347,6 +12353,7 @@
 				CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */,
 				800A5BBC27586AE1009DE2CD /* products_reviews_6162.json in Resources */,
 				80A6430E2A026D0800F65C0C /* complete_cash_simple_payment.json in Resources */,
+				267B01662B338FF6007BD5E4 /* oauth2_token_2fa.json in Resources */,
 				80A643022A010F2100F65C0C /* connection_tokens.json in Resources */,
 				CEF5A2912A68467C0059CFD3 /* stats_summary_week.json in Resources */,
 				CEF5A2972A6846A50059CFD3 /* stats_summary_year.json in Resources */,
@@ -12612,6 +12619,7 @@
 				C064EE2B2783480000D54B0D /* OrderDataStructs.swift in Sources */,
 				CC5C278727EE19A700B25D2A /* UnifiedOrderScreen.swift in Sources */,
 				3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */,
+				26F300902B33C71B00EDE717 /* TwoFAScreen.swift in Sources */,
 				3F0CF3042704490A00EF3D71 /* PeriodStatsTable.swift in Sources */,
 				3F0CF3142704494A00EF3D71 /* TabNavComponent.swift in Sources */,
 				3F0CF3072704490A00EF3D71 /* LoginEmailScreen.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -17,6 +17,7 @@ class LoginFlow {
         try PrologueScreen().tapContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .enterValidPassword()
+            .enterValidTwoFACode()
 
         return try LoginEpilogueScreen()
             .verifyEpilogueDisplays(email: "e2eflowtestingmobile@example.com", siteUrl: TestCredentials.siteUrl)
@@ -30,5 +31,6 @@ class LoginFlow {
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .enterValidPassword()
+            .enterValidTwoFACode()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/auth/oauth2_token.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/auth/oauth2_token.json
@@ -6,11 +6,14 @@
     "response": {
         "status": 200,
         "jsonBody": {
-            "access_token": "valid_token",
-            "token_type": "bearer",
-            "blog_id": "0",
-            "blog_url": null,
-            "scope": "global"
+            "success" : "true",
+            "data" : {
+                "user_id" : 123,
+                "two_step_supported_auth_types" : [
+                    "webauthn"
+                ],
+                "two_step_nonce_webauthn" : "aabbccdd"
+            }
         },
         "headers": {
             "Content-Type": "application/json",

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/auth/oauth2_token_2fa.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/auth/oauth2_token_2fa.json
@@ -1,0 +1,25 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/oauth2/token",
+        "bodyPatterns": [
+            {
+                "matches": ".*wpcom_otp=.*"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "access_token": "valid_token",
+            "token_type": "bearer",
+            "blog_id": "0",
+            "blog_url": null,
+            "scope": "global"
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -21,6 +21,7 @@ final class LoginTests: XCTestCase {
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .enterValidPassword()
+            .enterValidTwoFACode()
 
         try TabNavComponent()
             .goToMenuScreen()

--- a/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
@@ -2,6 +2,7 @@
 struct TestCredentials {
     static let emailAddress: String = "t@wp.com"
     static let password: String = "pw"
+    static let twoFACode: String = "123456"
     static let siteUrl: String = "http://yourwoosite.com"
     static let siteUrlHost: String = "yourwoosite.com"
     static let storeName: String = "Your WooCommerce Store"


### PR DESCRIPTION
part of https://github.com/woocommerce/woocommerce-ios/issues/11167

# Why

Recently we had a case where an external update to the `WordPressAuthenticator` library caused a regression when a user tried to login with their 2FA code. pe5pgL-42c-p2

This PR adds a new step in the `LoginTest` so the 2FA screen is UI tested.

# How

- Update the mocked auth response for the app to present the 2FA screen
- Added a new `TwoFAScreen` type that represents and tests the 2FA screen.

# Todo

I'll be improving this test further after updating the `WordPressAuthenticator` with some more accessibility identifiers.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
