### PR TITLE
Lightweight Storefront: Remove feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -82,8 +82,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .customLoginUIForAccountCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .lightweightStorefront:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .scanToUpdateInventory:
             return true
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -180,10 +180,6 @@ public enum FeatureFlag: Int {
     ///
     case subscriptionProducts
 
-    /// Enables lightweight storefront project
-    ///
-    case lightweightStorefront
-
     /// Enables the Scan to Update Inventory feature.
     ///
     case scanToUpdateInventory

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [**] Payments: merchants can collect payment directly from the order creation form [https://github.com/woocommerce/woocommerce-ios/pull/11490]
 - [*] Store creation: Inform user once store ready if app killed while waiting for store to be ready. [https://github.com/woocommerce/woocommerce-ios/pull/11478]
 - [*] Dashboard: Resolves a decoding error with certain payment gateway plugins that previously caused an error loading data in the dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/11489]
+- [**] Lightweight Storefront: Added option to select themes for WPCom store in both Settings and Store Creation flows. [https://github.com/woocommerce/woocommerce-ios/issues/11291]
 
 16.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesEligibilityUseCase.swift
@@ -11,10 +11,6 @@ final class ThemeEligibilityUseCase {
     }
 
     func isEligible(site: Site) -> Bool {
-        guard featureFlagService.isFeatureFlagEnabled(.lightweightStorefront) else {
-            return false
-        }
-
         return site.isWordPressComStore
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,7 +21,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let productCreationAI: Bool
     private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
-    private let isLightweightStorefrontEnabled: Bool
     private let isScanToUpdateInventoryEnabled: Bool
 
     init(isInboxOn: Bool = false,
@@ -43,7 +42,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          productCreationAI: Bool = false,
          productBundles: Bool = false,
          productBundlesInOrderForm: Bool = false,
-         isLightweightStorefrontEnabled: Bool = false,
          isScanToUpdateInventoryEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
@@ -64,7 +62,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.productCreationAI = productCreationAI
         self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
-        self.isLightweightStorefrontEnabled = isLightweightStorefrontEnabled
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
     }
 
@@ -106,8 +103,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return productBundles
         case .productBundlesInOrderForm:
             return productBundlesInOrderForm
-        case .lightweightStorefront:
-            return isLightweightStorefrontEnabled
         case .scanToUpdateInventory:
             return isScanToUpdateInventoryEnabled
         default:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemeEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemeEligibilityUseCaseTests.swift
@@ -3,24 +3,11 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
-class ThemeEligibilityUseCaseTests: XCTestCase {
-    func test_site_not_eligible_for_lightweight_storefront_if_feature_flag_disabled() {
+final class ThemeEligibilityUseCaseTests: XCTestCase {
+
+    func test_site_not_eligible_for_lightweight_storefront_if_store_is_not_wpcom() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: false)
-        let checker = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
-        let site = Site.fake().copy(isWordPressComStore: true)
-
-        // When
-        let isEligibleForLightweightStorefront = checker.isEligible(site: site)
-
-        // Then
-        XCTAssertFalse(isEligibleForLightweightStorefront)
-    }
-
-    func test_site_not_eligible_for_lightweight_storefront_if_feature_flag_enabled_but_is_not_wpcom_store() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: true)
-        let checker = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
+        let checker = ThemeEligibilityUseCase()
         let site = Site.fake().copy(isWordPressComStore: false)
 
         // When
@@ -30,10 +17,9 @@ class ThemeEligibilityUseCaseTests: XCTestCase {
         XCTAssertFalse(isEligibleForLightweightStorefront)
     }
 
-    func test_site_eligible_for_lightweight_storefront_if_feature_flag_enabled_and_is_wpcom_store() {
+    func test_site_eligible_for_lightweight_storefront_if_store_is_wpcom() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: true)
-        let checker = ThemeEligibilityUseCase(featureFlagService: featureFlagService)
+        let checker = ThemeEligibilityUseCase()
         let site = Site.fake().copy(isWordPressComStore: true)
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11291
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the feature flag `lightweightStorefront` to make the feature available in production.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store and navigate to the Menu tab.
- Select Settings > Themes.
- Notice that the correct theme for your store is displayed.
- Select a theme in the suggested list.
- On the preview screen, try switching layouts and pages for the theme. Notice that everything works correctly.
- Apply the theme - the theme should be set for your store (doublecheck on the web).
- Navigate back to the menu tab and open the store picker.
- Select Add a store > Create a new store.
- Go through the profiler steps, then select a theme for your new store.
- After the store is ready, the new theme should be applied to it (double check on the web).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/5533851/257c70d8-9ffa-4f47-8a43-7c98d667763f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
