### PR TITLE
Lightweight Storefront: UI tweaks for theme preview screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -203,6 +203,7 @@ struct ThemesPreviewView: View {
                 Spacer()
             }
         }
+        .padding(.top, Layout.contentPadding)
     }
 
     private func menuItem(for device: PreviewDevice) -> some View {
@@ -232,7 +233,6 @@ private extension ThemesPreviewView {
 
 private extension ThemesPreviewView {
     private enum Layout {
-        static let toolbarPadding: CGFloat = 16
         static let dividerHeight: CGFloat = 1
         static let footerPadding: CGFloat = 16
         static let contentPadding: CGFloat = 16

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -203,7 +203,6 @@ struct ThemesPreviewView: View {
                 Spacer()
             }
         }
-        .padding(.top, Layout.contentPadding)
     }
 
     private func menuItem(for device: PreviewDevice) -> some View {
@@ -236,7 +235,7 @@ private extension ThemesPreviewView {
         static let dividerHeight: CGFloat = 1
         static let footerPadding: CGFloat = 16
         static let contentPadding: CGFloat = 16
-        static let pagesSheetPadding: EdgeInsets = .init(top: 20, leading: 16, bottom: 12, trailing: 16)
+        static let pagesSheetPadding: EdgeInsets = .init(top: 40, leading: 16, bottom: 12, trailing: 16)
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -98,7 +98,7 @@ struct ThemesPreviewView: View {
                         .foregroundColor(Color(.divider))
 
                     VStack {
-                        Button(viewModel.mode == .storeCreationProfiler ? Localization.startWithThemeButton : Localization.useThisThemeButton,
+                        Button(String.localizedStringWithFormat(viewModel.primaryButtonFormat, viewModel.theme.name),
                                action: {
                             Task { @MainActor in
                                 do {
@@ -112,8 +112,6 @@ struct ThemesPreviewView: View {
                         })
                         .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.installingTheme))
 
-                        Text(String(format: Localization.themeName, viewModel.theme.name))
-                            .secondaryBodyStyle()
                     }.padding(Layout.footerPadding)
 
                 } else {
@@ -261,21 +259,6 @@ private extension ThemesPreviewView {
             "themesPreviewView.menuMobile",
             value: "Desktop",
             comment: "Menu item: desktop"
-        )
-        static let startWithThemeButton = NSLocalizedString(
-            "themesPreviewView.startWithThemeButton",
-            value: "Start with This Theme",
-            comment: "Button in theme preview screen to pick a theme."
-        )
-        static let useThisThemeButton = NSLocalizedString(
-            "themesPreviewView.useThisThemeButton",
-            value: "Use this theme",
-            comment: "Button in theme preview screen to pick a theme."
-        )
-        static let themeName = NSLocalizedString(
-            "themesPreviewView.themeName",
-            value: "Theme: %@",
-            comment: "Name of the theme being previewed."
         )
 
         static let errorLoadingThemeDemo = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -165,17 +165,19 @@ struct ThemesPreviewView: View {
 
         // Here we show only a "Preview" label with no selector, both for loading and error cases.
         // In the case of page loading error, the home page is still usable, so showing "Preview" is better than nothing.
-        switch viewModel.state {
-        case .pagesLoading, .pagesLoadingError:
-            Text(Localization.preview)
-
-        case .pagesContent:
-            Button(action: { showPagesMenu = true }) {
-                HStack {
-                    Text(viewModel.selectedPage.title).bodyStyle()
-                    Image(uiImage: .chevronDownImage)
-                        .fixedSize()
-                        .bodyStyle()
+        Button(action: { showPagesMenu = true }) {
+            VStack(spacing: 0) {
+                Text(Localization.preview)
+                    .fontWeight(.semibold)
+                    .headlineStyle()
+                if case .pagesContent = viewModel.state {
+                    HStack {
+                        Text(viewModel.selectedPage.title)
+                            .foregroundColor(Color(.text))
+                            .footnoteStyle()
+                        Image(uiImage: .chevronDownImage)
+                            .captionStyle()
+                    }
                 }
             }
         }
@@ -183,7 +185,7 @@ struct ThemesPreviewView: View {
 
     private var pagesListSheet: some View {
         ScrollView {
-            VStack {
+            VStack(alignment: .leading) {
                 Text(Localization.pagesSheetHeading)
                     .subheadlineStyle()
                     .padding(Layout.pagesSheetPadding)
@@ -194,7 +196,7 @@ struct ThemesPreviewView: View {
                     }, label: {
                         Text(page.title)
                             .bodyStyle()
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .multilineTextAlignment(.leading)
                     })
                     .padding(Layout.contentPadding)
                 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -98,8 +98,7 @@ struct ThemesPreviewView: View {
                         .foregroundColor(Color(.divider))
 
                     VStack {
-                        Button(String.localizedStringWithFormat(viewModel.primaryButtonFormat, viewModel.theme.name),
-                               action: {
+                        Button(viewModel.primaryButtonTitle) {
                             Task { @MainActor in
                                 do {
                                     try await viewModel.confirmThemeSelection()
@@ -109,7 +108,7 @@ struct ThemesPreviewView: View {
                                     DDLogError("⛔️ ThemesPreviewView - Theme installation failed.")
                                 }
                             }
-                        })
+                        }
                         .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.installingTheme))
 
                     }.padding(Layout.footerPadding)

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -196,6 +196,7 @@ struct ThemesPreviewView: View {
                         Text(page.title)
                             .bodyStyle()
                             .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     })
                     .padding(Layout.contentPadding)
                 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
@@ -14,8 +14,9 @@ final class ThemesPreviewViewModel: ObservableObject {
     let mode: ThemesCarouselViewModel.Mode
     let theme: WordPressTheme
 
-    var primaryButtonFormat: String {
-        mode == .storeCreationProfiler ? Localization.startWithThemeButton : Localization.useThisThemeButton
+    var primaryButtonTitle: String {
+        let format = mode == .storeCreationProfiler ? Localization.startWithThemeButton : Localization.useThisThemeButton
+        return String.localizedStringWithFormat(format, theme.name)
     }
 
     private let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
@@ -14,6 +14,10 @@ final class ThemesPreviewViewModel: ObservableObject {
     let mode: ThemesCarouselViewModel.Mode
     let theme: WordPressTheme
 
+    var primaryButtonFormat: String {
+        mode == .storeCreationProfiler ? Localization.startWithThemeButton : Localization.useThisThemeButton
+    }
+
     private let siteID: Int64
     private let stores: StoresManager
     private let themeInstaller: ThemeInstaller
@@ -125,6 +129,18 @@ extension ThemesPreviewViewModel {
             "themesPreviewViewModel.themeInstallError",
             value: "Theme installation failed. Please try again.",
             comment: "Message to convey that theme installation failed."
+        )
+        static let startWithThemeButton = NSLocalizedString(
+            "themesPreviewViewModel.startWithThemeButton",
+            value: "Start with %1$@",
+            comment: "Button in theme preview screen to pick a theme. The placeholder is the theme name. " +
+            "Reads like: Start with Tsubaki"
+        )
+        static let useThisThemeButton = NSLocalizedString(
+            "themesPreviewViewModel.useThisThemeButton",
+            value: "Use %1$@",
+            comment: "Button in theme preview screen to pick a theme. The placeholder is the theme name. " +
+            "Reads like: Use Tsubaki"
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11291 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds some last-minute updates to the themes preview screen:
- Updated the title view to display both the Preview text and page title.
- Updated the primary button to include theme name and remove the theme name text at the bottom.
- Updated the alignment and top padding for the page list.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a WPCom store and navigate to the Menu tab.
- Select Settings > Themes.
- Notice that the correct theme for your store is displayed.
- Select a theme in the suggested list.
- On the preview screen, notice that the title now contains both Preview text and page title. The primary button should be "Use <theme name>", and alignment and padding on the page list should be correct.
- Navigate back to the menu tab and open the store picker.
- Select Add a store > Create a new store.
- Go through the profiler steps. On the theme picker screen, notice that the primary button title is "Start with <theme name>".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/9995fb6a-991e-4374-a71e-7e605bd59c9d" width=320 />
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/5806339d-1c44-4dbc-9c62-0932596e7f39" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
