### PR TITLE
[In-App Purchases] Log grace period transactions

### DIFF
--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -285,6 +285,15 @@ private extension InAppPurchaseStore {
         for await transaction in Transaction.currentEntitlements {
             switch transaction {
             case .verified(let transaction):
+                if let subscriptionStatus = await transaction.subscriptionStatus {
+                    switch subscriptionStatus.state {
+                    case .inGracePeriod:
+                        DDLogInfo("Subscription in Grace Period")
+                    default:
+                        continue
+                    }
+                }
+
                 // If we have current entitlements, we check for its transaction token, and extract the associated siteID.
                 // If this siteID matches the current siteID, then the site has current In-App Purchases.
                 guard let token = transaction.appAccountToken,


### PR DESCRIPTION
Blocked until CI runs Xcode 15
Closes: #11506 

## Description
Since we've set a 3 days "Grace Period" in the App Store Connect to deal with `DID_FAIL_TO_RENEW` notifications, this PR logs internally if an IAP subscription's status is currently in Grace Period. This is done merely so we can have more logged information if a merchant happens to reach support about troubles with their subscription upon renewal.

Full context: pdfdoF-4oP-p2 

## Changes
This PR does not modify anything IAP-related, all verified transactions will still follow the same flow as before and will be treated the same. The only difference is that we log a message when `Grace Period` is hit, we're still just waiting for the cancellation notification from Apple in order to cancel.

## Testing instructions
In the same fashion as previous IAP testing, Apple has decided to make this very cumbersome to test. The full instructions can be found [here](https://developer.apple.com/documentation/storekit/in-app_purchase/testing_in-app_purchases_with_sandbox/testing_failing_subscription_renewals_and_in-app_purchases#4133668):
* Set a breakpoint on line 290 `case .inGracePeriod`
* On a device with iOS16+, and logged into your Sandbox account.
* Successfully purchase a plan for your site via IAP.
* Then set the environment to simulate billing issues as [explained here](https://developer.apple.com/documentation/storekit/in-app_purchase/testing_in-app_purchases_with_sandbox/testing_failing_subscription_renewals_and_in-app_purchases#4133670)
* Wait for the subscription period to renew, since we're simulating billing issues the subscription now will enter into billing grace period.
* Go to Menu > Subscriptions.
* See that the breakpoint is triggered, and the message logged.
