### PR TITLE
Dashboard: add `date_type=date_created` parameter to revenue stats API request to be consistent with product stats

### DIFF
--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -36,7 +36,7 @@ public final class OrderStatsRemoteV4: Remote {
             ParameterKeys.forceRefresh: forceRefresh,
             // Product stats in `ProductsReportsRemote.loadTopProductsReport` are based on the order creation date, while the order/revenue
             // stats are based on a store option in the analytics settings with the order paid date as the default.
-            // In a later WC version, a new parameter `date_type` is available to override the date type so that we can
+            // In WC version 8.6+, a new parameter `date_type` is available to override the date type so that we can
             // show the order/revenue and product stats based on the same date column, order creation date.
             ParameterKeys.dateType: ParameterValues.dateType,
             ParameterKeys.fields: ParameterValues.fieldValues

--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -34,6 +34,11 @@ public final class OrderStatsRemoteV4: Remote {
             ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
             ParameterKeys.quantity: String(quantity),
             ParameterKeys.forceRefresh: forceRefresh,
+            // Product stats in `ProductsReportsRemote.loadTopProductsReport` are based on the order creation date, while the order/revenue
+            // stats are based on a store option in the analytics settings with the order paid date as the default.
+            // In a later WC version, a new parameter `date_type` is available to override the date type so that we can
+            // show the order/revenue and product stats based on the same date column, order creation date.
+            ParameterKeys.dateType: ParameterValues.dateType,
             ParameterKeys.fields: ParameterValues.fieldValues
         ]
 
@@ -62,10 +67,12 @@ private extension OrderStatsRemoteV4 {
         static let before = "before"
         static let quantity = "per_page"
         static let forceRefresh = "force_cache_refresh"
+        static let dateType = "date_type"
         static let fields = "fields"
     }
 
     enum ParameterValues {
+        static let dateType = "date_created"
         static let fieldValues = ["orders_count", "num_items_sold", "total_sales", "net_revenue", "avg_order_value"]
     }
 }

--- a/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
+++ b/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
@@ -95,4 +95,21 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
     }
+
+    func test_loadOrderStats_sets_date_type_parameter_to_date_created() throws {
+        // Given
+        let remote = OrderStatsRemoteV4(network: network)
+
+        // When
+        remote.loadOrderStats(for: sampleSiteID,
+                              unit: .hourly,
+                              timeZone: .current,
+                              earliestDateToInclude: Date(),
+                              latestDateToInclude: Date(),
+                              quantity: 24,
+                              forceRefresh: false) { _ in }
+
+        // Then
+        XCTAssertEqual(network.queryParametersDictionary?["date_type"] as? String, "date_created")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes #11496 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As described in pe5pgL-49w-p2, because the app displays the revenue and product stats on the same analytics screen, when the revenue stats are fetched with the WC date type option from the analytics settings (`date_paid` by default) that's different from the date column (`date_created`) used in product stats, the data could look inconsistent for orders completed on a different date from the creation date. As a relatively simpler solution, a new parameter `date_type` was added to the revenue stats endpoint in core https://github.com/woocommerce/woocommerce/pull/42938 that we can set to `date_created` so that the revenue stats can always be based on the same date column as product stats.

## How

In `OrderStatsRemoteV4.loadOrderStats`, a new parameter `date_type=date_created` was added. It's backward compatible, so stores without the parameter support just won't have the date type column overidden. The core PR isn't merged yet but the main spec is pretty settled. I'll update the WC version in the comment in a separate PR when it's included in a future core release.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand-testing is optional, as the parameter doesn't have any effect in existing stores right now.

Prerequisite: in the store analytics settings `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fsettings`, `Date type` option is `Date paid`. The store has at least one order with at least one product, created on a different day, but the status is pending / not completed.

- [x] @jaclync tests both scenarios below

### Store with parameter support

Additional prerequisite: the store has a WC version that includes the change in https://github.com/woocommerce/woocommerce/pull/42938

- In core or mobile, mark the order in the prerequisite as paid (in core, you can go to the order page and update the order status to `Processing` or one of the statuses in the analytics settings > `Actionable statuses`. in mobile, tap `Collect Payment` > `Cash` > `Mark as paid`)
- In the app, go to the My store tab and refresh the dashboard stats after 0.5-1 minute of the last step --> there should not be revenue shown in the dashboard
- Tap `See More`, then set the date range to include the creation date of the order in the prerequisite --> the revenue and product stats should be shown for the order

### Backward compatibility testing

Additional prerequisite: the store does not have a WC version that includes the change in https://github.com/woocommerce/woocommerce/pull/42938

- In the app, go to the My store tab --> the revenue/product stats should be shown as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

For example in the screenshots below, the order was created in November but paid in December.

before | after
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/a6e700bd-2d56-408f-8cec-2dd52c70ea30" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/1e1ee930-2544-4c8e-8a44-c6750f53b54b" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
