### PR TITLE
[Store creation] Fix flaky unit tests

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -63,11 +63,9 @@ final class StoreCreationCoordinator: Coordinator {
 
     func start() {
         analytics.track(event: .StoreCreation.siteCreationFlowStarted(source: source.analyticsValue))
-        Task { @MainActor in
-            let storeCreationNavigationController = WooNavigationController()
-            startStoreCreation(from: storeCreationNavigationController)
-            await presentStoreCreation(viewController: storeCreationNavigationController)
-        }
+        let storeCreationNavigationController = WooNavigationController()
+        startStoreCreation(from: storeCreationNavigationController)
+        presentStoreCreation(viewController: storeCreationNavigationController)
     }
 }
 
@@ -103,25 +101,16 @@ private extension StoreCreationCoordinator {
         navigationController.setViewControllers([controller], animated: true)
     }
 
-    @MainActor
-    func presentStoreCreation(viewController: UIViewController) async {
-        await withCheckedContinuation { continuation in
-            // If the navigation controller is already presenting another view, the view needs to be dismissed before store
-            // creation view can be presented.
-            if navigationController.presentedViewController != nil {
-                navigationController.dismiss(animated: true) { [weak self] in
-                    guard let self else {
-                        return continuation.resume()
-                    }
-                    self.navigationController.present(viewController, animated: true) {
-                        continuation.resume()
-                    }
-                }
-            } else {
-                navigationController.present(viewController, animated: true) {
-                    continuation.resume()
-                }
+    func presentStoreCreation(viewController: UIViewController) {
+        // If the navigation controller is already presenting another view, the view needs to be dismissed before store
+        // creation view can be presented.
+        if navigationController.presentedViewController != nil {
+            navigationController.dismiss(animated: true) { [weak self] in
+                guard let self else { return }
+                self.navigationController.present(viewController, animated: true)
             }
+        } else {
+            navigationController.present(viewController, animated: true)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11510 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

What? 

`StoreCreationCoordinator`'s start method uses a `Task` to wrap the navigation-related code. This makes the `StoreCreationCoordinatorTests` flaky when the Task is not executed before the unit test times out.

Why?

The `StoreCreationCoordinator`'s start method was using a `Task`, when it consisted IAP related code. Now that `StoreCreationCoordinator` no longer handles IAP related code we can remove the `Task` usage. 

How? 

- Make the `presentStoreCreation` synchronous. 
- Remove `Task` usage in `start` method. 

## Testing instructions

We have to ensure that store creation flow works as before. 

- Launch the app
- Logout if needed
- Tap "Create a store" button
- Login or create a account
- Tap "Try For Free" to initiate store creation
- Finish the profiler steps
- You should be navigated to the "My store" screen once store creation is complete
- Navigate to store "Menu -> Store picker" 
- Tap "+ Add a store" -> "Create a new store"
- Tap "Try For Free" to initiate store creation
- Finish the profiler steps and validate that store creation works as expected.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/e108f63a-bb71-4581-8d8e-8849e27a5180


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
