### PR TITLE
Lightweight Storefront: Prevent activation header to appear on theme demo pages

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -83,7 +83,7 @@ struct ThemesPreviewView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                if let url = URL(string: viewModel.selectedPage.link) {
+                if let url = viewModel.selectedPageUrl {
                     WebView(
                         isPresented: .constant(true),
                         url: url,

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -83,8 +83,7 @@ struct ThemesPreviewView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                // We append `demoModeUrl` to prevent any activation / purchase header to appear on the theme demo.
-                if let url = URL(string: viewModel.selectedPage.link + Constants.demoModeUrl) {
+                if let url = URL(string: viewModel.selectedPage.link) {
                     WebView(
                         isPresented: .constant(true),
                         url: url,
@@ -232,10 +231,6 @@ private extension ThemesPreviewView {
 }
 
 private extension ThemesPreviewView {
-    private enum Constants {
-        static let demoModeUrl = "?demo"
-    }
-
     private enum Layout {
         static let toolbarPadding: CGFloat = 16
         static let dividerHeight: CGFloat = 1

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -83,7 +83,8 @@ struct ThemesPreviewView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                if let url = URL(string: viewModel.selectedPage.link) {
+                // We append `demoModeUrl` to prevent any activation / purchase header to appear on the theme demo.
+                if let url = URL(string: viewModel.selectedPage.link + Constants.demoModeUrl) {
                     WebView(
                         isPresented: .constant(true),
                         url: url,
@@ -231,6 +232,10 @@ private extension ThemesPreviewView {
 }
 
 private extension ThemesPreviewView {
+    private enum Constants {
+        static let demoModeUrl = "?demo=true"
+    }
+
     private enum Layout {
         static let toolbarPadding: CGFloat = 16
         static let dividerHeight: CGFloat = 1

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -233,7 +233,7 @@ private extension ThemesPreviewView {
 
 private extension ThemesPreviewView {
     private enum Constants {
-        static let demoModeUrl = "?demo=true"
+        static let demoModeUrl = "?demo"
     }
 
     private enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
@@ -11,6 +11,11 @@ final class ThemesPreviewViewModel: ObservableObject {
     @Published private(set) var installingTheme: Bool = false
     @Published var notice: Notice?
 
+    // We need to append `demoModeSuffix` to prevent any activation / purchase header to appear on the theme demo.
+    var selectedPageUrl: URL? {
+        URL(string: selectedPage.link + Constants.demoModeSuffix)
+    }
+
     let mode: ThemesCarouselViewModel.Mode
     let theme: WordPressTheme
 
@@ -34,7 +39,7 @@ final class ThemesPreviewViewModel: ObservableObject {
 
         // Pre-fill the selected Page with the home page.
         // The id is set as zero so to not clash with other pages' ids.
-        let startingPage = WordPressPage(id: 0, title: Localization.homePage, link: theme.demoURI + Constants.demoModeUrl)
+        let startingPage = WordPressPage(id: 0, title: Localization.homePage, link: theme.demoURI)
         self.selectedPage = startingPage
         pages = [startingPage]
     }
@@ -44,11 +49,7 @@ final class ThemesPreviewViewModel: ObservableObject {
         do {
             // Append the list of pages to the existing home page value, since the API call result
             // does not include the home page.
-            pages += try await loadPages().map { page in
-                // We have to append `demoModeUrl` to prevent any activation / purchase header to appear on the theme demo.
-                let pageDemoLink = page.link + Constants.demoModeUrl
-                return WordPressPage(id: page.id, title: page.title, link: pageDemoLink)
-            }
+            pages += try await loadPages()
 
             state = .pagesContent
         } catch {
@@ -115,7 +116,7 @@ private extension ThemesPreviewViewModel {
 
 extension ThemesPreviewViewModel {
     private enum Constants {
-        static let demoModeUrl = "?demo"
+        static let demoModeSuffix = "?demo"
     }
 
     enum State: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewViewModel.swift
@@ -34,7 +34,7 @@ final class ThemesPreviewViewModel: ObservableObject {
 
         // Pre-fill the selected Page with the home page.
         // The id is set as zero so to not clash with other pages' ids.
-        let startingPage = WordPressPage(id: 0, title: Localization.homePage, link: theme.demoURI)
+        let startingPage = WordPressPage(id: 0, title: Localization.homePage, link: theme.demoURI + Constants.demoModeUrl)
         self.selectedPage = startingPage
         pages = [startingPage]
     }
@@ -43,8 +43,13 @@ final class ThemesPreviewViewModel: ObservableObject {
     func fetchPages() async {
         do {
             // Append the list of pages to the existing home page value, since the API call result
-            // do not include the home page.
-            pages += try await loadPages()
+            // does not include the home page.
+            pages += try await loadPages().map { page in
+                // We have to append `demoModeUrl` to prevent any activation / purchase header to appear on the theme demo.
+                let pageDemoLink = page.link + Constants.demoModeUrl
+                return WordPressPage(id: page.id, title: page.title, link: pageDemoLink)
+            }
+
             state = .pagesContent
         } catch {
             DDLogError("⛔️ Error loading pages: \(error)")
@@ -109,6 +114,10 @@ private extension ThemesPreviewViewModel {
 }
 
 extension ThemesPreviewViewModel {
+    private enum Constants {
+        static let demoModeUrl = "?demo"
+    }
+
     enum State: Equatable {
         case pagesLoading
         case pagesLoadingError

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesPreviewViewModelTests.swift
@@ -51,15 +51,20 @@ final class ThemesPreviewViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.pages.count, 1)
         XCTAssertEqual(viewModel.pages.first?.title, "Home")
+    }
 
-        guard let link = viewModel.pages.first?.link else {
-            XCTFail("Link is nil")
-            return
-        }
+    func test_initial_selectedPageURL() {
+        // Given
+        let viewModel = ThemesPreviewViewModel(siteID: 123,
+                                               mode: .storeCreationProfiler,
+                                               theme: .init(id: "123",
+                                                            description: "Woo Theme",
+                                                            name: "Woo",
+                                                            demoURI: "https://tsubakidemo.wpcomstaging.com/"),
+                                               stores: stores)
 
-        // Check that the URL is correct and has the required "?demo" suffix
-        XCTAssertTrue(link.hasPrefix("https://tsubakidemo.wpcomstaging.com/"))
-        XCTAssertTrue(link.hasSuffix(Expectations.demoSuffix))
+        // Then
+        XCTAssertEqual(viewModel.selectedPageUrl, URL(string: "https://tsubakidemo.wpcomstaging.com/" + Expectations.demoSuffix))
     }
 
     func test_fetchPages_sets_the_right_pages_and_state() async {
@@ -140,8 +145,7 @@ final class ThemesPreviewViewModelTests: XCTestCase {
         // Check home page still exists
         let homePage = viewModel.pages[0]
         XCTAssertEqual(homePage.title, "Home")
-        XCTAssertTrue(homePage.link.hasPrefix("https://tsubakidemo.wpcomstaging.com/"))
-        XCTAssertTrue(homePage.link.hasSuffix(Expectations.demoSuffix))
+        XCTAssertEqual(homePage.link, "https://tsubakidemo.wpcomstaging.com/")
 
         // Check remaining pages
         for (index, page) in viewModel.pages.enumerated() {
@@ -151,9 +155,8 @@ final class ThemesPreviewViewModelTests: XCTestCase {
             XCTAssertEqual(page.id, expectedPage.id)
             XCTAssertEqual(page.title, expectedPage.title)
 
-            // Check that the URL is correct and has the required suffix
-            XCTAssertTrue(page.link.hasPrefix(expectedPage.link))
-            XCTAssertTrue(page.link.hasSuffix(Expectations.demoSuffix))
+            // Check that the URL is correct
+            XCTAssertEqual(page.link, expectedPage.link)
         }
 
     }
@@ -190,15 +193,33 @@ final class ThemesPreviewViewModelTests: XCTestCase {
                                                theme: .init(id: "123",
                                                             description: "Woo Theme",
                                                             name: "Woo",
-                                                            demoURI: "testURL"),
+                                                            demoURI: "https://tsubakidemo.wpcomstaging.com/"),
                                                stores: stores)
-        let page = WordPressPage(id: 1, title: "Page1", link: "testURL")
+        let page = WordPressPage(id: 1, title: "Page1", link: "https://tsubakidemo.wpcomstaging.com/page1")
 
         // When
         viewModel.setSelectedPage(page: page)
 
         // Then
         XCTAssertEqual(viewModel.selectedPage, page)
+    }
+
+    func test_setSelectedPage_updates_selectedPageLink() {
+        // Given
+        let viewModel = ThemesPreviewViewModel(siteID: 123,
+                                               mode: .storeCreationProfiler,
+                                               theme: .init(id: "123",
+                                                            description: "Woo Theme",
+                                                            name: "Woo",
+                                                            demoURI: "https://tsubakidemo.wpcomstaging.com/"),
+                                               stores: stores)
+        let page = WordPressPage(id: 1, title: "Page1", link: "https://tsubakidemo.wpcomstaging.com/page1")
+
+        // When
+        viewModel.setSelectedPage(page: page)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedPageUrl, URL(string: page.link + Expectations.demoSuffix))
     }
 
     // MARK: installingTheme


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11513
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This quick PR adds a "?demo=true" to the end to any theme demo URL. This prevents a purchase/activation header to appear above the theme demo.

Related conversation with more reasoning and bg info in p1702557557441889-slack-C03L1NF1EA3

## Testing
This is a bit hard to replicate (apparently can happen on tablet view), so for now we're just making sure the demo pages still work as usual.

1. Use a WooExpress site, go to Settings > Themes, pick a theme.
2. Select different theme pages and ensure they all load correctly as before.
