### PR TITLE
[Order Creation] Project Lily Pad M1 analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -496,6 +496,7 @@ extension WooAnalyticsEvent {
             case creation
             case editing
             case list
+            case orderDetails = "order_details"
         }
 
         /// Possible item types to add to an Order
@@ -748,7 +749,8 @@ extension WooAnalyticsEvent {
                                                       hasFees: Bool,
                                                       hasShippingMethod: Bool,
                                                       products: [Product]) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderCollectPaymentButtonTapped, properties: [
+            WooAnalyticsEvent(statName: .collectPaymentTapped, properties: [
+                Keys.flow: Flow.creation.rawValue,
                 Keys.orderStatus: status.rawValue,
                 Keys.productCount: Int64(productCount),
                 Keys.customAmountsCount: Int64(customAmountsCount),
@@ -832,9 +834,9 @@ extension WooAnalyticsEvent {
 
         /// Tracked when the user taps to collect a payment
         ///
-        static func collectPaymentTapped() -> WooAnalyticsEvent {
+        static func collectPaymentTapped(flow: Flow) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentTapped,
-                              properties: [:])
+                              properties: [Keys.flow: flow.rawValue])
         }
 
         /// Tracked when accessing the system plugin list without it being in sync.
@@ -1203,7 +1205,7 @@ extension WooAnalyticsEvent {
         enum Flow: String {
             case simplePayment = "simple_payment"
             case orderPayment = "order_payment"
-            case orderCreation = "order_creation"
+            case orderCreation = "creation"
             case tapToPayTryAPayment = "tap_to_pay_try_a_payment"
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -557,6 +557,7 @@ extension WooAnalyticsEvent {
             static let type = "type"
             static let usesGiftCard = "use_gift_card"
             static let taxStatus = "tax_status"
+            static let expanded = "expanded"
         }
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
@@ -720,6 +721,14 @@ extension WooAnalyticsEvent {
                 Keys.to: newStatus.rawValue
             ]
             return WooAnalyticsEvent(statName: .orderStatusChange, properties: properties.compactMapValues { $0 })
+        }
+
+        static func orderTotalsExpansionChanged(flow: Flow,
+                                                expanded: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderFormTotalsPanelToggled, properties: [
+                Keys.flow: flow.rawValue,
+                Keys.expanded: expanded
+            ])
         }
 
         static func orderCreateButtonTapped(order: Order,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -416,6 +416,7 @@ public enum WooAnalyticsStat: String {
     case orderCreationEditCustomAmountTapped = "order_creation_edit_custom_amount_tapped"
     case orderCreationRemoveCustomAmountTapped = "order_creation_remove_custom_amount_tapped"
     case orderCreationClearAddressFromBottomSheetTapped = "tax_rate_auto_tax_rate_clear_address_tapped"
+    case orderFormTotalsPanelToggled = "order_form_totals_panel_toggled"
     case orderContactAction = "order_contact_action"
     case orderCustomerAdd = "order_customer_add"
     case orderEditButtonTapped = "order_edit_button_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -399,7 +399,6 @@ public enum WooAnalyticsStat: String {
     case orderNoteAddSuccess = "order_note_add_success"
     case orderNoteAddFailed = "order_note_add_failed"
     case orderCreateButtonTapped = "order_create_button_tapped"
-    case orderCollectPaymentButtonTapped = "order_collect_payment_button_tapped"
     case orderCreationSuccess = "order_creation_success"
     case orderCreationFailed = "order_creation_failed"
     case orderCreationCustomerAdded = "order_creation_customer_added"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -756,6 +756,10 @@ final class EditableOrderViewModel: ObservableObject {
         trackCustomerNoteAdded()
     }
 
+    func orderTotalsExpansionChanged(expanded: Bool) {
+        analytics.track(event: .Orders.orderTotalsExpansionChanged(flow: flow.analyticsFlow, expanded: expanded))
+    }
+
     // MARK: - API Requests
     /// Creates an order remotely using the provided order details.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -245,7 +245,7 @@ struct OrderForm: View {
             }
         }
         .safeAreaInset(edge: .bottom) {
-            ExpandableBottomSheet {
+            ExpandableBottomSheet(onChangeOfExpansion: viewModel.orderTotalsExpansionChanged) {
                 VStack {
                     HStack {
                         Text(Localization.orderTotal)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -618,7 +618,7 @@ private extension OrderDetailsViewController {
         collectPayment()
 
         // Track tapped event
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.collectPaymentTapped())
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.collectPaymentTapped(flow: .orderDetails))
     }
 
     private func collectPayment() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -15,8 +15,12 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
 
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
-    public init(@ViewBuilder alwaysVisibleContent: @escaping () -> AlwaysVisibleContent,
+    private var onChangeOfExpansion: ((Bool) -> Void)?
+
+    public init(onChangeOfExpansion: ((Bool) -> Void)? = nil,
+                @ViewBuilder alwaysVisibleContent: @escaping () -> AlwaysVisibleContent,
                 @ViewBuilder expandableContent: @escaping () -> ExpandableContent) {
+        self.onChangeOfExpansion = onChangeOfExpansion
         self.alwaysVisibleContent = alwaysVisibleContent
         self.expandableContent = expandableContent
     }
@@ -90,7 +94,8 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                     }
                 })
         })
-        .onChange(of: isExpanded, perform: { _ in
+        .onChange(of: isExpanded, perform: { newValue in
+            onChangeOfExpansion?(newValue)
             DispatchQueue.main.async {
                 withAnimation {
                     panelHeight = calculateHeight()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -59,6 +59,11 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                         }
                     }
                     .trackSize(size: $expandingContentSize)
+                    .onChange(of: expandingContentSize, perform: { _ in
+                        withAnimation {
+                            panelHeight = calculateHeight()
+                        }
+                    })
                 }
                 .scrollVerticallyIfNeeded()
 
@@ -74,6 +79,11 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
             // Always visible content
             alwaysVisibleContent()
                 .trackSize(size: $fixedContentSize)
+                .onChange(of: fixedContentSize, perform: { _ in
+                    withAnimation {
+                        panelHeight = calculateHeight()
+                    }
+                })
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(GeometryReader { geometryProxy in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11515 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates and adds analytic events that we'll need for measuring the impact of M1 and the overall Project Lily Pad changes. 

### Payment Flow Timing events
There was no change required here, just testing:

- `woocommerceios_orders_add_new`
- `woocommerceios_payments_flow_collect`
- `woocommerceios_card_present_collect_payment_success`
- `woocommerceios_card_interac_collect_payment_success`

These events are used in the timing funnels which we can use for our analysis of the speed improvements. We should continue to track the `milliseconds_since_order_add_new` property for these events.

### Track Collect Payment taps

Added a call to track `woocommerceios_payments_flow_order_collect_payment_tapped` when tapping Collect Payment on the Order Creation screen. Added the `flow` property mentioned below.

### Updates to Payments Flow events

To allow us to separately consider payments starting from the Create Order screen, this PR adds a new `order_creation` option for the `flow` property of the various `woocommerceios_payments_flow_` events:

- `*_order_collect_payment_tapped`
- `*_collect`
- `*_cancelled`
- `*_failed`
- `*_completed`

### New events

- `woocommerceios_order_form_totals_panel_toggled` – tracked when the panel is expanded or collapsed. Includes property `expanded: {true|false}` to match the new state.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app and navigate to the `Orders` tab
2. Tap `+` and observe that `order_add_new` is logged
3. Go through adding items to the order
4. Toggle the totals panel expansion and collapse
5. Tap `Collect Payment` and complete a payment
6. Observe that the expected events have been tracked in the console, and in the Tracks live view.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### `order_add_new` and following timed events
Note `milliseconds_since_order_add_new` property
<img width="1369" alt="Console log messages showing the order_add_new event flows working" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/7f234296-28d6-40d3-b7c3-05b267212795">

### Payment flow events
Note the `flow: creation` property
<img width="1384" alt="Console log messages showing the payment_flow analytic events with `flow: creation`" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/a6baa6f8-dd30-464e-a85c-d285f935d534">

### Toggling panel events
Note the `expanded` property, and this shows both `creation` and `editing` flows
<img width="1384" alt="Console log messages showing the `order_form_totals_panel_toggled` event with its `expanded: true/false` property" src="https://github.com/woocommerce/woocommerce-ios/assets/2472348/57018603-e136-4458-8c8e-3de4e70b8980">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
