### PR TITLE
[Order Creation] Resize totals panel as content changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -59,6 +59,11 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                         }
                     }
                     .trackSize(size: $expandingContentSize)
+                    .onChange(of: expandingContentSize, perform: { _ in
+                        withAnimation {
+                            panelHeight = calculateHeight()
+                        }
+                    })
                 }
                 .scrollVerticallyIfNeeded()
 
@@ -74,6 +79,11 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
             // Always visible content
             alwaysVisibleContent()
                 .trackSize(size: $fixedContentSize)
+                .onChange(of: fixedContentSize, perform: { _ in
+                    withAnimation {
+                        panelHeight = calculateHeight()
+                    }
+                })
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(GeometryReader { geometryProxy in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

Merge after: #11516 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I realised that I'd accidentally removed the resize functionality while I was fixing the landscape display of the totals panel.

This PR adds it back. Whenever the content of the panel changes, e.g. by adding or removing a product or other order component, the size is recalculated so that it takes the right amount of space.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Navigate to the `Orders` tab
3. Tap `+` to create an order
4. Expand the panel; it will not really change much as it's empty.
5. Add a product
6. Observe that the panel expands to show all the content
7. Add shipping
8. Observe that the panel expands again
9. Remove the product
10. Observe that the panel contracts so it's not using too much space.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/8966a408-8b32-48b9-b6fa-4e94984873f1



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
