### PR TITLE
Track debug path and description for JSON decoding errors

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -708,6 +708,7 @@
 		CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
+		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */; };
 		CEE9188129F7DC23004B23FF /* order-with-gift-cards.json in Resources */ = {isa = PBXBuildFile; fileRef = CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */; };
 		CEF88DAB233E911A00BED485 /* order-fully-refunded.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF88DAA233E911A00BED485 /* order-fully-refunded.json */; };
@@ -1742,6 +1743,7 @@
 		CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundListMapperTests.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
+		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderGiftCard.swift; sourceTree = "<group>"; };
 		CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-gift-cards.json"; sourceTree = "<group>"; };
 		CEF88DAA233E911A00BED485 /* order-fully-refunded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-fully-refunded.json"; sourceTree = "<group>"; };
@@ -3176,6 +3178,7 @@
 				B58E5BE920FFB3D0003C986E /* CodingUserInfoKey+Woo.swift */,
 				B5BB1D0B20A2050300112D92 /* DateFormatter+Woo.swift */,
 				CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */,
+				CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */,
 				B53EF5312180F21C003E146F /* Dictionary+Woo.swift */,
 				B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */,
 				021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */,
@@ -4118,6 +4121,7 @@
 				B9DFE4BE2AA2057B00174004 /* TaxRateListMapper.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
 				DE66C5532976508300DAA978 /* CookieNonceAuthenticator.swift in Sources */,
+				CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */,
 				02EBCB3E2AA03D520019085B /* OrderItemProductAddOn.swift in Sources */,
 				26650332261FFA1A0079A159 /* ProductAddOnEnvelope.swift in Sources */,
 				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -709,6 +709,7 @@
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
+		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
 		CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */; };
 		CEE9188129F7DC23004B23FF /* order-with-gift-cards.json in Resources */ = {isa = PBXBuildFile; fileRef = CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */; };
 		CEF88DAB233E911A00BED485 /* order-fully-refunded.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF88DAA233E911A00BED485 /* order-fully-refunded.json */; };
@@ -1744,6 +1745,7 @@
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
+		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
 		CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderGiftCard.swift; sourceTree = "<group>"; };
 		CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-gift-cards.json"; sourceTree = "<group>"; };
 		CEF88DAA233E911A00BED485 /* order-fully-refunded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-fully-refunded.json"; sourceTree = "<group>"; };
@@ -3205,6 +3207,7 @@
 				EE62EE64295AD46D009C965B /* String+URLTests.swift */,
 				02AD47712A6EB93A00E652D6 /* URLRequestConvertible+PathTests.swift */,
 				02AED9DB2AA04716006DC460 /* KeyedDecodingContainer+WooTests.swift */,
+				CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4484,6 +4487,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */,
 				45551F142523E7FF007EF104 /* UserAgentTests.swift in Sources */,
 				03EB998A2906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift in Sources */,
 				CCE5F39129F000AC00087332 /* SubscriptionListMapperTests.swift in Sources */,

--- a/Networking/Networking/Extensions/DecodingError+CodingPath.swift
+++ b/Networking/Networking/Extensions/DecodingError+CodingPath.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public extension DecodingError {
+    private var context: Context {
+        switch self {
+        case .dataCorrupted(let context), .keyNotFound(_, let context), .typeMismatch(_, let context), .valueNotFound(_, let context):
+            return context
+        @unknown default:
+            assertionFailure("⛔️ Unhandled Decoding Error: \(self)")
+            return Context(codingPath: [], debugDescription: "")
+        }
+    }
+
+    /// The path of coding keys taken to get to the point of the failing decode call, simplified.
+    ///
+    /// Outputs: `data.line_items.name`
+    var debugPath: String {
+        context.codingPath.map { $0.stringValue }.filter { !$0.hasPrefix("Index") }.joined(separator: ".")
+    }
+
+    /// A description of what went wrong, for debugging purposes.
+    ///
+    /// Outputs: `Expected to decode a Number but found a String instead`
+    var debugDescription: String {
+        context.debugDescription
+    }
+}

--- a/Networking/NetworkingTests/Extensions/DecodingError+CodingPathTests.swift
+++ b/Networking/NetworkingTests/Extensions/DecodingError+CodingPathTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+final class DecodingError_CodingPathTests: XCTestCase {
+    private let mockDebugDescription = "Mock decoding error"
+
+    func test_debugPath_creates_expected_string_from_codingPath() {
+        // Given
+        let mockCodingPath = [MockCodingKeys.items, MockCodingKeys.index, MockCodingKeys.name]
+        let error = DecodingError.dataCorrupted(.init(codingPath: mockCodingPath, debugDescription: mockDebugDescription))
+
+        // Then
+        assertEqual("items.name", error.debugPath)
+    }
+
+    func test_dataCorrupted_decoding_error_has_expected_properties() {
+        // Given
+        let error = DecodingError.dataCorrupted(.init(codingPath: [MockCodingKeys.name], debugDescription: mockDebugDescription))
+
+        // Then
+        assertEqual("name", error.debugPath)
+        assertEqual(mockDebugDescription, error.debugDescription)
+    }
+
+    func test_keyNotFound_decoding_error_has_expected_properties() {
+        // Given
+        let error = DecodingError.keyNotFound(MockCodingKeys.name, .init(codingPath: [MockCodingKeys.name], debugDescription: mockDebugDescription))
+
+        // Then
+        assertEqual("name", error.debugPath)
+        assertEqual(mockDebugDescription, error.debugDescription)
+    }
+
+    func test_typeMismatch_decoding_error_has_expected_properties() {
+        // Given
+        let error = DecodingError.typeMismatch(String.self, .init(codingPath: [MockCodingKeys.name], debugDescription: mockDebugDescription))
+
+        // Then
+        assertEqual("name", error.debugPath)
+        assertEqual(mockDebugDescription, error.debugDescription)
+    }
+
+    func test_valueNotFound_decoding_error_has_expected_properties() {
+        // Given
+        let error = DecodingError.valueNotFound(String.self, .init(codingPath: [MockCodingKeys.name], debugDescription: mockDebugDescription))
+
+        // Then
+        assertEqual("name", error.debugPath)
+        assertEqual(mockDebugDescription, error.debugDescription)
+    }
+
+}
+
+private extension DecodingError_CodingPathTests {
+    enum MockCodingKeys: String, CodingKey {
+        case items
+        case index = "Index 0"
+        case name
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2803,13 +2803,17 @@ extension WooAnalyticsEvent {
         enum Keys: String {
             case path
             case entityName = "entity"
+            case debugPath = "debug_path"
+            case debugDescription = "debug_description"
         }
 
         static func jsonParsingError(_ error: Error, path: String?, entityName: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .apiJSONParsingError,
                               properties: [
                                 Keys.path.rawValue: path,
-                                Keys.entityName.rawValue: entityName
+                                Keys.entityName.rawValue: entityName,
+                                Keys.debugPath.rawValue: (error as? DecodingError)?.debugPath,
+                                Keys.debugDescription.rawValue: (error as? DecodingError)?.debugDescription
                               ].compactMapValues { $0 },
                               error: error)
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2803,8 +2803,8 @@ extension WooAnalyticsEvent {
         enum Keys: String {
             case path
             case entityName = "entity"
-            case debugPath = "debug_path"
-            case debugDescription = "debug_description"
+            case debugDecodingPath = "debug_decoding_path"
+            case debugDecodingDescription = "debug_decoding_description"
         }
 
         static func jsonParsingError(_ error: Error, path: String?, entityName: String?) -> WooAnalyticsEvent {
@@ -2812,8 +2812,8 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.path.rawValue: path,
                                 Keys.entityName.rawValue: entityName,
-                                Keys.debugPath.rawValue: (error as? DecodingError)?.debugPath,
-                                Keys.debugDescription.rawValue: (error as? DecodingError)?.debugDescription
+                                Keys.debugDecodingPath.rawValue: (error as? DecodingError)?.debugPath,
+                                Keys.debugDecodingDescription.rawValue: (error as? DecodingError)?.debugDescription
                               ].compactMapValues { $0 },
                               error: error)
         }

--- a/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
@@ -138,8 +138,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         let eventProperties = analyticsProvider.receivedProperties[indexOfEvent]
         XCTAssertNil(eventProperties["path"])
         XCTAssertNil(eventProperties["entity"])
-        XCTAssertNotNil(eventProperties["debug_path"])
-        XCTAssertNotNil(eventProperties["debug_description"])
+        XCTAssertNotNil(eventProperties["debug_decoding_path"])
+        XCTAssertNotNil(eventProperties["debug_decoding_description"])
     }
 
     func test_json_parsing_failed_event_is_tracked_with_properties_upon_decoding_error_when_properties_are_avaiable() throws {
@@ -159,8 +159,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         let eventProperties = analyticsProvider.receivedProperties[indexOfEvent]
         XCTAssertEqual(eventProperties["path"] as? String, "wc/test")
         XCTAssertEqual(eventProperties["entity"] as? String, "Product")
-        XCTAssertEqual(eventProperties["debug_path"] as? String, "")
-        XCTAssertEqual(eventProperties["debug_description"] as? String, "The given data was not valid JSON.")
+        XCTAssertEqual(eventProperties["debug_decoding_path"] as? String, "")
+        XCTAssertEqual(eventProperties["debug_decoding_description"] as? String, "The given data was not valid JSON.")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
@@ -124,7 +124,7 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         assertEqual("other", actualProperties["cause"] as? String)
     }
 
-    func test_json_parsing_failed_event_is_tracked_with_nil_properties_upon_decoding_error_when_properties_are_not_set() throws {
+    func test_json_parsing_failed_event_is_tracked_with_expected_nil_properties_upon_decoding_error_when_properties_are_not_set() throws {
         // When
         let error = mockDecodingError()
         mockNotificationCenter.post(name: .RemoteDidReceiveJSONParsingError, object: error, userInfo: nil)
@@ -138,6 +138,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         let eventProperties = analyticsProvider.receivedProperties[indexOfEvent]
         XCTAssertNil(eventProperties["path"])
         XCTAssertNil(eventProperties["entity"])
+        XCTAssertNotNil(eventProperties["debug_path"])
+        XCTAssertNotNil(eventProperties["debug_description"])
     }
 
     func test_json_parsing_failed_event_is_tracked_with_properties_upon_decoding_error_when_properties_are_avaiable() throws {
@@ -157,6 +159,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
         let eventProperties = analyticsProvider.receivedProperties[indexOfEvent]
         XCTAssertEqual(eventProperties["path"] as? String, "wc/test")
         XCTAssertEqual(eventProperties["entity"] as? String, "Product")
+        XCTAssertEqual(eventProperties["debug_path"] as? String, "")
+        XCTAssertEqual(eventProperties["debug_description"] as? String, "The given data was not valid JSON.")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When analyzing common decoding errors, there is a lot of noise in the error description that we track. We want to make it easier to read and analyze decoding errors based on their coding path and debug description.

Related discussion: pe5pgL-4bk-p2#comment-3387

## How

This extracts the error coding path and debug description and tracks them as separate custom properties when a decoding error occurs, using a `DecodingError` extension.

The new `debugPath` variable also removes any `Index` strings from the coding path, because for our analysis it doesn't matter which index of an array the error occurs on. That way, we can more clearly see the affected field and count similar decoding errors, regardless of index.

h/t @Ecarrion for the suggested `DecodingError` extension!

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Optional testing:

1. Prerequisite: Install a plugin that causes a decoding error or use a tool like Charles Proxy to intercept and modify an API response to cause a decoding error.
2. Build and run the app.
3. Trigger a decoding error.
4. Confirm the tracked event includes the new `debug_path` and `debug_description` properties.

Alternately: Check the Tracks history for my username and the `woocommerceios_api_json_parsing_error` event to see an example of this tracked error with the following properties:

* `debug_path`: `data.line_items.product_id`
* `debug_description `: `Expected to decode Int64 but found a string/data instead.`


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.