### PR TITLE
Lightweight storefront: Disable theme picking in store creation for 16.7

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -181,6 +181,7 @@ extension WooAnalyticsEvent.StoreCreation {
         case profilerSellingStatusQuestion = "store_profiler_commerce_journey"
         case profilerSellingPlatformsQuestion = "store_profiler_ecommerce_platforms"
         case profilerCountryQuestion = "store_profiler_country"
+        case themePicker = "theme_picker"
         case domainPicker = "domain_picker"
         case storeSummary = "store_summary"
         case planPurchase = "plan_purchase"

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerView.swift
@@ -31,7 +31,7 @@ struct StoreCreationProfilerQuestionContainerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ProgressView(value: viewModel.currentQuestion.progress)
+            ProgressView(value: viewModel.progress)
                 .progressViewStyle(.linear)
 
             switch viewModel.currentQuestion {
@@ -79,7 +79,7 @@ struct StoreCreationProfilerQuestionContainerView: View {
                         viewModel.backtrackOrDismissProfiler()
                     }
                 }, label: {
-                    if viewModel.currentQuestion.previousQuestion == nil {
+                    if viewModel.previousQuestion == nil {
                         Text(Localization.cancel)
                     } else {
                         Image(systemName: "chevron.backward")

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModel.swift
@@ -135,6 +135,8 @@ final class StoreCreationProfilerQuestionContainerViewModel: ObservableObject {
     func saveTheme(_ theme: WordPressTheme?) {
         if let theme {
             themeInstaller.scheduleThemeInstall(themeID: theme.id, siteID: siteID)
+        } else {
+            analytics.track(event: .StoreCreation.siteCreationProfilerQuestionSkipped(step: .themePicker))
         }
         moveToNextQuestionIfAvailable()
     }

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerQuestionContainerViewModelTests.swift
@@ -60,6 +60,7 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
                                                                         onCompletion: {},
                                                                         uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
         // When
+        viewModel.saveSellingStatus(nil)
         viewModel.saveCategory(nil)
 
         // Then
@@ -102,12 +103,16 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveCountry_updates_currentQuestion_to_theme() {
         // Given
+        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: true)
         let viewModel = StoreCreationProfilerQuestionContainerViewModel(siteID: 123,
                                                                         storeName: "Test",
+                                                                        featureFlagService: featureFlagService,
                                                                         onCompletion: {},
                                                                         uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
+        viewModel.saveSellingStatus(nil)
+        viewModel.saveCategory(nil)
         viewModel.saveCountry(.US)
 
         // Then
@@ -133,13 +138,18 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
 
     func test_saveTheme_triggers_onCompletion() throws {
         // Given
+        let featureFlagService = MockFeatureFlagService(isLightweightStorefrontEnabled: true)
         var triggeredCompletion = false
         let viewModel = StoreCreationProfilerQuestionContainerViewModel(siteID: 123,
                                                                         storeName: "Test",
+                                                                        featureFlagService: featureFlagService,
                                                                         onCompletion: { triggeredCompletion = true },
                                                                         uploadAnswersUseCase: MockStoreCreationProfilerUploadAnswersUseCase())
 
         // When
+        viewModel.saveSellingStatus(nil)
+        viewModel.saveCategory(nil)
+        viewModel.saveCountry(.US)
         viewModel.saveTheme(nil)
 
         // Then
@@ -190,6 +200,7 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
                                                                         storeName: "Test",
                                                                         onCompletion: { triggeredCompletion = true },
                                                                         uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
+        viewModel.saveSellingStatus(nil)
         viewModel.saveCategory(nil)
 
         // When
@@ -296,10 +307,11 @@ final class StoreCreationProfilerQuestionContainerViewModelTests: XCTestCase {
                                                                         uploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCase(siteID: 123))
 
         // When
+        viewModel.saveSellingStatus(nil)
         viewModel.saveCategory(nil)
 
         // Then
-        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "site_creation_step" }))
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "site_creation_step" }))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
         XCTAssertEqual(eventProperties["step"] as? String, "store_profiler_country")
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11521 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a fix to not include the WIP theme picking feature in the store creation flow. This slipped through development since we didn't add a feature flag check while working on this.

To make the flow more generic and more straightforward to update in the future, I updated the logic in `StoreCreationProfilerQuestionContainerView`:

- Moved `progress` and `previousQuestion` from the question enum to the view model.
- Added an array for question types in the view model.
- Added a variable for question index.
- Added a new method named `moveToNextQuestionIfAvailable` to trigger after saving each question response.
- Updated question response handlers.
- Added a new analytic step for theme picker to track the step.

Note: I didn't add unit tests for the logic around the feature flag as this is removed in 16.8.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
With the feature flag `lightweightStorefront ` disabled: 
- Log in to a WPCom store and switch to the Menu tab.
- Select the store picker > Add a store > Create a new store > Start free trial.
- Confirm that the profiler flow contains only  3 questions: selling status, category and country. The progress bar should be updated correctly.

With the feature flag `lightweightStorefront` enabled:
- Log in to a WPCom store and switch to the Menu tab.
- Select the store picker > Add a store > Create a new store > Start free trial.
- Confirm that the profiler flow contains only  4 questions: selling status, category, country, and theme picking. The progress bar should be updated correctly.
- Confirm that saving country tracks `site_creation_step` with step `theme_picker`.
- Confirm that skipping theme tracks `site_creation_profiler_question_skipped` with step `theme_picker`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
With feature flag disabled:


https://github.com/woocommerce/woocommerce-ios/assets/5533851/df6e0004-68b3-4a2c-ae2c-628b05d38af3

With feature flag enabled:


https://github.com/woocommerce/woocommerce-ios/assets/5533851/2a7c8c7c-6342-48f7-b9f5-a88171d66fbe



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
