### PR TITLE
[Scan to Update Inventory] Address wrong button rendering for non-managed-stock products

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -37,7 +37,9 @@ struct UpdateProductInventoryView: View {
                 ScrollView {
                     VStack(alignment: .center, spacing: 0) {
                         AsyncImage(url: viewModel.imageURL) { image in
-                            image.resizable()
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
                         } placeholder: {
                             Rectangle()
                                 .foregroundColor(.gray)

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModel.swift
@@ -169,7 +169,11 @@ final class UpdateProductInventoryViewModel: ObservableObject {
             }
 
             enableQuantityButton = true
-            updateQuantityButtonMode = decimalValue == inventoryItem.stockQuantity ? .increaseOnce : .customQuantity
+            guard let stockQuantity = inventoryItem.stockQuantity else {
+                updateQuantityButtonMode = .increaseOnce
+                return
+            }
+            updateQuantityButtonMode = decimalValue == stockQuantity ? .increaseOnce : .customQuantity
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11465

## Description
When scanning to update inventory, we will always see a `Quantity +1` button by default, which allows us to tap and increase the stock on +1 directly. If instead we tap on the quantity textfield and change the number manually to something else, the button would change to be `Update Quantity` and update the quantity to whatever we input.

| Quantity +1 button | Update Quantity button |
|--------|--------|
| ![20231222-bug-fix-2](https://github.com/woocommerce/woocommerce-ios/assets/3812076/3fac4554-381e-44e3-abc8-3c4e8df69c8d) | ![20231222-bug-fix-1](https://github.com/woocommerce/woocommerce-ios/assets/3812076/9c60981f-178f-4cb4-a997-906b07548e8f) | 

We discovered a minor bug when dealing with products with their "Manage Stock" property turned off, where the `Quantity +1` button would never show after enabling stock management, but only `Update Quantity`.

## Changes

This happened because of the logic for the button: We check if the current inventory stock for the specific item is the same as the value input in order to render one button or another, but since products with "Manage Stock" turned off has its stock value as `nil`, this equality always returns false since `nil != 0`, which renders the `Update Quantity` button.

By adding an additional nil check to the stock quantity when deciding which button we want to render, we solve this issue.

## Testing instructions
You will need a product with inventory, and a QR or barcode assigned to its SKU. For easier testing I prepared the following one: 
![_qr-ok-tumblr-stickers](https://github.com/woocommerce/woocommerce-ios/assets/3812076/5062720f-03a2-4a82-89ce-adfc94f0945f), but feel free to create your own via https://www.barcode-generator.org/

1. Assign barcode to product: Go to `Menu` > `Products` > select a product > tap on `Inventory` > tap on the SKU scanner and assign a barcode to the product > Save the changes.
2. Disable manage stock: Edit the product again > Tap on `Inventory` > Confirm that `Manage Stock` is turned off and `Save` the changes to the product.
3. Attempt to update inventory for that product: Go to `Menu` > `Products`,  tap the "Scanner" icon in the top left corner of the screen, and scan the QR code for the product
4. Observe how the product is successfully found and you're prompted with a screen where you can see the product details, and a `Manage Stock` button. Tap that button.
5. Observe how the `Quantity +1` button appears, and the Quantity is set to `0`. 
6. Manually altering the quantity in the textfield will make the button change to `Update Quantity`, while tapping the `Quantity +1` directly will increase the stock quantity +1 and dismiss the view.

https://github.com/woocommerce/woocommerce-ios/assets/3812076/3390c214-8bc6-4849-87fc-ca5b0b2cde63



