### PR TITLE
[Blaze] Track Blaze completion event only once

### DIFF
--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -85,7 +85,7 @@ extension BlazeWebViewModel: AuthenticatedWebViewModel {
         }
 
         currentStep = extractCurrentStep(from: url) ?? currentStep
-        if currentStep == Constants.completionStep {
+        if currentStep == Constants.completionStep && !isCompleted {
             ServiceLocator.analytics.track(event: .Blaze.blazeFlowCompleted(source: source, step: currentStep))
             isCompleted = true
             userDefaults.restoreBlazeSectionOnMyStore(for: siteID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11523 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

### What?

`blaze_flow_completed` tracking event is tracked two times when a single Blaze campaign is created.

This results in wrong data when we measure how many Blaze campaigns are created from mobile. 

Internal - p1703219471394299/1703097526.540179-slack-C069RG07W6S

### Why?

`BlazeWebViewModel` doesn't check the `isCompleted` value before tracking the completion event. 

### How? 

- We already have a `isCompleted` flag to check whether Blaze campaign creation is complete. We can use that to ensure that completion event is not tracked twice. 
- Android follows the same logic. [Code](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeCampaignCreationViewModel.kt#L98)



## Testing instructions
Prereuisites
1. Create a JN site with Jetpack and Woo. 
1. Create a product and publish it.

Steps
1. Launch the app and login into the above created JN Woo store
1. Navigate to the products tab and open a product
1. Tap on "Promote with Blaze"
1. Fill in the form and submit the campaign
1. You will be navigated to the "All Set!" web page
1. From Xcode logs ensure that `blaze_flow_completed` event is tracked
1. Tap on "Go to my campaigns" to navigate to the list screen
1. Check Xcode logs and ensure that `blaze_flow_completed` event is tracked only once

⚠️ There is a known issue that `blaze_flow_completed` won't be tracked if the user opts to skip the "All Set!" web page and navigate to the campaigns list directly. We need to debug and address that separately. Internal - p1703222792958499-slack-C03L1NF1EA3

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/524475/4db7f63a-28cf-4e44-b098-2964d442f50d


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.