### PR TITLE
Update order list and order details to show dates in store time zone

### DIFF
--- a/WooCommerce/Classes/Model/StorageOrder+Woo.swift
+++ b/WooCommerce/Classes/Model/StorageOrder+Woo.swift
@@ -14,11 +14,11 @@ extension StorageOrder {
     ///
     @objc func normalizedAgeAsString() -> String {
         // Normalize Dates: Time must not be considered. Just the raw dates
-        guard let startDate = dateCreated?.normalizedDate() else {
+        guard let startDate = dateCreated?.startOfDay(timezone: .siteTimezone) else {
             return ""
         }
 
-        let toDate = Date().normalizedDate()
+        let toDate = Date().startOfDay(timezone: .siteTimezone)
         let age = Age.from(startDate: startDate, toDate: toDate)
 
         return age.rawValue

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -585,7 +585,7 @@ private extension OrderDetailsDataSource {
             return
         }
 
-        cell.dateCreated = noteHeader.toString(dateStyle: .medium, timeStyle: .none)
+        cell.dateCreated = noteHeader.toString(dateStyle: .medium, timeStyle: .none, timeZone: .siteTimezone)
     }
 
     private func configureOrderNote(cell: OrderNoteTableViewCell, at indexPath: IndexPath) {
@@ -596,7 +596,7 @@ private extension OrderDetailsDataSource {
         cell.isSystemAuthor = note.isSystemAuthor
         cell.isCustomerNote = note.isCustomerNote
         cell.author = note.author
-        cell.dateCreated = note.dateCreated.toString(dateStyle: .none, timeStyle: .short)
+        cell.dateCreated = note.dateCreated.toString(dateStyle: .none, timeStyle: .short, timeZone: .siteTimezone)
         cell.contents = orderNoteAsyncDictionary.value(forKey: note.noteID)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -41,6 +41,7 @@ struct OrderListCellViewModel {
     var dateCreated: String {
         let isSameYear = order.dateCreated.isSameYear(as: Date())
         let formatter: DateFormatter = isSameYear ? .monthAndDayFormatter : .mediumLengthLocalizedDateFormatter
+        formatter.timeZone = .siteTimezone
         return formatter.string(from: order.dateCreated)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -149,11 +149,14 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     var dateString: String {
         switch flow {
-        case .creation:
-            return DateFormatter.mediumLengthLocalizedDateFormatter.string(from: Date())
-        case .editing(let order):
-            let formatter = DateFormatter.dateAndTimeFormatter
-            return formatter.string(from: order.dateCreated)
+            case .creation:
+                let formatter = DateFormatter.mediumLengthLocalizedDateFormatter
+                formatter.timeZone = .siteTimezone
+                return formatter.string(from: Date())
+            case .editing(let order):
+                let formatter = DateFormatter.dateAndTimeFormatter
+                formatter.timeZone = .siteTimezone
+                return formatter.string(from: order.dateCreated)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -48,6 +48,7 @@ struct SummaryTableViewCellViewModel {
     ///
     var subtitle: String {
         let formatter = DateFormatter.dateAndTimeFormatter
+        formatter.timeZone = .siteTimezone
         return formatter.string(from: dateCreated)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10842
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As shared in the reasoning from the Mothra team pe5pgL-4bG-p2#comment-3401, we generally want to show the dates in the store time zone instead of the device time zone so that shop managers can see consistent dates from any time zone. After searching for code usage for a few date formatters, date string conversions like `toString(dateStyle:timeStyle:)`, and date helpers like `normalizedDate`, there are a lot more dates that are currently in the device time zone than just analytics and order list and details - shipping labels, coupons, order filters, product reviews, etc. To make incremental changes for easier review, this PR just focuses on the order list, order details (without data from extensions), and order form.

## How

- The order cell's date in the order list is updated in `OrderListCellViewModel`
- The order cell's section header in the order list is updated in `StorageOrder.normalizedAgeAsString`
- The order note's date in order details is updated in `OrderDetailsDataSource`
- The order date at the top of order details is updated in `SummaryTableViewCellViewModel.subtitle`
- The date at the top of the order form is updated in `EditableOrderViewModel.dateString`

I was considering adding an extension for `toString(dateStyle:timeStyle:timeZone:)` with the site time zone like `toStringInSiteTimeZone(dateStyle:timeStyle:)` but I'll leave that for a future PR to give more thought to adding some unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand-testing is optional, as this doesn't look like a risky change but feel free to do an extra check:

Prerequisite: the store has non-zero orders, ideally some in the last week/month

- In wp-admin Settings > General, set the store time zone to a value that is currently on a different day from the device time zone (I found the UTC offset options the easiest)
- In the app, go to the orders tab --> the date of each order in the orders tab should be the same as in core, with the relative date section header compared to the device time zone
- Tap on an order --> the date at the top should match the order creation date in core, and order notes should also match what's in core
- Tap `Edit` --> the date at the top should match the order creation date in core
- Go back to the orders tab
- Tap `+` to create an order --> the date at the top should be the current device time but in the site time zone
- Tap `Create` to create the order remotely
- Go back to the orders tab --> the newly created order should be in a section "TODAY"

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Example device time zone: GMT+8, on Dec 22
Store time zone: GMT+12, on Dec 23

before | after
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/df46d0d5-018b-42b6-a27e-5c135c4d38e3" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/586333cf-951c-42b8-852c-3b344836226b" width="300" />
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/f0694141-e2c0-40d1-8f2d-107409c13be4" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/3d0b776b-b00e-4d26-83dd-b40b0f094344" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.