### PR TITLE
Update order paid and refunded dates to use store time zone

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,8 @@
 - [*] Store creation: Inform user once store ready if app killed while waiting for store to be ready. [https://github.com/woocommerce/woocommerce-ios/pull/11478]
 - [*] Dashboard: Resolves a decoding error with certain payment gateway plugins that previously caused an error loading data in the dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/11489]
 - [**] Lightweight Storefront: Added option to select themes for WPCom store in both Settings and Store Creation flows. [https://github.com/woocommerce/woocommerce-ios/issues/11291]
+- [*] Orders: order creation/paid/refund dates are now shown in the store time zone instead of the device time zone. [https://github.com/woocommerce/woocommerce-ios/pull/11539, https://github.com/woocommerce/woocommerce-ios/pull/11536]
+- [*] Similar to orders above, the latest time range in analytics is now in the store time zone instead of the device time zone. [https://github.com/woocommerce/woocommerce-ios/pull/11479]
 
 16.7
 -----

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -18,6 +18,13 @@ extension Date {
         return formatter.string(from: self)
     }
 
+    /// Same as `toString(dateStyle:timeStyle:)` but in the site time zone.
+    /// The string returned will be localized in the device's current locale.
+    ///
+    func toStringInSiteTimeZone(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style) -> String {
+        toString(dateStyle: dateStyle, timeStyle: timeStyle, timeZone: .siteTimezone)
+    }
+
     /// Returns a localized update string relative to the receiver if it's within one day of now *or*
     /// a medium datestyle + short timestyle string otherwise.
     ///

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -8,7 +8,7 @@ extension Date {
     /// Returns the String Representation of the receiver, with the specified Date + Time Styles applied.
     /// The string returned will be localised in the device's current locale.
     ///
-    func toString(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style, timeZone: TimeZone = .current) -> String {
+    func toString(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style, timeZone: TimeZone = .current, locale: Locale = .current) -> String {
         let formatter = DateFormatter()
         formatter.dateStyle = dateStyle
         formatter.timeStyle = timeStyle
@@ -21,8 +21,8 @@ extension Date {
     /// Same as `toString(dateStyle:timeStyle:)` but in the site time zone.
     /// The string returned will be localized in the device's current locale.
     ///
-    func toStringInSiteTimeZone(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style) -> String {
-        toString(dateStyle: dateStyle, timeStyle: timeStyle, timeZone: .siteTimezone)
+    func toStringInSiteTimeZone(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style, locale: Locale = .current) -> String {
+        toString(dateStyle: dateStyle, timeStyle: timeStyle, timeZone: .siteTimezone, locale: locale)
     }
 
     /// Returns a localized update string relative to the receiver if it's within one day of now *or*

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -585,7 +585,7 @@ private extension OrderDetailsDataSource {
             return
         }
 
-        cell.dateCreated = noteHeader.toString(dateStyle: .medium, timeStyle: .none, timeZone: .siteTimezone)
+        cell.dateCreated = noteHeader.toStringInSiteTimeZone(dateStyle: .medium, timeStyle: .none)
     }
 
     private func configureOrderNote(cell: OrderNoteTableViewCell, at indexPath: IndexPath) {
@@ -596,7 +596,7 @@ private extension OrderDetailsDataSource {
         cell.isSystemAuthor = note.isSystemAuthor
         cell.isCustomerNote = note.isCustomerNote
         cell.author = note.author
-        cell.dateCreated = note.dateCreated.toString(dateStyle: .none, timeStyle: .short, timeZone: .siteTimezone)
+        cell.dateCreated = note.dateCreated.toStringInSiteTimeZone(dateStyle: .none, timeStyle: .short)
         cell.contents = orderNoteAsyncDictionary.value(forKey: note.noteID)
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -142,7 +142,11 @@ final class OrderPaymentDetailsViewModel {
         }
 
         // First, localize all the pieces of the sentence.
-        let dateCreated = DateFormatter.mediumLengthLocalizedDateFormatter.string(from: refund.dateCreated)
+        let dateCreated = {
+            let dateFormatter = DateFormatter.mediumLengthLocalizedDateFormatter
+            dateFormatter.timeZone = .siteTimezone
+            return dateFormatter.string(from: refund.dateCreated)
+        }()
 
         let hasRefundGateway = refund.isAutomated ?? false
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -109,7 +109,7 @@ final class OrderPaymentDetailsViewModel {
             return nil
         }
 
-        let styleDate = datePaid.toString(dateStyle: .medium, timeStyle: .none)
+        let styleDate = datePaid.toStringInSiteTimeZone(dateStyle: .medium, timeStyle: .none)
         let template = NSLocalizedString(
             "%1$@ via %2$@",
             comment: "Payment on <date> received via (payment method title)")

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -204,4 +204,38 @@ final class DateWooTests: XCTestCase {
         let expected = formatter.date(from: "2020-03-09T00:00:00Z")!
         XCTAssertEqual(actual, expected)
     }
+
+    // MARK: - `toString(dateStyle:timeStyle:timeZone:locale:)`
+
+    func test_toString_returns_date_string_in_given_time_zone() throws {
+        // Given
+        // GMT: Monday, December 25, 2023 3:23:31 AM
+        let date = Date(timeIntervalSince1970: 1703474611)
+        // For time zone GMT-12, the identifier used is "Etc/GMT+12" and not "Etc/GMT-12" which might seem more intuitive,
+        // this is due to the way that these identifiers are standardized.
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "Etc/GMT+12"))
+        let locale = Locale(identifier: "en_US")
+
+        // When
+        let dateString = date.toString(dateStyle: .short, timeStyle: .full, timeZone: timeZone, locale: locale)
+
+        // Then
+        XCTAssertEqual(dateString, "12/24/23, 3:23:31 PM GMT-12:00")
+    }
+
+    // MARK: - `toStringInSiteTimeZone(dateStyle:timeStyle:locale:)`
+
+    func test_toStringInSiteTimeZone_returns_date_string_in_site_time_zone() throws {
+        // Given
+        // GMT: Monday, December 25, 2023 3:23:31 AM
+        let date = Date(timeIntervalSince1970: 1703474611)
+        ServiceLocator.stores.updateDefaultStore(.fake().copy(gmtOffset: -12))
+        let locale = Locale(identifier: "en_US")
+
+        // When
+        let dateString = date.toStringInSiteTimeZone(dateStyle: .short, timeStyle: .full, locale: locale)
+
+        // Then
+        XCTAssertEqual(dateString, "12/24/23, 3:23:31 PM GMT-12:00")
+    }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -220,7 +220,7 @@ final class DateWooTests: XCTestCase {
         let dateString = date.toString(dateStyle: .short, timeStyle: .full, timeZone: timeZone, locale: locale)
 
         // Then
-        XCTAssertEqual(dateString, "12/24/23, 3:23:31 PM GMT-12:00")
+        XCTAssertEqual(dateString, "12/24/23, 3:23:31 PM GMT-12:00")
     }
 
     // MARK: - `toStringInSiteTimeZone(dateStyle:timeStyle:locale:)`
@@ -236,6 +236,6 @@ final class DateWooTests: XCTestCase {
         let dateString = date.toStringInSiteTimeZone(dateStyle: .short, timeStyle: .full, locale: locale)
 
         // Then
-        XCTAssertEqual(dateString, "12/24/23, 3:23:31 PM GMT-12:00")
+        XCTAssertEqual(dateString, "12/24/23, 3:23:31 PM GMT-12:00")
     }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -229,7 +229,8 @@ final class DateWooTests: XCTestCase {
         // Given
         // GMT: Monday, December 25, 2023 3:23:31 AM
         let date = Date(timeIntervalSince1970: 1703474611)
-        ServiceLocator.stores.updateDefaultStore(.fake().copy(gmtOffset: -12))
+        ServiceLocator.stores.updateDefaultStore(storeID: 1)
+        ServiceLocator.stores.updateDefaultStore(.fake().copy(siteID: 1, gmtOffset: -12))
         let locale = Locale(identifier: "en_US")
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10842 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As shared in the reasoning from the Mothra team pe5pgL-4bG-p2#comment-3401, we generally want to show the dates in the store time zone instead of the device time zone so that shop managers can see consistent dates from any time zone. After the last PR https://github.com/woocommerce/woocommerce-ios/pull/11536 updating the date time zone to the site time zone in the order list and order details, I tested other use cases of the date-to-string conversion and just found two more major dates (**order paid and refund dates**) in order details that do not match core.

For the following dates in order details, the device/client time zone is used in core and I decided not to make changes to minimize confusion for shop managers:
- Shipping labels: created and refund dates
- Shipment tracking: created/shipped date

## How

- Added `toStringInSiteTimeZone` as a wrapper of `toString` that always uses the site time zone. A locale parameter was added to allow unit testing. Then in `OrderDetailsDataSource`, `toStringInSiteTimeZone` was used for the two dates that were updated to use the site time zone in https://github.com/woocommerce/woocommerce-ios/pull/11536
- To update to use the site time zone:
  - For order paid date: `OrderPaymentDetailsViewModel.paymentSummary`
  - For order refund date: `OrderPaymentDetailsViewModel.refundSummary`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand-testing is optional, as this doesn't look like a risky change but feel free to do an extra check.

Prerequisite: the store has at least an order that is refundable and was paid by a payment method with a description ("Marked as paid with cash" didn't seem to set a description)

- In wp-admin Settings > General, set the store time zone to a value that is currently on a different day from the device time zone (I found the UTC offset options the easiest)
- In the app, go to the orders tab
- Tap on the order in the prerequisite --> the "paid date" near the bottom of the payment totals section should be on the date in the site time zone
- Tap `Issue Refund` and select at least one item with non-zero amount to refund --> after the refund is issued, the refund date in the payment totals section in order details should be on the date in the site time zone

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Example device time zone: GMT+8, on Dec 25
Store time zone: GMT-12, on Dec 24

\ | before | after
-- | -- | --
paid date | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/b0b3047d-ce2d-455e-9b47-a6ba7f9d1b29" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/a3f2b3fa-7ecf-4ca7-ba06-0dee9d2f45e2" width="300" />
refund date | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/821d90ad-2350-4a33-8fb6-193750a9d521" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/a1a56fc9-c16f-4aa9-a496-a3d6c2a99a9f" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
