### PR TITLE
[Tablet Orders] Update edit icon on Gift Card row to match other edit buttons 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderFormGiftCardRow.swift
@@ -10,7 +10,7 @@ struct OrderFormGiftCardRow: View {
                 Text(Localization.giftCard)
                     .foregroundColor(.init(uiColor: .accent))
                     .bodyStyle()
-                Image(uiImage: .pencilImage)
+                Image(systemName: "pencil")
             }
             .foregroundColor(.init(uiColor: .accent))
 
@@ -26,7 +26,7 @@ private extension OrderFormGiftCardRow {
     }
 
     enum Constants {
-        static let horizontalSpacing: CGFloat = 8
+        static let horizontalSpacing: CGFloat = 4
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11543 

## Description
When adding Gift Cards to an Order, the current "pencil" edit button is rendered from an UIImage, which is different that the other Order buttons do (rendered from SFSymbols). This PR updates the icon for consistency:

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2023-12-26 at 10 35 52](https://github.com/woocommerce/woocommerce-ios/assets/3812076/65f13f37-68a5-4dc1-b327-0a624dbbb250) | ![Simulator Screenshot - iPhone 15 - 2023-12-26 at 10 44 48](https://github.com/woocommerce/woocommerce-ios/assets/3812076/428b4fb2-b776-45d0-ba9c-4421475056d3) | 

## Testing instructions
1. Logged with your a8c account, go to `https://woo.com/my-account/downloads/` and download, install, and activate `https://woo.com/products/gift-cards/` in your test site
2. In the app, go to `Orders` > Tap `+` > Observe that `+ Add Gift Card` is greyed out
3. Add a product to your order, then tap `+ Add Gift Card` and enter `1234-1234-1234-1234` and save it
4. Expand the bottom drawer ( Order total ) and observe that the pencil icon is the SFSymbol one (you can compare these by adding other values to the rows, for example `+ Add Shipping`)
